### PR TITLE
Update Rakefile to make 'rake dependencies' more reliable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org' do
   gem 'rake'
   gem 'cocoapods', '~> 1.5.2'
-  gem 'cocoapods-repo-update', '0.0.3'
+  gem 'cocoapods-repo-update', '~> 0.0.4'
   gem 'cocoapods-check'
   gem 'xcpretty-travis-formatter'
   gem 'danger'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org' do
   gem 'rake'
   gem 'cocoapods', '~> 1.5.2'
   gem 'cocoapods-repo-update', '0.0.3'
+  gem 'cocoapods-check'
   gem 'xcpretty-travis-formatter'
   gem 'danger'
   gem 'danger-swiftlint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.1)
       xcodeproj (>= 1.5.7, < 2.0)
+    cocoapods-check (1.0.2)
+      cocoapods (~> 1.0)
     cocoapods-core (1.5.3)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
@@ -238,6 +240,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.5.2)!
+  cocoapods-check!
   cocoapods-repo-update (= 0.0.3)!
   danger!
   danger-swiftlint!
@@ -248,4 +251,4 @@ DEPENDENCIES
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     cocoapods-downloader (1.2.0)
     cocoapods-plugins (1.0.0)
       nap
-    cocoapods-repo-update (0.0.3)
+    cocoapods-repo-update (0.0.4)
       cocoapods (~> 1.0, >= 1.3.0)
     cocoapods-search (1.0.0)
     cocoapods-stats (1.0.0)
@@ -241,7 +241,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.5.2)!
   cocoapods-check!
-  cocoapods-repo-update (= 0.0.3)!
+  cocoapods-repo-update (~> 0.0.4)!
   danger!
   danger-swiftlint!
   dotenv!


### PR DESCRIPTION
There have been some recent improvements to `rake dependencies` on WordPress-iOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/10455, https://github.com/wordpress-mobile/WordPress-iOS/pull/10675

This PR incorporates these improvements here. Here are the main points:

- Use `pod check` & `bundle check` to check if install is required to make it more reliable.
- Check if `Podfile` matches `Podfile.lock`. This means `pod install` will be triggered by `rake dependencies` when the `Podfile` (not just `Podfile.lock`) is updated.