### PR TITLE
Add source files for app store metadata and related lane

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -32,19 +32,19 @@ msgid ""
 "\n"
 "WooCommerce is the most customizable eCommerce platform for building your online business. Built on WordPress, it is integrated with the world’s best content management tools. From coffee subscriptions to Spanish lessons to gym memberships to complex enterprise-level eCommerce – visit WooCommerce.com/start to launch a new store and ship your idea.\n"
 "\n"
-"Requirements: WooCommerce v3.5+, the Jetpack plugin.\n"
+"Requirements: WooCommerce v3.5+, the Jetpack plugin."
 msgstr ""
 
 #. translators: Keywords used in the App Store search engine to find the app.
 #. Delimit with a comma between each keyword. Limit to 100 characters including spaces and commas.
 msgctxt "app_store_keywords"
-msgid "Woocommerce, woocommerce app, woocommerce mobile, woo app, woocommerce order alert, wordpress, eComm\n"
+msgid "Woocommerce, woocommerce app, woocommerce mobile, woo app, woocommerce order alert, wordpress, eComm"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.
 #. Limit to 170 characters including spaces and commas.
 msgctxt "app_store_promo_text"
-msgid "Run your store wherever you are. The WooCommerce app makes it easy to manage orders and inventory, track sales, and monitor store activity like new orders and reviews.\n"
+msgid "Run your store wherever you are. The WooCommerce app makes it easy to manage orders and inventory, track sales, and monitor store activity like new orders and reviews."
 msgstr ""
 
 msgctxt "v1.0-whats-new"
@@ -56,5 +56,4 @@ msgid ""
 "\n"
 "Thank you to everyone involved in development and early testing!\n"
 msgstr ""
-
 

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,0 +1,6 @@
+With the WooCommerce mobile app, you’ve got your online store in your pocket: manage orders, receive sales notifications, and view key metrics on the go.
+
+Drumroll, please: it’s our very first public release! We’re looking forward to iterating early and often and we can’t wait to hear your feedback and improvement suggestions.
+Get in touch via “Support” in the app or at ideas.woocommerce.com.
+
+Thank you to everyone involved in development and early testing!

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,39 @@ Dotenv.load('~/.wcios-env.default')
 ENV[GHHELPER_REPO="woocommerce/woocommerce-iOS"]
 
 ########################################################################
+# Release Lanes
+########################################################################
+  #####################################################################################
+  # update_appstore_strings
+  # -----------------------------------------------------------------------------------
+  # This lane updates the AppStoreStrings.pot files with the latest content from
+  # the release_notes.txt file and the other text sources
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane update_appstore_strings version:<release note version>
+  #
+  # Example:
+  # bundle exec fastlane update_appstore_strings version:1.1
+  #####################################################################################
+  desc "Updates the AppStoreStrings.pot file with the latest data"
+  lane :update_appstore_strings do | options |
+    prj_folder = Pathname.new(File.join(Dir.pwd, "..")).expand_path.to_s
+    source_metadata_folder = File.join(prj_folder, "fastlane/appstoreres/metadata/source")
+
+    files = {
+      whats_new: File.join(prj_folder,  "/WooCommerce/Resources/release_notes.txt"),
+      app_store_subtitle: File.join(source_metadata_folder, "subtitle.txt"),
+      app_store_desc: File.join(source_metadata_folder, "description.txt"),
+      app_store_keywords: File.join(source_metadata_folder, "keywords.txt"),
+      "app_store_promo_text" => File.join(source_metadata_folder, "app_store_promo_text.txt")
+    }
+
+    ios_update_metadata_source(po_file_path: prj_folder + "/WooCommerce/Resources/AppStoreStrings.pot", 
+      source_files: files, 
+      release_version: options[:version])
+  end
+
+########################################################################
 # Helper Lanes
 ########################################################################  
 desc "Get a list of pull request from `start_tag` to the current state"

