### PR TITLE
Dashboard: Fixes pull-to-refresh

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -146,10 +146,26 @@ private extension DashboardViewController {
 
     func reloadData() {
         DDLogInfo("♻️ Requesting dashboard data be reloaded...")
-        storeStatsViewController.syncAllStats()
-        newOrdersViewController.syncNewOrders()
-        topPerformersViewController.syncTopPerformers()
-        refreshControl.endRefreshing()
+        let group = DispatchGroup()
+
+        group.enter()
+        storeStatsViewController.syncAllStats() {
+            group.leave()
+        }
+
+        group.enter()
+        newOrdersViewController.syncNewOrders() {
+            group.leave()
+        }
+
+        group.enter()
+        topPerformersViewController.syncTopPerformers() {
+            group.leave()
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            self?.refreshControl.endRefreshing()
+        }
     }
 
     func applyUnhideAnimation(for view: UIView) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -48,8 +48,9 @@ class NewOrdersViewController: UIViewController {
 //
 extension NewOrdersViewController {
 
-    func syncNewOrders() {
+    func syncNewOrders(onCompletion: (() -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+            onCompletion?()
             return
         }
 
@@ -57,6 +58,7 @@ extension NewOrdersViewController {
             if let error = error {
                 DDLogError("⛔️ Dashboard (New Orders) — Error synchronizing orders: \(error)")
             }
+            onCompletion?()
         }
 
         StoresManager.shared.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -51,10 +51,24 @@ extension StoreStatsViewController {
         }
     }
 
-    func syncAllStats() {
+    func syncAllStats(onCompletion: (() -> Void)? = nil) {
+        let group = DispatchGroup()
+
         periodVCs.forEach { (vc) in
-            syncOrderStats(for: vc.granularity)
-            syncVisitorStats(for: vc.granularity)
+            group.enter()
+            syncOrderStats(for: vc.granularity) { _ in
+                WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": vc.granularity.rawValue])
+                group.leave()
+            }
+
+            group.enter()
+            syncVisitorStats(for: vc.granularity) { _ in
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            onCompletion?()
         }
     }
 }
@@ -106,9 +120,10 @@ private extension StoreStatsViewController {
 //
 private extension StoreStatsViewController {
 
-    func syncVisitorStats(for granularity: StatGranularity) {
+    func syncVisitorStats(for granularity: StatGranularity, onCompletion: ((Error?) -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
             DDLogWarn("⚠️ Tried to sync order stats without a current defaultStoreID")
+            onCompletion?(nil)
             return
         }
 
@@ -118,14 +133,17 @@ private extension StoreStatsViewController {
                                                         quantity: quantity(for: granularity)) { (error) in
             if let error = error {
                 DDLogError("⛔️ Dashboard (Site Stats) — Error synchronizing site visit stats: \(error)")
+                onCompletion?(error)
             }
+            onCompletion?(nil)
         }
         StoresManager.shared.dispatch(action)
     }
 
-    func syncOrderStats(for granularity: StatGranularity) {
+    func syncOrderStats(for granularity: StatGranularity, onCompletion: ((Error?) -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
             DDLogWarn("⚠️ Tried to sync order stats without a current defaultStoreID")
+            onCompletion?(nil)
             return
         }
 
@@ -135,8 +153,9 @@ private extension StoreStatsViewController {
                                                     quantity: quantity(for: granularity)) { (error) in
             if let error = error {
                 DDLogError("⛔️ Dashboard (Order Stats) — Error synchronizing order stats: \(error)")
+                onCompletion?(error)
             }
-            WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
+            onCompletion?(nil)
         }
         StoresManager.shared.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -133,9 +133,8 @@ private extension StoreStatsViewController {
                                                         quantity: quantity(for: granularity)) { (error) in
             if let error = error {
                 DDLogError("⛔️ Dashboard (Site Stats) — Error synchronizing site visit stats: \(error)")
-                onCompletion?(error)
             }
-            onCompletion?(nil)
+            onCompletion?(error)
         }
         StoresManager.shared.dispatch(action)
     }
@@ -153,9 +152,8 @@ private extension StoreStatsViewController {
                                                     quantity: quantity(for: granularity)) { (error) in
             if let error = error {
                 DDLogError("⛔️ Dashboard (Order Stats) — Error synchronizing order stats: \(error)")
-                onCompletion?(error)
             }
-            onCompletion?(nil)
+            onCompletion?(error)
         }
         StoresManager.shared.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -86,9 +86,9 @@ class TopPerformerDataViewController: UIViewController, IndicatorInfoProvider {
 //
 extension TopPerformerDataViewController {
 
-    func syncTopPerformers(onCompletion: ((Error?) -> ())? = nil) {
+    func syncTopPerformers(onCompletion: (() -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
-            onCompletion?(nil)
+            onCompletion?()
             return
         }
 
@@ -98,6 +98,7 @@ extension TopPerformerDataViewController {
             } else {
                 WooAnalytics.shared.track(.dashboardTopPerformersLoaded, withProperties: ["granularity": self?.granularity.rawValue ?? String()])
             }
+            onCompletion?()
         }
         StoresManager.shared.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -41,9 +41,18 @@ class TopPerformersViewController: ButtonBarPagerTabStripViewController {
 //
 extension TopPerformersViewController {
 
-    func syncTopPerformers() {
+    func syncTopPerformers(onCompletion: (() -> Void)? = nil) {
+        let group = DispatchGroup()
+
         dataVCs.forEach { (vc) in
-            vc.syncTopPerformers()
+            group.enter()
+            vc.syncTopPerformers() {
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            onCompletion?()
         }
     }
 }


### PR DESCRIPTION
This PR addresses the immediate dismissal of the refresh spinner on the dashboard screen after pull-to-refresh occurs:

![pulltorefresh_after](https://user-images.githubusercontent.com/154014/46889973-f9d16c80-ce2a-11e8-87a6-7882e3a281cc.gif)

In short, I added `DispatchGroup`s to the stats syncing logic so the `refreshControl` animation can be stopped in more of a controlled manner. Note that this PR simply addresses just the refresh spinner. Any major refactoring around the overall data synchronization logic will be addressed in #322.

Fixes: #309 

## Testing

0. Make sure everything builds without issue
1. Verify the unit tests are ✅ 
2. Run the app and on the dashboard screen pull-to-refresh.
3. Verify the `refreshControl` is not immediately dismissed after it starts animating.

@jleandroperez and @mindgraffiti would either of you mind taking a peek at this? First :shipit: wins! 😃 