### PR TITLE
Add a secrets Swift Template

### DIFF
--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+DERIVED_PATH=${SOURCE_ROOT}/DerivedSources
+SCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb
+
+CREDS_INPUT_PATH=${SOURCE_ROOT}/Credentials/ApiCredentials.tpl
+CREDS_OUTPUT_PATH=${DERIVED_PATH}/ApiCredentials.swift
+
+CREDS_TEMPLATE_PATH=${SOURCE_ROOT}/Credentials/Templates/ApiCredentials-Template.swift
+
+PLIST_INPUT_PATH=${SOURCE_ROOT}/Credentials/InfoPlist.tpl
+PLIST_OUTPUT_PATH=${DERIVED_PATH}/InfoPlist.h
+
+PLIST_TEMPLATE_PATH=${SOURCE_ROOT}/Credentials/Templates/InfoPlist-Template.h
+
+BASH_INPUT_PATH=${SOURCE_ROOT}/Credentials/bash_secrets.tpl
+BASH_OUTPUT_PATH=${DERIVED_PATH}/bash_secrets
+
+## Validate Secrets!
+##
+if [ ! -f $SECRETS_PATH ]; then
+
+    echo ">> Using Templated Secrets"
+
+    ## Generate the Derived Folder. If needed
+    ##
+    mkdir -p ${DERIVED_PATH}
+
+    ## Create a credentials file from the template (if needed)
+    ## then copy it into place for the build.
+    ##
+    if [ ! -f $CREDS_OUTPUT_PATH ]; then
+        echo ">> Creating Credentials File from Template: ${CREDS_FILE_PATH}"
+        cp ${CREDS_TEMPLATE_PATH} ${CREDS_OUTPUT_PATH}
+    fi
+
+    ## Create a plist file from the template (if needed)
+    ## then copy it into place for the build.
+    ##
+    if [ ! -f $PLIST_OUTPUT_PATH ]; then
+        echo ">> Creating plist File from Template: ${PLIST_OUTPUT_PATH}"
+        cp ${PLIST_TEMPLATE_PATH} ${PLIST_OUTPUT_PATH}
+    fi
+
+    ## Create a bash secrets file from the template (if needed)
+    ## then copy it into place for the build.
+    ##
+    if [ ! -f $BASH_OUTPUT_PATH ]; then
+        echo ">> Creating Bash Secrets File from Template: ${BASH_FILE_PATH}"
+        cp ${BASH_INPUT_PATH} ${BASH_OUTPUT_PATH}
+    fi
+
+else
+
+    echo ">> Loading Secrets ${SECRETS_PATH}"
+
+    ## Generate the Derived Folder. If needed
+    ##
+    mkdir -p ${DERIVED_PATH}
+
+    ## Generate ApiCredentials.swift
+    ##
+    echo ">> Generating Credentials ${CREDS_OUTPUT_PATH}"
+    ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > ${CREDS_OUTPUT_PATH}
+
+    ## Generate InfoPlist.h
+    ##
+    echo ">> Generating Credentials ${PLIST_OUTPUT_PATH}"
+    ruby ${SCRIPT_PATH} -i ${PLIST_INPUT_PATH} -s ${SECRETS_PATH} > ${PLIST_OUTPUT_PATH}
+
+    ## Generate bash_secrets
+    ##
+    echo ">> Generating Credentials ${BASH_OUTPUT_PATH}"
+    ruby ${SCRIPT_PATH} -i ${BASH_INPUT_PATH} -s ${SECRETS_PATH} > ${BASH_OUTPUT_PATH}
+
+fi

--- a/WooCommerce/Credentials/Templates/ApiCredentials-Template.swift
+++ b/WooCommerce/Credentials/Templates/ApiCredentials-Template.swift
@@ -1,0 +1,43 @@
+/// WooCommerce API Credentials
+struct ApiCredentials {
+
+    /// WordPress.com AppID
+    ///
+    static let dotcomAppId: String =  <#Wordpress.com App ID#>
+
+    /// WordPress.com Secret
+    ///
+    static let dotcomSecret: String = <#Wordpress.com App Secret#>
+
+    /// WordPress.com Magic Link Scheme
+    ///
+    static let dotcomAuthScheme: String = <#Wordpress.com Auth Scheme#>
+
+    /// Google SDK's ClientID
+    ///
+    static let googleClientId: String = <#Google Client ID#>
+
+    /// Google SDK's ServerID
+    ///
+    static let googleServerId: String = <#Google Server ID#>
+
+    /// Google SDK's Auth Scheme
+    ///
+    static let googleAuthScheme: String = <#Google Auth Scheme#>
+
+    /// Tracks Prefix
+    ///
+    static let tracksPrefix: String = <#Tracks Prefix#>
+
+    /// Zendesk App ID
+    ///
+    static let zendeskAppId: String = <#Zendesk App ID#>
+
+    /// Zendesk URL
+    ///
+    static let zendeskUrl: String = <#Zendesk URL#>
+
+    /// Zendesk Client ID
+    ///
+    static let zendeskClientId: String = <#Zendesk Client ID#>
+}

