### PR TITLE
Disabled mark-as-seen on the notification list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -152,8 +152,12 @@ class NotificationsViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        synchronizeNotifications { [weak self] in
-            self?.updateLastSeenTime()
+        synchronizeNotifications() {
+            // FIXME: This is being disabled temporarily because of a race condition caused with WPiOS.
+            // We should consider updating and re-enabling this logic (when updates happen on the server) at a later time.
+            // See this issue for more deets: https://github.com/woocommerce/woocommerce-ios/issues/469
+            //
+            //self?.updateLastSeenTime()
         }
     }
 }


### PR DESCRIPTION
Tiny PR that temporarily disables the mark-as-seen call when sync'ing notifications on `NotificationsViewController`. Hopefully we can bring this back some day. 😿

Fixes #469 