### PR TITLE
Podfile: Updating dependencies

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,9 +17,9 @@ target 'WooCommerce' do
   # ====================
   #
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
-  pod 'Gridicons', '0.15'
-  pod 'WordPressAuthenticator', '1.0.6'
-  pod 'WordPressShared', '1.0.8'
+  pod 'Gridicons', '0.16'
+  pod 'WordPressAuthenticator', '1.1.0-beta.1'
+  pod 'WordPressShared', '1.1.1-beta.2'
   pod 'WordPressUI', '~> 1.0'
 
 
@@ -31,7 +31,7 @@ target 'WooCommerce' do
   pod 'KeychainAccess', '~> 3.1'
   pod 'CocoaLumberjack', '~> 3.4'
   pod 'XLPagerTabStrip', '~> 8.0'
-  pod 'Charts', '~> 3.1'
+  pod 'Charts', '~> 3.2'
 
   # Unit Tests
   # ==========
@@ -118,7 +118,7 @@ end
 #
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-      if ['Charts', 'XLPagerTabStrip', 'WordPressShared'].include? target.name
+      if ['XLPagerTabStrip'].include? target.name
           target.build_configurations.each do |config|
               config.build_settings['SWIFT_VERSION'] = '4.0'
           end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - 1PasswordExtension (1.8.5)
-  - Alamofire (4.7.2)
+  - Alamofire (4.7.3)
   - Automattic-Tracks-iOS (0.2.3):
     - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
-  - Charts (3.1.1):
-    - Charts/Core (= 3.1.1)
-  - Charts/Core (3.1.1)
+  - Charts (3.2.0):
+    - Charts/Core (= 3.2.0)
+  - Charts/Core (3.2.0)
   - CocoaLumberjack (3.4.2):
     - CocoaLumberjack/Default (= 3.4.2)
     - CocoaLumberjack/Extensions (= 3.4.2)
@@ -31,7 +31,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.1.4)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
-  - Gridicons (0.15)
+  - Gridicons (0.16)
   - KeychainAccess (3.1.1)
   - lottie-ios (2.5.0)
   - NSObject-SafeExpectations (0.0.3)
@@ -39,9 +39,9 @@ PODS:
   - Reachability (3.2)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPressAuthenticator (1.0.6):
+  - WordPressAuthenticator (1.1.0-beta.1):
     - 1PasswordExtension (= 1.8.5)
-    - Alamofire (= 4.7.2)
+    - Alamofire (= 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - GoogleSignInRepacked (= 4.1.2)
     - Gridicons (~> 0.15)
@@ -49,18 +49,18 @@ PODS:
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressKit (~> 1.0)
-    - WordPressShared (~> 1.0)
+    - WordPressKit (= 1.4.1-beta.2)
+    - WordPressShared (= 1.1.1-beta.2)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.4.0):
-    - Alamofire (~> 4.7)
+  - WordPressKit (1.4.1-beta.2):
+    - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.0.3)
+    - WordPressShared (= 1.1.1-beta.2)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.0.8):
+  - WordPressShared (1.1.1-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.7)
@@ -70,13 +70,13 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.7)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.2.3`)
-  - Charts (~> 3.1)
+  - Charts (~> 3.2)
   - CocoaLumberjack (~> 3.4)
   - Crashlytics (~> 3.10)
-  - Gridicons (= 0.15)
+  - Gridicons (= 0.16)
   - KeychainAccess (~> 3.1)
-  - WordPressAuthenticator (= 1.0.6)
-  - WordPressShared (= 1.0.8)
+  - WordPressAuthenticator (= 1.1.0-beta.1)
+  - WordPressShared (= 1.1.1-beta.2)
   - WordPressUI (~> 1.0)
   - XLPagerTabStrip (~> 8.0)
 
@@ -118,16 +118,16 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
-  Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   Automattic-Tracks-iOS: d8c6c6c1351b1905a73e45f431b15598d71963b5
-  Charts: 90a4d61da0f6e06684c591e3bcab11940fe61736
+  Charts: 680c8328bd5e90cb14f67e00d2176f3113d19141
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: ccaac42660eb9351b9960c0d66106b0bcf99f4fa
   Fabric: f233c9492b3bbc1f04e3882986740f7988a58edb
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
-  Gridicons: 0e5e76ad9fc6f7cbc3da137a9751ef516c5aef73
+  Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
   KeychainAccess: 7bd430028059754a3debab3cfc0bd1fc7fb85df3
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
@@ -135,13 +135,13 @@ SPEC CHECKSUMS:
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressAuthenticator: 56538a229185640b41912c10c3f1891c2cc9bbb9
-  WordPressKit: 5d4b9840aed4329d61b3efbe40714c9dce719309
-  WordPressShared: 063e1e8b1a7aaf635abf17f091a2d235a068abdc
+  WordPressAuthenticator: 904e24e2bcaff4b9d91b34514e87ac55bee470fa
+  WordPressKit: a4ccc4bbbc6f8e194becf18b47af212f367fe3ab
+  WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
   WordPressUI: cfcac4a2a033e3ed5def6504bb8e28447c54423b
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   XLPagerTabStrip: c908b17cbf42fcd2598ee1adfc49bae25444d88a
 
-PODFILE CHECKSUM: be80e5be4b1bc58b9474d58a7533a6d2e2498ce6
+PODFILE CHECKSUM: 981be965167cc86fe91da27bdad699c37a296081
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
### Details:
This PR updates the following dependencies:

- WordPressAuthenticator
- WordPressShared
- Gridicons
- Charts

We're also nuking (partially) the Swift 4.2 workaround, since most of the updated dependencies are now Swift 4.2 friendly (woooo!!!).

### Testing:
- [ ] Verify the unit tests are green
- [ ] Run a smoke test in your favorite device!

Thanks in advance!! 
cc @mindgraffiti @bummytime 
