### PR TITLE
Dashboard Mark 2: Adds OrderStatsAction +Store +Tests

### DIFF
--- a/Networking/Networking/Extensions/DateFormatter+Woo.swift
+++ b/Networking/Networking/Extensions/DateFormatter+Woo.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// DateFormatter Extensions
 ///
-extension DateFormatter {
+public extension DateFormatter {
 
     /// Default Formatters
     ///
@@ -11,11 +11,61 @@ extension DateFormatter {
 
         /// Date And Time Formatter
         ///
-        static let dateTimeFormatter: DateFormatter = {
+        public static let dateTimeFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.timeZone = TimeZone(identifier: "GMT")
             formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH:mm:ss"
+            return formatter
+        }()
+    }
+
+
+    /// Stats Formatters
+    ///
+    struct Stats {
+
+        /// Date formatter used for creating the properly-formatted date string for **day** granularity. Typically
+        /// used when setting the `latestDateToInclude` on `OrderStatsRemote`.
+        ///
+        public static let statsDayFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "yyyy'-'MM'-'dd"
+            return formatter
+        }()
+
+        /// Date formatter used for creating the properly-formatted date string for **week** granularity. Typically
+        /// used when setting the `latestDateToInclude` on `OrderStatsRemote`.
+        ///
+        public static let statsWeekFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "yyyy'-W'ww"
+            return formatter
+        }()
+
+        /// Date formatter used for creating the properly-formatted date string for **month** granularity. Typically
+        /// used when setting the `latestDateToInclude` on `OrderStatsRemote`.
+        ///
+        public static let statsMonthFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "yyyy'-'MM"
+            return formatter
+        }()
+
+        /// Date formatter used for creating the properly-formatted date string for **year** granularity. Typically
+        /// used when setting the `latestDateToInclude` on `OrderStatsRemote`.
+        ///
+        public static let statsYearFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "yyyy"
             return formatter
         }()
     }

--- a/Networking/Networking/Remote/OrderStatsRemote.swift
+++ b/Networking/Networking/Remote/OrderStatsRemote.swift
@@ -11,7 +11,7 @@ public class OrderStatsRemote: Remote {
     /// - Parameters:
     ///   - siteID: The site ID
     ///   - unit: Defines the granularity of the stats we are fetching (one of 'day', 'week', 'month', or 'year')
-    ///   - latestDateToInclude: The latest date to include in the results. This string should match the `unit`, e.g.: 'day':'1955-11-05', 'week':'1955-W44', 'month':'1955-11', 'year':'1955'
+    ///   - latestDateToInclude: The latest date to include in the results. This string should match the `unit`, e.g.: 'day':'1955-11-05', 'week':'1955-W44', 'month':'1955-11', 'year':'1955'.
     ///   - quantity: How many `unit`s to fetch
     ///   - completion: Closure to be executed upon completion.
     ///

--- a/Networking/NetworkingTests/Extensions/DateFormatterWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/DateFormatterWooTests.swift
@@ -11,7 +11,7 @@ class DateFormatterWooTests: XCTestCase {
     let datetimeAsString = "2018-01-24T16:21:48"
 
 
-    /// Verifies that a Woo Datetime is properly parsed by `DateFormatter.Defaults.dateTimeFormatter.
+    /// Verifies that a Woo Datetime is properly parsed by `DateFormatter.Defaults.dateTimeFormatter`.
     ///
     func testWooFormattedDateIsProperlyParsed() {
         guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: datetimeAsString) else {
@@ -23,5 +23,57 @@ class DateFormatterWooTests: XCTestCase {
         XCTAssertEqual(calendar.component(.year, from: date), 2018)
         XCTAssertEqual(calendar.component(.month, from: date), 1)
         XCTAssertEqual(calendar.component(.day, from: date), 24)
+    }
+
+    /// Verifies that a valid stats **day** string is produced by `DateFormatter.Defaults.statsDayFormatter`.
+    ///
+    func testStatsDayDateStringIsProperlyParsed() {
+        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: datetimeAsString) else {
+            XCTFail()
+            return
+        }
+
+        let dayDateString = DateFormatter.Stats.statsDayFormatter.string(from: date)
+        XCTAssertFalse(dayDateString.isEmpty)
+        XCTAssertEqual(dayDateString, "2018-01-24")
+    }
+
+    /// Verifies that a valid stats **week** string is produced by `DateFormatter.Defaults.statsWeekFormatter`.
+    ///
+    func testStatsWeekDateStringIsProperlyParsed() {
+        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: datetimeAsString) else {
+            XCTFail()
+            return
+        }
+
+        let weekDateString = DateFormatter.Stats.statsWeekFormatter.string(from: date)
+        XCTAssertFalse(weekDateString.isEmpty)
+        XCTAssertEqual(weekDateString, "2018-W04")
+    }
+
+    /// Verifies that a valid stats **month** string is produced by `DateFormatter.Defaults.statsMonthFormatter`.
+    ///
+    func testStatsMonthDateStringIsProperlyParsed() {
+        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: datetimeAsString) else {
+            XCTFail()
+            return
+        }
+
+        let monthDateString = DateFormatter.Stats.statsMonthFormatter.string(from: date)
+        XCTAssertFalse(monthDateString.isEmpty)
+        XCTAssertEqual(monthDateString, "2018-01")
+    }
+
+    /// Verifies that a valid stats **year** string is produced by `DateFormatter.Defaults.statsYearFormatter`.
+    ///
+    func testStatsYearDateStringIsProperlyParsed() {
+        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: datetimeAsString) else {
+            XCTFail()
+            return
+        }
+
+        let yearDateString = DateFormatter.Stats.statsYearFormatter.string(from: date)
+        XCTAssertFalse(yearDateString.isEmpty)
+        XCTAssertEqual(yearDateString, "2018")
     }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		7499936620EFBC7200CF01CD /* OrderNoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7499936520EFBC7200CF01CD /* OrderNoteStore.swift */; };
 		7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */; };
 		7499936C20EFC20100CF01CD /* order-notes.json in Resources */ = {isa = PBXBuildFile; fileRef = 7499936B20EFC20100CF01CD /* order-notes.json */; };
