### PR TITLE
Store Picker: Make user re-auth if app is force closed without selecting a default store

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -137,7 +137,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
-
+        DDLogVerbose("👀 Application terminating...")
+        NotificationCenter.default.post(name: .applicationTerminating, object: nil)
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -11,6 +11,10 @@ extension NSNotification.Name {
     /// Posted whenever the Default Account is updated.
     ///
     public static let defaultAccountWasUpdated = Foundation.Notification.Name(rawValue: "DefaultAccountWasUpdated")
+
+    /// Posted whenever the app is about to terminate.
+    ///
+    public static let applicationTerminating = Foundation.Notification.Name(rawValue: "ApplicationTerminating")
 }
 
 


### PR DESCRIPTION
This PR fixes #466 — we are now forcing the user to re-auth if the app is terminated on the store picker screen (instead of automagically picking the currently-selected site). This patch is needed because we do not want a < WC 3.4.7 store accidentally being used.

## Testing

### Scenario 1
0. Build and run the app and log out of the currently selected store if needed
1. Log into the app and remain on the Store Picker screen
2. Force close the app
3. Relaunch the app
- [ ] Verify you are at the beginning of the auth flow and a default store is **not** selected

### Scenario 2
0. Build and run the app and log out of the currently selected store if needed
1. Log into the app, select a store, and tap continue
2. On the dashboard screen, force close the app
3. Relaunch the app
- [ ] Verify you are still logged in and the default store is still active
