### PR TITLE
Sends logging entries over to Crashlytics in case the app dies

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -230,6 +230,7 @@ private extension AppDelegate {
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7
 
         DDLog.add(DDOSLogger.sharedInstance)
+        DDLog.add(CrashlyticsLogger.shared)
         DDLog.add(fileLogger)
     }
 

--- a/WooCommerce/Classes/Tools/Logging/CocoaLumberjack.swift
+++ b/WooCommerce/Classes/Tools/Logging/CocoaLumberjack.swift
@@ -23,9 +23,6 @@ import CocoaLumberjack
 // * Neither the name of Deusty nor the names of its contributors may be used
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
-
-import Foundation
-
 extension DDLogFlag {
     static func from(_ logLevel: DDLogLevel) -> DDLogFlag {
         return DDLogFlag(rawValue: logLevel.rawValue)

--- a/WooCommerce/Classes/Tools/Logging/CrashlyticsLogger.swift
+++ b/WooCommerce/Classes/Tools/Logging/CrashlyticsLogger.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CocoaLumberjack
+import Crashlytics
+
+class CrashlyticsLogger: DDAbstractLogger {
+    /// Shared Instance
+    ///
+    static var shared = CrashlyticsLogger()
+
+    override func log(message logMessage: DDLogMessage) {
+        var message = logMessage.message
+
+        if let ivar = class_getInstanceVariable(object_getClass(self), "_logFormatter"),
+            let logFormatter = object_getIvar(self, ivar) as? DDLogFormatter,
+            let formattedMessage = logFormatter.format(message: logMessage) {
+            message = formattedMessage
+        }
+
+        CLSLogv("%@", getVaList([message]))
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		74F9E9CD214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */; };
 		74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
+		9324401421DE99FC0067CD83 /* CrashlyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9324401321DE99FC0067CD83 /* CrashlyticsLogger.swift */; };
 		93BCF01F20DC2CE200EBF7A1 /* bash_secrets.tpl in Resources */ = {isa = PBXBuildFile; fileRef = 93BCF01E20DC2CE200EBF7A1 /* bash_secrets.tpl */; };
 		93FA787221CD2A1A00B663E5 /* MoneyFormatSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA787121CD2A1A00B663E5 /* MoneyFormatSettingsTests.swift */; };
 		93FA787421CD7E9E00B663E5 /* MoneyFormatSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FA787321CD7E9E00B663E5 /* MoneyFormatSettings.swift */; };
@@ -356,6 +357,7 @@
 		74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoPeriodDataTableViewCell.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
 		90AC1C0B391E04A837BDC64E /* Pods-WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.debug.xcconfig"; sourceTree = "<group>"; };
+		9324401321DE99FC0067CD83 /* CrashlyticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashlyticsLogger.swift; sourceTree = "<group>"; };
 		93BCF01E20DC2CE200EBF7A1 /* bash_secrets.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = bash_secrets.tpl; sourceTree = "<group>"; };
 		93FA787121CD2A1A00B663E5 /* MoneyFormatSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyFormatSettingsTests.swift; sourceTree = "<group>"; };
 		93FA787321CD7E9E00B663E5 /* MoneyFormatSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyFormatSettings.swift; sourceTree = "<group>"; };
@@ -1001,6 +1003,7 @@
 			isa = PBXGroup;
 			children = (
 				B5A0369A214C0E8500774E2C /* CocoaLumberjack.swift */,
+				9324401321DE99FC0067CD83 /* CrashlyticsLogger.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -1728,6 +1731,7 @@
 				B59D1EE321907C7B009D1978 /* NSAttributedString+Helpers.swift in Sources */,
 				CE17C2E220ACA06800AFBD20 /* BillingDetailsTableViewCell.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
+				9324401421DE99FC0067CD83 /* CrashlyticsLogger.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */,
 				B5F355EF21CD500200A7077A /* OrderSearchViewController.swift in Sources */,


### PR DESCRIPTION
Helps with #567 so that we have some logging in place when a crash report comes in.

You can test this by changing `CLSLogv` to `CLSNSLogv` and you'll see all log entries duplicated. That proves logging is being sent to the Crashlytics class. We'll want to mindful of any app lockups that might occur because we're accessing things in the `DDAbstractLogger` parent class that are threaded. We haven't run into an issue with this in WordPress-iOS but then the logger is all in Objective-C and not Swift.