### PR TITLE
Dashboard: Fix account update issue with pending orders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -26,14 +26,14 @@ class DashboardViewController: UIViewController {
 
     // MARK: View Lifecycle
 
+    deinit {
+        stopListeningToNotifications()
+    }
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         startListeningToNotifications()
         tabBarItem.image = Gridicon.iconOfType(.statsAlt)
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidLoad() {
@@ -92,9 +92,35 @@ private extension DashboardViewController {
 
         navigationItem.backBarButtonItem = backButton
     }
+}
 
+
+// MARK: - Notifications
+//
+extension DashboardViewController {
+
+    /// Wires all of the Notification Hooks
+    ///
     func startListeningToNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+    }
+
+    /// Stops listening to all related Notifications
+    ///
+    func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// Runs whenever the default Account is updated.
+    ///
+    @objc func defaultAccountWasUpdated() {
+        guard storeStatsViewController != nil, StoresManager.shared.isAuthenticated == false else {
+            return
+        }
+
+        storeStatsViewController.clearAllFields()
+        applyHideAnimation(for: newOrdersContainerView)
     }
 }
 
@@ -134,13 +160,6 @@ extension DashboardViewController: NewOrdersDelegate {
 // MARK: - Private Helpers
 //
 private extension DashboardViewController {
-
-    @objc func defaultAccountWasUpdated(sender: Notification) {
-        guard storeStatsViewController != nil, StoresManager.shared.isAuthenticated == false else {
-            return
-        }
-        storeStatsViewController.clearAllFields()
-    }
 
     func reloadData() {
         DDLogInfo("♻️ Requesting dashboard data be reloaded...")


### PR DESCRIPTION
![neworders_before_after](https://user-images.githubusercontent.com/154014/49744150-cd3aa500-fc61-11e8-8b8e-d7f5da6b87db.png)

Inspired by @jleandroperez's #500 PR, I made a quick patch to the new orders UI on the Dashboard. Previously, when a user would logout of **Store A** (where new orders are pending) and then log into **Store B**, **Store A**'s new orders alert + values would momentarily display until the data refresh call came back. This PR fixes that.

## Testing

0. Don't kill the app, at any point. This is a "runtime state" bug
1. Log into **Store A** (with pending orders)
2. Make sure you see the new orders alert in the dashboard
3. Logout, and log into **Store B** (with or without pending orders)

- [x] Verify immediately after logging into **Store B** you do not see the new orders alert in the dashboard (and it eventually animates in if there are pending orders in **Store B**)