### PR TITLE
Remove parenthesis to silence danger warning

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/StarRatingView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/StarRatingView.swift
@@ -16,7 +16,7 @@ class RatingView: UIView {
             return _rating
         }
         set (newRating) {
-            guard (newRating >= Defaults.minRating) else {
+            guard newRating >= Defaults.minRating else {
                 _rating = Defaults.minRating
                 return
             }


### PR DESCRIPTION
Danger was grouchy about the parenthesis – this makes it happy (but is danger ever _really_ happy?)