### PR TITLE
Settings: Added link to Settings.app

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -97,7 +97,7 @@ private extension SettingsViewController {
             Section(title: improveTheAppTitle, rows: [.privacy, .featureRequest], footerHeight: UITableView.automaticDimension),
             Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
             Section(title: otherTitle, rows: [.appSettings], footerHeight: CGFloat.leastNonzeroMagnitude),
-            Section(title: nil, rows: [.logout], footerHeight: UITableView.automaticDimension)
+            Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
         ]
     }
 


### PR DESCRIPTION
![settings](https://user-images.githubusercontent.com/154014/50167433-cbe72900-02ae-11e9-9896-af43b367bb44.gif)

This PR adds a new row to our Settings screen which is a shortcut to Settings.app's custom settings: 

<img width="271" alt="screen shot 2018-12-18 at 10 25 44 am" src="https://user-images.githubusercontent.com/154014/50167741-77907900-02af-11e9-937d-6589cd0ca708.png">

The menu item is meant as a stopgap for #252 for MVLP because the alternative would require a lot more work (probably server-side).

Partially addresses #252 

## Testing

1. Build and run the app
2. Go to Dashboard → Settings and tap on the "Open device settings" row
3. Verify Settings.app opens

@mindgraffiti or @jleandroperez would you mind doing a quick review? Thanks!!