+		74A18C562113827E00DCF8A8 /* OrderStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A18C552113827E00DCF8A8 /* OrderStatsStore.swift */; };
+		74A18C58211382A000DCF8A8 /* OrderStatsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A18C57211382A000DCF8A8 /* OrderStatsAction.swift */; };
 		74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A7688B20D45EBA00F9D437 /* OrderStore.swift */; };
 		74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A7688D20D45ED400F9D437 /* OrderStoreTests.swift */; };
 		74A7689020D45F9300F9D437 /* OrderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A7688F20D45F9300F9D437 /* OrderAction.swift */; };
@@ -70,6 +72,8 @@
 		7499936520EFBC7200CF01CD /* OrderNoteStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderNoteStore.swift; sourceTree = "<group>"; };
 		7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteStoreTests.swift; sourceTree = "<group>"; };
 		7499936B20EFC20100CF01CD /* order-notes.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-notes.json"; sourceTree = "<group>"; };
+		74A18C552113827E00DCF8A8 /* OrderStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsStore.swift; sourceTree = "<group>"; };
+		74A18C57211382A000DCF8A8 /* OrderStatsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsAction.swift; sourceTree = "<group>"; };
 		74A7688B20D45EBA00F9D437 /* OrderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStore.swift; sourceTree = "<group>"; };
 		74A7688D20D45ED400F9D437 /* OrderStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStoreTests.swift; sourceTree = "<group>"; };
 		74A7688F20D45F9300F9D437 /* OrderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAction.swift; sourceTree = "<group>"; };
@@ -167,6 +171,7 @@
 				B5BC736420D1A98500B5B6FA /* AccountStore.swift */,
 				74A7688B20D45EBA00F9D437 /* OrderStore.swift */,
 				7499936520EFBC7200CF01CD /* OrderNoteStore.swift */,
+				74A18C552113827E00DCF8A8 /* OrderStatsStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -306,6 +311,7 @@
 				B5DC3CB020D1B8720063AC41 /* AccountAction.swift */,
 				74A7688F20D45F9300F9D437 /* OrderAction.swift */,
 				7499936320EFBC1A00CF01CD /* OrderNoteAction.swift */,
+				74A18C57211382A000DCF8A8 /* OrderStatsAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -510,6 +516,7 @@
 				B5DC3CB120D1B8720063AC41 /* AccountAction.swift in Sources */,
 				B5BC736520D1A98500B5B6FA /* AccountStore.swift in Sources */,
 				B56C1EC220EAE2E500D749F9 /* ReadOnlyConvertible.swift in Sources */,
