### PR TITLE
Updates the background color on the order screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderDetailsViewController.swift
@@ -79,6 +79,8 @@ private extension OrderDetailsViewController {
     /// Setup: TableView
     ///
     func configureTableView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedSectionFooterHeight = Constants.rowHeight
         tableView.estimatedRowHeight = Constants.rowHeight

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -90,6 +90,8 @@ private extension OrdersViewController {
     }
 
     func configureTableView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.refreshControl = refreshControl


### PR DESCRIPTION
Just a quick update to the background color of the order screens to bring it more inline with our designs.

<img width="1012" alt="order_bg_color" src="https://user-images.githubusercontent.com/154014/44044638-d1c3b252-9eeb-11e8-9f8f-ba0b4b3a1d7e.png">
