### PR TITLE
OrdersRemote: Search Order API

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -64,6 +64,35 @@ public class OrdersRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Retrieves all of the `Orders` available.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote orders.
+    ///     - keyword: Search string that should be matched by the orders.
+    ///     - pageNumber: Number of page that should be retrieved.
+    ///     - pageSize: Number of Orders to be retrieved per page.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func searchOrders(for siteID: Int,
+                             keyword: String,
+                             pageNumber: Int = Defaults.pageNumber,
+                             pageSize: Int = Defaults.pageSize,
+                             completion: @escaping ([Order]?, Error?) -> Void)
+    {
+        let parameters = [
+            ParameterKeys.keyword: keyword,
+            ParameterKeys.page: String(pageNumber),
+            ParameterKeys.perPage: String(pageSize),
+            ParameterKeys.status: Defaults.statusAny
+        ]
+
+        let path = Constants.ordersPath
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = OrderListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Updates the `OrderStatus` of a given Order.
     ///
     /// - Parameters:
@@ -121,6 +150,7 @@ public extension OrdersRemote {
     private enum ParameterKeys {
         static let addedByUser: String      = "added_by_user"
         static let customerNote: String     = "customer_note"
+        static let keyword: String          = "search"
         static let note: String             = "note"
         static let page: String             = "page"
         static let perPage: String          = "per_page"

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -108,6 +108,42 @@ class OrdersRemoteTests: XCTestCase {
     }
 
 
+    // MARK: - Search Orders
+
+    /// Verifies that searchOrders properly parses the `orders-load-all` sample response.
+    ///
+    func testSearchOrdersProperlyReturnsParsedOrders() {
+        let remote = OrdersRemote(network: network)
+        let expectation = self.expectation(description: "Load All Orders")
+
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
+
+        remote.searchOrders(for: sampleSiteID, keyword: String()) { (orders, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(orders)
+            XCTAssert(orders!.count == 3)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that searchOrders properly relays Networking Layer errors.
+    ///
+    func testSearchOrdersProperlyRelaysNetwokingErrors() {
+        let remote = OrdersRemote(network: network)
+        let expectation = self.expectation(description: "Load All Orders")
+
+        remote.searchOrders(for: sampleSiteID, keyword: String()) { (orders, error) in
+            XCTAssertNil(orders)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+
     // MARK: - Update Orders Tests
 
     /// Verifies that updateOrder properly parses the `order` sample response.


### PR DESCRIPTION
### Details:
This PR implements a new API: `searchOrders`. Unit tests and batteries included!!

Ref. #63
cc @bummytime @mindgraffiti 
Thank youuuu
