### PR TITLE
Notice: Restoring Backgrounding Support

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -124,19 +124,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-
-        let info = NoticeNotificationInfo(identifier: UUID().uuidString,
-                                          categoryIdentifier: "lalala",
-                                          title: "Title",
-                                          body: "Some Body",
-                                          userInfo: [:])
-
-        let title = NSLocalizedString("Testing Background Notice", comment: "")
-        let message = NSLocalizedString("Message LALALALALA", comment: "")
-        let notice = Notice(title: title, message: message, feedbackType: .error, notificationInfo: info)
-
-
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {


### PR DESCRIPTION
### Details:
This is a (super quick!!) tech debt PR: we're restoring the NoticePresenter's ability to display Notifications, while the app is in Background.

Closes #187
cc @bummytime 

### Testing
1. Check out this commit: [bf60183](https://github.com/woocommerce/woocommerce-ios/commit/bf601837971d07f3e67fab55e40ec0d6646afb8d)
2. Log into your Store
3. Allow Push Notifications
4. Send the app to Background
5. Verify a Local Notification comes thru, a second after the app goes into BG
6. Open the Settings.app and disable Push Notifications for Woo
7. Repeat the same test. Verify no Push is posted: a notice should be onscreen, as soon as you bring the app back to FG.