### PR TITLE
Add promo strings for screenshots

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -57,3 +57,69 @@ msgid ""
 "Thank you to everyone involved in development and early testing!\n"
 msgstr ""
 
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-1"
+msgid ""
+"Your Store\n"
+"in Your Pocket"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-1_b"
+msgid ""
+"Made with\n"
+"at Automattic"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-2"
+msgid "View and manage orders"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-3"
+msgid "Get real-time order alerts"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-4"
+msgid "Track order status"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-5"
+msgid ""
+"Scroll through, filter,\n"
+"or look up specific orders"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-6"
+msgid ""
+"View store data by week,\n"
+"month, and year"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-7"
+msgid ""
+"Check which products are\n"
+"performing best"
+msgstr ""
+
+#. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
+#. No specified characters limit here, but try to keep as short as the source one. 
+msgctxt "app_store_screenshot-8"
+msgid ""
+"Get notified about new\n"
+"customer reviews"
+msgstr ""
+

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,16 @@ ENV[GHHELPER_REPO="woocommerce/woocommerce-iOS"]
       app_store_subtitle: File.join(source_metadata_folder, "subtitle.txt"),
       app_store_desc: File.join(source_metadata_folder, "description.txt"),
       app_store_keywords: File.join(source_metadata_folder, "keywords.txt"),
-      "app_store_promo_text" => File.join(source_metadata_folder, "app_store_promo_text.txt")
+      "app_store_promo_text" => File.join(source_metadata_folder, "app_store_promo_text.txt"),
+      "app_store_screenshot-1" => File.join(source_metadata_folder, "promo_screenshot_1.txt"),
+      "app_store_screenshot-1_b" => File.join(source_metadata_folder, "promo_screenshot_1_b.txt"),
+      "app_store_screenshot-2" => File.join(source_metadata_folder, "promo_screenshot_2.txt"),
+      "app_store_screenshot-3" => File.join(source_metadata_folder, "promo_screenshot_3.txt"),
+      "app_store_screenshot-4" => File.join(source_metadata_folder, "promo_screenshot_4.txt"),
+      "app_store_screenshot-5" => File.join(source_metadata_folder, "promo_screenshot_5.txt"),
+      "app_store_screenshot-6" => File.join(source_metadata_folder, "promo_screenshot_6.txt"),
+      "app_store_screenshot-7" => File.join(source_metadata_folder, "promo_screenshot_7.txt"),
+      "app_store_screenshot-8" => File.join(source_metadata_folder, "promo_screenshot_8.txt")
     }
 
     ios_update_metadata_source(po_file_path: prj_folder + "/WooCommerce/Resources/AppStoreStrings.pot", 

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
@@ -1,0 +1,2 @@
+Your Store
+in Your Pocket

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_1_b.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_1_b.txt
@@ -1,0 +1,2 @@
+Made with
+at Automattic

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
@@ -1,0 +1,1 @@
+View and manage orders

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
@@ -1,0 +1,1 @@
+Get real-time order alerts

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
@@ -1,0 +1,1 @@
+Track order status

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
@@ -1,0 +1,2 @@
+Scroll through, filter,
+or look up specific orders

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
@@ -1,0 +1,2 @@
+View store data by week,
+month, and year

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
@@ -1,0 +1,2 @@
+Check which products are
+performing best

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_8.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_8.txt
@@ -1,0 +1,2 @@
+Get notified about new
+customer reviews


### PR DESCRIPTION
This PR adds the strings used as promotional messages in the screenshots to the set of strings to send to translators.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
