### PR TITLE
AlamofireNetwork: Passthru NSURLErrors

### DIFF
--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -48,7 +48,10 @@ public class AlamofireNetwork: Network {
 ///
 private extension Alamofire.DataResponse {
 
-    /// Returns the Networking Layer Error (if any): Whenever the statusCode is not within the [200, 300) range.
+    /// Returns the Networking Layer Error (if any):
+    ///
+    ///     -   Whenever the statusCode is not within the [200, 300) range.
+    ///     -   Whenever there's a `NSURLErrorDomain` error: Bad Certificate, Unreachable, Cancelled (and few others!)
     ///
     /// NOTE: that we're not doing the standard Alamofire Validation, because the stock routine, on error, will never relay
     /// back the response body. And since the Jetpack Tunneling API does not relay the proper statusCodes, we're left in
@@ -57,6 +60,12 @@ private extension Alamofire.DataResponse {
     /// Precisely: Request Timeout should be a 408, but we just get a 400, with the details in the response's body.
     ///
     var networkingError: Error? {
+
+        // Passthru URL Errors: These are right there, even without calling Alamofire's validation.
+        if let error = error as NSError?, error.domain == NSURLErrorDomain {
+            return error
+        }
+
         return response.flatMap { response in
             NetworkError(from: response.statusCode)
         }


### PR DESCRIPTION
### Details:
I've missed something huge in PR #534: Networking Errors aren't just tied up to Response's status codes. We must also account for Peer Trust, Host Unreachable, and others.

In this PR we're adding a passthru for Errors that are present without calling Alamofire's `validate()`.
For the time being, and to minimize other potential side effects, i've capped this passthru to the **NSURLError** Domain.

Closes #560

### Testing: Host Unreachable
1. Log into your Store
2. Send the app to BG
3. Enable Airplane mode (Wifi + Cellular should be off)
4. Bring the app to FG

- [x] Verify the "WC < 3.5" alert doesn't show up

### Testing: Jetpack Tunnel Timeout
1. Log into a testing site with a breaking Jetpack Tunnel
2. Open the Orders Tab

- [x] Verify the following shows up, shortly, in the console:

```
🔵 Tracked jetpack_tunnel_timeout
```

I'm leaving a breaking Site's details in the One Time tool, under few keys. (Same message everywhere).
It's the same site we've used to verify #534!

```
44889.0:64fcce7d8af33a3f45bb54e7616e02bd02e021de19576e27c9d858d32aac5081
44890.1:12a5ba448877cc2a41e281a75dd023ee620d3b28ed33f0d8d9bc64bfbf96fa2f
44891.2:b11d1fbf96fed6f9fb939a58f4143c1685d6bde63d8d84dd33f9db3d2e83fb07
44892.3:fa7a1511eab44c1051d844ed00d232460077a0352e22fe83da649e54457b5cb8
44893.4:3d978055d535d9d83cfa836b578fd21111db8c99bd130c4462902a0cab9c8ff0
```
