### PR TITLE
Notifications: Bring text style inline with design

### DIFF
--- a/WooCommerce/Classes/Extensions/NSParagraphStyle+Woo.swift
+++ b/WooCommerce/Classes/Extensions/NSParagraphStyle+Woo.swift
@@ -18,6 +18,12 @@ extension NSParagraphStyle {
         return NSMutableParagraphStyle(standardLineHeightUsingFont: UIFont.body)
     }
 
+    /// Returns a ParagraphStyle with it's minimum Line Height set to accomodate `UIFont.footnote`
+    ///
+    static var footnote: NSParagraphStyle {
+        return NSMutableParagraphStyle(standardLineHeightUsingFont: UIFont.footnote)
+    }
+
     /// Returns a ParagraphStyle with it's minimum Line Height set to accomodate `UIFont.body` / Centered
     ///
     static var badge: NSParagraphStyle {

--- a/WooCommerce/Classes/Tools/StringFormatter/StringStyles.swift
+++ b/WooCommerce/Classes/Tools/StringFormatter/StringStyles.swift
@@ -60,11 +60,11 @@ extension StringStyles {
     /// Styles: Notifications List / Subject Block
     ///
     static let subject: StringStyles = {
-        let regular: Style      = [.paragraphStyle: NSParagraphStyle.subheadline, .font: UIFont.subheadline, .foregroundColor: StyleManager.defaultTextColor]
-        let bold: Style         = [.paragraphStyle: NSParagraphStyle.subheadline, .font: UIFont.subheadline.bold]
-        let blockquote: Style   = [.paragraphStyle: NSParagraphStyle.subheadline, .font: UIFont.subheadline.italics]
-        let italics: Style      = [.paragraphStyle: NSParagraphStyle.subheadline, .font: UIFont.subheadline.italics]
-        let noticon: Style      = [.paragraphStyle: NSParagraphStyle.subheadline, .font: UIFont.noticon(forStyle: .subheadline), .foregroundColor: StyleManager.defaultTextColor]
+        let regular: Style      = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body, .foregroundColor: StyleManager.defaultTextColor]
+        let bold: Style         = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.bold]
+        let blockquote: Style   = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.italics]
+        let italics: Style      = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.italics]
+        let noticon: Style      = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.noticon(forStyle: .body), .foregroundColor: StyleManager.wooGreyMid]
 
         return StringStyles(regular: regular, bold: bold, blockquote: blockquote, italics: italics, match: nil, noticon: noticon)
     }()
@@ -73,8 +73,7 @@ extension StringStyles {
     /// Styles: Notifications List / Snippet Block
     ///
     static let snippet: StringStyles = {
-        let regular: Style      = [.paragraphStyle: NSParagraphStyle.subheadline, .font: UIFont.footnote, .foregroundColor: StyleManager.defaultTextColor]
-
+        let regular: Style = [.paragraphStyle: NSParagraphStyle.footnote, .font: UIFont.footnote, .foregroundColor: StyleManager.defaultTextColor]
         return StringStyles(regular: regular)
     }()
 
@@ -108,7 +107,7 @@ extension StringStyles {
         let match: Style        = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.bold, .foregroundColor: StyleManager.defaultTextColor]
         let noticon: Style      = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.noticon(forStyle: .body), .foregroundColor: StyleManager.defaultTextColor]
         let italic: Style       = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.italics, .foregroundColor: StyleManager.defaultTextColor]
-        let link: Style         = [.foregroundColor: StyleManager.defaultTextColor]
+        let link: Style         = [.foregroundColor: StyleManager.wooCommerceBrandColor]
 
         return StringStyles(regular: regular, bold: bold, blockquote: blockquote, match: match, noticon: noticon, link: link)
     }()

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.xib
@@ -27,8 +27,8 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fNu-km-jyX">
-                        <rect key="frame" x="55" y="11" width="304" height="39"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="fNu-km-jyX">
+                        <rect key="frame" x="55" y="11" width="304" height="42"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Subject" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ow4-CR-HAI" userLabel="Subject Label">
                                 <rect key="frame" x="0.0" y="0.0" width="304" height="19.5"/>
@@ -37,7 +37,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Snippet" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQs-0C-rb6" userLabel="Snippet Label">
-                                <rect key="frame" x="0.0" y="19.5" width="304" height="19.5"/>
+                                <rect key="frame" x="0.0" y="22.5" width="304" height="19.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>


### PR DESCRIPTION
![3 copy_resized](https://user-images.githubusercontent.com/154014/48568005-05013780-e8c4-11e8-95e9-67214af7a6b5.png)

Just a quick PR to bring the notification text style inline with the [i6 designs](https://sketch.cloud/s/gZ75a/Og2zJw). Also removes the `NukeMe` struct.

Ref: #19

## Testing

1. Open the notifications screen (for testing, it may help to remove the [filter here](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift#L22))
2. Make sure everything looks ok.

@jleandroperez can you take a quick 👀 at this? Thanks!
