### PR TITLE
Notification List: Updates FSM states and placeholders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -291,6 +291,7 @@ private extension NotificationsViewController {
 
         // Filter right away the cached orders
         refreshResultsPredicate()
+        transitionToResultsUpdatedState()
     }
 }
 
@@ -604,9 +605,24 @@ private extension NotificationsViewController {
         resultsController.startForwardingEvents(to: self.tableView)
     }
 
+
+    /// Displays the Empty State (with filters applied!) Overlay.
+    ///
+    func displayEmptyFilteredOverlay() {
+        let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
+        overlayView.messageImage = .waitingForCustomersImage
+        overlayView.messageText = NSLocalizedString("No results for the selected criteria", comment: "Notifications List (Empty State + Filters)")
+        overlayView.actionText = NSLocalizedString("Remove Filters", comment: "Action: removes the current filters from the notifications list")
+        overlayView.onAction = { [weak self] in
+            self?.currentTypeFilter = .all
+        }
+
+        overlayView.attach(to: view)
+    }
+
     /// Displays the Empty State Overlay.
     ///
-    func displayEmptyNotesOverlay() {
+    func displayEmptyUnfilteredOverlay() {
         let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
         overlayView.messageImage = .waitingForCustomersImage
         overlayView.messageText = NSLocalizedString("No Notifications Yet!", comment: "Empty Notifications List Message")
@@ -684,9 +700,12 @@ private extension NotificationsViewController {
     ///
     func didEnter(state: State) {
         switch state {
-        case .empty:
-            displayEmptyNotesOverlay()
+        case .emptyUnfiltered:
+            displayEmptyUnfilteredOverlay()
             updateNavBarButtonsState(enabled: false)
+        case .emptyFiltered:
+            displayEmptyFilteredOverlay()
+            updateNavBarButtonsState(enabled: true)
         case .results:
             updateNavBarButtonsState(enabled: true)
             break
@@ -700,7 +719,9 @@ private extension NotificationsViewController {
     ///
     func didLeave(state: State) {
         switch state {
-        case .empty:
+        case .emptyFiltered:
+            removeAllOverlays()
+        case .emptyUnfiltered:
             removeAllOverlays()
         case .results:
             break
@@ -715,10 +736,21 @@ private extension NotificationsViewController {
         state = isEmpty ? .syncing : .results
     }
 
-    /// Should be called after Sync'ing wraps up: Transitions to .empty / .results
+    /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
+    /// Transitions to `.results` / `.emptyFiltered` / `.emptyUnfiltered` accordingly.
     ///
     func transitionToResultsUpdatedState() {
-        state = isEmpty ? .empty : .results
+        if isEmpty == false {
+            state = .results
+            return
+        }
+
+        if currentTypeFilter != .all {
+            state = .emptyFiltered
+            return
+        }
+
+        state = .emptyUnfiltered
     }
 }
 
@@ -733,6 +765,7 @@ private extension NotificationsViewController {
     ///
     func updateNavBarButtonsState(enabled: Bool) {
         leftBarButton.isEnabled = enabled
+        rightBarButton.isEnabled = enabled
     }
 }
 
@@ -770,7 +803,8 @@ private extension NotificationsViewController {
     }
 
     enum State {
-        case empty
+        case emptyUnfiltered
+        case emptyFiltered
         case results
         case syncing
     }


### PR DESCRIPTION
This PR updates the FSM states on the notifications screen to now include `emptyUnfiltered` and `emptyFiltered` (just like Orders). 

![notes_state](https://user-images.githubusercontent.com/154014/50313510-32b44000-0471-11e9-9182-06831ff45617.gif)

Now you will see the empty placeholder displayed if a given filter does not have corresponding notes (along with a button to remove the filter). The existing "no notifications" placeholder overlay displays when the filter == `.all` and the results are empty.

Fixes #542 

## Testing

1. Build and run the app. (Try to have only one kind of notification in your list)
2. Open the notifications tab
- [x] Verify you see the notes
3. Select a filter (either orders or reviews) where there are no notes
- [x] Verify you see the empty filter placeholder
4. Tap the "Remove filter" button in the placeholder
- [x] Verify the filter is removed and you see all the notes again.
5. Select a filter (either orders or reviews) where there ARE notes
- [x] Verify you see the notes
6. Select the all filter and then remove (trash all the notes)
- [x] Verify you see "no notifications" placeholder

@jleandroperez would you mind doing a quick review?