### PR TITLE
Ignore Local Configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ fastlane/test_output
 fastlane/README.md 
 
 \.DS_Store
+
+# Ignore Local Configuration files (like the ones used for Fastlane)
+.env


### PR DESCRIPTION
Ignore the fastlane `.env` file, as well as any others that come up 