### PR TITLE
Mark the app as only using exempt encryption

### DIFF
--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -93,6 +93,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Copied from the WPiOS app:

https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Info.plist#L63-L64