### PR TITLE
Change right nav bar button from .menu to .filter grid icon.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,9 +21,7 @@ target 'WooCommerce' do
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
   pod 'Automattic-Tracks-iOS', '0.2.4'
 
-
-  # pod 'Gridicons', '~> 0.18-beta'
-  pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/filter-icon-update'
+  pod 'Gridicons', '~> 0.18-beta'
   
   # allow pod to pick up beta versions, such as 1.1.7-beta.1
   pod 'WordPressAuthenticator', '~> 1.1-beta'

--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,8 @@ target 'WooCommerce' do
   pod 'Automattic-Tracks-iOS', '0.2.4'
 
 
-  pod 'Gridicons', '0.16'
+  # pod 'Gridicons', '~> 0.18-beta'
+  pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/filter-icon-update'
   
   # allow pod to pick up beta versions, such as 1.1.7-beta.1
   pod 'WordPressAuthenticator', '~> 1.1-beta'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,7 +31,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.1.4)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
-  - Gridicons (0.16)
+  - Gridicons (0.18)
   - KeychainAccess (3.1.2)
   - lottie-ios (2.5.0)
   - NSObject-SafeExpectations (0.0.3)
@@ -82,7 +82,7 @@ DEPENDENCIES:
   - Charts (~> 3.2)
   - CocoaLumberjack (~> 3.4)
   - Crashlytics (~> 3.10)
-  - Gridicons (= 0.16)
+  - Gridicons (from `https://github.com/Automattic/Gridicons-iOS.git`, branch `feature/filter-icon-update`)
   - KeychainAccess (~> 3.1)
   - WordPressAuthenticator (~> 1.1-beta)
   - WordPressShared (~> 1.1)
@@ -102,7 +102,6 @@ SPEC REPOS:
     - FormatterKit
     - GoogleSignInRepacked
     - GoogleToolboxForMac
-    - Gridicons
     - KeychainAccess
     - lottie-ios
     - NSObject-SafeExpectations
@@ -118,6 +117,16 @@ SPEC REPOS:
     - XLPagerTabStrip
     - ZendeskSDK
 
+EXTERNAL SOURCES:
+  Gridicons:
+    :branch: feature/filter-icon-update
+    :git: https://github.com/Automattic/Gridicons-iOS.git
+
+CHECKOUT OPTIONS:
+  Gridicons:
+    :commit: af9ba1b48de0149e5aeb2897c6322f89dd17c641
+    :git: https://github.com/Automattic/Gridicons-iOS.git
+
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
@@ -129,7 +138,7 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
-  Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
+  Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
   KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
@@ -145,6 +154,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 22d4c58200d7c105e0e407ab6bfd01a5d85014be
   ZendeskSDK: af6509ad7968d367f95b2645713802712152f879
 
-PODFILE CHECKSUM: 880d8baedc29161687f4027d119a56f685385f1f
+PODFILE CHECKSUM: d911e7f4902eefe2a0395e50ca16b0894f75f968
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -82,7 +82,7 @@ DEPENDENCIES:
   - Charts (~> 3.2)
   - CocoaLumberjack (~> 3.4)
   - Crashlytics (~> 3.10)
-  - Gridicons (from `https://github.com/Automattic/Gridicons-iOS.git`, branch `feature/filter-icon-update`)
+  - Gridicons (~> 0.18-beta)
   - KeychainAccess (~> 3.1)
   - WordPressAuthenticator (~> 1.1-beta)
   - WordPressShared (~> 1.1)
@@ -102,6 +102,7 @@ SPEC REPOS:
     - FormatterKit
     - GoogleSignInRepacked
     - GoogleToolboxForMac
+    - Gridicons
     - KeychainAccess
     - lottie-ios
     - NSObject-SafeExpectations
@@ -116,16 +117,6 @@ SPEC REPOS:
     - wpxmlrpc
     - XLPagerTabStrip
     - ZendeskSDK
-
-EXTERNAL SOURCES:
-  Gridicons:
-    :branch: feature/filter-icon-update
-    :git: https://github.com/Automattic/Gridicons-iOS.git
-
-CHECKOUT OPTIONS:
-  Gridicons:
-    :commit: af9ba1b48de0149e5aeb2897c6322f89dd17c641
-    :git: https://github.com/Automattic/Gridicons-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -154,6 +145,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 22d4c58200d7c105e0e407ab6bfd01a5d85014be
   ZendeskSDK: af6509ad7968d367f95b2645713802712152f879
 
-PODFILE CHECKSUM: d911e7f4902eefe2a0395e50ca16b0894f75f968
+PODFILE CHECKSUM: 8ef4c97eb133dc1f2e258ced7df0eff00031d890
 
 COCOAPODS: 1.5.3

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -177,7 +177,7 @@ private extension OrdersViewController {
         }()
 
         navigationItem.rightBarButtonItem = {
-            let button = UIBarButtonItem(image: Gridicon.iconOfType(.menus),
+            let button = UIBarButtonItem(image: Gridicon.iconOfType(.filter),
                                                  style: .plain,
                                                  target: self,
                                                  action: #selector(displayFiltersAlert))


### PR DESCRIPTION
Fixes #601. Requires changes made in https://github.com/Automattic/Gridicons-iOS/pull/36.

This PR updates the right nav bar button icon from .menu to .filter in the Order List. 
**Note:** this PR will not be merged until it is approved AND Gridicons 0.18 pod is published.

cc: @danielebogo 

<img src="https://user-images.githubusercontent.com/1062444/51146645-11026a80-181d-11e9-9916-38facd65cc08.png" width="350" />