### PR TITLE
Adds company name to address (if available)

### DIFF
--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -13,6 +13,22 @@ extension Address {
         return firstName + " " + lastName
     }
 
+    /// Returns the `fullName` and `company` (on a new line). If either the `fullname` or `company` is empty,
+    /// then a single line is returned containing the other value.
+    ///
+    var fullNameWithCompany: String {
+        var output: [String] = []
+
+        if fullName.isEmpty == false {
+            output.append(fullName)
+        }
+        if let company = company, company.isEmpty == false {
+            output.append(company)
+        }
+
+        return output.joined(separator: "\n")
+    }
+
     /// Returns the Postal Address, formated and ready for display.
     ///
     var formattedPostalAddress: String? {

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -285,7 +285,7 @@ private extension FulfillViewController {
         }
 
         cell.title = NSLocalizedString("Shipping details", comment: "Shipping title for customer info cell")
-        cell.name = address.fullName
+        cell.name = address.fullNameWithCompany
         cell.address = address.formattedPostalAddress
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -309,7 +309,7 @@ private extension OrderDetailsViewController {
         let billingAddress = viewModel.order.billingAddress
 
         cell.title = NSLocalizedString("Billing details", comment: "Billing title for customer info cell")
-        cell.name = billingAddress?.fullName
+        cell.name = billingAddress?.fullNameWithCompany
         cell.address = billingAddress?.formattedPostalAddress ?? NSLocalizedString("No address specified.", comment: "Order details > customer info > billing details. This is where the address would normally display.")
     }
 
@@ -427,7 +427,7 @@ private extension OrderDetailsViewController {
         let shippingAddress = viewModel.order.shippingAddress
 
         cell.title = NSLocalizedString("Shipping details", comment: "Shipping title for customer info cell")
-        cell.name = shippingAddress?.fullName
+        cell.name = shippingAddress?.fullNameWithCompany
         cell.address = shippingAddress?.formattedPostalAddress ?? NSLocalizedString("No address specified.", comment: "Order details > customer info > shipping details. This is where the address would normally display.")
     }
 


### PR DESCRIPTION
Quick little PR that adds a convenience `var` to `Address+Woo.swift` which returns the `fullName` and `company` on a new line (if it exists):

![3](https://user-images.githubusercontent.com/154014/50653425-17f0c980-0f4f-11e9-91a7-4eb2743da8ce.png)

![33](https://user-images.githubusercontent.com/154014/50653432-1c1ce700-0f4f-11e9-9e74-ef594b40c941.png)

Fixes: #355 

## Testing

1. Place an order on the web - include Company Name in Billing or Shipping Address or both;
2. Build and run the app
3. Open the Orders tab
4. Open the order with a company name
- [x] Verify a company name is displayed on order details (billing and/or shipping address)
- [x] Verify a company name is displayed on the fulfillment screen

5. Open another order without a company name
- [x] Verify only the `fullName` is displayed on order details (billing and/or shipping address) — no newline should be present
- [x] Verify only the `fullName` is displayed on  the fulfillment screen — no newline should be present

@mindgraffiti Would you mind taking a quick look?