### PR TITLE
Notifications: Tweaked NoteTableViewCell for dynamic type

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.xib
@@ -18,27 +18,28 @@
                 <rect key="frame" x="0.0" y="0.0" width="375" height="87.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDO-G5-bNl">
-                        <rect key="frame" x="14" y="11" width="25" height="20.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDO-G5-bNl">
+                        <rect key="frame" x="14" y="11" width="25" height="25"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="25" id="Eqv-DJ-O5N"/>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="25" id="Eqv-DJ-O5N"/>
+                            <constraint firstAttribute="width" secondItem="MDO-G5-bNl" secondAttribute="height" multiplier="1:1" id="GCe-Ud-F7E"/>
                         </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="fNu-km-jyX">
-                        <rect key="frame" x="55" y="11" width="304" height="42"/>
+                        <rect key="frame" x="55" y="11" width="304" height="39.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Subject" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ow4-CR-HAI" userLabel="Subject Label">
-                                <rect key="frame" x="0.0" y="0.0" width="304" height="19.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Subject" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ow4-CR-HAI" userLabel="Subject Label">
+                                <rect key="frame" x="0.0" y="0.0" width="304" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Snippet" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQs-0C-rb6" userLabel="Snippet Label">
-                                <rect key="frame" x="0.0" y="22.5" width="304" height="19.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Snippet" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQs-0C-rb6" userLabel="Snippet Label">
+                                <rect key="frame" x="0.0" y="23.5" width="304" height="16"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>


### PR DESCRIPTION
![3](https://user-images.githubusercontent.com/154014/48581172-ac8f6180-e8e6-11e8-9849-867c26e71987.png)

Just some small layout tweaks for NoteTableViewCell — makes dynamic type work better.

Ref: #19 

## Testing

1. Build and run the app
2. Increase the type size in Settings (or use the Accessibility inspector with the sim - note, you may have to stop and re-launch the app to get the newly-changed settings to render properly)
3. Verify everything in the Notifications lists looks ok (with various type sizes)

@jleandroperez a quick peek if you don't mind?