### PR TITLE
Notifications: Adds last seen logic to NotificationsVC

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -14,6 +14,7 @@ extension UserDefaults {
         case userOptedInCrashlytics
         case versionOfLastRun
         case analyticsUsername
+        case notificationsLastSeenTime
     }
 }
 


### PR DESCRIPTION
Just a quick PR to add the "last seen" logic to `NotificationsViewController`. Last seen will only be updated for the first notification in the filtered list (vs. all of a user's .com notifications).  

Additionally the the update is triggered on `viewWillAppear()` in `NotificationsViewController` — if this is not correct, please advise @jleandroperez :-)

Ref: #19 

## Testing

### Scenario 1: Send update after receiving new notification
0. Set a breakpoint on L239 in `NotificationsViewController`
1. Build and run the app
2. On the web, review a product and wait to receive the notification
3. In WCiOS navigate to the Notifications tab
4. Verify the breakpoint on L239 is hit 

### Scenario 2: Don't send update if notifications are all seen
0. Set a breakpoint on L231 in `NotificationsViewController`
1. Build and run the app
2. On the web, ensure that there are no new product review or new order notifications
3. In WCiOS navigate to the Notifications tab
4. Verify the breakpoint on L231 is hit

@jleandroperez could you take a quick peek at this?