### PR TITLE
Dashboard Mark 6: Adds charts to dashboard

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,6 +30,7 @@ target 'WooCommerce' do
   pod 'KeychainAccess', '~> 3.1'
   pod 'CocoaLumberjack/Swift', '~> 3.4'
   pod 'XLPagerTabStrip', '~> 8.0'
+  pod 'Charts', '~> 3.1'
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
     - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
+  - Charts (3.1.1):
+    - Charts/Core (= 3.1.1)
+  - Charts/Core (3.1.1)
   - CocoaLumberjack (3.4.2):
     - CocoaLumberjack/Default (= 3.4.2)
     - CocoaLumberjack/Extensions (= 3.4.2)
@@ -69,6 +72,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.7)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.2.3`)
+  - Charts (~> 3.1)
   - CocoaLumberjack/Swift (~> 3.4)
   - Crashlytics (~> 3.10)
   - Gridicons (= 0.15)
@@ -81,6 +85,7 @@ SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - 1PasswordExtension
     - Alamofire
+    - Charts
     - CocoaLumberjack
     - Crashlytics
     - Fabric
@@ -116,6 +121,7 @@ SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
   Automattic-Tracks-iOS: d8c6c6c1351b1905a73e45f431b15598d71963b5
+  Charts: 90a4d61da0f6e06684c591e3bcab11940fe61736
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: 7f2e38d302d9da96475b3d64d86fb29e31a542b7
   Fabric: a2917d3895e4c1569b9c3170de7320ea1b1e6661
@@ -137,6 +143,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   XLPagerTabStrip: c908b17cbf42fcd2598ee1adfc49bae25444d88a
 
-PODFILE CHECKSUM: fad8937db279e4bf9807a4985a2418c4832c9b35
+PODFILE CHECKSUM: a2a2362208b6735d77e2c6358fbcdf29aead6bff
 
 COCOAPODS: 1.5.3

--- a/WooCommerce/Classes/Extensions/Date+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Date+Helpers.swift
@@ -18,4 +18,50 @@ extension DateFormatter {
             return formatter
         }()
     }
+
+    /// Chart Formatters
+    ///
+    struct Charts {
+
+        /// Date formatter used for creating the date displayed on a chart axis for **day** granularity.
+        ///
+        public static let chartsDayFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "MMM dd"
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart axis for **week** granularity.
+        ///
+        public static let chartsWeekFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "MMM yyyy"
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart axis for **month** granularity.
+        ///
+        public static let chartsMonthFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "MMM yyyy"
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart axis for **year** granularity.
+        ///
+        public static let chartsYearFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "GMT")
+            formatter.dateFormat = "yyyy"
+            return formatter
+        }()
+    }
+
 }

--- a/WooCommerce/Classes/Extensions/Date+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Date+Helpers.swift
@@ -29,7 +29,7 @@ extension DateFormatter {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "MMM dd"
+            formatter.dateFormat = "MMM d"
             return formatter
         }()
 
@@ -39,7 +39,7 @@ extension DateFormatter {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "MMM yyyy"
+            formatter.dateFormat = "MMM d"
             return formatter
         }()
 
@@ -49,7 +49,7 @@ extension DateFormatter {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "MMM yyyy"
+            formatter.dateFormat = "MMM"
             return formatter
         }()
 

--- a/WooCommerce/Classes/Model/OrderStats+Woo.swift
+++ b/WooCommerce/Classes/Model/OrderStats+Woo.swift
@@ -18,4 +18,13 @@ extension OrderStats {
 
         return Locale(identifier: identifier).currencySymbol ?? currency
     }
+
+    /// Returns the sum of total sales this stats period. This value is typically used in the dashboard for revenue reporting.
+    ///
+    /// *Note:* The value returned here is an aggrigation of all the `OrderStatsItem.totalSales` values and
+    /// _not_ `OrderStats.totalGrossSales` or `OrderStats.totalNetSales`.
+    ///
+    var totalSales: Double {
+        return items?.map({ $0.totalSales }).reduce(0.0, +) ?? 0.0
+    }
 }

--- a/WooCommerce/Classes/Model/OrderStats+Woo.swift
+++ b/WooCommerce/Classes/Model/OrderStats+Woo.swift
@@ -21,7 +21,7 @@ extension OrderStats {
 
     /// Returns the sum of total sales this stats period. This value is typically used in the dashboard for revenue reporting.
     ///
-    /// *Note:* The value returned here is an aggrigation of all the `OrderStatsItem.totalSales` values and
+    /// *Note:* The value returned here is an aggregation of all the `OrderStatsItem.totalSales` values and
     /// _not_ `OrderStats.totalGrossSales` or `OrderStats.totalNetSales`.
     ///
     var totalSales: Double {

--- a/WooCommerce/Classes/Model/OrderStats+Woo.swift
+++ b/WooCommerce/Classes/Model/OrderStats+Woo.swift
@@ -27,18 +27,4 @@ extension OrderStats {
     var totalSales: Double {
         return items?.map({ $0.totalSales }).reduce(0.0, +) ?? 0.0
     }
-
-    /// Returns a dictionary containing all of the `OrderStatsItem` periods and their related total sales values.
-    ///
-    var totalSalesItems: [String: Double]? {
-        guard let items = items, !items.isEmpty else {
-            return nil
-        }
-
-        var returnVal: [String: Double] = [:]
-        for item in items {
-            returnVal[item.period] = item.totalSales
-        }
-        return returnVal
-    }
 }

--- a/WooCommerce/Classes/Model/OrderStats+Woo.swift
+++ b/WooCommerce/Classes/Model/OrderStats+Woo.swift
@@ -27,4 +27,18 @@ extension OrderStats {
     var totalSales: Double {
         return items?.map({ $0.totalSales }).reduce(0.0, +) ?? 0.0
     }
+
+    /// Returns a dictionary containing all of the `OrderStatsItem` periods and their related total sales values.
+    ///
+    var totalSalesItems: [String: Double]? {
+        guard let items = items, !items.isEmpty else {
+            return nil
+        }
+
+        var returnVal: [String: Double] = [:]
+        for item in items {
+            returnVal[item.period] = item.totalSales
+        }
+        return returnVal
+    }
 }

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -16,6 +16,7 @@ protocol Style {
     var buttonDisabledHighlightedColor: UIColor { get }
     var buttonDisabledTitleColor: UIColor { get }
     var cellSeparatorColor: UIColor { get }
+    var chartLabelFont: UIFont { get }
     var defaultTextColor: UIColor { get }
     var destructiveActionColor: UIColor { get }
     var navBarImage: UIImage { get }
@@ -51,6 +52,7 @@ class DefaultStyle: Style {
     let actionButtonTitleFont           = UIFont.font(forStyle: .headline, weight: .semibold)
     let alternativeLoginsTitleFont      = UIFont.font(forStyle: .subheadline, weight: .semibold)
     let subheadlineFont                 = UIFont.font(forStyle: .subheadline, weight: .regular)
+    let chartLabelFont                  = UIFont.font(forStyle: .caption2, weight: .ultraLight)
 
     // Colors!
     //
@@ -180,6 +182,10 @@ class StyleManager {
 
     static var cellSeparatorColor: UIColor {
         return active.cellSeparatorColor
+    }
+
+    static var chartLabelFont: UIFont {
+        return active.chartLabelFont
     }
 
     static var defaultTextColor: UIColor {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Charts
 
-/// This class is a custom view which is displayed over a chart element (e.g. a Bar) when it is highlighted. It
-/// basically is a duplicate of the `BalloonMarker` class found in the Charts demo project.
+
+/// This class is a custom view which is displayed over a chart element (e.g. a Bar) when it is highlighted.
 ///
 /// See: https://github.com/danielgindi/Charts/blob/master/ChartsDemo-iOS/Swift/Components/BalloonMarker.swift
 ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -8,7 +8,7 @@ import Charts
 ///
 class ChartMarker: MarkerImage {
     @objc open var color: UIColor
-    @objc open var arrowSize = CGSize(width: 15, height: 11)
+    @objc open var arrowSize = Constants.arrowSize
     @objc open var font: UIFont
     @objc open var textColor: UIColor
     @objc open var insets: UIEdgeInsets
@@ -19,7 +19,7 @@ class ChartMarker: MarkerImage {
     private var _paragraphStyle: NSMutableParagraphStyle?
     private var _drawAttributes = [NSAttributedStringKey: AnyObject]()
 
-    @objc public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets) {
+    @objc public init(chartView: ChartViewBase?, color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets) {
         self.color = color
         self.font = font
         self.textColor = textColor
@@ -28,6 +28,7 @@ class ChartMarker: MarkerImage {
         _paragraphStyle = NSParagraphStyle.default.mutableCopy() as? NSMutableParagraphStyle
         _paragraphStyle?.alignment = .center
         super.init()
+        self.chartView = chartView
     }
 
     open override func offsetForDrawing(atPoint point: CGPoint) -> CGPoint {
@@ -44,25 +45,25 @@ class ChartMarker: MarkerImage {
 
         let width = size.width
         let height = size.height
-        let padding: CGFloat = 8.0
+        let padding = Constants.offsetPadding
 
         var origin = point
         origin.x -= width / 2
         origin.y -= height
 
-        if origin.x + offset.x < 0.0 {
+        if (origin.x + offset.x) < 0.0 {
             offset.x = -origin.x + padding
-        } else if let chart = chartView, origin.x + width + offset.x > chart.bounds.size.width {
+        } else if let chart = chartView, (origin.x + width + offset.x) > chart.bounds.size.width {
             offset.x = chart.bounds.size.width - origin.x - width - padding
         }
 
-        if origin.y + offset.y < 0 {
+        if (origin.y + offset.y) < 0 {
             offset.y = height + padding
-        } else if let chart = chartView, origin.y + height + offset.y > chart.bounds.size.height {
+        } else if let chart = chartView, (origin.y + height + offset.y) > chart.bounds.size.height {
             offset.y = chart.bounds.size.height - origin.y - height - padding
         }
 
-        return offset
+        return CGPoint(x: round(offset.x), y: round(offset.y))
     }
 
     open override func draw(context: CGContext, point: CGPoint) {
@@ -80,6 +81,7 @@ class ChartMarker: MarkerImage {
             size: size)
         rect.origin.x -= size.width / 2.0
         rect.origin.y -= size.height
+        rect = rect.integral
 
         context.saveGState()
         context.setFillColor(color.cgColor)
@@ -92,7 +94,8 @@ class ChartMarker: MarkerImage {
             context.addLine(to: CGPoint(
                 x: rect.origin.x + (rect.size.width - arrowSize.width) / 2.0,
                 y: rect.origin.y + arrowSize.height))
-            //arrow vertex
+
+            // Arrow vertex
             context.addLine(to: CGPoint(
                 x: point.x,
                 y: point.y))
@@ -126,7 +129,8 @@ class ChartMarker: MarkerImage {
             context.addLine(to: CGPoint(
                 x: rect.origin.x + (rect.size.width + arrowSize.width) / 2.0,
                 y: rect.origin.y + rect.size.height - arrowSize.height))
-            //arrow vertex
+
+            //Arrow vertex
             context.addLine(to: CGPoint(
                 x: point.x,
                 y: point.y))
@@ -148,6 +152,7 @@ class ChartMarker: MarkerImage {
             rect.origin.y += self.insets.top
         }
         rect.size.height -= self.insets.top + self.insets.bottom
+        rect = rect.integral
         UIGraphicsPushContext(context)
         label.draw(in: rect, withAttributes: _drawAttributes)
         UIGraphicsPopContext()
@@ -174,5 +179,15 @@ class ChartMarker: MarkerImage {
         size.width = max(minimumSize.width, size.width)
         size.height = max(minimumSize.height, size.height)
         self.size = size
+    }
+}
+
+
+// MARK: -  Constants!
+//
+private extension ChartMarker {
+    enum Constants {
+        static let arrowSize                = CGSize(width: 20, height: 14)
+        static let offsetPadding: CGFloat   = 4.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Charts
+
+/// This class is a custom view which is displayed over a chart element (e.g. a Bar) when it is highlighted. It
+/// basically is a duplicate of the `BalloonMarker` class found in the Charts demo project.
+///
+/// See: https://github.com/danielgindi/Charts/blob/master/ChartsDemo-iOS/Swift/Components/BalloonMarker.swift
+///
+class ChartMarker: MarkerImage {
+    @objc open var color: UIColor
+    @objc open var arrowSize = CGSize(width: 15, height: 11)
+    @objc open var font: UIFont
+    @objc open var textColor: UIColor
+    @objc open var insets: UIEdgeInsets
+    @objc open var minimumSize = CGSize()
+
+    private  var label: String?
+    private var _labelSize: CGSize = CGSize()
+    private var _paragraphStyle: NSMutableParagraphStyle?
+    private var _drawAttributes = [NSAttributedStringKey: AnyObject]()
+
+    @objc public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets) {
+        self.color = color
+        self.font = font
+        self.textColor = textColor
+        self.insets = insets
+
+        _paragraphStyle = NSParagraphStyle.default.mutableCopy() as? NSMutableParagraphStyle
+        _paragraphStyle?.alignment = .center
+        super.init()
+    }
+
+    open override func offsetForDrawing(atPoint point: CGPoint) -> CGPoint {
+        var offset = self.offset
+        var size = self.size
+
+        if size.width == 0.0 && image != nil {
+            size.width = image!.size.width
+        }
+
+        if size.height == 0.0 && image != nil {
+            size.height = image!.size.height
+        }
+
+        let width = size.width
+        let height = size.height
+        let padding: CGFloat = 8.0
+
+        var origin = point
+        origin.x -= width / 2
+        origin.y -= height
+
+        if origin.x + offset.x < 0.0 {
+            offset.x = -origin.x + padding
+        } else if let chart = chartView, origin.x + width + offset.x > chart.bounds.size.width {
+            offset.x = chart.bounds.size.width - origin.x - width - padding
+        }
+
+        if origin.y + offset.y < 0 {
+            offset.y = height + padding
+        } else if let chart = chartView, origin.y + height + offset.y > chart.bounds.size.height {
+            offset.y = chart.bounds.size.height - origin.y - height - padding
+        }
+
+        return offset
+    }
+
+    open override func draw(context: CGContext, point: CGPoint) {
+        guard let label = label else {
+            return
+        }
+
+        let offset = self.offsetForDrawing(atPoint: point)
+        let size = self.size
+
+        var rect = CGRect(
+            origin: CGPoint(
+                x: point.x + offset.x,
+                y: point.y + offset.y),
+            size: size)
+        rect.origin.x -= size.width / 2.0
+        rect.origin.y -= size.height
+
+        context.saveGState()
+        context.setFillColor(color.cgColor)
+
+        if offset.y > 0 {
+            context.beginPath()
+            context.move(to: CGPoint(
+                x: rect.origin.x,
+                y: rect.origin.y + arrowSize.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + (rect.size.width - arrowSize.width) / 2.0,
+                y: rect.origin.y + arrowSize.height))
+            //arrow vertex
+            context.addLine(to: CGPoint(
+                x: point.x,
+                y: point.y))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + (rect.size.width + arrowSize.width) / 2.0,
+                y: rect.origin.y + arrowSize.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + rect.size.width,
+                y: rect.origin.y + arrowSize.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + rect.size.width,
+                y: rect.origin.y + rect.size.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x,
+                y: rect.origin.y + rect.size.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x,
+                y: rect.origin.y + arrowSize.height))
+            context.fillPath()
+        } else {
+            context.beginPath()
+            context.move(to: CGPoint(
+                x: rect.origin.x,
+                y: rect.origin.y))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + rect.size.width,
+                y: rect.origin.y))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + rect.size.width,
+                y: rect.origin.y + rect.size.height - arrowSize.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + (rect.size.width + arrowSize.width) / 2.0,
+                y: rect.origin.y + rect.size.height - arrowSize.height))
+            //arrow vertex
+            context.addLine(to: CGPoint(
+                x: point.x,
+                y: point.y))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x + (rect.size.width - arrowSize.width) / 2.0,
+                y: rect.origin.y + rect.size.height - arrowSize.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x,
+                y: rect.origin.y + rect.size.height - arrowSize.height))
+            context.addLine(to: CGPoint(
+                x: rect.origin.x,
+                y: rect.origin.y))
+            context.fillPath()
+        }
+
+        if offset.y > 0 {
+            rect.origin.y += self.insets.top + arrowSize.height
+        } else {
+            rect.origin.y += self.insets.top
+        }
+        rect.size.height -= self.insets.top + self.insets.bottom
+        UIGraphicsPushContext(context)
+        label.draw(in: rect, withAttributes: _drawAttributes)
+        UIGraphicsPopContext()
+        context.restoreGState()
+    }
+
+    open override func refreshContent(entry: ChartDataEntry, highlight: Highlight) {
+        let hintString = entry.accessibilityValue ?? String(entry.y)
+        setLabel(hintString)
+    }
+
+    @objc open func setLabel(_ newLabel: String) {
+        label = newLabel
+
+        _drawAttributes.removeAll()
+        _drawAttributes[.font] = self.font
+        _drawAttributes[.paragraphStyle] = _paragraphStyle
+        _drawAttributes[.foregroundColor] = self.textColor
+        _labelSize = label?.size(withAttributes: _drawAttributes) ?? CGSize.zero
+
+        var size = CGSize()
+        size.width = _labelSize.width + self.insets.left + self.insets.right
+        size.height = _labelSize.height + self.insets.top + self.insets.bottom
+        size.width = max(minimumSize.width, size.width)
+        size.height = max(minimumSize.height, size.height)
+        self.size = size
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -34,12 +34,12 @@ class ChartMarker: MarkerImage {
         var offset = self.offset
         var size = self.size
 
-        if size.width == 0.0 && image != nil {
-            size.width = image!.size.width
+        if let image = image, size.width == 0.0 {
+            size.width = image.size.width
         }
 
-        if size.height == 0.0 && image != nil {
-            size.height = image!.size.height
+        if let image = image, size.height == 0.0 {
+            size.height = image.size.height
         }
 
         let width = size.width

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -87,9 +87,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
 //
 extension PeriodDataViewController {
     func clearAllFields() {
-        if barChartView != nil {
-            barChartView.clear()
-        }
+        barChartView?.clear()
         orderStats = nil
         siteStats = nil
         reloadAllFields()
@@ -185,7 +183,7 @@ extension PeriodDataViewController: ChartViewDelegate {
             return
         }
 
-        let marker: ChartMarker = ChartMarker(color: StyleManager.wooSecondary,
+        let marker = ChartMarker(color: StyleManager.wooSecondary,
                                               font: StyleManager.chartLabelFont,
                                               textColor: StyleManager.wooWhite,
                                               insets: Constants.chartMarkerInsets)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -169,6 +169,7 @@ private extension PeriodDataViewController {
         yAxis.axisLineColor = StyleManager.wooGreyBorder
         yAxis.gridColor = StyleManager.wooGreyBorder
         yAxis.zeroLineColor = StyleManager.wooGreyBorder
+        yAxis.valueFormatter = self
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
         yAxis.drawAxisLineEnabled = false
@@ -247,12 +248,20 @@ private extension PeriodDataViewController {
 //
 extension PeriodDataViewController: IAxisValueFormatter {
     func stringForValue(_ value: Double, axis: AxisBase?) -> String {
-        guard let item = orderStats?.items?[Int(value)] else {
+        guard let axis = axis, let orderStats = orderStats else {
             return ""
         }
 
-        //TODO: This is not right!
-        return String(item.period)
+        if axis is XAxis {
+            if let item = orderStats.items?[Int(value)] {
+                //TODO: This is not right!
+                return String(item.period)
+            } else {
+                return ""
+            }
+        } else {
+            return orderStats.currencySymbol + value.friendlyString()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -183,10 +183,11 @@ extension PeriodDataViewController: ChartViewDelegate {
             return
         }
 
-        let marker = ChartMarker(color: StyleManager.wooSecondary,
-                                              font: StyleManager.chartLabelFont,
-                                              textColor: StyleManager.wooWhite,
-                                              insets: Constants.chartMarkerInsets)
+        let marker = ChartMarker(chartView: chartView,
+                                 color: StyleManager.wooSecondary,
+                                 font: StyleManager.chartLabelFont,
+                                 textColor: StyleManager.wooWhite,
+                                 insets: Constants.chartMarkerInsets)
         marker.minimumSize = Constants.chartMarkerMinimumSize
         marker.arrowSize = Constants.chartMarkerArrowSize
         chartView.marker = marker

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -56,7 +56,11 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
         var dataEntries: [BarChartDataEntry] = []
         var barCount = 0
         for salesItem in totalSalesItems {
-            dataEntries.append(BarChartDataEntry(x: Double(barCount), y: salesItem.value))
+            if salesItem.value > 0.0 {
+                // By only including the values that are greater than zero (but still incrementing barCount),
+                // we will create nice "gaps" in the chart instead of a bunch of zero value bars.
+                dataEntries.append(BarChartDataEntry(x: Double(barCount), y: salesItem.value))
+            }
             barCount += 1
         }
 
@@ -138,7 +142,6 @@ private extension PeriodDataViewController {
         barChartView.pinchZoomEnabled = false
         barChartView.rightAxis.enabled = false
         barChartView.legend.enabled = false
-        barChartView.fitBars = true
         barChartView.isUserInteractionEnabled = false
         barChartView.noDataText = NSLocalizedString("No data available", comment: "Text displayed when no data is available for revenue chart.")
         barChartView.noDataFont = StyleManager.chartLabelFont
@@ -220,6 +223,7 @@ private extension PeriodDataViewController {
             return
         }
         barChartView.data = chartData
+        barChartView.fitBars = true
         barChartView.notifyDataSetChanged()
         barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -158,7 +158,7 @@ private extension PeriodDataViewController {
         if let orderStats = orderStats {
             totalOrdersText = Double(orderStats.totalOrders).friendlyString()
             let currencySymbol = orderStats.currencySymbol
-            let totalRevenue = orderStats.totalGrossSales.friendlyString()
+            let totalRevenue = orderStats.totalSales.friendlyString()
             totalRevenueText = "\(currencySymbol)\(totalRevenue)"
         }
         ordersData.text = totalOrdersText

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -155,19 +155,25 @@ private extension PeriodDataViewController {
         xAxis.labelTextColor = StyleManager.wooSecondary
         xAxis.axisLineColor = StyleManager.wooGreyBorder
         xAxis.gridColor = StyleManager.wooGreyBorder
-        xAxis.drawLabelsEnabled = false
+        xAxis.drawLabelsEnabled = true
         xAxis.drawGridLinesEnabled = false
-        xAxis.drawAxisLineEnabled = true
+        xAxis.drawAxisLineEnabled = false
+        xAxis.granularity = 1.0
+        xAxis.granularityEnabled = true
+        xAxis.setLabelCount(2, force: true)
+        xAxis.valueFormatter = self
 
         let yAxis = barChartView.leftAxis
         yAxis.labelFont = StyleManager.chartLabelFont
         yAxis.labelTextColor = StyleManager.wooSecondary
         yAxis.axisLineColor = StyleManager.wooGreyBorder
         yAxis.gridColor = StyleManager.wooGreyBorder
+        yAxis.zeroLineColor = StyleManager.wooGreyBorder
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
-        yAxis.drawAxisLineEnabled = true
-        yAxis.drawZeroLineEnabled = false
+        yAxis.drawAxisLineEnabled = false
+        yAxis.drawZeroLineEnabled = true
+        yAxis.axisMinimum = 0
     }
 }
 
@@ -233,6 +239,20 @@ private extension PeriodDataViewController {
 
     func reloadLastUpdatedField() {
         if lastUpdated != nil { lastUpdated.text = summaryDateUpdated }
+    }
+}
+
+
+// MARK: - IAxisValueFormatter Conformance
+//
+extension PeriodDataViewController: IAxisValueFormatter {
+    func stringForValue(_ value: Double, axis: AxisBase?) -> String {
+        guard let item = orderStats?.items?[Int(value)] else {
+            return ""
+        }
+
+        //TODO: This is not right!
+        return String(item.period)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -179,7 +179,6 @@ extension PeriodDataViewController: IAxisValueFormatter {
 
         if axis is XAxis {
             if let item = orderStats.items?[Int(value)] {
-                // FIXME: This logic could prolly be pushed into a model extension
                 var dateString = ""
                 switch orderStats.granularity {
                 case .day:
@@ -188,7 +187,8 @@ extension PeriodDataViewController: IAxisValueFormatter {
                     }
                 case .week:
                     if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
-                        dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: periodDate)
+                        let firstMonday = Calendar.current.date(byAdding: .day, value: 1, to: periodDate) ?? periodDate
+                        dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: firstMonday)
                     }
                 case .month:
                     if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -254,13 +254,33 @@ extension PeriodDataViewController: IAxisValueFormatter {
 
         if axis is XAxis {
             if let item = orderStats.items?[Int(value)] {
-                //TODO: This is not right!
-                return String(item.period)
+                // FIXME: This logic could prolly be pushed into a model extension
+                var dateString = ""
+                switch orderStats.granularity {
+                case .day:
+                    if let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: item.period) {
+                        dateString = DateFormatter.Charts.chartsDayFormatter.string(from: periodDate)
+                    }
+                case .week:
+                    if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
+                        dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: periodDate)
+                    }
+                case .month:
+                    if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
+                        dateString = DateFormatter.Charts.chartsMonthFormatter.string(from: periodDate)
+                    }
+                case .year:
+                    if let periodDate = DateFormatter.Stats.statsYearFormatter.date(from: item.period) {
+                        dateString = DateFormatter.Charts.chartsYearFormatter.string(from: periodDate)
+                    }
+                }
+
+                return dateString
             } else {
                 return ""
             }
         } else {
-            return orderStats.currencySymbol + value.friendlyString()
+            return value.friendlyString()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -66,6 +66,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
         }
 
         let dataSet =  BarChartDataSet(values: dataEntries, label: "Data")
+        dataSet.setColor(StyleManager.wooCommerceBrandColor)
         return BarChartData(dataSet: dataSet)
     }
 
@@ -148,9 +149,11 @@ private extension PeriodDataViewController {
         barChartView.noDataText = NSLocalizedString("No data available", comment: "Text displayed when no data is available for revenue chart.")
         barChartView.noDataFont = StyleManager.chartLabelFont
         barChartView.noDataTextColor = StyleManager.wooSecondary
+        barChartView.extraRightOffset = Constants.chartExtraRightOffset
 
         let xAxis = barChartView.xAxis
         xAxis.labelPosition = .bottom
+        xAxis.setLabelCount(2, force: true)
         xAxis.labelFont = StyleManager.chartLabelFont
         xAxis.labelTextColor = StyleManager.wooSecondary
         xAxis.axisLineColor = StyleManager.wooGreyBorder
@@ -158,9 +161,8 @@ private extension PeriodDataViewController {
         xAxis.drawLabelsEnabled = true
         xAxis.drawGridLinesEnabled = false
         xAxis.drawAxisLineEnabled = false
-        xAxis.granularity = 1.0
+        xAxis.granularity = Constants.chartXAxisGranularity
         xAxis.granularityEnabled = true
-        xAxis.setLabelCount(2, force: true)
         xAxis.valueFormatter = self
 
         let yAxis = barChartView.leftAxis
@@ -168,13 +170,15 @@ private extension PeriodDataViewController {
         yAxis.labelTextColor = StyleManager.wooSecondary
         yAxis.axisLineColor = StyleManager.wooGreyBorder
         yAxis.gridColor = StyleManager.wooGreyBorder
+        yAxis.gridLineDashLengths = Constants.chartXAxisDashLengths
+        yAxis.axisLineDashPhase = Constants.chartXAxisDashPhase
         yAxis.zeroLineColor = StyleManager.wooGreyBorder
-        yAxis.valueFormatter = self
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
         yAxis.drawAxisLineEnabled = false
         yAxis.drawZeroLineEnabled = true
-        yAxis.axisMinimum = 0
+        yAxis.axisMinimum = Constants.chartYAxisMinimum
+        yAxis.valueFormatter = self
     }
 }
 
@@ -280,7 +284,12 @@ extension PeriodDataViewController: IAxisValueFormatter {
                 return ""
             }
         } else {
-            return value.friendlyString()
+            if value == 0.0 {
+                // Do not show the 0 label on the Y axis
+                return ""
+            } else {
+                return value.friendlyString()
+            }
         }
     }
 }
@@ -290,7 +299,14 @@ extension PeriodDataViewController: IAxisValueFormatter {
 //
 private extension PeriodDataViewController {
     enum Constants {
-        static let placeholderText = "-"
-        static let chartAnimationDuration = 0.75
+        static let placeholderText                      = "-"
+
+        static let chartAnimationDuration: TimeInterval = 0.75
+        static let chartExtraRightOffset: CGFloat       = 20.0
+
+        static let chartXAxisDashLengths: [CGFloat]     = [5.0, 5.0]
+        static let chartXAxisDashPhase: CGFloat         = 0.0
+        static let chartXAxisGranularity: Double        = 1.0
+        static let chartYAxisMinimum: Double            = 0.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import Charts
 import XLPagerTabStrip
 import WordPressShared
 import CocoaLumberjack
@@ -15,8 +16,8 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     @IBOutlet private weak var ordersData: UILabel!
     @IBOutlet private weak var revenueTitle: UILabel!
     @IBOutlet private weak var revenueData: UILabel!
+    @IBOutlet private weak var barChartView: BarChartView!
     @IBOutlet private weak var lastUpdated: UILabel!
-    @IBOutlet private weak var chartView: UIView!
     @IBOutlet private weak var borderView: UIView!
     private var lastUpdatedDate: Date?
 
@@ -67,6 +68,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
+        configureBarChart()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -108,6 +110,21 @@ private extension PeriodDataViewController {
         // Footer
         lastUpdated.font = UIFont.footnote
         lastUpdated.textColor = StyleManager.wooGreyMid
+    }
+
+    func configureBarChart() {
+        barChartView.chartDescription?.enabled = false
+
+        barChartView.dragEnabled = true
+        barChartView.setScaleEnabled(true)
+        barChartView.pinchZoomEnabled = false
+
+        // ChartYAxis *leftAxis = chartView.leftAxis;
+
+        let xAxis = barChartView.xAxis
+        xAxis.labelPosition = .bottom
+
+        barChartView.rightAxis.enabled = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -75,6 +75,11 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
         super.viewDidAppear(animated)
         reloadAllFields()
     }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        clearChartMarkers()
+    }
 }
 
 
@@ -176,7 +181,7 @@ extension PeriodDataViewController: ChartViewDelegate {
     func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
         guard entry.y != 0.0 else {
             // Do not display the marker if the Y-value is zero
-            chartView.highlightValue(nil, callDelegate: false)
+            clearChartMarkers()
             return
         }
 
@@ -209,8 +214,7 @@ extension PeriodDataViewController: IAxisValueFormatter {
                     }
                 case .week:
                     if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
-                        let firstMonday = Calendar.current.date(byAdding: .day, value: 1, to: periodDate) ?? periodDate
-                        dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: firstMonday)
+                        dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: periodDate)
                     }
                 case .month:
                     if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
@@ -290,6 +294,10 @@ private extension PeriodDataViewController {
 
     func reloadLastUpdatedField() {
         if lastUpdated != nil { lastUpdated.text = summaryDateUpdated }
+    }
+
+    func clearChartMarkers() {
+        barChartView.highlightValue(nil, callDelegate: false)
     }
 
     func generateBarDataSet() -> BarChartData? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -49,17 +49,18 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     }
 
     private var chartData: BarChartData? {
-        guard let totalSalesItems = orderStats?.totalSalesItems, !totalSalesItems.isEmpty else {
+        guard let statItems = orderStats?.items, !statItems.isEmpty else {
             return nil
         }
 
         var dataEntries: [BarChartDataEntry] = []
         var barCount = 0
-        for salesItem in totalSalesItems {
-            if salesItem.value > 0.0 {
+
+        statItems.forEach { (item) in
+            if item.totalSales > 0.0 {
                 // By only including the values that are greater than zero (but still incrementing barCount),
                 // we will create nice "gaps" in the chart instead of a bunch of zero value bars.
-                dataEntries.append(BarChartDataEntry(x: Double(barCount), y: salesItem.value))
+                dataEntries.append(BarChartDataEntry(x: Double(barCount), y: item.totalSales))
             }
             barCount += 1
         }
@@ -142,6 +143,7 @@ private extension PeriodDataViewController {
         barChartView.pinchZoomEnabled = false
         barChartView.rightAxis.enabled = false
         barChartView.legend.enabled = false
+        barChartView.drawValueAboveBarEnabled = true
         barChartView.isUserInteractionEnabled = false
         barChartView.noDataText = NSLocalizedString("No data available", comment: "Text displayed when no data is available for revenue chart.")
         barChartView.noDataFont = StyleManager.chartLabelFont
@@ -151,20 +153,21 @@ private extension PeriodDataViewController {
         xAxis.labelPosition = .bottom
         xAxis.labelFont = StyleManager.chartLabelFont
         xAxis.labelTextColor = StyleManager.wooSecondary
-        xAxis.axisLineColor = StyleManager.wooSecondary
+        xAxis.axisLineColor = StyleManager.wooGreyBorder
         xAxis.gridColor = StyleManager.wooGreyBorder
-        xAxis.drawLabelsEnabled = true
+        xAxis.drawLabelsEnabled = false
         xAxis.drawGridLinesEnabled = false
         xAxis.drawAxisLineEnabled = true
 
         let yAxis = barChartView.leftAxis
         yAxis.labelFont = StyleManager.chartLabelFont
         yAxis.labelTextColor = StyleManager.wooSecondary
-        yAxis.axisLineColor = StyleManager.wooSecondary
+        yAxis.axisLineColor = StyleManager.wooGreyBorder
         yAxis.gridColor = StyleManager.wooGreyBorder
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
         yAxis.drawAxisLineEnabled = true
+        yAxis.drawZeroLineEnabled = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
@@ -158,13 +158,32 @@
                                 </view>
                             </subviews>
                         </stackView>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
                             <rect key="frame" x="0.0" y="88.5" width="375" height="508.5"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
-                            </constraints>
-                        </view>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
+                                    <rect key="frame" x="0.0" y="0.0" width="14" height="508.5"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
+                                    <rect key="frame" x="14" y="0.0" width="347" height="508.5"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
+                                    </constraints>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
+                                    <rect key="frame" x="361" y="0.0" width="14" height="508.5"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="14" id="KRJ-Jf-3tM"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                        </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Wi-nd-Ucs">
                             <rect key="frame" x="0.0" y="597" width="375" height="50"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
@@ -11,8 +11,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PeriodDataViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="barChartView" destination="zPE-Y0-ax8" id="3VU-s1-JmV"/>
                 <outlet property="borderView" destination="IHi-Ph-CQQ" id="bgg-u3-bda"/>
-                <outlet property="chartView" destination="zPE-Y0-ax8" id="zfG-E5-6vg"/>
                 <outlet property="lastUpdated" destination="0Wi-nd-Ucs" id="XPO-tH-TLR"/>
                 <outlet property="ordersData" destination="6HA-Qe-PkT" id="zOF-dV-3LN"/>
                 <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
@@ -158,7 +158,7 @@
                                 </view>
                             </subviews>
                         </stackView>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
                             <rect key="frame" x="0.0" y="88.5" width="375" height="508.5"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -180,7 +180,7 @@ private extension StoreStatsViewController {
         static let quantityDefaultForDay = 30
         static let quantityDefaultForWeek = 13
         static let quantityDefaultForMonth = 12
-        static let quantityDefaultForYear = 15
+        static let quantityDefaultForYear = 10
     }
 
     enum TabStrip {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -180,7 +180,7 @@ private extension StoreStatsViewController {
         static let quantityDefaultForDay = 30
         static let quantityDefaultForWeek = 13
         static let quantityDefaultForMonth = 12
-        static let quantityDefaultForYear = 10
+        static let quantityDefaultForYear = 5
     }
 
     enum TabStrip {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		748C7780211E18A600814F2C /* OrderStats+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748C777F211E18A600814F2C /* OrderStats+Woo.swift */; };
 		748C7782211E294000814F2C /* Double+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748C7781211E294000814F2C /* Double+Woo.swift */; };
 		748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748C7783211E2D8400814F2C /* DoubleWooTests.swift */; };
+		74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AAF6A4212A04A900C612B0 /* ChartMarker.swift */; };
 		74AFF2EA211B9B1B0038153A /* StoreStatsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AFF2E9211B9B1B0038153A /* StoreStatsViewController.swift */; };
 		74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74E0F440211C9AE600A79CCE /* PeriodDataViewController.xib */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
@@ -209,6 +210,7 @@
 		748C777F211E18A600814F2C /* OrderStats+Woo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OrderStats+Woo.swift"; sourceTree = "<group>"; };
 		748C7781211E294000814F2C /* Double+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Woo.swift"; sourceTree = "<group>"; };
 		748C7783211E2D8400814F2C /* DoubleWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DoubleWooTests.swift; sourceTree = "<group>"; };
+		74AAF6A4212A04A900C612B0 /* ChartMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartMarker.swift; sourceTree = "<group>"; };
 		74AFF2E9211B9B1B0038153A /* StoreStatsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsViewController.swift; sourceTree = "<group>"; };
 		74E0F440211C9AE600A79CCE /* PeriodDataViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PeriodDataViewController.xib; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 		74036CBE211B87FD00E462C2 /* MyStore */ = {
 			isa = PBXGroup;
 			children = (
+				74AAF6A4212A04A900C612B0 /* ChartMarker.swift */,
 				74036CBF211B882100E462C2 /* PeriodDataViewController.swift */,
 				74E0F440211C9AE600A79CCE /* PeriodDataViewController.xib */,
 				74AFF2E9211B9B1B0038153A /* StoreStatsViewController.swift */,
@@ -1174,6 +1177,7 @@
 				B57B678C2107638C00AF8905 /* Order+Woo.swift in Sources */,
 				CE1EC8CA20B479F1009762BF /* TwoColumnLabelView.swift in Sources */,
 				CE21B3DD20FF9BC200A259D5 /* ProductListViewController.swift in Sources */,
+				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* ProductListTableViewCell.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE1EC8EC20B8A3FF009762BF /* LeftImageTableViewCell.swift in Sources */,
@@ -1254,7 +1258,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
+				SECRETS_PATH = $HOME/.woo_app_credentials.json;
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Debug;
@@ -1265,7 +1269,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
+				SECRETS_PATH = $HOME/.woo_app_credentials.json;
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Release;
@@ -1403,7 +1407,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce Development";
-				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
+				SECRETS_PATH = $HOME/.woo_app_credentials.json;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1429,7 +1433,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce App Store";
-				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
+				SECRETS_PATH = $HOME/.woo_app_credentials.json;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1033,6 +1033,7 @@
 				"${BUILT_PRODUCTS_DIR}/1PasswordExtension/OnePasswordExtension.framework",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
+				"${BUILT_PRODUCTS_DIR}/Charts/Charts.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack.default-Swift/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
 				"${PODS_ROOT}/GoogleSignInRepacked/Frameworks/GoogleSignIn.framework",
@@ -1057,6 +1058,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OnePasswordExtension.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AutomatticTracks.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Charts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
@@ -1252,7 +1254,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Debug;
@@ -1263,7 +1265,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Release;
@@ -1401,7 +1403,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce Development";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1427,7 +1429,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce App Store";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.woo_app_credentials.json";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";


### PR DESCRIPTION
![charts](https://user-images.githubusercontent.com/154014/44311186-70606980-a3a8-11e8-875b-677bbe9e36e6.gif)

Title has it — this PR is the continuation of work for #177. It uses the Charts library [found here](https://github.com/danielgindi/Charts)... a Swift version of the same lib that Woo Android uses. The chart itself has been styled in a similar fashion to Woo Android as well.

### Chart Markers

For grins, I added interactive chart markers to the iOS version (which doubles as accessibility text for each bar item). Let me know your thoughts:

![chart-markers](https://user-images.githubusercontent.com/154014/44313070-5da95d00-a3c7-11e8-9cb3-8fbbbae32b26.gif)

## Testing

Log into a variety of stores and see if all 4 charts (days, weeks, months, years) look "ok" (as compared to similar data you would see on the web dashboard).

@mindgraffiti and @jleandroperez would you mind taking a peek?
