### PR TITLE
OrderDetailsViewController: Hiding products section whenever appropiate

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderDetailsViewController.swift
@@ -174,7 +174,11 @@ private extension OrderDetailsViewController {
     func reloadSections() {
         let summary = Section(row: .summary)
 
-        let products: Section = {
+        let products: Section? = {
+            guard viewModel.items.isEmpty == false else {
+                return nil
+            }
+
             let rows: [Row] = viewModel.isProcessingPayment ? [.productList] : [.productList, .productDetails]
             return Section(title: Title.product, rightTitle: Title.quantity, rows: rows)
         }()


### PR DESCRIPTION
### Details:
This PR hides the entire Products Section (Order Details) whenever there are no items in the order.

This appears to be caused by a broken / faulty data import. Nevertheless, let's add a tiny check, just in case!!

### Testing:
1. Log into the iTC's Demo Account (DM me and i'll send you over the creds!!)
2. Open any order's details
3. Verify that the products section doesn't even show up

cc @bummytime @mindgraffiti 
Thanks in advance!!
