### PR TITLE
Order Details: Fixing BillingDetails Row Touch Detection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/BillingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/BillingDetailsTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 
 /// Displays Billing Details: Used for Email / Phone Number Rendering.
@@ -15,7 +16,7 @@ class BillingDetailsTableViewCell: UITableViewCell {
 
     /// Closure to be executed whenever the cell is pressed.
     ///
-    var didTapButton: (() -> Void)?
+    var onTouchUp: (() -> Void)?
 
 
     // MARK: - Overridden Methods
@@ -28,17 +29,17 @@ class BillingDetailsTableViewCell: UITableViewCell {
 
         accessoryView = accessoryImageView
 
-        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(buttonWasPressed))
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.on { [weak self] gesture in
+            self?.onTouchUp?()
+        }
+
         contentView.gestureRecognizers = [gestureRecognizer]
     }
 
     func configure(text: String?, image: UIImage) {
         accessoryImageView.image = image
         textLabel?.text = text
-    }
-
-    @objc func buttonWasPressed() {
-        didTapButton?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderDetailsViewController.swift
@@ -132,12 +132,12 @@ private extension OrderDetailsViewController {
     private func configure(_ cell: BillingDetailsTableViewCell, for billingRow: Row) {
         if billingRow == .billingPhone {
             cell.configure(text: viewModel.billingViewModel.phoneNumber, image: Gridicon.iconOfType(.ellipsis))
-            cell.didTapButton = { [weak self] in
+            cell.onTouchUp = { [weak self] in
                 self?.phoneButtonAction()
             }
         } else if billingRow == .billingEmail {
             cell.configure(text: viewModel.billingViewModel.email, image: Gridicon.iconOfType(.mail))
-            cell.didTapButton = { [weak self] in
+            cell.onTouchUp = { [weak self] in
                 self?.emailButtonAction()
             }
         } else {


### PR DESCRIPTION
### Details:
I've noticed pressing over any of the Billing Details rows (Phone / Email) wasn't triggering any of the expected actions. It all boiled down to this snippet, which isn't working as expected.

```
button.addTarget(self, action: #selector(getter: didTapButton), for: .touchUpInside)
```

In this PR we're replacing the UIButton instance with a UITapGestureRecognizer, which allows us to detect press events anywhere in the cell (not just in the right corner). 

###  Testing:
1. Log into WC
2. Open the Order List > Order Details
3. Press over the `Show Billing` button

Verify that pressing the Email /  Phone rows actually causes the AlertController to display options onscreen.

cc @mindgraffiti (Thanks Thuy!!)
