### PR TITLE
Accessibility: Added VoiceOver support to revenue chart

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -127,9 +127,10 @@ private extension PeriodDataViewController {
         // Accessibility elements
         xAxisAccessibilityLabel.isAccessibilityElement = true
         xAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
+        xAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("X Axis", comment: "VoiceOver accessibility label for the X-axis.")
         yAxisAccessibilityLabel.isAccessibilityElement = true
         yAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
-
+        yAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("Y Axis", comment: "VoiceOver accessibility label for the Y-axis.")
     }
 
     func configureBarChart() {
@@ -317,13 +318,11 @@ private extension PeriodDataViewController {
     }
 
     func updateAxisAccessibility() {
-        let yAxisAccessibilityString = String.localizedStringWithFormat(NSLocalizedString("Y axis. Minimum value %@, maximum value %@.",
-                                                                                     comment: "VoiceOver accessibility label, informs the user about the Y-axis. It reads: Y axis. Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
+        yAxisAccessibilityLabel.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@.",
+                                                                                     comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
 
-        let xAxisAccessibilityString = String.localizedStringWithFormat(NSLocalizedString("X axis. Starting date %@, ending date %@.",
-                                                                                     comment: "VoiceOver accessibility label, informs the user about the X-axis. It reads: X axis. Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
-        xAxisAccessibilityLabel.accessibilityLabel = xAxisAccessibilityString
-        yAxisAccessibilityLabel.accessibilityLabel = yAxisAccessibilityString
+        xAxisAccessibilityLabel.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Starting date %@, ending date %@.",
+                                                                                     comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
     }
 
     func generateBarDataSet() -> BarChartData? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -147,6 +147,8 @@ private extension PeriodDataViewController {
         chartAccessibilityView.isAccessibilityElement = true
         chartAccessibilityView.accessibilityTraits = UIAccessibilityTraitImage
         chartAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart", comment: "VoiceOver accessibility label for the store revenue chart.")
+        chartAccessibilityView.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Store revenue chart %@",
+                                                                                                       comment: "VoiceOver accessibility label for the store revenue chart. It reads: Store revenue chart {chart granularity}."), granularity.pluralizedString)
     }
 
     func configureBarChart() {
@@ -253,6 +255,40 @@ extension PeriodDataViewController: IAxisValueFormatter {
 }
 
 
+// MARK: - Accessibility Helpers
+//
+private extension PeriodDataViewController {
+
+    func updateChartAccessibilityValues() {
+        yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@",
+                                                                                                       comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
+        xAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Starting period %@, ending period %@",
+                                                                                                       comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
+        chartAccessibilityView.accessibilityValue = chartSummaryString()
+    }
+
+
+    func chartSummaryString() -> String {
+        guard let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet, dataSet.entryCount > 0 else {
+            return barChartView.noDataText
+        }
+
+        var chartSummaryString = ""
+        for i in 0..<dataSet.entryCount {
+            // We are not including zero value bars here to keep things shorter
+            guard let entry = dataSet.entryForIndex(i), entry.y != 0.0 else {
+                continue
+            }
+
+            let entrySummaryString = (entry.accessibilityValue ?? String(entry.y))
+            chartSummaryString += String.localizedStringWithFormat(NSLocalizedString("Bar number %i, %@, ",
+                                                                                     comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."), i+1, entrySummaryString)
+        }
+        return chartSummaryString
+    }
+}
+
+
 // MARK: - Private Helpers
 //
 private extension PeriodDataViewController {
@@ -311,30 +347,6 @@ private extension PeriodDataViewController {
 
     func clearChartMarkers() {
         barChartView.highlightValue(nil, callDelegate: false)
-    }
-
-    func updateChartAccessibilityValues() {
-        yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@",
-                                                                                     comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
-
-        xAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Starting period %@, ending period %@",
-                                                                                     comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
-        var chartSummaryString = ""
-        if let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet, dataSet.entryCount > 0 {
-            for i in 0..<dataSet.entryCount {
-                // We are not including zero value bars here to keep things shorter
-                guard let entry = dataSet.entryForIndex(i), entry.y != 0.0 else {
-                    continue
-                }
-
-                let entrySummaryString = (entry.accessibilityValue ?? String(entry.y))
-                chartSummaryString += String.localizedStringWithFormat(NSLocalizedString("Bar number %i, %@, ",
-                                                                   comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."), i+1, entrySummaryString)
-            }
-        } else {
-            chartSummaryString = barChartView.noDataText
-        }
-        chartAccessibilityView.accessibilityValue = chartSummaryString
     }
 
     func generateBarDataSet() -> BarChartData? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -24,8 +24,6 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     private var lastUpdatedDate: Date?
     private var yAxisMinimum: String = Constants.chartYAxisMinimum.friendlyString()
     private var yAxisMaximum: String = ""
-    private var xAxisMinimum: String = ""
-    private var xAxisMaximum: String = ""
 
     public let granularity: StatGranularity
     public var orderStats: OrderStats? {
@@ -53,6 +51,20 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
         } else {
             return ""
         }
+    }
+
+    private var xAxisMinimum: String {
+        guard let item = orderStats?.items?.first else {
+            return ""
+        }
+        return formattedPeriodString(for: item)
+    }
+
+    private var xAxisMaximum: String {
+        guard let item = orderStats?.items?.last else {
+            return ""
+        }
+        return formattedPeriodString(for: item)
     }
 
     // MARK: - Initialization
@@ -220,28 +232,7 @@ extension PeriodDataViewController: IAxisValueFormatter {
 
         if axis is XAxis {
             if let item = orderStats.items?[Int(value)] {
-                var dateString = ""
-                switch orderStats.granularity {
-                case .day:
-                    if let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: item.period) {
-                        dateString = DateFormatter.Charts.chartsDayFormatter.string(from: periodDate)
-                    }
-                case .week:
-                    if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
-                        dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: periodDate)
-                    }
-                case .month:
-                    if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
-                        dateString = DateFormatter.Charts.chartsMonthFormatter.string(from: periodDate)
-                    }
-                case .year:
-                    if let periodDate = DateFormatter.Stats.statsYearFormatter.date(from: item.period) {
-                        dateString = DateFormatter.Charts.chartsYearFormatter.string(from: periodDate)
-                    }
-                }
-
-                // TODO: Fill in max and min values
-                return dateString
+                return formattedPeriodString(for: item)
             } else {
                 return ""
             }
@@ -346,6 +337,29 @@ private extension PeriodDataViewController {
         dataSet.highlightAlpha = Constants.chartHighlightAlpha
         dataSet.drawValuesEnabled = false // Do not draw value labels on the top of the bars
         return BarChartData(dataSet: dataSet)
+    }
+
+    func formattedPeriodString(for item: OrderStatsItem) -> String {
+        var dateString = ""
+        switch granularity {
+        case .day:
+            if let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartsDayFormatter.string(from: periodDate)
+            }
+        case .week:
+            if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: periodDate)
+            }
+        case .month:
+            if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartsMonthFormatter.string(from: periodDate)
+            }
+        case .year:
+            if let periodDate = DateFormatter.Stats.statsYearFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartsYearFormatter.string(from: periodDate)
+            }
+        }
+        return dateString
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -20,7 +20,12 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     @IBOutlet private weak var borderView: UIView!
     @IBOutlet private weak var yAxisAccessibilityLabel: UILabel!
     @IBOutlet private weak var xAxisAccessibilityLabel: UILabel!
+
     private var lastUpdatedDate: Date?
+    private var yAxisMinimum: String = Constants.chartYAxisMinimum.friendlyString()
+    private var yAxisMaximum: String = ""
+    private var xAxisMinimum: String = ""
+    private var xAxisMaximum: String = ""
 
     public let granularity: StatGranularity
     public var orderStats: OrderStats? {
@@ -122,11 +127,9 @@ private extension PeriodDataViewController {
         // Accessibility elements
         xAxisAccessibilityLabel.isAccessibilityElement = true
         xAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
-        xAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("This is the X axis", comment: "VoiceOver accessibility label, informs the user about the X-axis on the dashboard chart.")
-
         yAxisAccessibilityLabel.isAccessibilityElement = true
         yAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
-        yAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("This is the Y axis", comment: "VoiceOver accessibility label, informs the user about the Y-axis on the dashboard chart.")
+
     }
 
     func configureBarChart() {
@@ -236,6 +239,7 @@ extension PeriodDataViewController: IAxisValueFormatter {
                     }
                 }
 
+                // TODO: Fill in max and min values
                 return dateString
             } else {
                 return ""
@@ -245,7 +249,8 @@ extension PeriodDataViewController: IAxisValueFormatter {
                 // Do not show the "0" label on the Y axis
                 return ""
             } else {
-                return value.friendlyString()
+                yAxisMaximum = value.friendlyString()
+                return yAxisMaximum
             }
         }
     }
@@ -300,6 +305,7 @@ private extension PeriodDataViewController {
         barChartView.fitBars = true
         barChartView.notifyDataSetChanged()
         barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
+        updateAxisAccessibility()
     }
 
     func reloadLastUpdatedField() {
@@ -308,6 +314,16 @@ private extension PeriodDataViewController {
 
     func clearChartMarkers() {
         barChartView.highlightValue(nil, callDelegate: false)
+    }
+
+    func updateAxisAccessibility() {
+        let yAxisAccessibilityString = String.localizedStringWithFormat(NSLocalizedString("Y axis. Minimum value %@, maximum value %@.",
+                                                                                     comment: "VoiceOver accessibility label, informs the user about the Y-axis. It reads: Y axis. Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
+
+        let xAxisAccessibilityString = String.localizedStringWithFormat(NSLocalizedString("X axis. Starting date %@, ending date %@.",
+                                                                                     comment: "VoiceOver accessibility label, informs the user about the X-axis. It reads: X axis. Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
+        xAxisAccessibilityLabel.accessibilityLabel = xAxisAccessibilityString
+        yAxisAccessibilityLabel.accessibilityLabel = yAxisAccessibilityString
     }
 
     func generateBarDataSet() -> BarChartData? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -262,7 +262,7 @@ private extension PeriodDataViewController {
         reloadSiteFields()
         reloadChart()
         reloadLastUpdatedField()
-        view.accessibilityElements = [visitorsTitle, visitorsData, ordersTitle, ordersData, revenueTitle, revenueData, lastUpdated]
+        view.accessibilityElements = [visitorsTitle, visitorsData, ordersTitle, ordersData, revenueTitle, revenueData, lastUpdated, yAxisAccessibilityView, xAxisAccessibilityView, chartAccessibilityView]
     }
 
     func reloadOrderFields() {
@@ -302,7 +302,7 @@ private extension PeriodDataViewController {
         barChartView.fitBars = true
         barChartView.notifyDataSetChanged()
         barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
-        updateAccessibilityValues()
+        updateChartAccessibilityValues()
     }
 
     func reloadLastUpdatedField() {
@@ -313,7 +313,7 @@ private extension PeriodDataViewController {
         barChartView.highlightValue(nil, callDelegate: false)
     }
 
-    func updateAccessibilityValues() {
+    func updateChartAccessibilityValues() {
         yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@",
                                                                                      comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
 
@@ -328,7 +328,7 @@ private extension PeriodDataViewController {
                 }
 
                 let entrySummaryString = (entry.accessibilityValue ?? String(entry.y))
-                chartSummaryString += String.localizedStringWithFormat(NSLocalizedString("Bar number %i %@, ",
+                chartSummaryString += String.localizedStringWithFormat(NSLocalizedString("Bar number %i, %@, ",
                                                                    comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."), i+1, entrySummaryString)
             }
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -18,6 +18,8 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     @IBOutlet private weak var barChartView: BarChartView!
     @IBOutlet private weak var lastUpdated: UILabel!
     @IBOutlet private weak var borderView: UIView!
+    @IBOutlet private weak var yAxisAccessibilityLabel: UILabel!
+    @IBOutlet private weak var xAxisAccessibilityLabel: UILabel!
     private var lastUpdatedDate: Date?
 
     public let granularity: StatGranularity
@@ -116,6 +118,15 @@ private extension PeriodDataViewController {
         // Footer
         lastUpdated.font = UIFont.footnote
         lastUpdated.textColor = StyleManager.wooGreyMid
+
+        // Accessibility elements
+        xAxisAccessibilityLabel.isAccessibilityElement = true
+        xAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
+        xAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("This is the X axis", comment: "VoiceOver accessibility label, informs the user about the X-axis on the dashboard chart.")
+
+        yAxisAccessibilityLabel.isAccessibilityElement = true
+        yAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
+        yAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("This is the Y axis", comment: "VoiceOver accessibility label, informs the user about the Y-axis on the dashboard chart.")
     }
 
     func configureBarChart() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -18,8 +18,9 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     @IBOutlet private weak var barChartView: BarChartView!
     @IBOutlet private weak var lastUpdated: UILabel!
     @IBOutlet private weak var borderView: UIView!
-    @IBOutlet private weak var yAxisAccessibilityLabel: UILabel!
-    @IBOutlet private weak var xAxisAccessibilityLabel: UILabel!
+    @IBOutlet private weak var yAxisAccessibilityView: UIView!
+    @IBOutlet private weak var xAxisAccessibilityView: UIView!
+    @IBOutlet private weak var chartAccessibilityView: UIView!
 
     private var lastUpdatedDate: Date?
     private var yAxisMinimum: String = Constants.chartYAxisMinimum.friendlyString()
@@ -137,12 +138,15 @@ private extension PeriodDataViewController {
         lastUpdated.textColor = StyleManager.wooGreyMid
 
         // Accessibility elements
-        xAxisAccessibilityLabel.isAccessibilityElement = true
-        xAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
-        xAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("X Axis", comment: "VoiceOver accessibility label for the X-axis.")
-        yAxisAccessibilityLabel.isAccessibilityElement = true
-        yAxisAccessibilityLabel.accessibilityTraits = UIAccessibilityTraitStaticText
-        yAxisAccessibilityLabel.accessibilityLabel = NSLocalizedString("Y Axis", comment: "VoiceOver accessibility label for the Y-axis.")
+        xAxisAccessibilityView.isAccessibilityElement = true
+        xAxisAccessibilityView.accessibilityTraits = UIAccessibilityTraitStaticText
+        xAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: X Axis", comment: "VoiceOver accessibility label for the store revenue chart's X-axis.")
+        yAxisAccessibilityView.isAccessibilityElement = true
+        yAxisAccessibilityView.accessibilityTraits = UIAccessibilityTraitStaticText
+        yAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: Y Axis", comment: "VoiceOver accessibility label for the store revenue chart's Y-axis.")
+        chartAccessibilityView.isAccessibilityElement = true
+        chartAccessibilityView.accessibilityTraits = UIAccessibilityTraitImage
+        chartAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart", comment: "VoiceOver accessibility label for the store revenue chart.")
     }
 
     func configureBarChart() {
@@ -158,9 +162,6 @@ private extension PeriodDataViewController {
         barChartView.noDataTextColor = StyleManager.wooSecondary
         barChartView.extraRightOffset = Constants.chartExtraRightOffset
         barChartView.delegate = self
-        barChartView.isAccessibilityElement = true
-        barChartView.accessibilityTraits = UIAccessibilityTraitImage
-        barChartView.accessibilityLabel = NSLocalizedString("Store revenue chart", comment: "VoiceOver accessibility label for the store revenue chart.")
 
         let xAxis = barChartView.xAxis
         xAxis.labelPosition = .bottom
@@ -312,13 +313,13 @@ private extension PeriodDataViewController {
     }
 
     func updateAccessibilityValues() {
-        yAxisAccessibilityLabel.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@",
+        yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@",
                                                                                      comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
 
-        xAxisAccessibilityLabel.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Starting date %@, ending date %@",
+        xAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Starting period %@, ending period %@",
                                                                                      comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
         var chartSummaryString = ""
-        if let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet {
+        if let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet, dataSet.entryCount > 0 {
             for i in 0..<dataSet.entryCount {
                 // We are not including zero value bars here to keep things shorter
                 guard let entry = dataSet.entryForIndex(i), entry.y != 0.0 else {
@@ -327,11 +328,12 @@ private extension PeriodDataViewController {
 
                 let entrySummaryString = (entry.accessibilityValue ?? String(entry.y))
                 chartSummaryString += String.localizedStringWithFormat(NSLocalizedString("Bar number %i %@, ",
-                                                                   comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number}, {summary of bar}."), i+1, entrySummaryString)
+                                                                   comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."), i+1, entrySummaryString)
             }
-
-            barChartView.accessibilityValue = chartSummaryString
+        } else {
+            chartSummaryString = barChartView.noDataText
         }
+        chartAccessibilityView.accessibilityValue = chartSummaryString
     }
 
     func generateBarDataSet() -> BarChartData? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
@@ -21,6 +21,8 @@
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
                 <outlet property="visitorsData" destination="SZF-f7-8Va" id="ZY0-s6-PDq"/>
                 <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
+                <outlet property="xAxisAccessibilityLabel" destination="TTF-Fx-NHe" id="CNT-Mg-1VA"/>
+                <outlet property="yAxisAccessibilityLabel" destination="yvj-Kj-G3f" id="Eno-Q1-dk9"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -57,7 +59,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NaX-4V-XP2">
-                                            <rect key="frame" x="16" y="67.5" width="93.5" height="20"/>
+                                            <rect key="frame" x="16" y="67.5" width="94" height="20"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="Ekr-OV-et5"/>
@@ -159,24 +161,44 @@
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
-                            <rect key="frame" x="0.0" y="88.5" width="375" height="508.5"/>
+                            <rect key="frame" x="0.0" y="88.5" width="375" height="509"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
-                                    <rect key="frame" x="0.0" y="0.0" width="14" height="508.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="14" height="509"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
-                                    <rect key="frame" x="14" y="0.0" width="347" height="508.5"/>
+                                    <rect key="frame" x="14" y="0.0" width="347" height="509"/>
+                                    <subviews>
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f" customClass="UILabel">
+                                            <rect key="frame" x="0.0" y="8" width="32" height="485"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="32" id="sUS-FA-4ab"/>
+                                            </constraints>
+                                        </view>
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe" customClass="UILabel">
+                                            <rect key="frame" x="0.0" y="493" width="347" height="16"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="16" id="feO-ed-bxp"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
+                                        <constraint firstItem="TTF-Fx-NHe" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="3m2-3S-Woi"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
+                                        <constraint firstAttribute="trailing" secondItem="TTF-Fx-NHe" secondAttribute="trailing" id="JA8-YG-kdu"/>
+                                        <constraint firstItem="yvj-Kj-G3f" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="TcO-x3-t7A"/>
+                                        <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="yvj-Kj-G3f" secondAttribute="bottom" id="X68-Fa-xY5"/>
+                                        <constraint firstItem="yvj-Kj-G3f" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="aCl-eO-awT"/>
+                                        <constraint firstAttribute="bottom" secondItem="TTF-Fx-NHe" secondAttribute="bottom" id="prr-z8-NDw"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
-                                    <rect key="frame" x="361" y="0.0" width="14" height="508.5"/>
+                                    <rect key="frame" x="361" y="0.0" width="14" height="509"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="14" id="KRJ-Jf-3tM"/>
@@ -185,7 +207,7 @@
                             </subviews>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Wi-nd-Ucs">
-                            <rect key="frame" x="0.0" y="597" width="375" height="50"/>
+                            <rect key="frame" x="0.0" y="597.5" width="375" height="49.5"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="sz5-Uv-FMw" userLabel="height = 44"/>
@@ -206,7 +228,7 @@
                 <constraint firstItem="dAO-9u-HGh" firstAttribute="bottom" secondItem="0he-5g-kXa" secondAttribute="bottom" id="YB7-vo-uKz"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="dAO-9u-HGh"/>
-            <point key="canvasLocation" x="22" y="-428"/>
+            <point key="canvasLocation" x="21.5" y="-428.5"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="barChartView" destination="zPE-Y0-ax8" id="3VU-s1-JmV"/>
                 <outlet property="borderView" destination="IHi-Ph-CQQ" id="bgg-u3-bda"/>
+                <outlet property="chartAccessibilityView" destination="NEo-bw-gS4" id="Ep1-tI-L3J"/>
                 <outlet property="lastUpdated" destination="0Wi-nd-Ucs" id="XPO-tH-TLR"/>
                 <outlet property="ordersData" destination="6HA-Qe-PkT" id="zOF-dV-3LN"/>
                 <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
@@ -21,8 +22,8 @@
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
                 <outlet property="visitorsData" destination="SZF-f7-8Va" id="ZY0-s6-PDq"/>
                 <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
-                <outlet property="xAxisAccessibilityLabel" destination="TTF-Fx-NHe" id="CNT-Mg-1VA"/>
-                <outlet property="yAxisAccessibilityLabel" destination="yvj-Kj-G3f" id="Eno-Q1-dk9"/>
+                <outlet property="xAxisAccessibilityView" destination="TTF-Fx-NHe" id="cdX-lJ-DWe"/>
+                <outlet property="yAxisAccessibilityView" destination="yvj-Kj-G3f" id="MRf-C4-jUk"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -173,28 +174,38 @@
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
                                     <rect key="frame" x="14" y="0.0" width="347" height="509"/>
                                     <subviews>
-                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f" customClass="UILabel">
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
                                             <rect key="frame" x="0.0" y="8" width="32" height="485"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="32" id="sUS-FA-4ab"/>
                                             </constraints>
                                         </view>
-                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe" customClass="UILabel">
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
                                             <rect key="frame" x="0.0" y="493" width="347" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="feO-ed-bxp"/>
                                             </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
+                                            <rect key="frame" x="40" y="8" width="307" height="485"/>
+                                            <accessibility key="accessibilityConfiguration">
+                                                <accessibilityTraits key="traits" notEnabled="YES"/>
+                                            </accessibility>
                                         </view>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstItem="TTF-Fx-NHe" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="3m2-3S-Woi"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
+                                        <constraint firstItem="NEo-bw-gS4" firstAttribute="leading" secondItem="yvj-Kj-G3f" secondAttribute="trailing" constant="8" id="EcA-ZK-LGL"/>
                                         <constraint firstAttribute="trailing" secondItem="TTF-Fx-NHe" secondAttribute="trailing" id="JA8-YG-kdu"/>
                                         <constraint firstItem="yvj-Kj-G3f" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="TcO-x3-t7A"/>
                                         <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="yvj-Kj-G3f" secondAttribute="bottom" id="X68-Fa-xY5"/>
+                                        <constraint firstItem="NEo-bw-gS4" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="Xsc-Oa-g5y"/>
                                         <constraint firstItem="yvj-Kj-G3f" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="aCl-eO-awT"/>
+                                        <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="NEo-bw-gS4" secondAttribute="bottom" id="mFp-ya-fbL"/>
                                         <constraint firstAttribute="bottom" secondItem="TTF-Fx-NHe" secondAttribute="bottom" id="prr-z8-NDw"/>
+                                        <constraint firstAttribute="trailing" secondItem="NEo-bw-gS4" secondAttribute="trailing" id="y4j-07-4hx"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">


### PR DESCRIPTION
This PR adds VoiceOver support to the store revenue chart on the My Store tab:

<img width="994" alt="napkin 92 08-30-18 4 30 47 pm" src="https://user-images.githubusercontent.com/154014/44880478-2d3cab00-ac72-11e8-8a17-9812462b527a.png">

There are 3 main elements here:
* The Y-Axis: VoiceOver describes the min and max values
* The X-Axis: VoiceOver describes the min and max values
* The main chart itself: A summary of every non-zero bar in the chart

Regarding the chart summary, I am not sure if it is considered a best practice to skip the 0-value bars, but I did so in the name of brevity. I'm willing to change anything with this summary if desired.

## To Test

### Preconditions:
1. Make sure the app builds and runs and the unit tests are ✅ 
2. On a device, turn on VoiceOver access in your triple-click menu by visiting General > Accessibility > Accessibility Shortcut (select VoiceOver)

### Testing
1. Open the dashboard and wait for data to load in the chart — Verify VoiceOver works on the Y-Axis, X-Axis, and chart itself
2. Rinse and repeat ☝️ for each chart
3. Rotate the device to landscape mode and test steps 1 & 2 again
4. Turn off VoiceOver and verify the individual bars are selectable and display the `ChartMarker` UI like always.

@mindgraffiti would you mind taking a peek? Thanks!


