### PR TITLE
Accessibility: Site Picker with dynamic type support

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.xib
@@ -11,24 +11,24 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="54" id="8he-cT-5iI" customClass="StoreTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="72" id="8he-cT-5iI" customClass="StoreTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="72"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8he-cT-5iI" id="KTm-Fu-oXz">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="53.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="71.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LL0-HO-TaM">
-                        <rect key="frame" x="16" y="0.0" width="359" height="53.5"/>
+                        <rect key="frame" x="16" y="0.0" width="359" height="71.5"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bER-Qc-gQZ" userLabel="Checkmark  ContainerView">
-                                <rect key="frame" x="0.0" y="0.0" width="35" height="53.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="35" height="71.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eHN-Ud-mEG" userLabel="Checkmark ImageView">
-                                        <rect key="frame" x="0.0" y="17" width="20" height="20"/>
+                                        <rect key="frame" x="0.0" y="24" width="24" height="24"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="20" id="4Sv-qE-YJO"/>
-                                            <constraint firstAttribute="height" constant="20" id="QEn-V8-PZY"/>
+                                            <constraint firstAttribute="width" constant="24" id="4Sv-qE-YJO"/>
+                                            <constraint firstAttribute="height" constant="24" id="QEn-V8-PZY"/>
                                         </constraints>
                                     </imageView>
                                 </subviews>
@@ -41,30 +41,27 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rmH-TD-Oll" userLabel="TextContainerView">
-                                <rect key="frame" x="35" y="0.0" width="324" height="53.5"/>
+                                <rect key="frame" x="35" y="0.0" width="324" height="71.5"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejj-Pj-vZz">
-                                        <rect key="frame" x="0.0" y="6" width="324" height="30"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="30" id="XU8-SX-Pk9"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ejj-Pj-vZz">
+                                        <rect key="frame" x="0.0" y="10" width="324" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="URL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CjK-ri-inj">
-                                        <rect key="frame" x="0.0" y="22" width="324" height="31.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="URL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CjK-ri-inj">
+                                        <rect key="frame" x="0.0" y="30.5" width="324" height="31"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="CjK-ri-inj" secondAttribute="bottom" id="Lm9-hT-2q8"/>
+                                    <constraint firstAttribute="bottom" secondItem="CjK-ri-inj" secondAttribute="bottom" constant="10" id="Lm9-hT-2q8"/>
                                     <constraint firstAttribute="trailing" secondItem="ejj-Pj-vZz" secondAttribute="trailing" id="TbP-lu-lfk"/>
-                                    <constraint firstItem="CjK-ri-inj" firstAttribute="top" secondItem="ejj-Pj-vZz" secondAttribute="bottom" constant="-14" id="TlB-rO-jhZ"/>
-                                    <constraint firstItem="ejj-Pj-vZz" firstAttribute="top" secondItem="rmH-TD-Oll" secondAttribute="top" constant="6" id="Wis-Fp-VuN"/>
+                                    <constraint firstItem="CjK-ri-inj" firstAttribute="top" secondItem="ejj-Pj-vZz" secondAttribute="bottom" id="TlB-rO-jhZ"/>
+                                    <constraint firstItem="ejj-Pj-vZz" firstAttribute="top" secondItem="rmH-TD-Oll" secondAttribute="top" constant="10" id="Wis-Fp-VuN"/>
                                     <constraint firstItem="ejj-Pj-vZz" firstAttribute="leading" secondItem="rmH-TD-Oll" secondAttribute="leading" id="cPs-D8-OhR"/>
                                     <constraint firstAttribute="trailing" secondItem="CjK-ri-inj" secondAttribute="trailing" id="g9N-8j-ngN"/>
                                     <constraint firstItem="CjK-ri-inj" firstAttribute="leading" secondItem="rmH-TD-Oll" secondAttribute="leading" id="xAD-Oc-lC1"/>


### PR DESCRIPTION
This PR contains changes to support dynamic type in the Site Picker. Bonus: standardized layout and font sizes to match the Sketch file. 

## Dynamic type

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1062444/50795719-c15bf600-1294-11e9-8a96-bf7f0e89f690.png) | ![after](https://user-images.githubusercontent.com/1062444/50795730-cb7df480-1294-11e9-98e1-c472b37cf2fc.png) |

## Follow Sketch layout

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1062444/50795783-fd8f5680-1294-11e9-9657-fdcf4edd22bc.png) | ![after](https://user-images.githubusercontent.com/1062444/50795797-0849eb80-1295-11e9-9800-df760b44e695.png) |
