### PR TITLE
Notifications: Disable the "mark all read" navbar button if everything is read

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -697,7 +697,7 @@ private extension NotificationsViewController {
 //
 private extension NotificationsViewController {
 
-    /// Runs whenever the prior to the FSM entering a new state.
+    /// Runs prior to the FSM entering a new state.
     ///
     /// Note: Just because this func runs does not guarantee `didEnter()` or `didLeave()` will run as well.
     ///


### PR DESCRIPTION
This PR disables the "mark all as read" button if there are no unread notes in the current filter setting (also during sync'ing and empty states):

![markallasread](https://user-images.githubusercontent.com/154014/50664332-4fbd3880-0f72-11e9-8707-de37fa288164.gif)

The logic to manage this is handled inside a new FSM func `willEnter()`.

Fixes: #564 

## Testing

In short, we want to test that the "mark as read" icon is enabled when it needs to be and disabled when it shouldn't. The following is a sample test flow, but feel free to vary if desired.

1. On a current test store, queue up both review and order notifications (and leave unread)
2. Do a fresh install and log into your store
3. Tap the notifications tab

- [x] Verify the "mark as read" button is **disabled** while sync'ing
- [x] Verify the "mark as read" button is **enabled** post-sync (when unread notifications appear)

4. Tap on the order notification (which marks it as read) and then navigate back to the notifications list
5. Assuming you have some unread review notifications and a read order notification at this point

- [x] Verify the "mark as read" button is **enabled** on the All filter
- [x] Verify the "mark as read" button is **disabled** on the Orders filter
- [x] Verify the "mark as read" button is **enabled** on the Reviews filter

6. Select the Reviews filter on the notifications list
7. Tap the "mark as read" button

- [x] Verify the "mark as read" button is **disabled** after everything is marked as read

8. Switch to the All filter

- [x] Verify the "mark as read" button is **disabled**


@astralbodies or @mindgraffiti Would you mind taking a 👀 at this?