### PR TITLE
Help & Support: Add the app log feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 - bugfix: add help button to store picker screen
 - bugfix: on the store picker, don't allow the tableview cell to be selected if there only is a single store
+- new feature: application logs. Share your application logs for support purposes.

--- a/WooCommerce/Classes/Tools/SharingHelper.swift
+++ b/WooCommerce/Classes/Tools/SharingHelper.swift
@@ -40,6 +40,28 @@ class SharingHelper {
 
         viewController.present(avc, animated: true)
     }
+
+    /// List all activity types.
+    /// UIActivity.ActivityType is not CaseIterable. :sadface:
+    ///
+    static func allActivityTypes() -> [UIActivity.ActivityType] {
+        return [.postToFacebook,
+                .postToTwitter,
+                .postToWeibo,
+                .message,
+                .mail,
+                .print,
+                .copyToPasteboard,
+                .assignToContact,
+                .saveToCameraRoll,
+                .addToReadingList,
+                .postToFlickr,
+                .postToVimeo,
+                .postToTencentWeibo,
+                .airDrop,
+                .openInIBooks,
+                .markupAsPDF]
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -267,11 +267,27 @@
                     </view>
                     <connections>
                         <outlet property="tableView" destination="pYs-VV-dST" id="Cqx-Lg-UJh"/>
+                        <segue destination="dyy-ah-iUY" kind="show" identifier="ShowApplicationLogDetailViewController" id="Ws4-zy-SlV"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fOe-oS-ZTi" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2356" y="811"/>
+        </scene>
+        <!--Application Log Detail View Controller-->
+        <scene sceneID="EFa-xb-BCc">
+            <objects>
+                <viewController id="dyy-ah-iUY" customClass="ApplicationLogDetailViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="TC5-cg-3Zt">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="qu3-Gh-sHY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="gfH-Fa-ysG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3385" y="811"/>
         </scene>
         <!--Help And Support View Controller-->
         <scene sceneID="k0p-fl-BDY">

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -239,6 +239,21 @@
             </objects>
             <point key="canvasLocation" x="1388" y="2389.6551724137935"/>
         </scene>
+        <!--Application Log View Controller-->
+        <scene sceneID="bod-JW-RLg">
+            <objects>
+                <viewController id="cZP-lH-gTc" customClass="ApplicationLogViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="kTI-Ip-3qK">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="qMn-MK-zzV"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fOe-oS-ZTi" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2356" y="811"/>
+        </scene>
         <!--Help And Support View Controller-->
         <scene sceneID="k0p-fl-BDY">
             <objects>
@@ -267,11 +282,12 @@
                     </view>
                     <connections>
                         <outlet property="tableView" destination="egg-mo-Y4S" id="Q6m-Fm-qjc"/>
+                        <segue destination="cZP-lH-gTc" kind="show" identifier="ShowApplicationLogViewController" id="C0s-Ys-0iv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FQx-lA-JpF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1388" y="1584.5577211394304"/>
+            <point key="canvasLocation" x="1342" y="1036"/>
         </scene>
         <!--Dashboard-->
         <scene sceneID="GIl-fY-LQR">

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -281,9 +281,27 @@
                     <view key="view" contentMode="scaleToFill" id="TC5-cg-3Zt">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="VZ4-xD-33I">
+                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="qu3-Gh-sHY" firstAttribute="trailing" secondItem="VZ4-xD-33I" secondAttribute="trailing" id="8wA-JR-wkn"/>
+                            <constraint firstItem="qu3-Gh-sHY" firstAttribute="bottom" secondItem="VZ4-xD-33I" secondAttribute="bottom" id="IXk-tT-3gh"/>
+                            <constraint firstItem="VZ4-xD-33I" firstAttribute="leading" secondItem="qu3-Gh-sHY" secondAttribute="leading" id="cqp-3w-94p"/>
+                            <constraint firstItem="VZ4-xD-33I" firstAttribute="top" secondItem="qu3-Gh-sHY" secondAttribute="top" id="vvb-90-1BA"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="qu3-Gh-sHY"/>
                     </view>
+                    <connections>
+                        <outlet property="textview" destination="VZ4-xD-33I" id="02L-PL-IgW"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gfH-Fa-ysG" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -246,9 +246,28 @@
                     <view key="view" contentMode="scaleToFill" id="kTI-Ip-3qK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="pYs-VV-dST">
+                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="cZP-lH-gTc" id="elE-X0-kT3"/>
+                                    <outlet property="delegate" destination="cZP-lH-gTc" id="Pq1-iP-TpG"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="qMn-MK-zzV" firstAttribute="trailing" secondItem="pYs-VV-dST" secondAttribute="trailing" id="9bn-9p-K1Z"/>
+                            <constraint firstItem="pYs-VV-dST" firstAttribute="leading" secondItem="qMn-MK-zzV" secondAttribute="leading" id="OUm-VB-DJ3"/>
+                            <constraint firstItem="pYs-VV-dST" firstAttribute="top" secondItem="qMn-MK-zzV" secondAttribute="top" id="nJg-fe-Omp"/>
+                            <constraint firstItem="qMn-MK-zzV" firstAttribute="bottom" secondItem="pYs-VV-dST" secondAttribute="bottom" id="o10-zc-2HE"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="qMn-MK-zzV"/>
                     </view>
+                    <connections>
+                        <outlet property="tableView" destination="pYs-VV-dST" id="Cqx-Lg-UJh"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fOe-oS-ZTi" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -283,7 +283,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="VZ4-xD-33I">
-                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <rect key="frame" x="16" y="64" width="343" height="554"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -292,10 +292,10 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="qu3-Gh-sHY" firstAttribute="trailing" secondItem="VZ4-xD-33I" secondAttribute="trailing" id="8wA-JR-wkn"/>
-                            <constraint firstItem="qu3-Gh-sHY" firstAttribute="bottom" secondItem="VZ4-xD-33I" secondAttribute="bottom" id="IXk-tT-3gh"/>
-                            <constraint firstItem="VZ4-xD-33I" firstAttribute="leading" secondItem="qu3-Gh-sHY" secondAttribute="leading" id="cqp-3w-94p"/>
-                            <constraint firstItem="VZ4-xD-33I" firstAttribute="top" secondItem="qu3-Gh-sHY" secondAttribute="top" id="vvb-90-1BA"/>
+                            <constraint firstItem="VZ4-xD-33I" firstAttribute="bottom" secondItem="qu3-Gh-sHY" secondAttribute="bottom" id="4Ax-uJ-Iya"/>
+                            <constraint firstItem="VZ4-xD-33I" firstAttribute="leading" secondItem="qu3-Gh-sHY" secondAttribute="leading" constant="16" id="8fn-dv-dTY"/>
+                            <constraint firstItem="VZ4-xD-33I" firstAttribute="top" secondItem="qu3-Gh-sHY" secondAttribute="top" id="B4a-y2-5Qj"/>
+                            <constraint firstItem="qu3-Gh-sHY" firstAttribute="trailing" secondItem="VZ4-xD-33I" secondAttribute="trailing" constant="16" id="Pft-fy-5s7"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="qu3-Gh-sHY"/>
                     </view>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ApplicationLogDetailViewController.swift
+//  WooCommerce
+//
+//  Created by Thuy Copeland on 1/29/19.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class ApplicationLogDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -17,7 +17,7 @@ class ApplicationLogDetailViewController: UIViewController {
 
     // MARK: - Overridden Methods
     //
-    
+
     /// Designated initializer
     ///
     init(with contents: String, for date: String) {
@@ -72,14 +72,21 @@ class ApplicationLogDetailViewController: UIViewController {
     }
 
     /// Specifies the activity types that should be excluded.
-    /// - returns: all supported types except `.copyToPasteboard` and `.mail`.
+    /// - returns: all unsupported types
+    /// Preserves support only for `.copyToPasteboard` and `.mail`
     ///
     func assembleExcludedSupportTypes() -> [UIActivity.ActivityType] {
         let activityTypes = NSMutableSet(array: SharingHelper.allActivityTypes())
-        let unsupportedTypes = Set(arrayLiteral: [UIActivity.ActivityType.copyToPasteboard,
-                                                  UIActivity.ActivityType.mail])
 
-        activityTypes.minus(unsupportedTypes)
+        /*
+         * Don't use Set(arrayLiteral:) here, because it will convert the enums to the raw string value,
+         * which would be wrong, because the allActivityTypes listed above are stored as enum types.
+         */
+        let supportedTypes = NSSet(objects: UIActivity.ActivityType.copyToPasteboard,
+                                            UIActivity.ActivityType.mail)
+
+        // Now you can downcast to Set, because the type was preserved on init of the NSSet.
+        activityTypes.minus(supportedTypes as! Set<AnyHashable>)
 
         return activityTypes.allObjects as! [UIActivity.ActivityType]
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -73,7 +73,7 @@ class ApplicationLogDetailViewController: UIViewController {
 
     /// Specifies the activity types that should be excluded.
     /// - returns: all unsupported types
-    /// Preserves support only for `.copyToPasteboard` and `.mail`
+    /// Preserves support for `.copyToPasteboard`, `.mail`, and `.airDrop`
     ///
     func assembleExcludedSupportTypes() -> [UIActivity.ActivityType] {
         let activityTypes = NSMutableSet(array: SharingHelper.allActivityTypes())
@@ -83,7 +83,8 @@ class ApplicationLogDetailViewController: UIViewController {
          * which would be wrong, because the allActivityTypes listed above are stored as enum types.
          */
         let supportedTypes = NSSet(objects: UIActivity.ActivityType.copyToPasteboard,
-                                            UIActivity.ActivityType.mail)
+                                            UIActivity.ActivityType.mail,
+                                            UIActivity.ActivityType.airDrop)
 
         // Now you can downcast to Set, because the type was preserved on init of the NSSet.
         activityTypes.minus(supportedTypes as! Set<AnyHashable>)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -1,30 +1,82 @@
-//
-//  ApplicationLogDetailViewController.swift
-//  WooCommerce
-//
-//  Created by Thuy Copeland on 1/29/19.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-
 import UIKit
 
 class ApplicationLogDetailViewController: UIViewController {
 
+    /// The contents of the log file.
+    ///
+    let logText: String
+
+    /// The log file's creation date as a formatted string.
+    ///
+    let logDate: String
+
+
+    // MARK: - Overridden Methods
+    //
+    
+    /// Designated initializer
+    ///
+    init(with contents: String, for date: String) {
+        self.logText = contents
+        self.logDate = date
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    /// Unsupported: NSCoder
+    ///
+    required init?(coder aDecoder: NSCoder) {
+        assertionFailure()
+        return nil
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        configureNavigation()
+        configureMainView()
     }
-    
 
-    /*
-    // MARK: - Navigation
+    /// Add styles and buttons to nav bar
+    ///
+    func configureNavigation() {
+        title = NSLocalizedString("Application Log", comment: "Application Log navigation bar title - this screen is where users view a single log file.")
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        // Don't show the Application Log title in the next-view's back button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+
+        let shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(showShareActivity))
+        navigationItem.rightBarButtonItem = shareButton
     }
-    */
 
+    /// Apply Woo styles.
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Display the share activity
+    /// Uses @objc attribute because this function is called from a #selector
+    ///
+    @objc
+    func showShareActivity(_ sender: UIBarButtonItem) {
+        let activityVC = UIActivityViewController(activityItems: [logText], applicationActivities: nil)
+        activityVC.modalPresentationStyle = .popover
+        activityVC.popoverPresentationController?.barButtonItem = sender
+        activityVC.excludedActivityTypes = assembleExcludedSupportTypes()
+        present(activityVC, animated: true, completion: nil)
+    }
+
+    /// Specifies the activity types that should be excluded.
+    /// - returns: all supported types except `.copyToPasteboard` and `.mail`.
+    ///
+    func assembleExcludedSupportTypes() -> [UIActivity.ActivityType] {
+        let activityTypes = NSMutableSet(array: SharingHelper.allActivityTypes())
+        let unsupportedTypes = Set(arrayLiteral: [UIActivity.ActivityType.copyToPasteboard,
+                                                  UIActivity.ActivityType.mail])
+
+        activityTypes.minus(unsupportedTypes)
+
+        return activityTypes.allObjects as! [UIActivity.ActivityType]
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -10,6 +10,10 @@ class ApplicationLogDetailViewController: UIViewController {
     ///
     let logDate: String
 
+    /// The textview for displaying the log data
+    ///
+    @IBOutlet private var textview: UITextView!
+
 
     // MARK: - Overridden Methods
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogDetailViewController.swift
@@ -4,11 +4,11 @@ class ApplicationLogDetailViewController: UIViewController {
 
     /// The contents of the log file.
     ///
-    let logText: String
+    var logText: String
 
     /// The log file's creation date as a formatted string.
     ///
-    let logDate: String
+    var logDate: String
 
     /// The textview for displaying the log data
     ///
@@ -24,14 +24,13 @@ class ApplicationLogDetailViewController: UIViewController {
         self.logText = contents
         self.logDate = date
 
-        super.init(nibName: nil, bundle: nil)
+        super.init(nibName: "ApplicationLogDetailViewController", bundle: Bundle.main)
     }
 
-    /// Unsupported: NSCoder
-    ///
     required init?(coder aDecoder: NSCoder) {
-        assertionFailure()
-        return nil
+        self.logText = ""
+        self.logDate = ""
+        super.init(coder: aDecoder)
     }
 
     override func viewDidLoad() {
@@ -39,12 +38,13 @@ class ApplicationLogDetailViewController: UIViewController {
 
         configureNavigation()
         configureMainView()
+        textview.text = logText
     }
 
     /// Add styles and buttons to nav bar
     ///
     func configureNavigation() {
-        title = NSLocalizedString("Application Log", comment: "Application Log navigation bar title - this screen is where users view a single log file.")
+        title = logDate
 
         // Don't show the Application Log title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -224,7 +224,16 @@ private extension ApplicationLogViewController {
     /// Clear old logs action
     ///
     func clearLogsWasPressed() {
+        for logFileInfo in logFiles {
+            if logFileInfo.isArchived {
+                try? FileManager.default.removeItem(atPath: logFileInfo.filePath)
+            }
+        }
 
+        DDLogWarn("⚠️ All archived log files erased.")
+
+        loadLogFiles()
+        tableView.reloadData()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -224,15 +224,14 @@ private extension ApplicationLogViewController {
     /// Clear old logs action
     ///
     func clearLogsWasPressed() {
-        for logFileInfo in logFiles {
-            if logFileInfo.isArchived {
-                try? FileManager.default.removeItem(atPath: logFileInfo.filePath)
-            }
+        for logFileInfo in logFiles where logFileInfo.isArchived {
+            try? FileManager.default.removeItem(atPath: logFileInfo.filePath)
         }
 
         DDLogWarn("⚠️ All archived log files erased.")
 
         loadLogFiles()
+        configureSections()
         tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -1,30 +1,19 @@
-//
-//  ApplicationLogViewController.swift
-//  WooCommerce
-//
-//  Created by Thuy Copeland on 1/28/19.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-
 import UIKit
 
+// MARK: - ApplicationLogViewController
+//
 class ApplicationLogViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        configureNavigation()
     }
-    
 
-    /*
-    // MARK: - Navigation
+    func configureNavigation() {
+        title = NSLocalizedString("Activity Log", comment: "Activity Log navigation bar title")
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+        // Don't show the Help & Support title in the next-view's back button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
     }
-    */
-
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -42,9 +42,7 @@ class ApplicationLogViewController: UIViewController {
         configureNavigation()
         configureMainView()
         configureTableView()
-
         loadLogFiles()
-
         configureSections()
         registerTableViewCells()
     }
@@ -52,7 +50,7 @@ class ApplicationLogViewController: UIViewController {
     /// Style the back button, add the title to nav bar.
     ///
     func configureNavigation() {
-        title = NSLocalizedString("Activity Logs", comment: "Activity Log navigation bar title")
+        title = NSLocalizedString("Application Logs", comment: "Application Logs navigation bar title - this screen is where users view the list of application logs available to them.")
 
         // Don't show the Help & Support title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
@@ -150,7 +148,7 @@ extension ApplicationLogViewController: UITableViewDelegate {
 
         switch rowAtIndexPath(indexPath) {
         case .logFile:
-            logFileWasPressed()
+            logFileWasPressed(in: indexPath.row)
         case .clearLogs:
             clearLogsWasPressed()
         }
@@ -204,8 +202,16 @@ private extension ApplicationLogViewController {
 
     /// View log file action
     ///
-    func logFileWasPressed() {
-
+    func logFileWasPressed(in row: Int) {
+        let logFileInfo = logFiles[row]
+        do {
+            let contents = try String(contentsOfFile: logFileInfo.filePath)
+            let date = dateFormatter.string(from: logFileInfo.creationDate)
+            let detailVC = ApplicationLogDetailViewController(with: contents, for: date)
+            navigationController?.pushViewController(detailVC, animated: true)
+        } catch {
+            DDLogError("Error: attempted to get contents of logFileInfo. Contents not found.")
+        }
     }
 
     /// Clear old logs action

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -47,6 +47,20 @@ class ApplicationLogViewController: UIViewController {
         registerTableViewCells()
     }
 
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if let vc = segue.destination as? ApplicationLogDetailViewController, segue.identifier == Segues.detailSegue {
+            let logFileInfo = sender as! DDLogFileInfo
+            do {
+                let contents = try String(contentsOfFile: logFileInfo.filePath)
+                let date = dateFormatter.string(from: logFileInfo.creationDate)
+                vc.logText = contents
+                vc.logDate = date
+            } catch {
+                DDLogError("Error: attempted to get contents of logFileInfo. Contents not found.")
+            }
+        }
+    }
+
     /// Style the back button, add the title to nav bar.
     ///
     func configureNavigation() {
@@ -204,14 +218,7 @@ private extension ApplicationLogViewController {
     ///
     func logFileWasPressed(in row: Int) {
         let logFileInfo = logFiles[row]
-        do {
-            let contents = try String(contentsOfFile: logFileInfo.filePath)
-            let date = dateFormatter.string(from: logFileInfo.creationDate)
-            let detailVC = ApplicationLogDetailViewController(with: contents, for: date)
-            navigationController?.pushViewController(detailVC, animated: true)
-        } catch {
-            DDLogError("Error: attempted to get contents of logFileInfo. Contents not found.")
-        }
+        performSegue(withIdentifier: Segues.detailSegue, sender: logFileInfo)
     }
 
     /// Clear old logs action
@@ -250,4 +257,8 @@ private enum Row: CaseIterable {
     var reuseIdentifier: String {
         return type.reuseIdentifier
     }
+}
+
+private struct Segues {
+    static let detailSegue = "ShowApplicationLogDetailViewController"
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -186,8 +186,6 @@ private extension ApplicationLogViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = indexPath.row == 0 ? NSLocalizedString("Current", comment:"Cell title: the current date.") : dateFormatter.string(from: logFileInfo.creationDate)
-        print(logFileInfo.creationDate)
-        print(dateFormatter.string(from: logFileInfo.creationDate))
     }
 
     /// Clear application logs cell.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -1,19 +1,249 @@
 import UIKit
+import CocoaLumberjack
+
 
 // MARK: - ApplicationLogViewController
 //
 class ApplicationLogViewController: UIViewController {
 
+    /// Main TableView
+    ///
+    @IBOutlet weak var tableView: UITableView!
+
+    /// Table Sections to be rendered
+    ///
+    private var sections = [Section]()
+
+    /// Access the shared DDFileLogger
+    ///
+    let fileLogger = AppDelegate.shared.fileLogger
+
+    /// List of log files
+    ///
+    var logFiles = [DDLogFileInfo]()
+
+    /// Date formatter
+    ///
+    let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.doesRelativeDateFormatting = true
+        formatter.timeStyle = .short
+
+        return formatter
+    }()
+
+
+    // MARK: - Overridden Methods
+    //
     override func viewDidLoad() {
         super.viewDidLoad()
 
         configureNavigation()
+        configureMainView()
+        configureTableView()
+
+        loadLogFiles()
+
+        configureSections()
+        registerTableViewCells()
     }
 
+    /// Style the back button, add the title to nav bar.
+    ///
     func configureNavigation() {
-        title = NSLocalizedString("Activity Log", comment: "Activity Log navigation bar title")
+        title = NSLocalizedString("Activity Logs", comment: "Activity Log navigation bar title")
 
         // Don't show the Help & Support title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+    }
+
+    /// Apply Woo styles.
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Configure common table properties.
+    ///
+    func configureTableView() {
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Get the sorted log files
+    ///
+    func loadLogFiles() {
+        logFiles = fileLogger.logFileManager.sortedLogFileInfos
+    }
+
+    /// Define section data.
+    ///
+    func configureSections() {
+        let logFileTitle = NSLocalizedString("Log files by created date", comment: "Explains that the files are sorted by LIFO date: most recent day listed first.")
+        let logFileFooter = NSLocalizedString("Up to seven days՚ worth of logs are saved.", comment: "Footer text below the list of logs explaining the maximum number of logs saved.")
+
+        var logFileRows = [Row]()
+        for _ in logFiles {
+            logFileRows.append(.logFile)
+        }
+
+        sections = [
+            Section(title: logFileTitle, footer: logFileFooter, rows: logFileRows),
+            Section(title: nil, footer:nil, rows:[.clearLogs])
+        ]
+    }
+
+    /// Register table cells.
+    ///
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+        }
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ApplicationLogViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].title
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ApplicationLogViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch rowAtIndexPath(indexPath) {
+        case .logFile:
+            logFileWasPressed()
+        case .clearLogs:
+            clearLogsWasPressed()
+        }
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ApplicationLogViewController {
+    /// Convenience method returns a single row's data
+    ///
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as BasicTableViewCell where row == .logFile:
+            configureLogFile(cell: cell, indexPath: indexPath)
+        case let cell as BasicTableViewCell where row == .clearLogs:
+            configureClearLogs(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    /// Application Log cell.
+    ///
+    func configureLogFile(cell: BasicTableViewCell, indexPath: IndexPath) {
+        let logFileInfo: DDLogFileInfo = logFiles[indexPath.row]
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = indexPath.row == 0 ? NSLocalizedString("Current", comment:"Cell title: the current date.") : dateFormatter.string(from: logFileInfo.creationDate)
+        print(logFileInfo.creationDate)
+        print(dateFormatter.string(from: logFileInfo.creationDate))
+    }
+
+    /// Clear application logs cell.
+    ///
+    func configureClearLogs(cell: BasicTableViewCell) {
+        cell.selectionStyle = .default
+        cell.textLabel?.textAlignment = .center
+        cell.textLabel?.textColor = StyleManager.destructiveActionColor
+        cell.textLabel?.text = NSLocalizedString("Clear old activity logs", comment: "Deletes all activity logs except for the marked 'Current'.")
+    }
+}
+
+// MARK: - Actions
+//
+private extension ApplicationLogViewController {
+
+    /// View log file action
+    ///
+    func logFileWasPressed() {
+
+    }
+
+    /// Clear old logs action
+    ///
+    func clearLogsWasPressed() {
+
+    }
+}
+
+
+// MARK: - Private types
+//
+private struct Constants {
+    static let rowHeight = CGFloat(44)
+}
+
+private struct Section {
+    let title: String?
+    let footer: String?
+    let rows: [Row]
+}
+
+private enum Row: CaseIterable {
+    case logFile
+    case clearLogs
+
+    var type: UITableViewCell.Type {
+        switch self {
+        case .logFile:
+            return BasicTableViewCell.self
+        case .clearLogs:
+            return BasicTableViewCell.self
+        }
+    }
+
+    var reuseIdentifier: String {
+        return type.reuseIdentifier
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ApplicationLogViewController.swift
+//  WooCommerce
+//
+//  Created by Thuy Copeland on 1/28/19.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class ApplicationLogViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -101,7 +101,8 @@ private extension HelpAndSupportViewController {
             Section(title: helpAndSupportTitle, rows: [.browseFaq,
                                                        .contactSupport,
                                                        .myTickets,
-                                                       .contactEmail])
+                                                       .contactEmail,
+                                                       .applicationLog])
         ]
     }
 
@@ -139,6 +140,8 @@ private extension HelpAndSupportViewController {
             configureMyTickets(cell: cell)
         case let cell as ValueOneTableViewCell where row == .contactEmail:
             configureMyContactEmail(cell: cell)
+        case let cell as ValueOneTableViewCell where row == .applicationLog:
+            configureApplicationLog(cell: cell)
         default:
             fatalError()
         }
@@ -178,6 +181,15 @@ private extension HelpAndSupportViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Contact Email", comment: "Contact Email title")
         cell.detailTextLabel?.text = accountEmail
+    }
+
+    /// Application Log cell.
+    ///
+    func configureApplicationLog(cell: ValueOneTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("View Application Log", comment: "View application log cell title")
+        cell.detailTextLabel?.text = NSLocalizedString("Advanced tool to review the app status", comment: "Cell subtitle explaining why you might want to navigate to view the application log.")
     }
 }
 
@@ -238,6 +250,12 @@ private extension HelpAndSupportViewController {
         }
     }
 
+    /// View application log action
+    ///
+    func applicationLogWasPressed() {
+        performSegue(withIdentifier: Constants.appLogSegue, sender: nil)
+    }
+
     @objc func dismissWasPressed() {
         dismiss(animated: true, completion: nil)
     }
@@ -288,6 +306,8 @@ extension HelpAndSupportViewController: UITableViewDelegate {
             myTicketsWasPressed()
         case .contactEmail:
             contactEmailWasPressed()
+        case .applicationLog:
+            applicationLogWasPressed()
         }
     }
 }
@@ -299,6 +319,7 @@ private struct Constants {
     static let rowHeight = CGFloat(44)
     static let footerHeight = 44
     static let devEmail = "@automattic.com"
+    static let appLogSegue = "ShowApplicationLogViewController"
 }
 
 private struct Section {
@@ -311,6 +332,7 @@ private enum Row: CaseIterable {
     case contactSupport
     case myTickets
     case contactEmail
+    case applicationLog
 
     var type: UITableViewCell.Type {
         switch self {
@@ -321,6 +343,8 @@ private enum Row: CaseIterable {
         case .myTickets:
             return ValueOneTableViewCell.self
         case .contactEmail:
+            return ValueOneTableViewCell.self
+        case .applicationLog:
             return ValueOneTableViewCell.self
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */; };
 		CE17C2E220ACA06800AFBD20 /* BillingDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE17C2E020ACA06800AFBD20 /* BillingDetailsTableViewCell.swift */; };
 		CE17C2E320ACA06800AFBD20 /* BillingDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE17C2E120ACA06800AFBD20 /* BillingDetailsTableViewCell.xib */; };
+		CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1AFE612200B1BD00432745 /* ApplicationLogDetailViewController.swift */; };
 		CE1CCB402056F21C000EE3AC /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB3F2056F21C000EE3AC /* Style.swift */; };
 		CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */; };
 		CE1EC8C520B46819009762BF /* PaymentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */; };
@@ -547,6 +548,7 @@
 		CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationConstants.swift; sourceTree = "<group>"; };
 		CE17C2E020ACA06800AFBD20 /* BillingDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		CE17C2E120ACA06800AFBD20 /* BillingDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BillingDetailsTableViewCell.xib; sourceTree = "<group>"; };
+		CE1AFE612200B1BD00432745 /* ApplicationLogDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogDetailViewController.swift; sourceTree = "<group>"; };
 		CE1CCB3F2056F21C000EE3AC /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTableViewCell.swift; sourceTree = "<group>"; };
 		CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentTableViewCell.swift; sourceTree = "<group>"; };
@@ -1228,6 +1230,7 @@
 			children = (
 				CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */,
 				CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */,
+				CE1AFE612200B1BD00432745 /* ApplicationLogDetailViewController.swift */,
 			);
 			path = Help;
 			sourceTree = "<group>";
@@ -1781,6 +1784,7 @@
 				748C7780211E18A600814F2C /* OrderStats+Woo.swift in Sources */,
 				CE4DA5C621DD755E00074607 /* CurrencyFormatter.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
+				CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				B50911322049E27A007D25DC /* SettingsViewController.swift in Sources */,
 				B5E96B3821137AA100DF68D0 /* OrderStatus+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		CE021535215BE3AB00C19555 /* LoginNavigationController+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE021534215BE3AB00C19555 /* LoginNavigationController+Woo.swift */; };
 		CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14452D2188C11700A991D8 /* ZendeskManager.swift */; };
+		CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */; };
 		CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */; };
 		CE17C2E220ACA06800AFBD20 /* BillingDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE17C2E020ACA06800AFBD20 /* BillingDetailsTableViewCell.swift */; };
 		CE17C2E320ACA06800AFBD20 /* BillingDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE17C2E120ACA06800AFBD20 /* BillingDetailsTableViewCell.xib */; };
@@ -542,6 +543,7 @@
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE021534215BE3AB00C19555 /* LoginNavigationController+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginNavigationController+Woo.swift"; sourceTree = "<group>"; };
 		CE14452D2188C11700A991D8 /* ZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskManager.swift; sourceTree = "<group>"; };
+		CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewController.swift; sourceTree = "<group>"; };
 		CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationConstants.swift; sourceTree = "<group>"; };
 		CE17C2E020ACA06800AFBD20 /* BillingDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		CE17C2E120ACA06800AFBD20 /* BillingDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BillingDetailsTableViewCell.xib; sourceTree = "<group>"; };
@@ -1225,6 +1227,7 @@
 			isa = PBXGroup;
 			children = (
 				CE27257B21924A8C002B22EB /* HelpAndSupportViewController.swift */,
+				CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */,
 			);
 			path = Help;
 			sourceTree = "<group>";
@@ -1732,6 +1735,7 @@
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,
 				B5DB01B52114AB2D00A4F797 /* FabricManager.swift in Sources */,
 				7459A6C621B0680300F83A78 /* RequirementsChecker.swift in Sources */,
+				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,


### PR DESCRIPTION
Closes #618.

This PR adds the ability to view, share, and send application logs. 

## To Test
1. Log in and navigate to My store > Settings > Help & Support > View Application Log.
2. Select any log available and view it.
3. Select the share button and send it, save it, or share it. Verify it arrived at the expected place.
4. When ready, select the "Clear old activity logs" button. Verify only the "Current" row and application log remains.

<img src="https://user-images.githubusercontent.com/1062444/51944148-e3065400-23e0-11e9-9112-ab0ffcc539b8.gif" width="300" />

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc: @bummytime or @astralbodies first review wins 😀 