### PR TITLE
Re-enabled review moderation notice logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -107,7 +107,7 @@ private extension NotificationDetailsViewController {
         }
 
         entityListener.onDelete = { [weak self] in
-            self?.navigationController?.popViewController(animated: true)
+            self?.navigationController?.popToRootViewController(animated: true)
             self?.displayNoteDeletedNotice()
         }
     }


### PR DESCRIPTION
This PR re-enables the commented notice/tracks logic when moderating a comment. See #470 for details on why they were commented out in the first place. 😄 

Fixes #470 

## Testing
0. On the web, leave a few reviews on the store you are logged into
1. On the device, log into a site that has the latest version of JP installed (6.8.1)
2. Tap on notifications and select a comment to see it's detail
3. Trash/Spam/Approve/Unapprove the comment
4. Verify you see an appropriate notice in the app (no errors!)
5. Repeat step 3 a few times, again, verifying you don't see any errors

Note: Approving/unapproving a comment does NOT seem to update the server's note object...so even though you approve/unapprove a comment, the new status will not be reflected in our Notif list immediately. 