### PR TITLE
Dashboard: Updated stat labels to support i18n

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -214,8 +214,11 @@ private extension PeriodDataViewController {
         borderView.backgroundColor = StyleManager.wooGreyBorder
 
         // Titles
+        visitorsTitle.text = NSLocalizedString("Visitors", comment: "Visitors stat label on dashboard - should be plural.")
         visitorsTitle.applyFootnoteStyle()
+        ordersTitle.text = NSLocalizedString("Orders", comment: "Orders stat label on dashboard - should be plural.")
         ordersTitle.applyFootnoteStyle()
+        revenueTitle.text = NSLocalizedString("Revenue", comment: "Revenue stat label on dashboard.")
         revenueTitle.applyFootnoteStyle()
 
         // Data


### PR DESCRIPTION
![3](https://user-images.githubusercontent.com/154014/50315663-406dc380-0479-11e9-9e7e-f5be5e46b385.png)

This PR localizes the visitors, orders, and revenue stat labels in the dashboard.

Fixes: #504 

## Testing

1. Build and run the app
2. Verify the PeriodVCs in the dashboard look ok (try editing the WooCommerce scheme and setting the app language to `pseudolanguage`).
