### PR TITLE
Adds order search analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -119,6 +119,7 @@ public enum WooAnalyticsStat: String {
     case ordersReselected                       = "main_tab_orders_reselected"
     case ordersListPulledToRefresh              = "orders_list_pulled_to_refresh"
     case ordersListFilterTapped                 = "orders_list_menu_filter_tapped"
+    case ordersListSearchTapped                 = "orders_list_menu_search_tapped"
     case filterOrdersOptionSelected             = "filter_orders_by_status_dialog_option_selected"
     case orderDetailAddNoteButtonTapped         = "order_detail_add_note_button_tapped"
     case orderDetailPulledToRefresh             = "order_detail_pulled_to_refresh"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
@@ -284,7 +284,7 @@ private extension OrderSearchViewController {
 
         transitionToSyncingState()
         StoresManager.shared.dispatch(action)
-        DDLogInfo("🔍 Searching for Orders: [\(keyword)]...")
+        WooAnalytics.shared.track(.ordersListFilterOrSearch, withProperties: ["filter": "", "search": "\(keyword)"])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -262,6 +262,7 @@ extension OrdersViewController {
             return
         }
 
+        WooAnalytics.shared.track(.ordersListSearchTapped)
         let searchViewController = OrderSearchViewController(storeID: storeID)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 


### PR DESCRIPTION
Just a quick PR to add some missing Tracks calls when searching orders.

Ref #63 

## Testing

1. Build and run the app — open the orders tab
2. Tap the search navbar icon in the upper left hand corner of the screen

- [ ] Verify you see something like the following in the console:
`🔵 Tracked orders_list_menu_search_tapped, properties: [AnyHashable("blog_id"): 999999, AnyHashable("is_wpcom_store"): true]`

3. On the search VC, start typing in a search term

- [ ] Verify you see something like the following in the console as you type each letter:
`🔵 Tracked orders_list_filter, properties: [AnyHashable("filter"): "", AnyHashable("blog_id"): 999999, AnyHashable("search"): "T", AnyHashable("is_wpcom_store"): true]`
`🔵 Tracked orders_list_filter, properties: [AnyHashable("filter"): "", AnyHashable("blog_id"): 999999, AnyHashable("search"): "Te", AnyHashable("is_wpcom_store"): true]`
`🔵 Tracked orders_list_filter, properties: [AnyHashable("filter"): "", AnyHashable("blog_id"): 999999, AnyHashable("search"): "Tes", AnyHashable("is_wpcom_store"): true]`
`🔵 Tracked orders_list_filter, properties: [AnyHashable("filter"): "", AnyHashable("blog_id"): 999999, AnyHashable("search"): "Test", AnyHashable("is_wpcom_store"): true]`

@mindgraffiti and/or @astralbodies ... mind taking a quick peek at this. First :shipit: wins! :-)