### PR TITLE
Log out should reset Zendesk email / username

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,4 +2,5 @@
 - bugfix: Improved localization support on the charts in "My Store"
 
 - bugfix: hide orders that have a created date listed in the future. (They no longer display under the "Today" section of an order list).
-- Bugfix: remove the payment method summary in the payment section when the no payment has been received.
+- bugfix: remove the payment method summary in the payment section when the no payment has been received.
+- bugfix: logging out resets Zendesk username / email

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -57,7 +57,6 @@ class ZendeskManager: NSObject {
     }
 
 
-
     /// Deinitializer
     ///
     deinit {
@@ -89,6 +88,13 @@ class ZendeskManager: NSObject {
 
         haveUserIdentity = getUserProfile()
         zendeskEnabled = true
+    }
+
+    /// Deletes all known user default keys
+    ///
+    func reset() {
+        removeUserProfile()
+        removeUnreadCount()
     }
 
 
@@ -494,6 +500,14 @@ private extension ZendeskManager {
 
     func saveUnreadCount() {
         UserDefaults.standard.set(unreadNotificationsCount, forKey: Constants.unreadNotificationsKey)
+    }
+
+    func removeUserProfile() {
+        UserDefaults.standard.removeObject(forKey: Constants.zendeskProfileUDKey)
+    }
+
+    func removeUnreadCount() {
+        UserDefaults.standard.removeObject(forKey: Constants.unreadNotificationsKey)
     }
 
 

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -111,6 +111,7 @@ class StoresManager {
 
         sessionManager.reset()
         WooAnalytics.shared.refreshUserData()
+        ZendeskManager.shared.reset()
         AppDelegate.shared.storageManager.reset()
 
         return self


### PR DESCRIPTION
Fixes #606.

## To test:
- log in with a WP.com account
- navigate to My store > Settings > Help & Support
- check Contact Email
- log out
- log in with a different WP.com account
- navigate to My store > Settings > Help & Support
- check Contact Email

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
