### PR TITLE
Updating XLPagerTabStrip Dependency: Swift 4.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ target 'WooCommerce' do
   pod 'Crashlytics', '~> 3.10'
   pod 'KeychainAccess', '~> 3.1'
   pod 'CocoaLumberjack', '~> 3.4'
-  pod 'XLPagerTabStrip', '~> 8.0'
+  pod 'XLPagerTabStrip', '~> 8.1'
   pod 'Charts', '~> 3.2'
 
   # Unit Tests
@@ -116,19 +116,6 @@ end
 # ============
 #
 post_install do |installer|
-
-  # Workaround: SWIFT_VERSION = 4.0 in dependencies that need it
-  # ============================================================
-  #
-  # TODO: Remove as soon as the dependencies get updated!
-  #
-  installer.pods_project.targets.each do |target|
-      if ['XLPagerTabStrip'].include? target.name
-          target.build_configurations.each do |config|
-              config.build_settings['SWIFT_VERSION'] = '4.0'
-          end
-      end
-  end
 
   # Workaround: Drop 32 Bit Architectures
   # =====================================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,18 +5,18 @@ PODS:
     - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
-  - Charts (3.2.0):
-    - Charts/Core (= 3.2.0)
-  - Charts/Core (3.2.0)
+  - Charts (3.2.1):
+    - Charts/Core (= 3.2.1)
+  - Charts/Core (3.2.1)
   - CocoaLumberjack (3.4.2):
     - CocoaLumberjack/Default (= 3.4.2)
     - CocoaLumberjack/Extensions (= 3.4.2)
   - CocoaLumberjack/Default (3.4.2)
   - CocoaLumberjack/Extensions (3.4.2):
     - CocoaLumberjack/Default
-  - Crashlytics (3.10.7):
-    - Fabric (~> 1.7.11)
-  - Fabric (1.7.11)
+  - Crashlytics (3.10.9):
+    - Fabric (~> 1.7.13)
+  - Fabric (1.7.13)
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
@@ -32,7 +32,7 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
   - Gridicons (0.16)
-  - KeychainAccess (3.1.1)
+  - KeychainAccess (3.1.2)
   - lottie-ios (2.5.0)
   - NSObject-SafeExpectations (0.0.3)
   - "NSURL+IDN (0.3)"
@@ -63,9 +63,9 @@ PODS:
   - WordPressShared (1.1.1-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.0.7)
+  - WordPressUI (1.0.8)
   - wpxmlrpc (0.8.3)
-  - XLPagerTabStrip (8.0.1)
+  - XLPagerTabStrip (8.1.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
@@ -78,7 +78,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (= 1.1.0-beta.1)
   - WordPressShared (= 1.1.1-beta.2)
   - WordPressUI (~> 1.0)
-  - XLPagerTabStrip (~> 8.0)
+  - XLPagerTabStrip (~> 8.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -120,15 +120,15 @@ SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   Automattic-Tracks-iOS: d8c6c6c1351b1905a73e45f431b15598d71963b5
-  Charts: 680c8328bd5e90cb14f67e00d2176f3113d19141
+  Charts: f122fb70b19847fa5817d018b77d6c5a2296ab25
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
-  Crashlytics: ccaac42660eb9351b9960c0d66106b0bcf99f4fa
-  Fabric: f233c9492b3bbc1f04e3882986740f7988a58edb
+  Crashlytics: 55e24fc23989680285a21cb1146578d9d18e432c
+  Fabric: 25d0963b691fc97be566392243ff0ecef5a68338
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  KeychainAccess: 7bd430028059754a3debab3cfc0bd1fc7fb85df3
+  KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
@@ -138,10 +138,10 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 904e24e2bcaff4b9d91b34514e87ac55bee470fa
   WordPressKit: a4ccc4bbbc6f8e194becf18b47af212f367fe3ab
   WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
-  WordPressUI: cfcac4a2a033e3ed5def6504bb8e28447c54423b
+  WordPressUI: e50965adee24b4f10da398f6cdbdd3a822274158
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
-  XLPagerTabStrip: c908b17cbf42fcd2598ee1adfc49bae25444d88a
+  XLPagerTabStrip: 22d4c58200d7c105e0e407ab6bfd01a5d85014be
 
-PODFILE CHECKSUM: 8f65818d967811f7366275f2d16515dd15ac0f9e
+PODFILE CHECKSUM: 7b743e34a694c562ebbc18dd87495d82a7781ad7
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
### Details:
- Nukes Swift 4.0 workarounds
- Updates XLPagerTabStrip dependency

@bummytime may i bug you with a tiny PR?

Thanks in advance!!!