### PR TITLE
Dashboard: data loading fixes

### DIFF
--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
@@ -7,7 +7,7 @@ class OrderDetailsViewModel {
     let order: Order
     let moneyFormatter: MoneyFormatter
     let couponLines: [OrderCouponLine]?
-    
+
     let orderStatusViewModel: OrderStatusViewModel
 
     init(order: Order) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -31,7 +31,7 @@ class DashboardViewController: UIViewController {
         startListeningToNotifications()
         tabBarItem.image = Gridicon.iconOfType(.statsAlt)
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -41,7 +41,7 @@ class DashboardViewController: UIViewController {
         configureNavigation()
         configureView()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if storeStatsViewController.isDataMissing {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Gridicons
 import CocoaLumberjack
 import WordPressUI
+import Yosemite
 
 
 // MARK: - DashboardViewController
@@ -27,7 +28,12 @@ class DashboardViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        startListeningToNotifications()
         tabBarItem.image = Gridicon.iconOfType(.statsAlt)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidLoad() {
@@ -82,6 +88,10 @@ private extension DashboardViewController {
 
         navigationItem.backBarButtonItem = backButton
     }
+
+    func startListeningToNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+    }
 }
 
 
@@ -116,6 +126,14 @@ extension DashboardViewController: NewOrdersDelegate {
 // MARK: - Private Helpers
 //
 private extension DashboardViewController {
+
+    @objc func defaultAccountWasUpdated(sender: Notification) {
+        guard storeStatsViewController != nil, StoresManager.shared.isAuthenticated == false else {
+            return
+        }
+        storeStatsViewController.clearAllFields()
+    }
+
     func reloadData() {
         DDLogInfo("♻️ Requesting dashboard data be reloaded...")
         storeStatsViewController.syncAllStats()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -40,7 +40,13 @@ class DashboardViewController: UIViewController {
         super.viewDidLoad()
         configureNavigation()
         configureView()
-        reloadData()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if storeStatsViewController.isDataMissing {
+            reloadData()
+        }
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -29,7 +29,11 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     public let granularity: StatGranularity
     public var orderStats: OrderStats? {
         didSet {
-            lastUpdatedDate = Date()
+            if orderStats != nil {
+                lastUpdatedDate = Date()
+            } else {
+                lastUpdatedDate = nil
+            }
             reloadOrderFields()
             reloadChart()
             reloadLastUpdatedField()
@@ -37,7 +41,11 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     }
     public var siteStats: SiteVisitStats? {
         didSet {
-            lastUpdatedDate = Date()
+            if siteStats != nil {
+                lastUpdatedDate = Date()
+            } else {
+                lastUpdatedDate = nil
+            }
             reloadSiteFields()
             reloadLastUpdatedField()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -13,7 +13,7 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
     @IBOutlet private weak var bottomBorder: UIView!
 
     private var periodVCs = [PeriodDataViewController]()
-    
+
     public var isDataMissing: Bool {
         return (periodVCs.contains { $0.orderStats == nil }) ||
             (periodVCs.contains { $0.siteStats == nil })
@@ -50,7 +50,7 @@ extension StoreStatsViewController {
             vc.clearAllFields()
         }
     }
-    
+
     func syncAllStats() {
         clearAllFields()
         periodVCs.forEach { (vc) in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -13,6 +13,11 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
     @IBOutlet private weak var bottomBorder: UIView!
 
     private var periodVCs = [PeriodDataViewController]()
+    
+    public var isDataMissing: Bool {
+        return (periodVCs.contains { $0.orderStats == nil }) ||
+            (periodVCs.contains { $0.siteStats == nil })
+    }
 
     // MARK: - View Lifecycle
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -40,9 +40,15 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
 // MARK: - Public Interface
 //
 extension StoreStatsViewController {
-    func syncAllStats() {
+    func clearAllFields() {
         periodVCs.forEach { (vc) in
             vc.clearAllFields()
+        }
+    }
+    
+    func syncAllStats() {
+        clearAllFields()
+        periodVCs.forEach { (vc) in
             syncOrderStats(for: vc.granularity)
             syncVisitorStats(for: vc.granularity)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListCell.swift
@@ -13,7 +13,7 @@ class OrderListCell: UITableViewCell {
 
         totalLabel.text = viewModel.totalFriendlyString
         totalLabel.applyBodyStyle()
-        
+
         paymentStatusLabel.text = viewModel.paymentStatus
         paymentStatusLabel.applyStatusStyle(for: viewModel.orderStatusViewModel.orderStatus)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/IntrinsicTableView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/IntrinsicTableView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class IntrinsicTableView: UITableView {
 
-    override var contentSize:CGSize {
+    override var contentSize: CGSize {
         didSet {
             invalidateIntrinsicContentSize()
         }


### PR DESCRIPTION
This PR addresses 3 issues with data loading in the Dashboard:

1) Previously, if the user logged out the old data was never cleared. To fix this I added a notification observer for `defaultAccountWasUpdated`. If that notif is fired _and_ the user is no longer authenticated, we clear the chart VCs

2) After logging in or launching the app, the Dashboard data would not refresh and could possibly be blank (until the user pulled-to-refresh). Now we are looking for missing data on `viewDidAppear` and reloading it if needed.

3) The `Updated X minutes ago` text on the chart is now cleared when pull-to-refresh is activated or the user logs out.

**NOTE:** Most of this ☝️☝️☝️  will be replaced when #258 is addressed. The goal here is to give our open beta users a better experience. 

Fixes #260 

## Testing

### Scenario 1: Fresh Login
- [x] 1. From a fresh install, log into the app
- [x] 2. Before the data is loaded, verify the `Updated X ... ago` text is blank while data is loading
- [x] 3. Verify the dashboard data loads after a few seconds

### Scenario 2: Logout -> Login
- [x] 1. After scenario one is completed, log out of the app
- [x] 2. Log into the app again and pick a different store
- [x] 3. Before the data is loaded, verify:
  a. The `Updated X ... ago` text is blank while data is loading
  b. The Dashboard is **not** displaying any stale data from the previous store.
- [x] 4. Verify the dashboard data loads after a few seconds

### Misc Other Things
- [x] * Switch tabs: `Dashboard -> Orders -> Dashboard` — verify there isn't any double animations on the charts
- [x] * Pull-to-refresh — verify the chart clears its data, the new orders alert hides, and everything eventually repopulates itself

@mindgraffiti and/or @jleandroperez could you take a peek at this?

 
