### PR TITLE
NotificationsViewController: Restoring `tableView.endUpdates()`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -158,13 +158,19 @@ private extension NotificationsViewController {
     ///
     func configureResultsController() {
         resultsController.startForwardingEvents(to: tableView)
+
+        // The following two assignments are actually overridding wiring performed by `startForwardingEvents`.
+        // FIXME: NUKE them ASAP
+        //
         resultsController.onDidChangeContent = { [weak self] in
             // FIXME: This should be removed once `PushNotificationsManager` is in place
             self?.updateNotificationsTabIfNeeded()
+            self?.tableView?.endUpdates()
         }
-        resultsController.onDidResetContent = {
+        resultsController.onDidResetContent = { [weak self] in
             // FIXME: This should be removed once `PushNotificationsManager` is in place
             MainTabBarController.hideDotOn(.notifications)
+            self?.tableView?.reloadData()
         }
         try? resultsController.performFetch()
     }


### PR DESCRIPTION
### Details:
I've spotted inconsistencies between the sqlite DB and the actual UI. Bottom line is:

`resultsController.startForwardingEvents(to: tableView)` sets up a series of closures, so that they keep in sync the UITableView <> DB.

One line below that call, we're reassigning `onDidChangeContent` and `onDidResetContent`, which resulted in missing `tableView.endUpdates`.

This means that the tableView was getting stuck in Update mode, and not actually rendering the latest.

In this PR we're implementing a (temporary) band aid fix, which is just to manually call the `endUpdates` method.

cc @bummytime 
Closes #445

Thanks in advance Matt!!

### Testing:
@bummytime mind trying to re-trigger #445?. On my end, repro steps were as simple as:

1. Launch WC
2. Open the Notifications Tab
3. Wait until the Sync OP finishes
4. As a result, there would be several (invisible) rows taking space.
