### PR TITLE
Updated default text color to WooSecondary

### DIFF
--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -41,6 +41,7 @@ protocol Style {
     var wooWhite: UIColor { get }
 }
 
+
 // MARK: - WooCommerce's Default Style
 //
 class DefaultStyle: Style {
@@ -51,7 +52,7 @@ class DefaultStyle: Style {
     let alternativeLoginsTitleFont      = UIFont.font(forStyle: .subheadline, weight: .semibold)
     let subheadlineFont                 = UIFont.font(forStyle: .subheadline, weight: .regular)
 
-    // Misc colors
+    // Colors
     //
     let buttonPrimaryColor              = UIColor(red: 0x96/255.0, green: 0x58/255.0, blue: 0x8A/255.0, alpha: 0xFF/255.0)
     let buttonPrimaryHighlightedColor   = UIColor(red: 0x6E/255.0, green: 0x29/255.0, blue: 0x67/255.0, alpha: 0xFF/255.0)
@@ -62,35 +63,57 @@ class DefaultStyle: Style {
     let buttonDisabledColor             = UIColor.white
     let buttonDisabledHighlightedColor  = UIColor(red: 233.0/255.0, green: 239.0/255.0, blue: 234.0/255.0, alpha: 1.0)
     let buttonDisabledTitleColor        = UIColor(red: 233.0/255.0, green: 239.0/255.0, blue: 234.0/255.0, alpha: 1.0)
-    let cellSeparatorColor              = UIColor(red: 230.0/255.0, green: 230.0/255.0, blue: 230.0/255.0, alpha: 1.0)  // wooGreyBorder
-    let defaultTextColor                = UIColor(red: 60.0/255.0, green: 60.0/255.0, blue: 60.0/255.0, alpha: 1.0)     // wooSecondary
+    let cellSeparatorColor              = HandbookColors.wooGreyBorder
+    let defaultTextColor                = HandbookColors.wooSecondary
     let destructiveActionColor          = UIColor(red: 197.0/255.0, green: 60.0/255.0, blue: 53.0/255.0, alpha: 1.0)
     let navBarImage                     = UIImage(named: "woo-logo")!
-    let sectionBackgroundColor          = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)  // wooGreyLight
-    let sectionTitleColor               = UIColor(red: 60.0/255.0, green: 60.0/255.0, blue: 60.0/255.0, alpha: 1.0)     // wooSecondary
-    let tableViewBackgroundColor        = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)  // wooGreyLight
+    let sectionBackgroundColor          = HandbookColors.wooGreyLight
+    let sectionTitleColor               = HandbookColors.wooSecondary
+    let tableViewBackgroundColor        = HandbookColors.wooGreyLight
 
-    // Status Colors
-    //
-    let statusDangerColor               = UIColor(red: 255.0/255.0, green: 230.0/255.0, blue: 229.0/255.0, alpha: 1.0)  // Status Red Dimmed
-    let statusDangerBoldColor           = UIColor(red: 255.0/255.0, green: 197.0/255.0, blue: 195.0/255.0, alpha: 1.0)  // Status Red
-    let statusNotIdentifiedColor        = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)  // wooGreyLight
-    let statusNotIdentifiedBoldColor    = UIColor(red: 230.0/255.0, green: 230.0/255.0, blue: 230.0/255.0, alpha: 1.0)  // wooGreyBorder
-    let statusPrimaryColor              = UIColor(red: 244.0/255.0, green: 249.0/255.0, blue: 251.0/255.0, alpha: 1.0)  // Status Blue Dimmed
-    let statusPrimaryBoldColor          = UIColor(red: 188.0/255.0, green: 222.0/255.0, blue: 238.0/255.0, alpha: 1.0)  // Status Blue
-    let statusSuccessColor              = UIColor(red: 239.00/255.0, green: 249.0/255.0, blue: 230.0/255.0, alpha: 1.0) // Status Green Dimmed
-    let statusSuccessBoldColor          = UIColor(red: 201.0/255.0, green: 233.0/255.0, blue: 169.0/255.0, alpha: 1.0)  // Status Green
+    let statusDangerColor               = HandbookColors.statusRedDimmed
+    let statusDangerBoldColor           = HandbookColors.statusRed
+    let statusNotIdentifiedColor        = HandbookColors.wooGreyLight
+    let statusNotIdentifiedBoldColor    = HandbookColors.wooGreyBorder
+    let statusPrimaryColor              = HandbookColors.statusBlueDimmed
+    let statusPrimaryBoldColor          = HandbookColors.statusBlue
+    let statusSuccessColor              = HandbookColors.statusGreenDimmed
+    let statusSuccessBoldColor          = HandbookColors.statusGreen
 
