### PR TITLE
Settings > Help: row titles and version number alignment

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -176,7 +176,7 @@ private extension HelpAndSupportViewController {
     func configureContactSupport(cell: ValueOneTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Contact support", comment: "Contact support title")
+        cell.textLabel?.text = NSLocalizedString("Contact Support", comment: "Contact Support title")
         cell.detailTextLabel?.text = NSLocalizedString("Reach our happiness engineers who can help answer tough questions", comment: "Subtitle for Contact Support")
     }
 
@@ -185,8 +185,8 @@ private extension HelpAndSupportViewController {
     func configureMyTickets(cell: ValueOneTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("My tickets", comment: "My tickets title")
-        cell.detailTextLabel?.text = NSLocalizedString("View previously submitted support tickets", comment: "subtitle for My tickets")
+        cell.textLabel?.text = NSLocalizedString("My Tickets", comment: "My Tickets title")
+        cell.detailTextLabel?.text = NSLocalizedString("View previously submitted support tickets", comment: "subtitle for My Tickets")
     }
 
     /// Contact Email cell.
@@ -194,7 +194,7 @@ private extension HelpAndSupportViewController {
     func configureMyContactEmail(cell: ValueOneTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Contact email", comment: "Contact email title")
+        cell.textLabel?.text = NSLocalizedString("Contact Email", comment: "Contact Email title")
         cell.detailTextLabel?.text = accountEmail
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -45,7 +45,6 @@ class HelpAndSupportViewController: UIViewController {
         configureMainView()
         configureSections()
         configureTableView()
-        configureTableViewFooter()
         registerTableViewCells()
         warnDeveloperIfNeeded()
     }
@@ -86,23 +85,6 @@ private extension HelpAndSupportViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = StyleManager.tableViewBackgroundColor
-    }
-
-    /// Display the version number in the footer.
-    ///
-    func configureTableViewFooter() {
-        let versionLabel = NSLocalizedString("Version", comment: "App version label")
-        let appVersion = UserAgent.bundleShortVersion
-        let versionSummary = versionLabel + " " + appVersion
-
-        /// `tableView.tableFooterView` can't handle a footerView that uses autolayout only.
-        /// Hence the container view with a defined frame.
-        let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
-        let footerView = TableFooterView.instantiateFromNib() as TableFooterView
-        footerView.footnoteText = versionSummary
-        footerView.footnoteColor = StyleManager.wooGreyMid
-        tableView.tableFooterView = footerContainer
-        footerContainer.addSubview(footerView)
     }
 
     /// Disable Zendesk if configuration on ZD init fails.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -176,7 +176,7 @@ private extension HelpAndSupportViewController {
     func configureContactSupport(cell: ValueOneTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Contact Support", comment: "Contact Support title")
+        cell.textLabel?.text = NSLocalizedString("Contact support", comment: "Contact support title")
         cell.detailTextLabel?.text = NSLocalizedString("Reach our happiness engineers who can help answer tough questions", comment: "Subtitle for Contact Support")
     }
 
@@ -185,8 +185,8 @@ private extension HelpAndSupportViewController {
     func configureMyTickets(cell: ValueOneTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("My Tickets", comment: "My Tickets title")
-        cell.detailTextLabel?.text = NSLocalizedString("View previously submitted support tickets", comment: "subtitle for My Tickets")
+        cell.textLabel?.text = NSLocalizedString("My tickets", comment: "My tickets title")
+        cell.detailTextLabel?.text = NSLocalizedString("View previously submitted support tickets", comment: "subtitle for My tickets")
     }
 
     /// Contact Email cell.
@@ -194,7 +194,7 @@ private extension HelpAndSupportViewController {
     func configureMyContactEmail(cell: ValueOneTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Contact Email", comment: "Contact Email title")
+        cell.textLabel?.text = NSLocalizedString("Contact email", comment: "Contact email title")
         cell.detailTextLabel?.text = accountEmail
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -48,7 +48,7 @@ class PrivacySettingsViewController: UIViewController {
 private extension PrivacySettingsViewController {
 
     func configureNavigation() {
-        title = NSLocalizedString("Privacy settings", comment: "Privacy settings screen title")
+        title = NSLocalizedString("Privacy Settings", comment: "Privacy settings screen title")
 
         // Don't show the Settings title in the next-view's back button
         let backButton = UIBarButtonItem(title: String(),
@@ -115,7 +115,7 @@ private extension PrivacySettingsViewController {
         cell.imageView?.tintColor = StyleManager.defaultTextColor
 
         // text
-        cell.title = NSLocalizedString("Collect information", comment: "Settings > Privacy Settings > collect info section. Label the `Collect information` toggle.")
+        cell.title = NSLocalizedString("Collect Information", comment: "Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle.")
 
         // switch
         cell.isOn = collectInfo
@@ -167,7 +167,7 @@ private extension PrivacySettingsViewController {
         cell.imageView?.tintColor = StyleManager.defaultTextColor
 
         // text
-        cell.title = NSLocalizedString("Report crashes", comment: "Settings > Privacy Settings > report crashes section. Label for the `Report crashes` toggle.")
+        cell.title = NSLocalizedString("Report Crashes", comment: "Settings > Privacy Settings > report crashes section. Label for the `Report Crashes` toggle.")
 
         // switch
         cell.isOn = reportCrashes

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -164,13 +164,13 @@ private extension SettingsViewController {
     func configureLicenses(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Open source licenses", comment: "Navigates to open source licenses screen")
+        cell.textLabel?.text = NSLocalizedString("Open Source Licenses", comment: "Navigates to open source licenses screen")
     }
 
     func configureAppSettings(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Open device settings", comment: "Opens iOS's Device Settings for the app")
+        cell.textLabel?.text = NSLocalizedString("Open Device Settings", comment: "Opens iOS's Device Settings for the app")
     }
 
     func configureLogout(cell: BasicTableViewCell) {


### PR DESCRIPTION
Fixes #598. 

In this PR the row titles change to consistent Title Casing for all Settings screens, and the version number is removed from the bottom of the Help screen.

@bummytime when you get time

| Before | After |
| ------ | ------ |
| ![settings-before](https://user-images.githubusercontent.com/1062444/51277149-69ac4180-199c-11e9-9d22-d49eeb49356b.png) | ![settings-after](https://user-images.githubusercontent.com/1062444/51277164-716be600-199c-11e9-826b-54797b517ea8.png) |
| ![privacy-before](https://user-images.githubusercontent.com/1062444/51277181-7a5cb780-199c-11e9-92ac-dbd494d6b9e0.png) | ![privacy-after](https://user-images.githubusercontent.com/1062444/51277195-80eb2f00-199c-11e9-8bf7-35f18e28a3f9.png) |
| ![help-before](https://user-images.githubusercontent.com/1062444/51277209-89dc0080-199c-11e9-84a8-21b951ebb8d6.png) | ![help-after](https://user-images.githubusercontent.com/1062444/51277215-8ea0b480-199c-11e9-9872-b62b383ea7fb.png) |