### PR TITLE
Disable "Add" button after it's tapped.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/AddNote/AddANoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetails/AddNote/AddANoteViewController.swift
@@ -64,7 +64,7 @@ class AddANoteViewController: UIViewController {
 
     @objc func addButtonTapped() {
         navigationItem.rightBarButtonItem?.isEnabled = false
-        
+
         WooAnalytics.shared.track(.orderNoteAddButtonTapped)
         WooAnalytics.shared.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.order.orderID,
                                                                   "status": viewModel.order.status.rawValue,


### PR DESCRIPTION
Fixes #430.

Disable the "Add" button when adding a new order note.