### PR TITLE
NotificationsViewController: Preventing contentOffset Jumps

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -79,6 +79,10 @@ class NotificationsViewController: UIViewController {
     ///
     private var snippetStorage = [Int64: NSAttributedString]()
 
+    /// Keep track of the (Autosizing Cell's) Height. This helps us prevent UI flickers, due to sizing recalculations.
+    ///
+    private var estimatedRowHeights = [IndexPath: CGFloat]()
+
     /// String Formatter: Given a NoteBlock, this tool will return an AttributedString.
     ///
     private let formatter = StringFormatter()
@@ -194,7 +198,6 @@ private extension NotificationsViewController {
     func configureTableView() {
         view.backgroundColor = StyleManager.tableViewBackgroundColor
         tableView.backgroundColor = StyleManager.tableViewBackgroundColor
-        tableView.rowHeight = UITableView.automaticDimension
         tableView.refreshControl = refreshControl
     }
 
@@ -445,6 +448,14 @@ extension NotificationsViewController: UITableViewDelegate {
         return UITableView.automaticDimension
     }
 
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return estimatedRowHeights[indexPath] ?? Settings.estimatedRowHeight
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return estimatedRowHeights[indexPath] ?? UITableView.automaticDimension
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
@@ -458,6 +469,16 @@ extension NotificationsViewController: UITableViewDelegate {
         default:
             presentNotificationDetails(for: note)
         }
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+
+        // Preserve the Cell Height
+        // Why: Because Autosizing Cells, upon reload, will need to be laid yout yet again. This might cause
+        // UI glitches / unwanted animations. By preserving it, *then* the estimated will be extremely close to
+        // the actual value. AKA no flicker!
+        //
+        estimatedRowHeights[indexPath] = cell.frame.height
     }
 }
 
@@ -717,6 +738,7 @@ private extension NotificationsViewController {
     }
 
     enum Settings {
+        static let estimatedRowHeight = CGFloat(86)
         static let placeholderRowsPerSection = [3]
     }
 


### PR DESCRIPTION
### Details:
This PR brings a fix analog to the one included in #456 (for Orders). We're implementing a Row Heights cache, which helps us prevent offset jumps.

cc @bummytime @mindgraffiti 
(Thank you!!)


### Testing:
1. Log into Woo
2. Open the notifications tab
3. Scroll all the way to the bottom
4. Switch to the Orders tab, and back to Notifications (so that a Sync event is triggered)

- [x] Verify that after few secodns (all of the) rows get refreshed (you should see a slight fade in)
- [x] Verify that the contentOffset.y doesn't jump during this refresh event
