### PR TITLE
OrdersViewController: Listening to Account Updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -88,6 +88,10 @@ class OrdersViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
+    deinit {
+        stopListeningToNotifications()
+    }
+
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         fatalError()
     }
@@ -104,11 +108,14 @@ class OrdersViewController: UIViewController {
 
         refreshTitle()
         refreshResultsPredicate()
+
         configureSyncingCoordinator()
         configureNavigation()
         configureTabBarItem()
         configureTableView()
         configureResultsController()
+
+        startListeningToNotifications()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -171,6 +178,31 @@ private extension OrdersViewController {
 
     func configureSyncingCoordinator() {
         syncingCoordinator.delegate = self
+    }
+}
+
+
+// MARK: - Notifications
+//
+extension OrdersViewController {
+
+    /// Wires all of the Notification Hooks
+    ///
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+    }
+
+    /// Stops listening to all related Notifications
+    ///
+    func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// Runs whenever the default Account is updated.
+    ///
+    @objc func defaultAccountWasUpdated() {
+        syncingCoordinator.resetInternalState()
     }
 }
 


### PR DESCRIPTION
### Details:
This PR adds a bit of logic to prevent the Orders List Infinite Scroll mechanism from getting stuck upon account switch.

cc @bummytime Thank you sir!!

Closes #498

### Testing:
0. Don't kill the app, at any point. This is a "runtime state" bug
1. Log into **Store A** (aim at a site with orders <50)
2. Open the Orders Tab
3. Scroll all the way to the bottom
4. Logout, and log into **Store B** with LOTS of orders (ie Bananza!)
5. Open the Orders tab
6. Scroll all the way to the bottom.

- [x] Verify the Infinite Scroll works properly!
