### PR TITLE
Notifications: Move read-all navbar button to left side

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -123,15 +123,15 @@ private extension NotificationsViewController {
     /// Setup: NavigationBar Buttons
     ///
     func configureNavigationBarButtons() {
-        let rightBarButton = UIBarButtonItem(image: Gridicon.iconOfType(.menus),
+        let leftBarButton = UIBarButtonItem(image: Gridicon.iconOfType(.checkmark),
                                              style: .plain,
                                              target: self,
                                              action: #selector(markAllAsRead))
-        rightBarButton.tintColor = .white
-        rightBarButton.accessibilityTraits = .button
-        rightBarButton.accessibilityLabel = NSLocalizedString("Mark All as Read", comment: "Accessibility label for the Mark All Notifications as Read Button")
-        rightBarButton.accessibilityHint = NSLocalizedString("Marks Every Notification as Read", comment: "VoiceOver accessibility hint for the Mark All Notifications as Read Action")
-        navigationItem.rightBarButtonItem = rightBarButton
+        leftBarButton.tintColor = .white
+        leftBarButton.accessibilityTraits = .button
+        leftBarButton.accessibilityLabel = NSLocalizedString("Mark All as Read", comment: "Accessibility label for the Mark All Notifications as Read Button")
+        leftBarButton.accessibilityHint = NSLocalizedString("Marks Every Notification as Read", comment: "VoiceOver accessibility hint for the Mark All Notifications as Read Action")
+        navigationItem.leftBarButtonItem = leftBarButton
     }
 
     /// Setup: TableView


### PR DESCRIPTION
Per the i6 designs, the "read all" navbar button is on the left side and a checkmark:

<img width="768" alt="screen shot 2018-11-15 at 3 36 40 pm" src="https://user-images.githubusercontent.com/154014/48583267-4ad1f600-e8ec-11e8-8177-7249e0d25db5.png">

This PR address that:

![3 copy](https://user-images.githubusercontent.com/154014/48583142-fcbcf280-e8eb-11e8-8f4e-11bbc8b86172.png)

Ref: #19 

## Testing

Make sure the read all button looks ok and still works!

