### PR TITLE
Store picker: don't allow cell selection for a single store

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,1 +1,2 @@
 - bugfix: add help button to store picker screen
+- bugfix: on the store picker, don't allow the tableview cell to be selected if there only is a single store

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -396,6 +396,14 @@ extension StorePickerViewController: UITableViewDelegate {
         return UITableView.automaticDimension
     }
 
+    func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        guard state.multipleStoresAvailable else {
+            // If we only have a single store available, don't allow the row to be selected
+            return false
+        }
+        return true
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let site = state.site(at: indexPath) else {
             tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
This PR disables cell selection if a user only has 1 store available on the store picker screen:

![site_picker_1_store](https://user-images.githubusercontent.com/154014/51856628-c5a88b80-22f5-11e9-9f55-0cc648f8b9ee.gif)

Fixes: #599 

/cc @astralbodies 

## Testing

### Scenario 1: User account with single store
0.  Build and run the app (log out if needed)
1. Log into the app and stop on the store picker screen
2. Attempt to select the (only) store tableview cell
- [x] Verify the tableview cell cannot be selected
- [x] When the store picker screen first appears, verify the requirements check runs on the store (and disables the "Continue" button if needed)

### Scenario 2: User account with multiple stores
0.  Build and run the app (log out if needed)
1. Log into the app and stop on the store picker screen
2. Attempt to select all of the store tableview cells
- [x] Verify all tableview cells can be selected and the check mark appears for the selected store
- [x] Verify the requirements check runs when a given store is selected (and disables the "Continue" button if needed)

@mindgraffiti would you mind 👀 at this one?

----
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
