### PR TITLE
Analytics: exclude site information for some tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -57,11 +57,6 @@ private extension TracksProvider {
         userProperties[UserProperties.platformKey] = "iOS"
         userProperties[UserProperties.voiceOverKey] = UIAccessibility.isVoiceOverRunning
         userProperties[UserProperties.rtlKey] = (UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft)
-        if StoresManager.shared.isAuthenticated {
-            let site = StoresManager.shared.sessionManager.defaultSite
-            userProperties[UserProperties.blogIDKey] = site?.siteID
-            userProperties[UserProperties.wpcomStoreKey] = site?.isWordPressStore
-        }
         tracksService.userProperties.removeAllObjects()
         tracksService.userProperties.addEntries(from: userProperties)
     }
@@ -80,7 +75,5 @@ private extension TracksProvider {
         static let platformKey          = "platform"
         static let voiceOverKey         = "accessibility_voice_over_enabled"
         static let rtlKey               = "is_rtl_language"
-        static let blogIDKey            = "blog_id"
-        static let wpcomStoreKey        = "is_wpcom_store"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -66,8 +66,8 @@ public extension WooAnalytics {
     ///   - properties: a collection of properties related to the event
     ///
     func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]?) {
-        if let properties = properties {
-            analyticsProvider.track(stat.rawValue, withProperties: properties)
+        if let updatedProperties = updatePropertiesIfNeeded(for: stat, properties: properties) {
+            analyticsProvider.track(stat.rawValue, withProperties: updatedProperties)
         } else {
             analyticsProvider.track(stat.rawValue)
         }
@@ -84,7 +84,8 @@ public extension WooAnalytics {
         let errorDictionary = [Constants.errorKeyCode: "\(err.code)",
                                Constants.errorKeyDomain: err.domain,
                                Constants.errorKeyDescription: err.description]
-        analyticsProvider.track(stat.rawValue, withProperties: errorDictionary)
+        let updatedProperties = updatePropertiesIfNeeded(for: stat, properties: errorDictionary)
+        analyticsProvider.track(stat.rawValue, withProperties: updatedProperties)
     }
 }
 
@@ -114,7 +115,21 @@ private extension WooAnalytics {
         }
 
         let timeInApp = round(Date().timeIntervalSince(applicationOpenedTime))
-        return [Constants.propertyKeyTimeInApp: timeInApp.description]
+        return [PropertyKeys.propertyKeyTimeInApp: timeInApp.description]
+    }
+
+    /// This function appends any additional properties to the provided properties dict if needed.
+    ///
+    func updatePropertiesIfNeeded(for stat: WooAnalyticsStat, properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
+        guard stat.shouldSendSiteProperties, StoresManager.shared.isAuthenticated else {
+            return properties
+        }
+
+        var updatedProperties = properties ?? [:]
+        let site = StoresManager.shared.sessionManager.defaultSite
+        updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
+        updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressStore
+        return updatedProperties
     }
 }
 
@@ -127,7 +142,11 @@ private extension WooAnalytics {
         static let errorKeyCode         = "error_code"
         static let errorKeyDomain       = "error_domain"
         static let errorKeyDescription  = "error_description"
+    }
 
+    enum PropertyKeys {
         static let propertyKeyTimeInApp = "time_in_app"
+        static let blogIDKey            = "blog_id"
+        static let wpcomStoreKey        = "is_wpcom_store"
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -4,8 +4,8 @@ import WordPressShared
 /// This enum contains all of the events we track in the app. Please reference the "Woo Mobile Events Draft i2"
 /// spreadsheet for more details.
 ///
-/// Note: if you would like to exclude site properties (e.g. `blog_id`) for a given event, please
-/// add the event to the `shouldSendSiteProperties` var.
+/// Note: If you would like to exclude site properties (e.g. `blog_id`) for a given event, please
+/// add the event to the `WooAnalyticsStat.shouldSendSiteProperties` var.
 ///
 public enum WooAnalyticsStat: String {
 


### PR DESCRIPTION
This PR fixes #361 by allowing you to add certain events to a new `shouldSendSiteProperties` var in the `WooAnalyticsStat` enum. If a given event is included there, we will no longer send `blog_id` or `is_wpcom_store` properties with the event.

## Testing

1. Build and run the app - verify the unit tests are ✅ 
2. Log out of the app if you are logged in.
3. Log into the app, open and close the app, and tap around the UI once logged in. 
4. Wait a few minutes and then in the tracks live view, search for event names with `woocommerceios_%` and your username.
5. Verify that the events [listed here](https://github.com/woocommerce/woocommerce-ios/blob/b7bdb257ef5576b1ab4e16006f5ae8865fcd71eb/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift#L140-L153) (maybe not _all_, but at least a few of the events 😄) _do not include_ the `blog_id` or `is_wpcom_store` props:

<img width="372" alt="napkin 102 10-18-18 11 47 49 am copy_resized" src="https://user-images.githubusercontent.com/154014/47170472-b87a0a80-d2cb-11e8-8726-daab1e8447d2.png">

(also in the same event, check out `eventprops` and verify `blog_id` and `is_wpcom_store` are not included)

6. Verify that other events not listed in `shouldSendSiteProperties` _include_ `blog_id` and `is_wpcom_store`:

<img width="372" alt="napkin 102 10-18-18 11 52 41 am copy_resized" src="https://user-images.githubusercontent.com/154014/47170737-65548780-d2cc-11e8-810c-6ce47ceaa76f.png">

@jleandroperez Could I trouble you for a quick review?

/cc @aforcier  
