### PR TITLE
Restore displaying taxes, even when amounts are zero.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,3 +3,4 @@
 - bugfix: improved localization support on the Orders & Notifications screens
 - bugfix: hide orders that have a created date listed in the future. (They no longer display under the "Today" section of an order list).
 - Bugfix: remove the payment method summary in the payment section when the no payment has been received.
+- bugfix: display Taxes line to payment and product details, including when amount is zero.

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
@@ -99,21 +99,13 @@ class OrderDetailsViewModel {
     }
 
     /// Taxes
-    /// - returns: 'Taxes' label and total taxes, or nil if zero.
+    /// - returns: 'Taxes' label and total taxes, including zero amounts.
     ///
     var taxesLabel: String? {
-        guard let total = currencyFormatter.convertToDecimal(from: order.totalTax), total.isZero() == false else {
-            return nil
-        }
-
         return NSLocalizedString("Taxes", comment: "Taxes label for payment view")
     }
 
     var taxesValue: String? {
-        guard let total = currencyFormatter.convertToDecimal(from: order.totalTax), total.isZero() == false else {
-            return nil
-        }
-
         return currencyFormatter.formatAmount(order.totalTax, with: order.currency)
     }
 

--- a/WooCommerce/Classes/ViewModels/OrderItemViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderItemViewModel.swift
@@ -45,13 +45,9 @@ struct OrderItemViewModel {
     }
 
     /// Item's Tax
-    /// Not all items have a tax. Return nil if amount is zero, so labels will hide.
+    /// Return $0.00 if there is no tax.
     ///
     var tax: String? {
-        guard let decimalAmount = currencyFormatter.convertToDecimal(from: item.totalTax), decimalAmount.isZero() == false else {
-            return nil
-        }
-
         let prefix = NSLocalizedString("Tax:", comment: "Tax label for total taxes line")
         let totalTax = currencyFormatter.formatAmount(item.totalTax, with: currency) ?? String()
         return prefix + " " + totalTax


### PR DESCRIPTION
Fixes #633.

## To Test:
- navigate to an order detail view (Orders > an Order > scroll to payment section) and check the payment section
- navigate to a product details view (Orders > Order No. 1939 > Details) and check for the Taxes line

<img src="https://user-images.githubusercontent.com/1062444/51699406-4738aa80-1fd2-11e9-8559-5aa6892c0aca.png" width="350" />
<img src="https://user-images.githubusercontent.com/1062444/51699412-4d2e8b80-1fd2-11e9-8f89-450baf9d3f3d.png" width="350" />


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
