### PR TITLE
Dashboard: Fix chart "flash" when switching tabs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -99,6 +99,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         clearChartMarkers()
+        barChartView?.clear()
     }
 }
 


### PR DESCRIPTION
This PR addresses the "flash" which occurred when switching tabs away from the dashboard and then switching back. The fix itself was a simple one-liner that clears the chart data on `viewDidDisappear` which then allows the animation to work smoothly the next time it appears onscreen:

![graph_flash2](https://user-images.githubusercontent.com/154014/45322777-dc993d80-b50e-11e8-84a2-bdb6922c641b.gif)

_(Note if any jitter appears in that gif it is due to the frame rate of the gif itself 😇)_

See the issue for more details on the problem.

Fixes: #292 

## Testing:

Testing should be pretty easy:

1. Run the app in the sim and/or device of your choosing. 
2. Make sure the Dashboard chart loads
3. Switch to another tab (e.g. Orders)
4. Switch back to the My Store tab and verify the chart "flash" doesn't occur
5. Double check that swiping between periods (Days, Weeks, Months, Years) also works smoothly.

@jleandroperez Would you mind checking this PR out...should be quick!
