### PR TITLE
Adjusts the size of the Woo logo on the About screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -222,8 +222,8 @@ extension AboutViewController: UITableViewDelegate {
 //
 private struct Constants {
     static let rowHeight       = CGFloat(44)
-    static let headerImageSize = CGSize(width: 140, height: 84)
-    static let headerPadding   = CGFloat(50)
+    static let headerImageSize = CGSize(width: 61, height: 36)
+    static let headerPadding   = CGFloat(60)
     static let footerHeight    = 44
 }
 


### PR DESCRIPTION
Title has it.

![3](https://user-images.githubusercontent.com/154014/50029072-60077680-ffb7-11e8-87ce-02ca365a84bb.png)

Fixes: #523 

## Testing

1. Build and run the app
2. Navigate the Dashboard → Settings → About
3. Verify the Woo logo in the table header is smaller :-)
