### PR TITLE
OrderNoteTableViewCell: Restoring statusLabel Default Color

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/OrderNoteTableViewCell.swift
@@ -85,8 +85,9 @@ private extension OrderNoteTableViewCell {
     ///
     func configureLabels() {
         dateLabel.applyBodyStyle()
-        statusLabel.applyBodyStyle()
         noteLabel.applyBodyStyle()
+        statusLabel.applyBodyStyle()
+        statusLabel.textColor = StyleManager.wooGreyMid
     }
 
     /// Setup: Icon Button


### PR DESCRIPTION
### Details:
I've missed the **OrderNote**'s Status Label Color, in one of the last refactors.

In this PR we're restoring the **Status Label**'s gray color.

cc @mindgraffiti @bummytime 
Sorry about missing this one!!

### Testing:
1. Launch Woo
2. Open Orders > Any Order

Verify that the Note's "Privacy Label" is displayed in the Grey Mid color (it's precisely the label that reeads `Private Note` or `Note to Customer`).
