### PR TITLE
Dashboard: Updated chart style

### DIFF
--- a/Networking/Networking/Extensions/DateFormatter+Woo.swift
+++ b/Networking/Networking/Extensions/DateFormatter+Woo.swift
@@ -31,7 +31,6 @@ public extension DateFormatter {
         public static let statsDayFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
             formatter.dateFormat = "yyyy'-'MM'-'dd"
             return formatter
         }()
@@ -42,7 +41,6 @@ public extension DateFormatter {
         public static let statsWeekFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
             formatter.dateFormat = "yyyy'-W'ww"
             return formatter
         }()
@@ -53,7 +51,6 @@ public extension DateFormatter {
         public static let statsMonthFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
             formatter.dateFormat = "yyyy'-'MM"
             return formatter
         }()
@@ -64,7 +61,6 @@ public extension DateFormatter {
         public static let statsYearFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
             formatter.dateFormat = "yyyy"
             return formatter
         }()

--- a/WooCommerce/Classes/Model/OrderStats+Woo.swift
+++ b/WooCommerce/Classes/Model/OrderStats+Woo.swift
@@ -6,17 +6,14 @@ import Yosemite
 //
 extension OrderStats {
 
-    /// Returns the Currency Symbol associated with the current order stats.
+    /// Returns the currency code associated with the current order stats.
     ///
-    var currencySymbol: String {
-        guard let currency = items?.filter({ !$0.currency.isEmpty }).first?.currency else {
-            return ""
-        }
-        guard let identifier = Locale.availableIdentifiers.first(where: { Locale(identifier: $0).currencyCode == currency }) else {
-            return currency
+    var currencyCode: String {
+        guard let currencyCode = items?.filter({ !$0.currency.isEmpty }).first?.currency else {
+            return String()
         }
 
-        return Locale(identifier: identifier).currencySymbol ?? currency
+        return currencyCode
     }
 
     /// Returns the sum of total sales this stats period. This value is typically used in the dashboard for revenue reporting.

--- a/WooCommerce/Classes/Model/TopEarnerStatsItem+Woo.swift
+++ b/WooCommerce/Classes/Model/TopEarnerStatsItem+Woo.swift
@@ -10,13 +10,9 @@ extension TopEarnerStatsItem {
     ///
     var currencySymbol: String {
         guard !currency.isEmpty else {
-            return ""
+            return String()
         }
-        guard let identifier = Locale.availableIdentifiers.first(where: { Locale(identifier: $0).currencyCode == currency }) else {
-            return currency
-        }
-
-        return Locale(identifier: identifier).currencySymbol ?? currency
+        return MoneyFormatter().currencySymbol(currencyCode: currency) ?? String()
     }
 
     /// Returns a friendly-formatted total string including the currency symbol

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -179,6 +179,7 @@ private extension PeriodDataViewController {
         barChartView.noDataFont = StyleManager.chartLabelFont
         barChartView.noDataTextColor = StyleManager.wooSecondary
         barChartView.extraRightOffset = Constants.chartExtraRightOffset
+        barChartView.extraTopOffset = Constants.chartExtraTopOffset
         barChartView.delegate = self
 
         let xAxis = barChartView.xAxis
@@ -419,6 +420,7 @@ private extension PeriodDataViewController {
 
         static let chartAnimationDuration: TimeInterval = 0.75
         static let chartExtraRightOffset: CGFloat       = 25.0
+        static let chartExtraTopOffset: CGFloat         = 20.0
         static let chartHighlightAlpha: CGFloat         = 1.0
 
         static let chartMarkerInsets: UIEdgeInsets      = UIEdgeInsets(top: 5.0, left: 2.0, bottom: 5.0, right: 2.0)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -54,7 +54,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     // MARK: - Computed Properties
 
     private var currencySymbol: String {
-        guard let code = orderStats?.currencySymbol else {
+        guard let code = orderStats?.currencyCode else {
             return String()
         }
         return MoneyFormatter().currencySymbol(currencyCode: code) ?? String()
@@ -325,9 +325,8 @@ private extension PeriodDataViewController {
         var totalRevenueText = Constants.placeholderText
         if let orderStats = orderStats {
             totalOrdersText = Double(orderStats.totalOrders).friendlyString()
-            let currencySymbol = orderStats.currencySymbol
             let totalRevenue = orderStats.totalSales.friendlyString()
-            totalRevenueText = "\(currencySymbol)\(totalRevenue)"
+            totalRevenueText = currencySymbol + totalRevenue
         }
         ordersData.text = totalOrdersText
         revenueData.text = totalRevenueText
@@ -373,7 +372,7 @@ private extension PeriodDataViewController {
         var dataEntries: [BarChartDataEntry] = []
         statItems.forEach { (item) in
             let entry = BarChartDataEntry(x: Double(barCount), y: item.totalSales)
-            entry.accessibilityValue = "\(item.period): \(orderStats.currencySymbol)\(item.totalSales.friendlyString())"
+            entry.accessibilityValue = "\(item.period): \(currencySymbol)\(item.totalSales.friendlyString())"
             dataEntries.append(entry)
             barCount += 1
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -197,7 +197,6 @@ private extension PeriodDataViewController {
 
         let yAxis = barChartView.leftAxis
         yAxis.labelFont = StyleManager.chartLabelFont
-        xAxis.setLabelCount(3, force: true)
         yAxis.labelTextColor = StyleManager.wooSecondary
         yAxis.axisLineColor = StyleManager.wooGreyBorder
         yAxis.gridColor = StyleManager.wooGreyBorder

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -53,6 +53,13 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
 
     // MARK: - Computed Properties
 
+    private var currencySymbol: String {
+        guard let code = orderStats?.currencySymbol else {
+            return String()
+        }
+        return MoneyFormatter().currencySymbol(currencyCode: code) ?? String()
+    }
+
     private var summaryDateUpdated: String {
         if let lastUpdatedDate = lastUpdatedDate {
             return String.localizedStringWithFormat(NSLocalizedString("Updated %@",
@@ -190,11 +197,10 @@ private extension PeriodDataViewController {
 
         let yAxis = barChartView.leftAxis
         yAxis.labelFont = StyleManager.chartLabelFont
+        xAxis.setLabelCount(3, force: true)
         yAxis.labelTextColor = StyleManager.wooSecondary
         yAxis.axisLineColor = StyleManager.wooGreyBorder
         yAxis.gridColor = StyleManager.wooGreyBorder
-        yAxis.gridLineDashLengths = Constants.chartXAxisDashLengths
-        yAxis.axisLineDashPhase = Constants.chartXAxisDashPhase
         yAxis.zeroLineColor = StyleManager.wooGreyBorder
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
@@ -202,6 +208,7 @@ private extension PeriodDataViewController {
         yAxis.drawZeroLineEnabled = true
         yAxis.axisMinimum = Constants.chartYAxisMinimum
         yAxis.valueFormatter = self
+        yAxis.setLabelCount(3, force: true)
     }
 }
 
@@ -257,7 +264,7 @@ extension PeriodDataViewController: IAxisValueFormatter {
                 return ""
             } else {
                 yAxisMaximum = value.friendlyString()
-                return yAxisMaximum
+                return currencySymbol + yAxisMaximum
             }
         }
     }
@@ -420,8 +427,6 @@ private extension PeriodDataViewController {
         static let chartMarkerMinimumSize: CGSize       = CGSize(width: 50.0, height: 30.0)
         static let chartMarkerArrowSize: CGSize         = CGSize(width: 8, height: 6)
 
-        static let chartXAxisDashLengths: [CGFloat]     = [5.0, 5.0]
-        static let chartXAxisDashPhase: CGFloat         = 0.0
         static let chartXAxisGranularity: Double        = 1.0
         static let chartYAxisMinimum: Double            = 0.0
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -370,16 +370,18 @@ private extension PeriodDataViewController {
         }
 
         var barCount = 0
+        var barColors: [UIColor] = []
         var dataEntries: [BarChartDataEntry] = []
         statItems.forEach { (item) in
             let entry = BarChartDataEntry(x: Double(barCount), y: item.totalSales)
             entry.accessibilityValue = "\(item.period): \(currencySymbol)\(item.totalSales.friendlyString())"
+            barColors.append(barColor(for: item.period))
             dataEntries.append(entry)
             barCount += 1
         }
 
         let dataSet =  BarChartDataSet(values: dataEntries, label: "Data")
-        dataSet.setColor(StyleManager.wooCommerceBrandColor)
+        dataSet.colors = barColors
         dataSet.highlightEnabled = true
         dataSet.highlightColor = StyleManager.wooAccent
         dataSet.highlightAlpha = Constants.chartHighlightAlpha
@@ -408,6 +410,16 @@ private extension PeriodDataViewController {
             }
         }
         return dateString
+    }
+
+    func barColor(for period: String) -> UIColor {
+        guard granularity == .day,
+            let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: period),
+            Calendar.current.isDateInWeekend(periodDate) else {
+                return StyleManager.wooCommerceBrandColor
+        }
+
+        return StyleManager.wooGreyMid
     }
 }
 


### PR DESCRIPTION
This is a quick PR that will bring the chart style more inline with the designs:

![3](https://user-images.githubusercontent.com/154014/45959660-0ad34e80-bfe0-11e8-89cd-3af028786ae1.png)

Updates:
* There are only 2 Y-Axis labels now
* The Y-Axis labels now include the currency formatting
* On the `days` chart only, weekend bars are colored with `wooGreyMid`

**Note:**  The designs do call for the y-Axis labels to be on the right-hand side, however there appears to be a layout bug in the iOS Charts lib which is causing the bars to "float" above the X-Axis:

<img width="440" alt="napkin 99 09-24-18 10 06 12 am" src="https://user-images.githubusercontent.com/154014/45960277-7d90f980-bfe1-11e8-8e06-7d2246627e21.png">

...so I'm leaving them on the left side for this PR.

## Testing

* Make sure the unit tests are ✅ 
* Log into Julia's test store and verify you see grey weekend bars on the days chart only
* Verify the Y-Axis updates:
  * Currency symbols on the labels
  * Only 2 axis labels/lines
