### PR TITLE
i18n: UI label improvements

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -78,7 +78,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
     private var summaryDateUpdated: String {
         if let lastUpdatedDate = lastUpdatedDate {
             return String.localizedStringWithFormat(NSLocalizedString("Updated %@",
-                                                                      comment: "Stats summary date"), lastUpdatedDate.mediumString())
+                                                                      comment: "Stats summary date. Examples: Updated just now. Updated 1 second ago. Updated 5 minutes ago."), lastUpdatedDate.mediumString())
         } else {
             return ""
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -281,7 +281,7 @@ private extension FulfillViewController {
 
         guard let address = order.shippingAddress ?? order.billingAddress else {
             cell.title = NSLocalizedString("Shipping details", comment: "Shipping title for customer info cell")
-            cell.address = NSLocalizedString("No address specified.", comment: "Fulfill order > customer info > where the address would normally display.")
+            cell.address = NSLocalizedString("No address specified.", comment: "Fulfill order > customer info > where the physical shipping address would normally display.")
             return
         }
 


### PR DESCRIPTION
Fixes #620. 

Nothing to test. Check the code for:
1. Translator comment has improved context for "No address specified"
2. (awaiting response)
3. Translator comment has new examples for "Updated %@" in My store > stats
4. Payment summaries have been removed for orders where a payment hasn't been received yet.
5. Ticket filed for this: #644. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
