### PR TITLE
Add AppStoreStrings file

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -1,0 +1,48 @@
+# Translation of Release Notes & Apple Store Description in English (US)
+# This file is distributed under the same license as the Release Notes & Apple Store Description package.
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2019-01-03 17:30-0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 2.0.1\n"
+"Project-Id-Version: Release Notes & Apple Store Description\n"
+"POT-Creation-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+
+#. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
+msgctxt "app_store_subtitle"
+msgid "Your store in your pocket"
+msgstr ""
+
+#. translators: Multi-paragraph text used to display in the Apple App Store.
+msgctxt "app_store_desc"
+msgid ""
+"VIEW AND MANAGE ORDERS\n"
+"Scroll through, filter, or look up specific orders. Tap to view order information – including product(s), value, customer data, shipping details, and notes.\n"
+"\n"
+"TRACK YOUR STORE\n"
+"See which products are performing best. Check your overall revenue and view order and visitor data by week, month, and year.\n"
+"\n"
+"REAL-TIME ORDER ALERTS\n"
+"Get notifications about store activity – including new orders and product reviews.\n"
+"\n"
+"WooCommerce is the most customizable eCommerce platform for building your online business. Built on WordPress, it is integrated with the world’s best content management tools. From coffee subscriptions to Spanish lessons to gym memberships to complex enterprise-level eCommerce – visit WooCommerce.com/start to launch a new store and ship your idea.\n"
+"\n"
+"Requirements: WooCommerce v3.5+, the Jetpack plugin.\n"
+msgstr ""
+
+#. translators: Keywords used in the App Store search engine to find the app.
+#. Delimit with a comma between each keyword. Limit to 100 characters including spaces and commas.
+msgctxt "app_store_keywords"
+msgid "Woocommerce, woocommerce app, woocommerce mobile, woo app, woocommerce order alert, wordpress, eComm\n"
+msgstr ""
+
+msgctxt "v1.0-whats-new"
+msgid ""
+"First public release.\n"
+msgstr ""
+


### PR DESCRIPTION
This PR adds the `AppStoreStrings.po` file that is used to upload the release notes and other store listing strings to GlotPress.