--- a/fastlane/actions/ios_update_metadata_source.rb
+++ b/fastlane/actions/ios_update_metadata_source.rb
@@ -1,0 +1,83 @@
+module Fastlane
+  module Actions
+    class IosUpdateMetadataSourceAction < Action
+      def self.run(params)
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        other_action.gp_update_metadata_source(po_file_path: params[:po_file_path],
+          source_files: params[:source_files], 
+          release_version: params[:release_version])
+
+        Action.sh("git add #{params[:po_file_path]}")
+        params[:source_files].each do | key, file |
+          Action.sh("git add #{file}")
+        end
+
+        repo_status = Actions.sh("git status --porcelain")
+        repo_clean = repo_status.empty?
+        if (!repo_clean) then
+          Action.sh("git commit -m \"Update metadata strings\"")
+          Action.sh("git push")
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Updates the AppStoreStrings.po file with the data from text source files"
+      end
+
+      def self.details
+        "Updates the AppStoreStrings.po file with the data from text source files"
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :po_file_path,
+                                        env_name: "FL_IOS_UPDATE_METADATA_SOURCE_PO_FILE_PATH", 
+                                        description: "The path of the .po file to update", 
+                                        is_string: true,
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                        end),
+          FastlaneCore::ConfigItem.new(key: :release_version,
+                                        env_name: "FL_IOS_UPDATE_METADATA_SOURCE_RELEASE_VERSION",
+                                        description: "The release version of the app (to use to mark the release notes)",
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?) 
+                                        end),
+          FastlaneCore::ConfigItem.new(key: :source_files,
+                                        env_name: "FL_IOS_UPDATE_METADATA_SOURCE_SOURCE_FILES",
+                                        description: "The hash with the path to the source files and the key to use to include their content",
+                                        is_string: false,
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                        end)
+        ]
+      end
+
+      def self.output
+
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/fastlane/appstoreres/metadata/source/app_store_promo_text.txt
+++ b/fastlane/appstoreres/metadata/source/app_store_promo_text.txt
@@ -1,0 +1,1 @@
+Run your store wherever you are. The WooCommerce app makes it easy to manage orders and inventory, track sales, and monitor store activity like new orders and reviews.

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -1,0 +1,12 @@
+VIEW AND MANAGE ORDERS
+Scroll through, filter, or look up specific orders. Tap to view order information – including product(s), value, customer data, shipping details, and notes.
+
+TRACK YOUR STORE
+See which products are performing best. Check your overall revenue and view order and visitor data by week, month, and year.
+
+REAL-TIME ORDER ALERTS
+Get notifications about store activity – including new orders and product reviews.
+
+WooCommerce is the most customizable eCommerce platform for building your online business. Built on WordPress, it is integrated with the world’s best content management tools. From coffee subscriptions to Spanish lessons to gym memberships to complex enterprise-level eCommerce – visit WooCommerce.com/start to launch a new store and ship your idea.
+
+Requirements: WooCommerce v3.5+, the Jetpack plugin.

--- a/fastlane/appstoreres/metadata/source/keywords.txt
+++ b/fastlane/appstoreres/metadata/source/keywords.txt
@@ -1,0 +1,1 @@
+Woocommerce, woocommerce app, woocommerce mobile, woo app, woocommerce order alert, wordpress, eComm

--- a/fastlane/appstoreres/metadata/source/subtitle.txt
+++ b/fastlane/appstoreres/metadata/source/subtitle.txt
@@ -1,0 +1,1 @@
+Your store in your pocket


### PR DESCRIPTION
This PR adds the source files for the App Store metadata and a Fastlane lane to automatically update the related .pot files.

To Test:
1. Run `bundle exec fastlane update_appstore_strings version:1.0` and verify that nothing changes in the .pot file.
2. Check out a new branch from this one.
3. Make some changes to one of the .txt files and commit them.
4. Run `bundle exec fastlane update_appstore_strings version:1.0` and verify that the .pot file has been correctly updated. (Note that the lane may fail on the last `git push` command if the branch you are using doesn't have an upstream set).