--- a/WooCommerce/Credentials/Templates/InfoPlist-Template.h
+++ b/WooCommerce/Credentials/Templates/InfoPlist-Template.h
@@ -1,0 +1,18 @@
+/// WooCommerce Preprocessed InfoPlist.h. Generated on %{timestamp}
+///
+/// Note: the following constants are being translated into `InfoPlist.h`, and can be picked up by the App's
+/// Info.plist.
+///
+
+
+/// Google Auth Callback Scheme
+///
+#define GOOGLE_AUTH_SCHEME <#Google Auth Scheme#>
+
+/// WordPress.com Auth Callback Scheme (AKA Magic Link!)
+///
+#define DOTCOM_AUTH_SCHEME <#Wordpress.com Auth Scheme#>
+
+/// Fabric / Crashlytics API key
+///
+#define FABRIC_API_KEY <#Fabric API Key#>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1610,6 +1610,8 @@
 				"$(SRCROOT)/Credentials/ApiCredentials.tpl",
 				"$(SRCROOT)/Credentials/InfoPlist.tpl",
 				"~/.mobile-secrets/iOS/WCiOS/woo_app_credentials.json",
+				"$(SRCROOT)/Credentials/Templates/APICredentials-Template.swift",
+				"$(SRCROOT)/Credentials/Templates/InfoPlist-Template.h",
 			);
 			outputPaths = (
 				"$(SRCROOT)/DerivedSources/ApiCredentials.swift",
@@ -1617,7 +1619,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "DERIVED_PATH=${SOURCE_ROOT}/DerivedSources\nSCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb\n\nCREDS_INPUT_PATH=${SOURCE_ROOT}/Credentials/ApiCredentials.tpl\nCREDS_OUTPUT_PATH=${DERIVED_PATH}/ApiCredentials.swift\n\nPLIST_INPUT_PATH=${SOURCE_ROOT}/Credentials/InfoPlist.tpl\nPLIST_OUTPUT_PATH=${DERIVED_PATH}/InfoPlist.h\n\nBASH_INPUT_PATH=${SOURCE_ROOT}/Credentials/bash_secrets.tpl\nBASH_OUTPUT_PATH=${DERIVED_PATH}/bash_secrets\n\n## Validate Secrets!\n##\nif [ ! -f $SECRETS_PATH ]\nthen\n    echo \">> Missing Secrets ${SECRETS_PATH}\"\n    exit -1\nfi\n\necho \">> Loading Secrets ${SECRETS_PATH}\"\n\n## Generate the Derived Folder. If needed\n##\nmkdir -p ${DERIVED_PATH}\n\n## Generate ApiCredentials.swift\n##\necho \">> Generating Credentials ${CREDS_OUTPUT_PATH}\"\nruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > ${CREDS_OUTPUT_PATH}\n\n## Generate InfoPlist.h\n##\necho \">> Generating Credentials ${PLIST_OUTPUT_PATH}\"\nruby ${SCRIPT_PATH} -i ${PLIST_INPUT_PATH} -s ${SECRETS_PATH} > ${PLIST_OUTPUT_PATH}\n\n## Generate bash_secrets\n##\necho \">> Generating Credentials ${BASH_OUTPUT_PATH}\"\nruby ${SCRIPT_PATH} -i ${BASH_INPUT_PATH} -s ${SECRETS_PATH} > ${BASH_OUTPUT_PATH}\n";
+			shellScript = "$SRCROOT/../Scripts/build-phases/generate-credentials.sh\n";
 		};
 		B7A94351C1ADC31EA528B895 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/WooCommerce/WooCommerceTests/Tools/ZendeskManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ZendeskManagerTests.swift
@@ -10,19 +10,9 @@ class ZendeskManagerTests: XCTestCase {
     ///
     private var zendesk: ZendeskManager!
 
-    /// The Zendesk web portal URL.
-    ///
-    private let zdUrl = "https://automattic.zendesk.com"
-
     /// Default ticket tags.
     ///
     private let zdTags = ["iOS", "woo-mobile-sdk", "jetpack"]
-
-    /// Ensure the Zendesk URL is set to the parent brand.
-    ///
-    func testZendeskUrl() {
-        XCTAssertEqual(ApiCredentials.zendeskUrl, zdUrl)
-    }
 
     /// Test default tags return as expected.
     ///


### PR DESCRIPTION
Ensures that users configure secrets before compiling.

**To Test:**
- Check out the branch
- Go to `~/.mobile-secrets`, rename `iOS` to `_iOS` (don't forget to change it back after testing!)
- Clean the build folder
- Delete `$SRCROOT/DerivedSources`
- Build the `WooCommerce` target.

**Before:**
- Build would fail across multiple targets without helpful error messaging.

**After:**
- Build will fail with actionable steps to define secrets. Once secrets are defined by hand, the build will complete and the app will run.
- Running tests fail on `ZendeskManagerTests::testZendeskUrl`. It looks like we've hardcoded the secret in that file. We'll likely need to clean that up before publishing the repo?

**Next Steps:**
Once this PR is merged, I propose adding another with a build script for the test target – it'll examine the `ApiCredentials.swift` file, and will find-and-replace any empty tokens with `""`. I propose this only happen in CI environments, in order to prevent the script from removing the on boarding benefits provided by the tokens.