-    // Colors as defined in the Woo Mobile Design Handbook
-    //
-    let wooCommerceBrandColor           = UIColor(red: 0x96/255.0, green: 0x58/255.0, blue: 0x8A/255.0, alpha: 0xFF/255.0)
-    let wooSecondary                    = UIColor(red: 60.0/255.0, green: 60.0/255.0, blue: 60.0/255.0, alpha: 1.0)
-    let wooAccent                       = UIColor(red: 113.0/255.0, green: 176.0/255.0, blue: 47.0/255.0, alpha: 1.0)
-    let wooGreyLight                    = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)
-    let wooGreyBorder                   = UIColor(red: 230.0/255.0, green: 230.0/255.0, blue: 230.0/255.0, alpha: 1.0)
-    let wooGreyMid                      = UIColor(red: 150.0/255.0, green: 150.0/255.0, blue: 150.0/255.0, alpha: 1.0)
-    let wooGreyTextMin                  = UIColor(red: 89.0/255.0, green: 89.0/255.0, blue: 89.0/255.0, alpha: 1.0)
-    let wooWhite                        = UIColor.white
+    let wooCommerceBrandColor           = HandbookColors.wooPrimary
+    let wooSecondary                    = HandbookColors.wooSecondary
+    let wooAccent                       = HandbookColors.wooAccent
+    let wooGreyLight                    = HandbookColors.wooGreyLight
+    let wooGreyBorder                   = HandbookColors.wooGreyBorder
+    let wooGreyMid                      = HandbookColors.wooGreyMid
+    let wooGreyTextMin                  = HandbookColors.wooGreyTextMin
+    let wooWhite                        = HandbookColors.wooWhite
+}
+
+
+// MARK: - Handbook colors!
+//
+private extension DefaultStyle {
+
+    /// Colors as defined in the Woo Mobile Design Handbook
+    ///
+    enum HandbookColors {
+        static let statusRedDimmed       = UIColor(red: 255.0/255.0, green: 230.0/255.0, blue: 229.0/255.0, alpha: 1.0)
+        static let statusRed             = UIColor(red: 255.0/255.0, green: 197.0/255.0, blue: 195.0/255.0, alpha: 1.0)
+        static let statusBlueDimmed      = UIColor(red: 244.0/255.0, green: 249.0/255.0, blue: 251.0/255.0, alpha: 1.0)
+        static let statusBlue            = UIColor(red: 188.0/255.0, green: 222.0/255.0, blue: 238.0/255.0, alpha: 1.0)
+        static let statusGreenDimmed     = UIColor(red: 239.00/255.0, green: 249.0/255.0, blue: 230.0/255.0, alpha: 1.0)
+        static let statusGreen           = UIColor(red: 201.0/255.0, green: 233.0/255.0, blue: 169.0/255.0, alpha: 1.0)
+
+        static let wooPrimary            = UIColor(red: 0x96/255.0, green: 0x58/255.0, blue: 0x8A/255.0, alpha: 0xFF/255.0)
+        static let wooSecondary          = UIColor(red: 60.0/255.0, green: 60.0/255.0, blue: 60.0/255.0, alpha: 1.0)
+        static let wooAccent             = UIColor(red: 113.0/255.0, green: 176.0/255.0, blue: 47.0/255.0, alpha: 1.0)
+        static let wooGreyLight          = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)
+        static let wooGreyBorder         = UIColor(red: 230.0/255.0, green: 230.0/255.0, blue: 230.0/255.0, alpha: 1.0)
+        static let wooWhite              = UIColor.white
+        static let wooGreyMid            = UIColor(red: 150.0/255.0, green: 150.0/255.0, blue: 150.0/255.0, alpha: 1.0)
+        static let wooGreyTextMin        = UIColor(red: 89.0/255.0, green: 89.0/255.0, blue: 89.0/255.0, alpha: 1.0)
+    }
 }
 
 


### PR DESCRIPTION
Title has it. This is a quick PR to update the default text color in the app (was `black` now `WooSecondary`.

![3](https://user-images.githubusercontent.com/154014/44055678-be515308-9f0b-11e8-98d3-82889dda5bad.png)

![6](https://user-images.githubusercontent.com/154014/44055690-c433c6b6-9f0b-11e8-8c2a-54202b5eee78.png)

![9](https://user-images.githubusercontent.com/154014/44055699-c96b51ee-9f0b-11e8-8066-608fb7a3bf00.png)

/cc @folletto  