### PR TITLE
Updated all Woo endpoints to v3

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -28,7 +28,7 @@ public class OrdersRemote: Remote {
         ]
 
         let path = Constants.ordersPath
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = OrderListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -43,7 +43,7 @@ public class OrdersRemote: Remote {
     ///
     public func loadOrder(for siteID: Int, orderID: Int, completion: @escaping (Order?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/\(orderID)"
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = OrderMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -58,7 +58,7 @@ public class OrdersRemote: Remote {
     ///
     public func loadOrderNotes(for siteID: Int, orderID: Int, completion: @escaping ([OrderNote]?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/\(orderID)/\(Constants.notesPath)/"
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = OrderNotesMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -77,7 +77,7 @@ public class OrdersRemote: Remote {
         let parameters = [ParameterKeys.status: status]
         let mapper = OrderMapper(siteID: siteID)
 
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
 
@@ -97,7 +97,7 @@ public class OrdersRemote: Remote {
                           ParameterKeys.customerNote: String(isCustomerNote)]
         let mapper = OrderNoteMapper()
 
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
 }

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -14,7 +14,7 @@ public class SiteSettingsRemote: Remote {
     ///
     public func loadGeneralSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.generalSettingsPath
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = SiteSettingsMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -41,6 +41,9 @@ struct JetpackRequest: URLRequestConvertible {
     ///     - parameters: Collection of Key/Value parameters, to be forwarded to the Jetpack Connected site.
     ///
     init(wooApiVersion: WooAPIVersion, method: HTTPMethod, siteID: Int, path: String, parameters: [String: String]? = nil) {
+        if [.mark1, .mark2].contains(wooApiVersion) {
+            DDLogWarn("⚠️ You are using an older version of the Woo REST API: \(wooApiVersion.rawValue), for path: \(path)")
+        }
         self.wooApiVersion = wooApiVersion
         self.method = method
         self.siteID = siteID

--- a/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
@@ -8,7 +8,7 @@ class JetpackRequestTests: XCTestCase {
 
     /// Testing API Version
     ///
-    private let sampleWooApiVersion = WooAPIVersion.mark2
+    private let sampleWooApiVersion = WooAPIVersion.mark3
 
     /// Sample SiteID
     ///
@@ -33,7 +33,7 @@ class JetpackRequestTests: XCTestCase {
     /// Verifies that a POST JetpackRequest will query the Jetpack Tunneled WordPress.com API.
     ///
     func testPostRequestQueriesDotcomJetpackTunnelEndpointWithNoExtraQueryParameters() {
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .post, siteID: sampleSiteID, path: sampleRPC, parameters: sampleParameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: sampleSiteID, path: sampleRPC, parameters: sampleParameters)
 
         let expectedURL = URL(string: jetpackEndpointBaseURL)!
         let generatedURL = try! request.asURLRequest().url!
@@ -43,7 +43,7 @@ class JetpackRequestTests: XCTestCase {
     /// Verifies that a POST JetpackRequest will serialize all of the Tunneling Parameters in the request body.
     ///
     func testPostRequestQueriesDotcomJetpackTunnelEndpointWithItsParametersInTheBody() {
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .post, siteID: sampleSiteID, path: sampleRPC, parameters: sampleParameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: sampleSiteID, path: sampleRPC, parameters: sampleParameters)
 
         guard let urlRequest = try? request.asURLRequest(),
             let generatedBodyAsData = urlRequest.httpBody,
@@ -60,7 +60,7 @@ class JetpackRequestTests: XCTestCase {
     /// Verifies that a GET JetpackRequest will query the Jetpack Tunneled WordPress.com API, with the expected query parameters.
     ///
     func testGetRequestQueriesDotcomJetpackTunnelEndpointWithExpectedQueryParameters() {
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: sampleSiteID, path: sampleRPC)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: sampleSiteID, path: sampleRPC)
 
         let expectedURL = URL(string: jetpackEndpointBaseURL + queryParameters(for: request))!
         let generatedURL = try! request.asURLRequest().url!
@@ -70,7 +70,7 @@ class JetpackRequestTests: XCTestCase {
     /// Verifies that a GET JetpackRequest will not serialize anything in the body.
     ///
     func testGetRequestDoesNotSerializeAnythingInTheBody() {
-        let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: sampleSiteID, path: sampleRPC, parameters: sampleParameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: sampleSiteID, path: sampleRPC, parameters: sampleParameters)
 
         let output = try! request.asURLRequest()
         XCTAssertNil(output.httpBody)


### PR DESCRIPTION
The first of a few PRs where we migrate to the WC REST v3 API.  This specific PR updates all of the `JetpackRequest` inits to use the `.mark3` API version.

Fixes #479 

## Testing

- [x] Make sure the unit tests are ✅ 
- [x] Build & run the app — verify all aspects of the Orders List screen works
- [x] Build & run the app — verify all aspects of the Order Detail screen works
- [x] Build & run the app — verify all aspects of the Order Notes screen works

Also, you may want to put a breakpoint [here](https://github.com/woocommerce/woocommerce-ios/blob/e68659863a979f7fb1ea887a676f260caf9da7ad/Networking/Networking/Requests/JetpackRequest.swift#L45) while testing (the runtime should never break on this line).

@jleandroperez or @mindgraffiti  would you mind taking a quick look at this?
