### PR TITLE
Login: Add help button to store picker screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,3 +5,4 @@
 - bugfix: remove the payment method summary in the payment section when the no payment has been received.
 - bugfix: logging out resets Zendesk username / email
 - bugfix: display Taxes line to payment and product details, including when amount is zero.
+- bugfix: add help button to store picker screen

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -35,6 +35,10 @@ class AccountHeaderView: UIView {
     ///
     @IBOutlet private weak var helpButton: UIButton!
 
+    /// Closure to be executed whenever the help button is pressed
+    ///
+    var onHelpRequested: (() -> Void)?
+
     // MARK: - Overridden Methods
 
     override func awakeFromNib() {
@@ -83,9 +87,8 @@ extension AccountHeaderView {
 private extension AccountHeaderView {
 
     func setupHelpButton() {
-        let helpButtonTitle = NSLocalizedString("Help", comment: "Help button on store picker screen.")
-        helpButton.setTitle(helpButtonTitle, for: .normal)
-        helpButton.setTitle(helpButtonTitle, for: .highlighted)
+        helpButton.setTitle(Strings.helpButtonTitle, for: .normal)
+        helpButton.setTitle(Strings.helpButtonTitle, for: .highlighted)
         helpButton.setTitleColor(StyleManager.wooCommerceBrandColor, for: .normal)
         helpButton.setTitleColor(StyleManager.wooGreyMid, for: .highlighted)
         helpButton.on(.touchUpInside) { [weak self] control in
@@ -96,6 +99,16 @@ private extension AccountHeaderView {
     /// Handle the help button being tapped
     ///
     func handleHelpButtonTapped(_ sender: AnyObject) {
-        //TODO: Imp the help on the picker screen
+        onHelpRequested?()
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension AccountHeaderView {
+
+    enum Strings {
+        static let helpButtonTitle = NSLocalizedString("Help", comment: "Help button on store picker screen.")
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -30,6 +30,17 @@ class AccountHeaderView: UIView {
             usernameLabel.textColor = StyleManager.wooGreyTextMin
         }
     }
+
+    /// Help Button
+    ///
+    @IBOutlet private weak var helpButton: UIButton!
+
+    // MARK: - Overridden Methods
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupHelpButton()
+    }
 }
 
 
@@ -63,5 +74,28 @@ extension AccountHeaderView {
     ///
     func downloadGravatar(with email: String) {
         gravatarImageView.downloadGravatarWithEmail(email)
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension AccountHeaderView {
+
+    func setupHelpButton() {
+        let helpButtonTitle = NSLocalizedString("Help", comment: "Help button on store picker screen.")
+        helpButton.setTitle(helpButtonTitle, for: .normal)
+        helpButton.setTitle(helpButtonTitle, for: .highlighted)
+        helpButton.setTitleColor(StyleManager.wooCommerceBrandColor, for: .normal)
+        helpButton.setTitleColor(StyleManager.wooGreyMid, for: .highlighted)
+        helpButton.on(.touchUpInside) { [weak self] control in
+            self?.handleHelpButtonTapped(control)
+        }
+    }
+
+    /// Handle the help button being tapped
+    ///
+    func handleHelpButtonTapped(_ sender: AnyObject) {
+        //TODO: Imp the help on the picker screen
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.xib
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,6 +35,11 @@
                     <color key="textColor" cocoaTouchSystemColor="scrollViewTexturedBackgroundColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VVa-5o-MfJ">
+                    <rect key="frame" x="316" y="2" width="36" height="33"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <state key="normal" title="Help"/>
+                </button>
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
@@ -41,9 +47,11 @@
                 <constraint firstItem="xHF-gJ-reo" firstAttribute="top" secondItem="vOQ-CP-fZ1" secondAttribute="bottom" constant="8" id="BTx-oz-REg"/>
                 <constraint firstItem="DAy-rN-ump" firstAttribute="trailing" secondItem="xHF-gJ-reo" secondAttribute="trailing" constant="10" id="JKO-gN-oNe"/>
                 <constraint firstItem="vOQ-CP-fZ1" firstAttribute="centerX" secondItem="wsJ-iY-FyE" secondAttribute="centerX" id="NgM-Yn-gMx"/>
+                <constraint firstItem="VVa-5o-MfJ" firstAttribute="top" secondItem="DAy-rN-ump" secondAttribute="top" constant="2" id="OI5-8Y-b7J"/>
                 <constraint firstItem="xHF-gJ-reo" firstAttribute="leading" secondItem="DAy-rN-ump" secondAttribute="leading" constant="10" id="bvI-bc-8La"/>
                 <constraint firstItem="LiJ-G2-nZS" firstAttribute="top" secondItem="xHF-gJ-reo" secondAttribute="bottom" constant="4" id="gOl-k9-naS"/>
                 <constraint firstItem="DAy-rN-ump" firstAttribute="trailing" secondItem="LiJ-G2-nZS" secondAttribute="trailing" constant="10" id="je2-Uv-FAR"/>
+                <constraint firstItem="DAy-rN-ump" firstAttribute="trailing" secondItem="VVa-5o-MfJ" secondAttribute="trailing" constant="23" id="pHG-lI-j8V"/>
                 <constraint firstItem="vOQ-CP-fZ1" firstAttribute="top" secondItem="DAy-rN-ump" secondAttribute="top" constant="29" id="yHD-B7-H48"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
@@ -53,9 +61,10 @@
             <connections>
                 <outlet property="fullnameLabel" destination="xHF-gJ-reo" id="ba9-Sw-RJO"/>
                 <outlet property="gravatarImageView" destination="vOQ-CP-fZ1" id="K0E-fC-gY9"/>
+                <outlet property="helpButton" destination="VVa-5o-MfJ" id="jqF-NU-aZe"/>
                 <outlet property="usernameLabel" destination="LiJ-G2-nZS" id="SiG-bv-eTM"/>
             </connections>
-            <point key="canvasLocation" x="-6.5" y="-333"/>
+            <point key="canvasLocation" x="-7.2000000000000002" y="-333.7331334332834"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -146,6 +146,9 @@ private extension StorePickerViewController {
         accountHeaderView.username = "@" + defaultAccount.username
         accountHeaderView.fullname = defaultAccount.displayName
         accountHeaderView.downloadGravatar(with: defaultAccount.email)
+        accountHeaderView.onHelpRequested = {
+            AppDelegate.shared.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin)
+        }
     }
 
     func refreshResults() {


### PR DESCRIPTION
This PR adds the ability to access help from the store picker screen:

![store_picker_help](https://user-images.githubusercontent.com/154014/51711767-90005b80-1ff2-11e9-8f5c-a674b9508299.gif)

Fixes: #619 

## Testing

**Test this flow on various devices including iPads**

1. Log into the app and get to the store picker screen
2. Tap the help button in the upper right-hand corner of the screen
3. Verify the support screen appears and works as expected
4. Rotate the device to landscape and attempt steps 1-3 again. 😃 

@mindgraffiti Could you take a quick look at this for me?

----
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
