### PR TITLE
Fixed: App crash upon tapping Filter Orders by Status

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -193,6 +193,10 @@ extension OrdersViewController {
             }
         }
 
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.barButtonItem = navigationItem.rightBarButtonItem
+        popoverController?.sourceView = self.view
+
         present(actionSheet, animated: true)
     }
 


### PR DESCRIPTION
Fixes #379. 

- crash due to missing implementation of UIPopoverPresentationController for iPad compatibility

## To test
- on an iPad simulator or testing device, open the Orders tab
- tap the 'Filter' button in the top right corner of the nav bar

Expected behavior:
The popover appears with filter options and filters orders by the chosen status.