### PR TITLE
Sites: Background Sync

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -40,6 +40,13 @@ extension UIImage {
         return UIImage(named: "icon-jetpack-gray")!
     }
 
+    /// Creates a bitmap image of the Woo "bubble" logo based on a vector image in our asset catalog.
+    ///
+    /// - Parameters:
+    ///   - size: desired size of the resulting bitmap image
+    ///   - tintColor: desired tint color of the resulting bitmap image
+    /// - Returns: a bitmap image
+    ///
     static func wooLogoImage(withSize size: CGSize = Metrics.defaultWooLogoSize, tintColor: UIColor = .white) -> UIImage? {
         let rect = CGRect(origin: .zero, size: size)
         let vectorImage = UIImage(named: "woo-logo")!


### PR DESCRIPTION
Similar to #513 — this quick Tech Debt PR moves the `AccountStore`'s `synchronizeSites` and `synchronizeSitePlan` CoreData logic to a BG thread.

Fixes #515 

## Testing:
- [x] Verify code is square
- [x] Verify unit tests are ✅ 
- [x] From a fresh install log into the app — verify everything works like it should (e.g. SitePicker)