### PR TITLE
"My Store" --> "My store"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -73,7 +73,7 @@ private extension DashboardViewController {
     }
 
     func configureNavigation() {
-        title = NSLocalizedString("My Store", comment: "Dashboard navigation title")
+        title = NSLocalizedString("My store", comment: "Dashboard navigation title")
         let rightBarButton = UIBarButtonItem(image: Gridicon.iconOfType(.cog),
                                              style: .plain,
                                              target: self,

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -22,7 +22,7 @@ enum WooTab: Int, CustomStringConvertible {
     var description: String {
         switch self {
         case .myStore:
-            return NSLocalizedString("My Store", comment: "Dashboard tab title")
+            return NSLocalizedString("My store", comment: "My store tab title")
         case .orders:
             return NSLocalizedString("Orders", comment: "Orders tab title")
         case .notifications:


### PR DESCRIPTION
![3 copy](https://user-images.githubusercontent.com/154014/47379535-c9a68b00-d6c0-11e8-90f2-0f7b290ccf1a.png)

Fixes #374 — "My Store" becomes "My store" in the navbar and tab bar.

## Testing

Build and run the app — verify that "My store" appears in the tab and nav bars.

@jleandroperez could you take a quick look at this?

/cc @aforcier 