+				74A18C562113827E00DCF8A8 /* OrderStatsStore.swift in Sources */,
 				B505254C20EE6491008090F5 /* Site+ReadOnlyConvertible.swift in Sources */,
 				B5B5C797208E49B600642956 /* Action+Internal.swift in Sources */,
 				74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */,
@@ -523,6 +530,7 @@
 				B56C1EBE20EABD2B00D749F9 /* ResultsController.swift in Sources */,
 				B5EED1A820F4F3CF00652449 /* Account+ReadOnlyConvertible.swift in Sources */,
 				B5F2AE9720EBB54A00FEDC59 /* FetchedResultsControllerDelegateWrapper.swift in Sources */,
+				74A18C58211382A000DCF8A8 /* OrderStatsAction.swift in Sources */,
 				7499936420EFBC1B00CF01CD /* OrderNoteAction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		7424B49420EAD37C00CC62F6 /* order.json in Resources */ = {isa = PBXBuildFile; fileRef = 7424B49320EAD37C00CC62F6 /* order.json */; };
 		74685D4E20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74685D4D20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift */; };
 		74685D5020F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74685D4F20F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift */; };
+		7495C5262114977600CDD33B /* order-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = 7495C5222114977600CDD33B /* order-stats.json */; };
+		7495C5292114979D00CDD33B /* OrderStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7495C5282114979D00CDD33B /* OrderStatsStoreTests.swift */; };
 		7499936420EFBC1B00CF01CD /* OrderNoteAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7499936320EFBC1A00CF01CD /* OrderNoteAction.swift */; };
 		7499936620EFBC7200CF01CD /* OrderNoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7499936520EFBC7200CF01CD /* OrderNoteStore.swift */; };
 		7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */; };
@@ -69,6 +71,8 @@
 		745D21C120D8043A00BBE7C3 /* generic_error.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = generic_error.json; sourceTree = "<group>"; };
 		74685D4D20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		74685D4F20F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderCoupon+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		7495C5222114977600CDD33B /* order-stats.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats.json"; sourceTree = "<group>"; };
+		7495C5282114979D00CDD33B /* OrderStatsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsStoreTests.swift; sourceTree = "<group>"; };
 		7499936320EFBC1A00CF01CD /* OrderNoteAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderNoteAction.swift; sourceTree = "<group>"; };
 		7499936520EFBC7200CF01CD /* OrderNoteStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderNoteStore.swift; sourceTree = "<group>"; };
 		7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteStoreTests.swift; sourceTree = "<group>"; };
@@ -184,6 +188,7 @@
 				B5BC736720D1AA8F00B5B6FA /* AccountStoreTests.swift */,
 				74A7688D20D45ED400F9D437 /* OrderStoreTests.swift */,
 				7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */,
+				7495C5282114979D00CDD33B /* OrderStatsStoreTests.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -197,6 +202,7 @@
 				7499936B20EFC20100CF01CD /* order-notes.json */,
 				74A7689120D47F9E00F9D437 /* orders.json */,
 				B5B914C120EFE03200F2F832 /* sites.json */,
+				7495C5222114977600CDD33B /* order-stats.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -444,6 +450,7 @@
 				B5B914C220EFE03200F2F832 /* sites.json in Resources */,
 				7499936C20EFC20100CF01CD /* order-notes.json in Resources */,
 				7424B49420EAD37C00CC62F6 /* order.json in Resources */,
