### PR TITLE
Dashboard: localize chart axis and chart markers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,1 +1,1 @@
-
+* Improved localization support on the charts in "My Store".

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -12,9 +12,7 @@ extension DateFormatter {
         ///
         public static let chartsDayFormatter: DateFormatter = {
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "MMM d"
+            formatter.setLocalizedDateFormatFromTemplate("MMM d")
             return formatter
         }()
 
@@ -22,9 +20,7 @@ extension DateFormatter {
         ///
         public static let chartsWeekFormatter: DateFormatter = {
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "MMM d"
+            formatter.setLocalizedDateFormatFromTemplate("MMM d")
             return formatter
         }()
 
@@ -32,9 +28,7 @@ extension DateFormatter {
         ///
         public static let chartsMonthFormatter: DateFormatter = {
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "MMM"
+            formatter.setLocalizedDateFormatFromTemplate("MMM")
             return formatter
         }()
 
@@ -42,9 +36,7 @@ extension DateFormatter {
         ///
         public static let chartsYearFormatter: DateFormatter = {
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.timeZone = TimeZone(identifier: "GMT")
-            formatter.dateFormat = "yyyy"
+            formatter.setLocalizedDateFormatFromTemplate("yyyy")
             return formatter
         }()
     }

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -45,7 +45,9 @@ extension DateFormatter {
 
         // MARK: - Chark marker formatters
 
-        /// Date formatter used for creating the date displayed on a chart marker for **day** granularity.
+        /// Date formatter used for creating a **localized** date string displayed on a chart marker for **day** granularity.
+        ///
+        /// Example Output: "Dec 30" or "12月30日"
         ///
         public static let chartMarkerDayFormatter: DateFormatter = {
             let formatter = DateFormatter()
@@ -53,7 +55,9 @@ extension DateFormatter {
             return formatter
         }()
 
-        /// Date formatter used for creating the date displayed on a chart marker for **week** granularity.
+        /// Date formatter used for creating a **localized** date string displayed on a chart marker for **week** granularity.
+        ///
+        /// Example Output: "1" or "23" (week number)
         ///
         public static let chartMarkerWeekFormatter: DateFormatter = {
             let formatter = DateFormatter()
@@ -63,7 +67,9 @@ extension DateFormatter {
             return formatter
         }()
 
-        /// Date formatter used for creating the date displayed on a chart marker for **month** granularity.
+        /// Date formatter used for creating a **localized** date string displayed on a chart marker for **month** granularity.
+        ///
+        /// Example Output: "Jan 2018" or "2018年1月"
         ///
         public static let chartMarkerMonthFormatter: DateFormatter = {
             let formatter = DateFormatter()
@@ -71,7 +77,9 @@ extension DateFormatter {
             return formatter
         }()
 
-        /// Date formatter used for creating the date displayed on a chart marker for **year** granularity.
+        /// Date formatter used for creating a **localized** date string displayed on a chart marker for **year** granularity.
+        ///
+        /// Example Output: "2018" or "2017"
         ///
         public static let chartMarkerYearFormatter: DateFormatter = {
             let formatter = DateFormatter()

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -10,7 +10,7 @@ extension DateFormatter {
 
         /// Date formatter used for creating the date displayed on a chart axis for **day** granularity.
         ///
-        public static let chartsDayFormatter: DateFormatter = {
+        public static let chartAxisDayFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("MMM d")
             return formatter
@@ -18,7 +18,7 @@ extension DateFormatter {
 
         /// Date formatter used for creating the date displayed on a chart axis for **week** granularity.
         ///
-        public static let chartsWeekFormatter: DateFormatter = {
+        public static let chartAxisWeekFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("MMM d")
             return formatter
@@ -26,7 +26,7 @@ extension DateFormatter {
 
         /// Date formatter used for creating the date displayed on a chart axis for **month** granularity.
         ///
-        public static let chartsMonthFormatter: DateFormatter = {
+        public static let chartAxisMonthFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("MMM")
             return formatter
@@ -34,7 +34,7 @@ extension DateFormatter {
 
         /// Date formatter used for creating the date displayed on a chart axis for **year** granularity.
         ///
-        public static let chartsYearFormatter: DateFormatter = {
+        public static let chartAxisYearFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("yyyy")
             return formatter

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -8,6 +8,8 @@ extension DateFormatter {
     ///
     struct Charts {
 
+        // MARK: - Chark axis formatters
+
         /// Date formatter used for creating the date displayed on a chart axis for **day** granularity.
         ///
         public static let chartAxisDayFormatter: DateFormatter = {
@@ -35,6 +37,43 @@ extension DateFormatter {
         /// Date formatter used for creating the date displayed on a chart axis for **year** granularity.
         ///
         public static let chartAxisYearFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("yyyy")
+            return formatter
+        }()
+
+
+        // MARK: - Chark marker formatters
+
+        /// Date formatter used for creating the date displayed on a chart marker for **day** granularity.
+        ///
+        public static let chartMarkerDayFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("MMM d")
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart marker for **week** granularity.
+        ///
+        public static let chartMarkerWeekFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            // Note: Passing "w Y" into `setLocalizedDateFormatFromTemplate()` will result in an empty string, however
+            // simply passing in "w" works. So that is what we have to unfortunately do here.
+            formatter.setLocalizedDateFormatFromTemplate("w")
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart marker for **month** granularity.
+        ///
+        public static let chartMarkerMonthFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("MMM yyyy")
+            return formatter
+        }()
+
+        /// Date formatter used for creating the date displayed on a chart marker for **year** granularity.
+        ///
+        public static let chartMarkerYearFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.setLocalizedDateFormatFromTemplate("yyyy")
             return formatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -542,19 +542,19 @@ private extension PeriodDataViewController {
         switch granularity {
         case .day:
             if let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartAxisDayFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartMarkerDayFormatter.string(from: periodDate)
             }
         case .week:
             if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartAxisWeekFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartMarkerWeekFormatter.string(from: periodDate)
             }
         case .month:
             if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartAxisMonthFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartMarkerMonthFormatter.string(from: periodDate)
             }
         case .year:
             if let periodDate = DateFormatter.Stats.statsYearFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartAxisYearFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartMarkerYearFormatter.string(from: periodDate)
             }
         }
         return dateString

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -88,14 +88,14 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
         guard let item = orderStats?.items?.first else {
             return ""
         }
-        return formattedPeriodString(for: item)
+        return formattedAxisPeriodString(for: item)
     }
 
     private var xAxisMaximum: String {
         guard let item = orderStats?.items?.last else {
             return ""
         }
-        return formattedPeriodString(for: item)
+        return formattedAxisPeriodString(for: item)
     }
 
     // MARK: - Initialization
@@ -336,7 +336,7 @@ extension PeriodDataViewController: IAxisValueFormatter {
 
         if axis is XAxis {
             if let item = orderStats.items?[Int(value)] {
-                return formattedPeriodString(for: item)
+                return formattedAxisPeriodString(for: item)
             } else {
                 return ""
             }
@@ -499,7 +499,7 @@ private extension PeriodDataViewController {
             let formattedAmount = CurrencyFormatter().formatCurrency(using: item.totalSales.friendlyString(),
                                                                      at: CurrencySettings.shared.currencyPosition,
                                                                      with: currencySymbol)
-            entry.accessibilityValue = "\(item.period): \(formattedAmount)"
+            entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"
             barColors.append(barColor(for: item.period))
             dataEntries.append(entry)
             barCount += 1
@@ -514,24 +514,47 @@ private extension PeriodDataViewController {
         return BarChartData(dataSet: dataSet)
     }
 
-    func formattedPeriodString(for item: OrderStatsItem) -> String {
+    func formattedAxisPeriodString(for item: OrderStatsItem) -> String {
         var dateString = ""
         switch granularity {
         case .day:
             if let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartsDayFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartAxisDayFormatter.string(from: periodDate)
             }
         case .week:
             if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartsWeekFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartAxisWeekFormatter.string(from: periodDate)
             }
         case .month:
             if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartsMonthFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartAxisMonthFormatter.string(from: periodDate)
             }
         case .year:
             if let periodDate = DateFormatter.Stats.statsYearFormatter.date(from: item.period) {
-                dateString = DateFormatter.Charts.chartsYearFormatter.string(from: periodDate)
+                dateString = DateFormatter.Charts.chartAxisYearFormatter.string(from: periodDate)
+            }
+        }
+        return dateString
+    }
+
+    func formattedChartMarkerPeriodString(for item: OrderStatsItem) -> String {
+        var dateString = ""
+        switch granularity {
+        case .day:
+            if let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartAxisDayFormatter.string(from: periodDate)
+            }
+        case .week:
+            if let periodDate = DateFormatter.Stats.statsWeekFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartAxisWeekFormatter.string(from: periodDate)
+            }
+        case .month:
+            if let periodDate = DateFormatter.Stats.statsMonthFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartAxisMonthFormatter.string(from: periodDate)
+            }
+        case .year:
+            if let periodDate = DateFormatter.Stats.statsYearFormatter.date(from: item.period) {
+                dateString = DateFormatter.Charts.chartAxisYearFormatter.string(from: periodDate)
             }
         }
         return dateString

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -85,6 +85,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "ja"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -85,7 +85,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = "ja"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
This PR fixes #621 by localizing the chart axis labels:

![3g](https://user-images.githubusercontent.com/154014/51632486-10508f00-1f15-11e9-8a91-3c5b5a579740.png)
![3j](https://user-images.githubusercontent.com/154014/51632490-12b2e900-1f15-11e9-9b77-446ee6a46983.png)
![3r](https://user-images.githubusercontent.com/154014/51632495-147cac80-1f15-11e9-8a66-c26414202e78.png)

As well as the chart markers on the chart bars:

![3](https://user-images.githubusercontent.com/154014/51632538-2bbb9a00-1f15-11e9-8049-6bffca44cfe4.png)

## Testing

* Build and run the app — verify the unit tests are ✅ and the code deltas look 👍 
* Build and run the app using different device languages in the simulator. You can do this by changing the schema settings in Xcode:

<img width="303" alt="xcode_schema_settings" src="https://user-images.githubusercontent.com/154014/51632681-88b75000-1f15-11e9-8c6b-144144c5616f.png">

Verify the chart markers and axis labels look like they are localized.

@mindgraffiti would you mind taking a peek at this?

----
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
