### PR TITLE
Adds feature request link to settings

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -40,4 +40,8 @@ enum WooConstants {
     /// FAQ URL
     ///
     static let faqURL = URL(string: "https://docs.woocommerce.com/document/frequently-asked-questions")!
+
+    /// Feature Request URL
+    ///
+    static let featureRequestURL = URL(string: "http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283")!
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -93,7 +93,7 @@ private extension SettingsViewController {
         sections = [
             Section(title: primaryStoreTitle, rows: [.primaryStore]),
             Section(title: nil, rows: [.support]),
-            Section(title: privacySettingsTitle, rows: [.privacy]),
+            Section(title: privacySettingsTitle, rows: [.privacy, .featureRequest]),
             Section(title: aboutSettingsTitle, rows: [.about, .licenses]),
             Section(title: nil, rows: [.logout]),
         ]
@@ -115,6 +115,8 @@ private extension SettingsViewController {
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
+        case let cell as BasicTableViewCell where row == .featureRequest:
+            configureFeatureSuggestions(cell: cell)
         case let cell as BasicTableViewCell where row == .about:
             configureAbout(cell: cell)
         case let cell as BasicTableViewCell where row == .licenses:
@@ -141,6 +143,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Privacy Settings", comment: "Navigates to Privacy Settings screen")
+    }
+
+    func configureFeatureSuggestions(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Feature Request", comment: "Navigates to the feature request screen")
     }
 
     func configureAbout(cell: BasicTableViewCell) {
@@ -217,6 +225,11 @@ private extension SettingsViewController {
         performSegue(withIdentifier: Segues.licensesSegue, sender: nil)
     }
 
+    func featureRequestWasPressed() {
+        let safariViewController = SFSafariViewController(url: WooConstants.featureRequestURL)
+        present(safariViewController, animated: true, completion: nil)
+    }
+
     func logOutUser() {
         StoresManager.shared.deauthenticate()
         navigationController?.popToRootViewController(animated: true)
@@ -286,6 +299,8 @@ extension SettingsViewController: UITableViewDelegate {
             supportWasPressed()
         case .privacy:
             privacyWasPressed()
+        case .featureRequest:
+            featureRequestWasPressed()
         case .licenses:
             licensesWasPressed()
         case .about:
@@ -314,6 +329,7 @@ private enum Row: CaseIterable {
     case support
     case logout
     case privacy
+    case featureRequest
     case about
     case licenses
 
@@ -326,6 +342,8 @@ private enum Row: CaseIterable {
         case .logout:
             return BasicTableViewCell.self
         case .privacy:
+            return BasicTableViewCell.self
+        case .featureRequest:
             return BasicTableViewCell.self
         case .about:
             return BasicTableViewCell.self


### PR DESCRIPTION
This tiny PR adds the feature request link to Settings as suggested by @jkmassel! 

![feature_request](https://user-images.githubusercontent.com/154014/50114443-25494c80-020a-11e9-8fb4-d19c6efbf25e.gif)

Closes: #525 

Ref: https://github.com/woocommerce/woocommerce-android/issues/590

## Testing

1. Build and run the app
2. Open settings
3. Verify the "Feature Request" row is present
4. Tap on the feature request row
5. Verify a `SFSafariViewController` opens on the Woo apps ideas board

/cc @kyleaparker 