+				7495C5262114977600CDD33B /* order-stats.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -542,6 +549,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7495C5292114979D00CDD33B /* OrderStatsStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockupAcount.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/OrderStatsAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderStatsAction.swift
@@ -5,5 +5,8 @@ import Networking
 // MARK: - OrderStatsAction: Defines all of the Actions supported by the OrderStatsStore.
 //
 public enum OrderStatsAction: Action {
+
+    // FIXME: We are returning OrderStats in the completion handler...this needs to eventually return an error/nil much like
+    // OrderAction.retrieveOrders. Update this once OrderStats storage is in place.
     case retrieveOrderStats(siteID: Int, granularity: OrderStatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: (OrderStats?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderStatsAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderStatsAction.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Networking
+
+
+// MARK: - OrderStatsAction: Defines all of the Actions supported by the OrderStatsStore.
+//
+public enum OrderStatsAction: Action {
+    case retrieveOrderStats(siteID: Int, granularity: OrderStatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: (OrderStats?, Error?) -> Void)
+}

--- a/Yosemite/Yosemite/Stores/OrderStatsStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStatsStore.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Networking
+
+// MARK: - OrderStatsStore
+//
+public class OrderStatsStore: Store {
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: OrderStatsAction.self)
+    }
+
+    /// Receives and executes Actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? OrderStatsAction else {
+            assertionFailure("OrderStatsStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .retrieveOrderStats(let siteID, let granularity, let latestDateToInclude, let quantity, let onCompletion):
+            retrieveOrderStats(siteID: siteID, granularity: granularity, latestDateToInclude: latestDateToInclude,  quantity: quantity, onCompletion: onCompletion)
+        }
+    }
+}
+
+
+// MARK: - Services!
+//
+private extension OrderStatsStore  {
+
+    /// Retrieves the order stats associated with the provided Site ID (if any!).
+    ///
+    func retrieveOrderStats(siteID: Int, granularity: OrderStatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: @escaping (OrderStats?, Error?) -> Void) {
+
+        let remote = OrderStatsRemote(network: network)
+        let formattedDateString = buildDateString(from: latestDateToInclude, with: granularity)
+
+        remote.loadOrderStats(for: siteID, unit: granularity, latestDateToInclude: formattedDateString, quantity: quantity) { (orderStats, error) in
+            guard let orderStats = orderStats else {
+                onCompletion(nil, error)
+                return
+            }
+
+            onCompletion(orderStats, nil)
+        }
+    }
+
+    /// Converts a Date into the appropriatly formatted string based on the `OrderStatGranularity`
+    ///
+    func buildDateString(from date: Date, with granularity: OrderStatGranularity) -> String {
+        switch granularity {
+        case .day:
+            return DateFormatter.Stats.statsDayFormatter.string(from: date)
+        case .week:
+            return DateFormatter.Stats.statsWeekFormatter.string(from: date)
+        case .month:
+            return DateFormatter.Stats.statsMonthFormatter.string(from: date)
+        case .year:
+            return DateFormatter.Stats.statsYearFormatter.string(from: date)
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Resources/order-stats.json
+++ b/Yosemite/YosemiteTests/Resources/order-stats.json
@@ -1,0 +1,380 @@
+{
+  "date": "2018-06-02",
+  "unit": "day",
+  "quantity": "2",
+  "fields": [
+    "period",
+    "orders",
+    "products",
+    "coupons",
+    "coupon_discount",
+    "total_sales",
+    "total_tax",
+    "total_shipping",
+    "total_shipping_tax",
+    "total_refund",
+    "total_tax_refund",
+    "total_shipping_refund",
+    "total_shipping_tax_refund",
+    "currency",
+    "gross_sales",
+    "net_sales",
+    "avg_order_value",
+    "avg_products_per_order"
+  ],
+  "data": [
+    [
+      "2018-06-01",
+      2,
+      2,
+      0,
+      0,
+      14.24,
+      0.12,
+      9.98,
+      0.28,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      14.24,
+      14.120000000000001,
+      7.12,
+      1
+    ],
+    [
+      "2018-06-02",
+      1,
+      1,
+      0,
+      0,
+      30.87,
+      0.87,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "USD",
+      30.87,
+      30,
+      30.87,
+      1
+    ]
+  ],
+  "delta_fields": [
+    "period",
+    "delta",
+    "percentage_change",
+    "reference_period",
+    "favorable",
+    "direction",
+    "currency"
+  ],
+  "deltas": [
+    {
+      "period": "2018-06-01",
+      "orders": [
+        "2018-06-01",
+        1,
+        1,
+        "2018-05-31",
+        "is-favorable",
+        "is-increase",
+        "USD"
+      ],
+      "products": [
+        "2018-06-01",
+        -3,
+        -0.6,
+        "2018-05-31",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "coupons": [
+        "2018-06-01",
+        0,
+        0,
+        "2018-05-31",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-06-01",
+        0,
+        0,
+        "2018-05-31",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-06-01",
+        -135.76,
+        -0.9051,
+        "2018-05-31",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-06-01",
+        0.12,
+        0,
+        "2018-05-31",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-06-01",
+        9.98,
+        0,
+        "2018-05-31",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-06-01",
+        0.28,
+        0,
+        "2018-05-31",
+        "is-favorable",
+        "is-undefined-increase",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-06-01",
+        0,
+        0,
+        "2018-05-31",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-06-01",
+        0,
+        0,
+        "2018-05-31",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-06-01",
+        0,
+        0,
+        "2018-05-31",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-06-01",
+        0,
+        0,
+        "2018-05-31",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-06-01",
+        -135.76,
+        -0.9051,
+        "2018-05-31",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-06-01",
+        -135.88,
+        -0.9059,
+        "2018-05-31",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-06-01",
+        -142.88,
+        -0.9525,
+        "2018-05-31",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-06-01",
+        -4,
+        -0.8,
+        "2018-05-31",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ]
+    },
+    {
+      "period": "2018-06-02",
+      "orders": [
+        "2018-06-02",
+        -1,
+        -0.5,
+        "2018-06-01",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "products": [
+        "2018-06-02",
+        -1,
+        -0.5,
+        "2018-06-01",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "coupons": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "coupon_discount": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_sales": [
+        "2018-06-02",
+        16.630000000000003,
+        1.1678,
+        "2018-06-01",
+        "is-favorable",
+        "is-increase",
+        "USD"
+      ],
+      "total_tax": [
+        "2018-06-02",
+        0.75,
+        6.25,
+        "2018-06-01",
+        "is-favorable",
+        "is-increase",
+        "USD"
+      ],
+      "total_shipping": [
+        "2018-06-02",
+        -9.98,
+        -1,
+        "2018-06-01",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "total_shipping_tax": [
+        "2018-06-02",
+        -0.28,
+        -1,
+        "2018-06-01",
+        "is-unfavorable",
+        "is-decrease",
+        "USD"
+      ],
+      "total_refund": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_tax_refund": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_refund": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "total_shipping_tax_refund": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ],
+      "gross_sales": [
+        "2018-06-02",
+        16.630000000000003,
+        1.1678,
+        "2018-06-01",
+        "is-favorable",
+        "is-increase",
+        "USD"
+      ],
+      "net_sales": [
+        "2018-06-02",
+        15.879999999999999,
+        1.1246,
+        "2018-06-01",
+        "is-favorable",
+        "is-increase",
+        "USD"
+      ],
+      "avg_order_value": [
+        "2018-06-02",
+        23.75,
+        3.3357,
+        "2018-06-01",
+        "is-favorable",
+        "is-increase",
+        "USD"
+      ],
+      "avg_products_per_order": [
+        "2018-06-02",
+        0,
+        0,
+        "2018-06-01",
+        "",
+        "is-neutral",
+        "USD"
+      ]
+    }
+  ],
+  "total_gross_sales": 439.23,
+  "total_net_sales": 438.24,
+  "total_orders": 9,
+  "total_products": 13,
+  "avg_gross_sales": 14.1687,
+  "avg_net_sales": 14.1368,
+  "avg_orders": 0.2903,
+  "avg_products": 0.4194
+}

--- a/Yosemite/YosemiteTests/Stores/OrderStatsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStatsStoreTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import Yosemite
+@testable import Networking
+
+
+/// OrderStatsStore Unit Tests
+///
+class OrderStatsStoreTests: XCTestCase {
+
+    /// Mockup Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mockup Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockupNetwork!
+
+    /// Mockup Storage: InMemory
+    ///
+    private var storageManager: MockupStorageManager!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID = 123
+
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockupStorageManager()
+        network = MockupNetwork()
+    }
+
+    /// Verifies that OrderStatsAction.retrieveOrderStats returns the expected stats.
+    ///
+    func testRetrieveOrderStatsReturnsExpectedFields() {
+        let expectation = self.expectation(description: "Retrieve order stats")
+        let orderStatsStore = OrderStatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let remoteOrderStats = sampleOrderStats()
+
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/orders/", filename: "order-stats")
+        let action = OrderStatsAction.retrieveOrderStats(siteID: sampleSiteID, granularity: .day,
+                                                         latestDateToInclude: date(with: "2018-06-23T17:06:55"), quantity: 2) { (orderStats, error) in
+                                                            XCTAssertNil(error)
+                                                            guard let orderStats = orderStats,
+                                                                let items = orderStats.items else {
+                                                                XCTFail()
+                                                                return
+                                                            }
+                                                            XCTAssertEqual(items.count, 2)
+                                                            XCTAssertEqual(orderStats, remoteOrderStats)
+                                                            expectation.fulfill()
+        }
+
+        orderStatsStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that OrderStatsAction.retrieveOrderStats returns an error whenever there is an error response from the backend.
+    ///
+    func testRetrieveOrderStatsReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve order stats error response")
+        let orderStatsStore = OrderStatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/orders/", filename: "generic_error")
+        let action = OrderStatsAction.retrieveOrderStats(siteID: sampleSiteID, granularity: .day,
+                                                         latestDateToInclude: date(with: "2018-06-23T17:06:55"), quantity: 2) { (orderStats, error) in
+                                                            XCTAssertNil(orderStats)
+                                                            XCTAssertNotNil(error)
+                                                            guard let _ = error else {
+                                                                XCTFail()
+                                                                return
+                                                            }
+                                                            expectation.fulfill()
+        }
+
+        orderStatsStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that OrderStatsAction.retrieveOrderStats returns an error whenever there is no backend response.
+    ///
+    func testRetrieveOrderNotesReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve order stats empty response")
+        let orderStatsStore = OrderStatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let action = OrderStatsAction.retrieveOrderStats(siteID: sampleSiteID, granularity: .day,
+                                                         latestDateToInclude: date(with: "2018-06-23T17:06:55"), quantity: 2) { (orderStats, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(orderStats)
+            guard let _ = error else {
+                XCTFail()
+                return
+            }
+            expectation.fulfill()
+        }
+
+        orderStatsStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension OrderStatsStoreTests {
+
+    func sampleOrderStats() -> OrderStats {
+        return OrderStats(date: "2018-06-02",
+                          granularity: .day,
+                          quantity: "2",
+                          fields: ["period", "orders", "products", "coupons", "coupon_discount", "total_sales", "total_tax", "total_shipping",
+                                   "total_shipping_tax", "total_refund", "total_tax_refund", "total_shipping_refund", "total_shipping_tax_refund",
+                                   "currency", "gross_sales", "net_sales", "avg_order_value", "avg_products_per_order"],
+                          items: [sampleOrderStatsItem1(), sampleOrderStatsItem2()],
+                          totalGrossSales: 439.23,
+                          totalNetSales: 438.24,
+                          totalOrders: 9,
+                          totalProducts: 13,
+                          averageGrossSales: 14.1687,
+                          averageNetSales: 14.1368,
+                          averageOrders: 0.2903,
+                          averageProducts: 0.4194)
+    }
+
+    func sampleOrderStatsItem1() -> OrderStatsItem {
+        return OrderStatsItem(fieldNames: ["period", "orders", "products", "coupons", "coupon_discount", "total_sales", "total_tax", "total_shipping",
+                                           "total_shipping_tax", "total_refund", "total_tax_refund", "total_shipping_refund", "total_shipping_tax_refund",
+                                           "currency", "gross_sales", "net_sales", "avg_order_value", "avg_products_per_order"],
+                              rawData: ["2018-06-01", 2, 2, 0, 0, 14.24, 0.12, 9.9800000000000004, 0.28000000000000003, 0, 0, 0, 0, "USD", 14.24, 14.120000000000001, 7.1200000000000001, 1])
+    }
+
+    func sampleOrderStatsItem2() -> OrderStatsItem {
+        return OrderStatsItem(fieldNames: ["period", "orders", "products", "coupons", "coupon_discount", "total_sales", "total_tax", "total_shipping",
+                                           "total_shipping_tax", "total_refund", "total_tax_refund", "total_shipping_refund", "total_shipping_tax_refund",
+                                           "currency", "gross_sales", "net_sales", "avg_order_value", "avg_products_per_order"],
+                              rawData: ["2018-06-02", 1, 1, 0, 0, 30.870000000000001, 0.87, 0, 0, 0, 0, 0, 0, "USD", 30.870000000000001, 30, 30.870000000000001, 1])
+    }
+
+    func date(with dateString: String) -> Date {
+        guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {
+            return Date()
+        }
+        return date
+    }
+}


### PR DESCRIPTION
This PR adds `OrderStatsAction` & `OrderStatsStore as well as the usual unit test suspects. In addition I added a few more date formatters to our `DateFormatter+Woo` for creating the various date strings the order stats endpoint expects.

Ref: #177

## Testing

* Make sure the unit tests are all green
* Build and run the app

@jleandroperez would you mind taking a quick peek? 

/cc @mindgraffiti 