### PR TITLE
CoreDataManager: Loading Store(s) synchronously

### DIFF
--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -77,7 +77,7 @@ extension CoreDataManager {
     ///
     var storeDescription: NSPersistentStoreDescription {
         let description = NSPersistentStoreDescription(url: storeURL)
-        description.shouldAddStoreAsynchronously = true
+        description.shouldAddStoreAsynchronously = false
         description.shouldMigrateStoreAutomatically = true
         return description
     }


### PR DESCRIPTION
### Details:
I've noticed the following warning is being displayed in the app, right after launch (develop):

```
2018-07-19 16:00:33.170359-0300 WooCommerce[1502:8251129] [error] warning:  View context accessed for persistent container WooCommerce with no stores loaded
CoreData: warning:  View context accessed for persistent container WooCommerce with no stores loaded
```

In this PR we're simply explicitly specifying the Stores load OP to be synchronous.

### Testing:
1. Launch WC
2. Verify no warning shows up in the console

cc @bummytime @astralbodies anyone oposed to this change? (NSPersistentStoreDescription is seriously new to me!!).

Thanks in advance!!