### PR TITLE
Crasher fix for large quantity value

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		746A9D1E214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopEarnerStats+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		746A9D1F214078080013F6FF /* TopEarnerStatsItem+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopEarnerStatsItem+CoreDataClass.swift"; sourceTree = "<group>"; };
 		746A9D20214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopEarnerStatsItem+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		74B053702153090F0068EB85 /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
 		74B7D6AB20F90CBB002667AC /* OrderNote+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderNote+CoreDataClass.swift"; sourceTree = "<group>"; };
 		74B7D6AC20F90CBB002667AC /* OrderNote+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderNote+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7C81935EDD982072BBDCC837 /* Pods-Storage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.release.xcconfig"; sourceTree = "<group>"; };
@@ -773,10 +774,11 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				74B053702153090F0068EB85 /* Model 3.xcdatamodel */,
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = 746A9D14214071F90013F6FF /* Model 2.xcdatamodel */;
+			currentVersion = 74B053702153090F0068EB85 /* Model 3.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,11 @@
 
 This file documents changes in the extensions data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 3
+- @bummytime 2018-09-19
+- Widened `quantity` attribute on `OrderItem` from Int16 to Int64
+- Widened `quantity` attribute on `TopEarnerStatsItem` from Int16 to Int64
+
 ## Model 2
 - @bummytime 2018-09-05
 - Added new entity: `TopEarnerStats`, to encapsulate all of the top earner stats for a given site & granularity

--- a/Storage/Storage/Model/OrderItem+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderItem+CoreDataProperties.swift
@@ -10,7 +10,7 @@ extension OrderItem {
 
     @NSManaged public var itemID: Int64
     @NSManaged public var name: String?
-    @NSManaged public var quantity: Int16
+    @NSManaged public var quantity: Int64
     @NSManaged public var productID: Int64
     @NSManaged public var sku: String?
     @NSManaged public var subtotal: String?

--- a/Storage/Storage/Model/TopEarnerStatsItem+CoreDataProperties.swift
+++ b/Storage/Storage/Model/TopEarnerStatsItem+CoreDataProperties.swift
@@ -10,7 +10,7 @@ extension TopEarnerStatsItem {
 
     @NSManaged public var productID: Int64
     @NSManaged public var productName: String?
-    @NSManaged public var quantity: Int16
+    @NSManaged public var quantity: Int64
     @NSManaged public var price: Double
     @NSManaged public var total: Double
     @NSManaged public var currency: String?

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 2.xcdatamodel</string>
+	<string>Model 3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 3.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 3.xcdatamodel/contents
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14315.18" systemVersion="17G65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="number" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="status" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem" syncable="YES"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote" syncable="YES"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="note" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="limit" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Account" positionX="-198" positionY="132" width="128" height="120"/>
+        <element name="Order" positionX="-20" positionY="27" width="128" height="690"/>
+        <element name="OrderCoupon" positionX="-200" positionY="456" width="128" height="120"/>
+        <element name="OrderItem" positionX="191.55859375" positionY="265.6484375" width="128" height="225"/>
+        <element name="OrderNote" positionX="214" positionY="539" width="128" height="118"/>
+        <element name="Site" positionX="-200" positionY="279" width="128" height="135"/>
+        <element name="TopEarnerStats" positionX="167.88671875" positionY="30.72265625" width="128" height="105"/>
+        <element name="TopEarnerStatsItem" positionX="333.09765625" positionY="31.7421875" width="128" height="165"/>
+    </elements>
+</model>

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -11,7 +11,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
     public func update(with orderItem: Yosemite.OrderItem) {
         itemID = Int64(orderItem.itemID)
         name = orderItem.name
-        quantity = Int16(orderItem.quantity)
+        quantity = Int64(orderItem.quantity)
         productID = Int64(orderItem.productID)
         sku = orderItem.sku
         subtotal = orderItem.subtotal

--- a/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
@@ -11,7 +11,7 @@ extension Storage.TopEarnerStatsItem: ReadOnlyConvertible {
     public func update(with statsItem: Yosemite.TopEarnerStatsItem) {
         productID = Int64(statsItem.productID)
         productName = statsItem.productName
-        quantity = Int16(statsItem.quantity)
+        quantity = Int64(statsItem.quantity)
         price = statsItem.price
         total = statsItem.total
         currency = statsItem.currency


### PR DESCRIPTION
This is a straight-forward PR to widen `quantity` from Int16 to Int64 on both the `TopEarnerStatsItem` and `OrderItem` entities. 

Fixes: #313 

## Testing

I would recommend the following:

1. Install and run the `develop` branch on a sim/device (choosing Julia's test store).
2. Verify her store crashes the app
3. Switch to this PR's branch and run the app on the same sim/device. 
4. Verify her store does not crash the app!
5. Log out and log into another store - make sure everything works as expected.

(Also, make sure the unit tests are ✅  and the app builds and runs.)

@jleandroperez and @mindgraffiti would you mind taking a peek?
