### PR TITLE
Tracks: fix username alias when switching to authenticated user

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -24,11 +24,7 @@ public class TracksProvider: AnalyticsProvider {
 //
 public extension TracksProvider {
     func refreshUserData() {
-        if StoresManager.shared.isAuthenticated, let account = StoresManager.shared.sessionManager.defaultAccount {
-            tracksService.switchToAuthenticatedUser(withUsername: account.username, userID: String(account.userID), skipAliasEventCreation: true)
-        } else {
-            tracksService.switchToAnonymousUser(withAnonymousID: StoresManager.shared.sessionManager.anonymousUserID)
-        }
+        switchTracksUsersIfNeeded()
         refreshMetadata()
     }
 
@@ -51,6 +47,27 @@ public extension TracksProvider {
 // MARK: - Private Helpers
 //
 private extension TracksProvider {
+    func switchTracksUsersIfNeeded() {
+        let currentAnalyticsUsername = UserDefaults.standard[.analyticsUsername] as? String ?? ""
+        if StoresManager.shared.isAuthenticated, let account = StoresManager.shared.sessionManager.defaultAccount {
+            if currentAnalyticsUsername.isEmpty {
+                // No previous username logged
+                UserDefaults.standard[.analyticsUsername] = account.username
+                tracksService.switchToAuthenticatedUser(withUsername: account.username, userID: String(account.userID), skipAliasEventCreation: false)
+            } else if currentAnalyticsUsername == account.username {
+                // Username did not change - just make sure Tracks client has it
+                tracksService.switchToAuthenticatedUser(withUsername: account.username, userID: String(account.userID), skipAliasEventCreation: true)
+            } else {
+                // Username changed for some reason - switch back to anonymous first
+                tracksService.switchToAnonymousUser(withAnonymousID: StoresManager.shared.sessionManager.anonymousUserID)
+                tracksService.switchToAuthenticatedUser(withUsername: account.username, userID: String(account.userID), skipAliasEventCreation: false)
+            }
+        } else {
+            UserDefaults.standard[.analyticsUsername] = nil
+            tracksService.switchToAnonymousUser(withAnonymousID: StoresManager.shared.sessionManager.anonymousUserID)
+        }
+    }
+
     func refreshMetadata() {
         DDLogInfo("♻️ Refreshing tracks metadata...")
         var userProperties = [String: Any]()

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -11,6 +11,7 @@ extension UserDefaults {
         case defaultStoreID
         case defaultAnonymousID
         case versionOfLastRun
+        case analyticsUsername
     }
 }
 


### PR DESCRIPTION
This PR fixes #370 by making sure we call `tracksService.switchToAuthenticatedUser(_, _, skipAliasEventCreation: true)` at the appropriate times. (We were not previously.)

## Testing

This is kind of hard to test, but try these steps:

0. Make sure my logic here makes sense (taken from WPiOS)
1. Build and run the unit tests - verify they are ✅ 
2. Set breakpoints in `TracksProvider.swift` on lines 56, 59, 62, and 67
3. Do a fresh install of the app
4. Log in and verify the breakpoint on line 56 hits — continue
5. Stop and start the app — verify the breakpoint on line 59 hits — continue
6. Log out of the app — verify the breakpoint on line 67 hits — continue

@jleandroperez would you be so kind to take a 👀 at this?

/cc @aforcier 