### PR TITLE
Adds site settings fetch

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -28,7 +28,8 @@ class AuthenticatedState: StoresManagerState {
             NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             OrderNoteStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
-            StatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+            StatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         ]
     }
 

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -161,6 +161,21 @@ private extension StoresManager {
         dispatch(action)
     }
 
+    /// Loads the specified site settings, if possible.
+    ///
+    func fetchSiteSettings(with siteID: Int) {
+        guard siteID != 0 else {
+            // Just return if the siteID == 0 so we are not making extra requests
+            return
+        }
+        let action = SettingAction.retrieveSiteSettings(siteID: siteID) { error in
+            if let error = error {
+                DDLogWarn("⚠️ Could not successfully fetch settings for siteID \(siteID): \(error)")
+            }
+        }
+        dispatch(action)
+    }
+
     /// Loads the Default Site into the current Session, if possible.
     ///
     func restoreSessionSiteIfPossible() {
@@ -169,6 +184,7 @@ private extension StoresManager {
         }
 
         restoreSessionSite(with: siteID)
+        fetchSiteSettings(with: siteID)
     }
 
     /// Loads the specified siteID into the Session, if possible.

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -11,7 +11,7 @@ public class SettingStore: Store {
     /// Registers for supported Actions.
     ///
     override public func registerSupportedActions(in dispatcher: Dispatcher) {
-        dispatcher.register(processor: self, for: OrderNoteAction.self)
+        dispatcher.register(processor: self, for: SettingAction.self)
     }
 
     /// Receives and executes Actions.


### PR DESCRIPTION
This PR adds the site settings fetch logic (once per app launch) by:

* Adding the new `SettingStore` to `AuthenticatedState`'s active services array
* Updates the `StoresManager` with a new `fetchSiteSettings()` func and calls it from `restoreSessionSiteIfPossible()` 
* Fixes a typo in `SettingStore` 

Ref: #312 

## Testing

1. Make sure unit tests are all ✅ 
2. Set a break point [here](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Stores/SettingStore.swift#L48)
3. Build and run the app — verify the breakpoint is hit shortly after launching (and the SQLite db is populated with values if you want)

@mindgraffiti and @jleandroperez could either of you take a peek at this quick PR?