### PR TITLE
ChartMarker: Nukes extra space

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -183,7 +183,7 @@ class ChartMarker: MarkerImage {
 }
 
 
-// MARK: -  Constants!
+// MARK: - Constants!
 //
 private extension ChartMarker {
     enum Constants {


### PR DESCRIPTION
### Details:
This PR nukes an extra space (which breaks nothing!!!), but the bot complains.

@bummytime may i bug you with a real quick one? (I've noticed this after merging develop > master).

Thanks in advance!!!