### PR TITLE
Fixes some localization issues on the Order List and Notification screens

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
-- bugfix: Improved localization support on the charts in "My Store"
+- bugfix: Improved localization support on the charts
+- bugfix: Improved localization support on the "Orders" & "Notifications" screens
 - bugfix: Hide orders that have a created date listed in the future. (They no longer display under the "Today" section of an order list)

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -142,6 +142,8 @@ class NotificationsViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+
+        // This 👇 should be called in init so the tab is correctly localized when the app launches
         configureTabBarItem()
     }
 
@@ -186,7 +188,7 @@ private extension NotificationsViewController {
     /// Setup: TabBar
     ///
     func configureTabBarItem() {
-        tabBarItem.title = NSLocalizedString("Notifications", comment: "Notifications tab title")
+        tabBarItem.title = NSLocalizedString("Notifications", comment: "Title of the Notifications tab — plural form of Notification")
         tabBarItem.image = Gridicon.iconOfType(.bell)
     }
 
@@ -240,11 +242,14 @@ private extension NotificationsViewController {
 
     func refreshTitle() {
         guard currentTypeFilter != .all else {
-            navigationItem.title = NSLocalizedString("Notifications", comment: "Notifications title")
+            navigationItem.title = NSLocalizedString("Notifications",
+                                                     comment: "Title that appears on top of the main Notifications screen when there is no filter applied to the list (plural form of the word Notification).")
             return
         }
 
-        navigationItem.title = NSLocalizedString("Notifications: \(currentTypeFilter.description)", comment: "Notifications filtered title")
+        let title = String.localizedStringWithFormat(NSLocalizedString("Notifications: %@",
+                                                                       comment: "Title that appears on top of the Notifications screen when a filter is applied. It reads: Notifications: {name of filter}"), currentTypeFilter.description.capitalized)
+        navigationItem.title = title
     }
 }
 
@@ -856,11 +861,11 @@ private extension NotificationsViewController {
         var description: String {
             switch self {
             case .all:
-                return NSLocalizedString("All", comment: "All filter title")
+                return NSLocalizedString("All", comment: "Name of the All filter on the Notifications screen - it means all notifications will be displayed.")
             case .orders:
-                return NSLocalizedString("Orders", comment: "Orders filter title")
+                return NSLocalizedString("Orders", comment: "Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. Plural form of the word Order.")
             case .reviews:
-                return NSLocalizedString("Reviews", comment: "Reviews filter title")
+                return NSLocalizedString("Reviews", comment: "Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. Plural form of the word Review.")
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -100,8 +100,8 @@ class OrdersViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
-        tabBarItem.title = NSLocalizedString("Orders", comment: "Orders Title")
-        tabBarItem.image = Gridicon.iconOfType(.pages)
+        // This 👇 should be called in init so the tab is correctly localized when the app launches
+        configureTabBarItem()
     }
 
     override func viewDidLoad() {
@@ -113,7 +113,6 @@ class OrdersViewController: UIViewController {
 
         configureSyncingCoordinator()
         configureNavigation()
-        configureTabBarItem()
         configureTableView()
         configureResultsController()
 
@@ -138,12 +137,13 @@ private extension OrdersViewController {
     /// Setup: Title
     ///
     func refreshTitle() {
-        guard let filter = statusFilter?.rawValue.capitalized else {
-            navigationItem.title = NSLocalizedString("Orders", comment: "Orders Title")
+        guard let filter = statusFilter?.description.capitalized else {
+            navigationItem.title = NSLocalizedString("Orders", comment: "Title that appears on top of the Order List screen when there is no filter applied to the list (plural form of the word Order).")
             return
         }
 
-        navigationItem.title = NSLocalizedString("Orders: \(filter)", comment: "Orders Title")
+        let title = String.localizedStringWithFormat(NSLocalizedString("Orders: %@", comment: "Title that appears on top of the Order List screen when a filter is applied. It reads: Orders: {name of filter}"), filter)
+        navigationItem.title = title
     }
 
     /// Setup: Filtering
@@ -213,7 +213,8 @@ private extension OrdersViewController {
     /// Setup: TabBar Item
     ///
     func configureTabBarItem() {
-        tabBarItem.title = NSLocalizedString("Orders", comment: "Orders Title")
+        tabBarItem.title = NSLocalizedString("Orders", comment: "Title of the Orders tab — plural form of Order")
+        tabBarItem.image = Gridicon.iconOfType(.pages)
     }
 
     /// Setup: TableView
@@ -681,7 +682,7 @@ private extension OrdersViewController {
 
     enum FilterAction {
         static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the action sheet")
-        static let displayAll = NSLocalizedString("All", comment: "All filter title")
+        static let displayAll = NSLocalizedString("All", comment: "Name of the All filter on the Order List screen - it means all orders will be displayed.")
     }
 
     enum Settings {


### PR DESCRIPTION
This PR cleans up some of the localization issues found in #631 (see the issue for specifics). In short, I added more detailed translator comments, made sure we are calling `String.localizedStringWithFormat` for the navbar titles when filters are used, and made sure we set each VC's tabbar title in `init()` and not `viewDidLoad()`.

Fixes: #631 

## Testing

This might be a little difficult to test since we don't have the i18n strings files in place yet for some of these words.....but in general, make sure the logic makes sense and try launching the sim using different default languages to make sure nothing breaks. 😃 

----
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
