### PR TITLE
Swiftling: Fixing project name

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,6 @@
 # Project configuration
 included:
-  - WordPress
+  - WooCommerce
 
 # Rules
 whitelist_rules:


### PR DESCRIPTION
### Details:
We've borrowed the `swiftling` settings from WPiOS... but somebody (me!!) forgot to patch the project name.

For this reason, the Linting rules weren't really being picked up.

### To test:
Please, verify Hound looks happy!

cc @mindgraffiti 