### PR TITLE
Update credentials file path

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1238,7 +1238,7 @@
 				"$(SRCROOT)/Credentials/replace_secrets.rb",
 				"$(SRCROOT)/Credentials/ApiCredentials.tpl",
 				"$(SRCROOT)/Credentials/InfoPlist.tpl",
-				"~/.woo_app_credentials.json",
+				"~/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json",
 			);
 			outputPaths = (
 				"$(SRCROOT)/DerivedSources/ApiCredentials.swift",
@@ -1539,7 +1539,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Debug;
@@ -1550,7 +1550,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_PREFIX_HEADER = InfoPlist.h;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json";
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Release;
@@ -1688,7 +1688,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce Development";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1713,7 +1713,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "WooCommerce App Store";
-				SECRETS_PATH = $HOME/.woo_app_credentials.json;
+				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";

--- a/WooCommerce/buddybuild_prebuild.sh
+++ b/WooCommerce/buddybuild_prebuild.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 echo "warning: Detected Prebuild Step"
-cp ${BUDDYBUILD_SECURE_FILES}/woo_app_credentials.json ~/.woo_app_credentials.json
+mkdir -p ~/.mobile-secrets/iOS/WCiOS/
+cp ${BUDDYBUILD_SECURE_FILES}/woo_app_credentials.json ~/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json
 echo "warning: Copied files over"
 


### PR DESCRIPTION
This PR updates the path of the credentials file so that it's picked from the credentials repository.

To Test:
1. Try to build the app and verify it raises an error because of the missing credentials file.
2. Update the credentials repository.
3. Try to build the app and verify the build succeeds.
4. Smoke test the services that use credentials (login, google logic, etc.).

