### PR TITLE
Dashboard: Ensure fresh data is always displayed within Orders and Visitors section

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -67,4 +67,11 @@ public extension StorageType {
         let predicate = NSPredicate(format: "granularity ==[c] %@", granularity)
         return firstObject(ofType: OrderStats.self, matching: predicate)
     }
+
+    /// Retrieves the Stored OrderStatsItem.
+    ///
+    public func loadOrderStatsItem(period: String) -> OrderStatsItem? {
+        let predicate = NSPredicate(format: "period ==[c] %@", period)
+        return firstObject(ofType: OrderStatsItem.self, matching: predicate)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -44,9 +44,7 @@ class DashboardViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if storeStatsViewController.isDataMissing {
-            reloadData()
-        }
+        reloadData()
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -130,7 +130,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
 extension PeriodDataViewController {
     func clearAllFields() {
         barChartView?.clear()
-        reloadAllFields()
+        reloadAllFields(animateChart: false)
     }
 }
 
@@ -350,7 +350,10 @@ private extension PeriodDataViewController {
             lastUpdatedDate = nil
         }
         reloadOrderFields()
-        reloadChart()
+
+        // Don't animate the chart here - this helps avoid a "double animation" effect if a
+        // small number of values change (the chart WILL be updated correctly however)
+        reloadChart(animateChart: false)
         reloadLastUpdatedField()
     }
 
@@ -364,10 +367,10 @@ private extension PeriodDataViewController {
         isInitialLoad = false
     }
 
-    func reloadAllFields() {
+    func reloadAllFields(animateChart: Bool = true) {
         reloadOrderFields()
         reloadSiteFields()
-        reloadChart()
+        reloadChart(animateChart: animateChart)
         reloadLastUpdatedField()
         view.accessibilityElements = [visitorsTitle, visitorsData, ordersTitle, ordersData, revenueTitle, revenueData, lastUpdated, yAxisAccessibilityView, xAxisAccessibilityView, chartAccessibilityView]
     }
@@ -400,14 +403,16 @@ private extension PeriodDataViewController {
         visitorsData.text = visitorsText
     }
 
-    func reloadChart() {
+    func reloadChart(animateChart: Bool = true) {
         guard barChartView != nil else {
             return
         }
         barChartView.data = generateBarDataSet()
         barChartView.fitBars = true
         barChartView.notifyDataSetChanged()
-        barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
+        if animateChart {
+            barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
+        }
         updateChartAccessibilityValues()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -14,11 +14,6 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
 
     private var periodVCs = [PeriodDataViewController]()
 
-    public var isDataMissing: Bool {
-        return (periodVCs.contains { $0.orderStats == nil }) ||
-            (periodVCs.contains { $0.siteStats == nil })
-    }
-
     // MARK: - View Lifecycle
 
     required init?(coder aDecoder: NSCoder) {

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -193,19 +193,34 @@ extension StatsStore {
 
     /// Updates the provided StorageOrderStats items using the provided read-only OrderStats items
     ///
-    private func handleOrderStatsItems(_ readOnlyStats: Networking.OrderStats, _ storageOrderStats: Storage.OrderStats, _ storage: StorageType) {
+    private func handleOrderStatsItems(_ readOnlyStats: Networking.OrderStats, _ storageStats: Storage.OrderStats, _ storage: StorageType) {
 
-        // Since we are treating the items in core data like a dumb cache, start by nuking all of the existing stored OrderStatsItems
-        storageOrderStats.items?.forEach {
-            storageOrderStats.removeFromItems($0)
-            storage.deleteObject($0)
+        guard let readOnlyItems = readOnlyStats.items, !readOnlyItems.isEmpty else {
+            // No items in the read-only order stats, so remove all the items in Storage.OrderStats
+            storageStats.items?.forEach {
+                storageStats.removeFromItems($0)
+                storage.deleteObject($0)
+            }
+            return
         }
 
-        // Insert the items from the read-only stats
-        readOnlyStats.items?.forEach({ readOnlyItem in
-            let newStorageItem = storage.insertNewObject(ofType: Storage.OrderStatsItem.self)
-            newStorageItem.update(with: readOnlyItem)
-            storageOrderStats.addToItems(newStorageItem)
+        // Upsert the items from the read-only order stats item
+        for readOnlyItem in readOnlyItems {
+            if let existingStorageItem = storage.loadOrderStatsItem(period: readOnlyItem.period) {
+                existingStorageItem.update(with: readOnlyItem)
+            } else {
+                let newStorageItem = storage.insertNewObject(ofType: Storage.OrderStatsItem.self)
+                newStorageItem.update(with: readOnlyItem)
+                storageStats.addToItems(newStorageItem)
+            }
+        }
+
+        // Now, remove any objects that exist in storageStats.items but not in readOnlyStats.items
+        storageStats.items?.forEach({ storageItem in
+            if readOnlyItems.first(where: { $0.period == storageItem.period } ) == nil {
+                storageStats.removeFromItems(storageItem)
+                storage.deleteObject(storageItem)
+            }
         })
     }
 }


### PR DESCRIPTION
This small PR address some dashboard synchronization issues found [here](https://github.com/woocommerce/woocommerce-ios/issues/322#issuecomment-430018772). Now whenever the user opens the dashboard, we will retrieve the latest stats data from the server and update the screen as needed. Additionally, the "double animation" that occurred on the chart should finally be fixed.

Note: that the new order sync issues will be addressed in #348.

Fixes #322 

## Testing

1. Build and run the app — verify unit tests are green
2. Play around with the dashboard screen (switch tabs, pull-to-refresh, background the app + reopen it) - verify the double animation in the chart no longer occurs 🔪 
3. Close the app, place a new order on the store you are logged into, reopen the app - verify the chart/orders fields are updated appropriately
4. With the app open switch to the orders tab, place a new order on the store you are logged into, switch back to the dashboard tab - verify the chart/orders fields are updated appropriately

@jleandroperez can you take a peek at this PR?
