### PR TITLE
Indicate the secrets directory this project uses

### DIFF
--- a/.configure
+++ b/.configure
@@ -3,5 +3,8 @@
   "pinned_hash": "cdd316c15ce772444b966709c7ab59d508396b40",
   "files_to_copy": [
 
+  ],
+  "file_dependencies": [
+    "iOS/WCiOS/"
   ]
 }


### PR DESCRIPTION
This is to prepare for the change in https://github.com/wordpress-mobile/release-toolkit/pull/12