### PR TITLE
When no payment method exists, hide payment summary from payment section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,1 +1,3 @@
+1.1 Release
 
+- Bugfix: remove the payment method summary in the payment section when the no payment has been received.

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
@@ -145,7 +145,11 @@ class OrderDetailsViewModel {
     /// Payment Summary
     /// - returns: A full sentence summary of how much was paid and using what method.
     ///
-    var paymentSummary: String {
+    var paymentSummary: String? {
+        if order.paymentMethodTitle.isEmpty {
+            return nil
+        }
+
         return NSLocalizedString("Payment of \(totalValue) received via \(order.paymentMethodTitle)", comment: "Payment of <currency symbol><payment total> received via (payment method title)")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
@@ -22,10 +22,26 @@ class PaymentTableViewCell: UITableViewCell {
     @IBOutlet public weak var totalLabel: UILabel!
     @IBOutlet public weak var totalValue: UILabel!
 
-    @IBOutlet var footerView: UIView!
-    @IBOutlet public weak var separatorLine: UIView!
-    @IBOutlet public weak var footerValue: UILabel!
+    @IBOutlet private var footerView: UIView?
+    @IBOutlet private weak var separatorLine: UIView?
+    @IBOutlet private weak var footerLabel: UILabel?
+    @IBOutlet private weak var totalBottomConstraint: NSLayoutConstraint?
 
+    public var footerText: String? {
+        get {
+            return footerLabel?.text
+        }
+        set {
+            guard newValue != nil, newValue?.isEmpty == false else {
+                separatorLine?.removeFromSuperview()
+                footerLabel?.removeFromSuperview()
+                footerView?.removeFromSuperview()
+                totalBottomConstraint?.constant = 0
+                return
+            }
+            footerLabel?.text = newValue
+        }
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -39,6 +55,9 @@ class PaymentTableViewCell: UITableViewCell {
         taxesValue.applyBodyStyle()
         totalLabel.applyHeadlineStyle()
         totalValue.applyHeadlineStyle()
-        footerValue.applyFootnoteStyle()
+
+        footerLabel?.text = nil
+        footerLabel?.applyFootnoteStyle()
+        separatorLine?.backgroundColor = StyleManager.cellSeparatorColor
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -227,7 +227,6 @@
                             <constraint firstItem="K4G-Fo-ooM" firstAttribute="leading" secondItem="QyU-yD-WDZ" secondAttribute="leading" id="qpJ-Mq-2TX"/>
                             <constraint firstAttribute="trailing" secondItem="BAA-Mv-unS" secondAttribute="trailing" priority="800" id="rHo-rR-9g9"/>
                             <constraint firstAttribute="bottom" secondItem="bJ7-xj-eoW" secondAttribute="bottom" id="x7r-6M-kgO"/>
-                            <constraint firstItem="bJ7-xj-eoW" firstAttribute="top" secondItem="K4G-Fo-ooM" secondAttribute="bottom" constant="4" id="yNc-0h-tOe"/>
                         </constraints>
                     </stackView>
                 </subviews>
@@ -243,7 +242,7 @@
                 <outlet property="discountLabel" destination="LgV-BP-GFN" id="bcG-pd-fZY"/>
                 <outlet property="discountValue" destination="f7h-H4-cVj" id="nXU-Ma-GQu"/>
                 <outlet property="discountView" destination="Q5b-zU-7fY" id="ROH-sd-az8"/>
-                <outlet property="footerValue" destination="ejg-uy-1nm" id="sjM-vT-Nu3"/>
+                <outlet property="footerLabel" destination="ejg-uy-1nm" id="MvN-KA-CyB"/>
                 <outlet property="footerView" destination="bJ7-xj-eoW" id="x60-fi-vtR"/>
                 <outlet property="separatorLine" destination="AAH-DG-Pee" id="ClZ-K6-poD"/>
                 <outlet property="shippingLabel" destination="gTx-ab-CBl" id="vFS-6X-myF"/>
@@ -255,6 +254,7 @@
                 <outlet property="taxesLabel" destination="z9r-YA-aG9" id="wEN-D1-H8l"/>
                 <outlet property="taxesValue" destination="pCA-4f-cjt" id="kP4-iN-Nx0"/>
                 <outlet property="taxesView" destination="BAA-Mv-unS" id="wOK-9o-G7C"/>
+                <outlet property="totalBottomConstraint" destination="D0q-sd-BVi" id="PVk-MW-JHQ"/>
                 <outlet property="totalLabel" destination="6Pa-jd-Tcj" id="Ebx-MN-9VH"/>
                 <outlet property="totalValue" destination="awb-Pi-AeE" id="rSC-nG-idX"/>
                 <outlet property="totalView" destination="K4G-Fo-ooM" id="TjD-wt-oyz"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -396,10 +396,13 @@ private extension OrderDetailsViewController {
         cell.totalLabel.text = viewModel.totalLabel
         cell.totalValue.text = viewModel.totalValue
 
-        cell.separatorLine.backgroundColor = StyleManager.cellSeparatorColor
-        cell.footerValue.text = viewModel.paymentSummary
+        cell.footerText = viewModel.paymentSummary
 
-        cell.accessibilityElements = [cell.subtotalLabel, cell.subtotalValue, cell.discountLabel, cell.discountValue, cell.shippingLabel, cell.shippingValue, cell.taxesLabel, cell.taxesValue, cell.totalLabel, cell.totalValue, cell.footerValue]
+        cell.accessibilityElements = [cell.subtotalLabel, cell.subtotalValue, cell.discountLabel, cell.discountValue, cell.shippingLabel, cell.shippingValue, cell.taxesLabel, cell.taxesValue, cell.totalLabel, cell.totalValue]
+
+        if let footerText = cell.footerText {
+            cell.accessibilityElements?.append(footerText)
+        }
     }
 
     func configureProductDetails(cell: BasicTableViewCell) {


### PR DESCRIPTION
Fixes #603.

This applies to **all** orders that do not have a defined payment method, but the easiest orders to spot this change is on orders with the "On Hold" or "Scheduled Payment" status.

cc: @astralbodies who wrote the bug ;)

| Before | After |
|------- | -----|
| <img src="https://user-images.githubusercontent.com/373903/51138145-f07ae600-1805-11e9-8923-8c0816aec587.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1062444/51633757-08deb500-1f18-11e9-849b-aff24dac2cad.png" width="300" /> |

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
