### PR TITLE
Notifications: Adds filtering

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -150,6 +150,12 @@ public enum WooAnalyticsStat: String {
     case notificationsListPulledToRefresh       = "notifications_list_pulled_to_refresh"
     case notificationsListReadAllTapped         = "notifications_list_menu_mark_read_button_tapped"
     case notificationsListFilterTapped          = "notifications_list_menu_filter_tapped"
+    case filterNotificationsOptionSelected      = "filter_notifications_by_status_dialog_option_selected"
+
+    // Notification Data/Action Events
+    //
+    case notificationListLoaded                 = "notifications_loaded"
+    case notificationListFilter                 = "notifications_filter"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -289,11 +289,10 @@ private extension NotificationsViewController {
 private extension NotificationsViewController {
 
     func didChangeFilter(newFilter: NoteTypeFilter?) {
-        //        WooAnalytics.shared.track(.filterOrdersOptionSelected,
-        //                                  withProperties: ["status": newFilter?.rawValue ?? String()])
-        //        WooAnalytics.shared.track(.ordersListFilterOrSearch,
-        //                                  withProperties: ["filter": newFilter?.rawValue ?? String(),
-        //                                                   "search": ""])
+                WooAnalytics.shared.track(.filterNotificationsOptionSelected,
+                                          withProperties: ["status": newFilter?.rawValue ?? String()])
+                WooAnalytics.shared.track(.notificationListFilter,
+                                          withProperties: ["range": newFilter?.rawValue ?? String()])
 
         // Display the Filter in the Title
         refreshTitle()
@@ -364,6 +363,8 @@ private extension NotificationsViewController {
         let action = NotificationAction.synchronizeNotifications { error in
             if let error = error {
                 DDLogError("⛔️ Error synchronizing notifications: \(error)")
+            } else {
+                WooAnalytics.shared.track(.notificationListLoaded)
             }
 
             self.transitionToResultsUpdatedState()


### PR DESCRIPTION
This PR adds filtering to the notifications screen:

![note_filtering](https://user-images.githubusercontent.com/154014/48802797-e04afc80-ecd5-11e8-8461-92db2819f8af.gif)

The logic is very similar to the way we filter things on the order list screen (which includes updating the screen title). Additionally, we are now disabling the navbar buttons if we enter the `syncing` or `empty` states:

![disable_navbars](https://user-images.githubusercontent.com/154014/48802852-f8bb1700-ecd5-11e8-993e-68a9ea6d4e08.gif) 

(and re-enabling the buttons in the `results` state).

Ref: #19 

## Testing

* Make sure all the code makes sense! 🤠 
* Make sure the code builds and all unit tests are ✅ 

### Scenario 1: Verify the navbar buttons are enabled when notifications exist
0. Build and run the app — log out of the current store
1. Log into a store **with existing notifs**
2. Switch to the notifications tab
3. Verify the navbar buttons are **not** enabled while the screen is sync'ing
4. Verify the navbar buttons **are** enabled when results appear

### Scenario 2: Verify the navbar buttons are disabled when no notifications exist
0. Build and run the app — log out of the current store
1. Log into a store with **no existing notifs**
2. Switch to the notifications tab
3. Verify the navbar buttons are **not** enabled while the screen is sync'ing
4. Verify the navbar buttons are **not**  enabled when the empty results appears

### Scenario 3: Verify the filter works properly
0. Build and run the app — log out of the current store
1. Log into a store with existing review **AND** order notifs
2. Switch to the notifications tab
3. Verify the screen initially loads all notifications
4. Switch to the Review filter
5. Verify the screen displays only review notifications
6. Switch to the Orders filter
7. Verify the screen displays loads only order notifications
8. Switch to the "All" filter
9. Verify the screen displays all notifications again

### Scenario 4: Verify the mark-all-as-read functionality still works
0. Build and run the app — log out of the current store
1. Log into a store with **NEW** review **AND** order notifs
2. Switch to the notifications tab
3. Verify the screen initially loads all notifications and the unread notifs are present
4. Switch to the Reviews filter
5. Verify the screen displays all unread+read review notifs
6. Tap the checkmark to mark all review notifs as read
7. Verify only the review notifs are marked as read (on web too after a few seconds
8. Switch to the Orders filter
9. Verify the screen displays all unread+read order notifs (there is only usually one 😏)
10. Tap the checkmark to mark all order notifs as read
11. Verify only the order notifs are marked as read (on the web too after a few seconds

@jleandroperez would you mind taking a look at this for me! Thanks!!
