### PR TITLE
Dashboard: Update recency message to match designs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,1 +1,2 @@
 - bugfix: add help button to store picker screen
+- bugfix: updated logic that determines "last update date" for store stats

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -28,27 +28,18 @@ extension Date {
     ///
     var relativelyFormattedUpdateString: String {
         let now = Date()
-        let longFormDate = self.toString(dateStyle: .medium, timeStyle: .short)
         let components = Calendar.current.dateComponents(
             [.year, .month, .weekOfYear, .day, .hour, .minute, .second],
             from: self,
             to: now
         )
 
-        if let years = components.year, years > 0 {
-            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
-        }
-
-        if let months = components.month, months > 0 {
-            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
-        }
-
-        if let weeks = components.weekOfYear, weeks > 0 {
-            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
-        }
-
-        if let days = components.day, days > 0 {
-            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
+        guard let years = components.year, years < 1,
+            let months = components.month, months < 1,
+            let weeks = components.weekOfYear, weeks < 1,
+            let days = components.day, days < 1 else {
+                let longFormDate = self.toString(dateStyle: .medium, timeStyle: .short)
+                return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
         }
 
         if let hours = components.hour, hours > 0 {

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -24,7 +24,7 @@ extension Date {
     /// - Example: Updated 55 minutes ago
     /// - Example: Updated 1 hour ago
     /// - Example: Updated 14 hours ago
-    /// - Example: Updated Jan 28, 2019 at 5:17 PM
+    /// - Example: Updated on Jan 28, 2019 at 5:17 PM
     ///
     var relativelyFormattedUpdateString: String {
         let now = Date()
@@ -77,6 +77,6 @@ private extension Date {
         static let pluralMinuteUpdateStatment   = NSLocalizedString("Updated %ld minutes ago", comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago")
         static let singularHourUpdateStatment   = NSLocalizedString("Updated %ld hour ago", comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago")
         static let pluralHourUpdateStatment     = NSLocalizedString("Updated %ld hours ago", comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago")
-        static let longFormUpdateStatement      = NSLocalizedString("Updated %@", comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated Jan 22, 2019 3:31PM")
+        static let longFormUpdateStatement      = NSLocalizedString("Updated on %@", comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated on Jan 22, 2019 3:31PM")
     }
 }

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -15,6 +15,52 @@ extension Date {
         return formatter.string(from: self)
     }
 
+    /// Returns a localized update string relative to the receiver if it's within one day of now *or*
+    /// a medium datestyle + short timestyle string otherwise.
+    ///
+    /// - Example: Updated moments ago
+    /// - Example: Updated 55 minutes ago
+    /// - Example: Updated 1 hour ago
+    /// - Example: Updated 14 hours ago
+    /// - Example: Updated Jan 28, 2019 at 5:17 PM
+    ///
+    var relativelyFormattedUpdateString: String {
+        let now = Date()
+        let longFormDate = self.toString(dateStyle: .medium, timeStyle: .short)
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .weekOfYear, .day, .hour, .minute, .second],
+            from: self,
+            to: now
+        )
+
+        if let years = components.year, years > 0 {
+            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
+        }
+
+        if let months = components.month, months > 0 {
+            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
+        }
+
+        if let weeks = components.weekOfYear, weeks > 0 {
+            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
+        }
+
+        if let days = components.day, days > 0 {
+            return String.localizedStringWithFormat(Strings.longFormUpdateStatement, longFormDate)
+        }
+
+        if let hours = components.hour, hours > 0 {
+            return String.pluralize(hours, singular: Strings.singularHourUpdateStatment, plural: Strings.pluralHourUpdateStatment)
+        }
+
+        // We only display the minutes update string when we have a time interval greater than 2 minutes...otherwise default to the present deictic expression
+        if let minutes = components.minute, minutes > 1 {
+            return String.pluralize(minutes, singular: Strings.singularMinuteUpdateStatment, plural: Strings.pluralMinuteUpdateStatment)
+        }
+
+        return Strings.presentDeicticExpression
+    }
+
     /// Gets today's date and returns tomorrow's date, starting at midnight.
     ///
     static func tomorrow() -> Date? {
@@ -24,5 +70,20 @@ extension Date {
         let today = Date()
 
         return calendar.date(byAdding: dayComponent, to: today)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension Date {
+
+    enum Strings {
+        static let presentDeicticExpression     = NSLocalizedString("Updated moments ago", comment: "Deictic expression for a data update that occurred in the very recent past - similar to 'Updated just now'")
+        static let singularMinuteUpdateStatment = NSLocalizedString("Updated %ld minute ago", comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. Usage example: Updated 1 minute ago")
+        static let pluralMinuteUpdateStatment   = NSLocalizedString("Updated %ld minutes ago", comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago")
+        static let singularHourUpdateStatment   = NSLocalizedString("Updated %ld hour ago", comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago")
+        static let pluralHourUpdateStatment     = NSLocalizedString("Updated %ld hours ago", comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago")
+        static let longFormUpdateStatement      = NSLocalizedString("Updated %@", comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated Jan 22, 2019 3:31PM")
     }
 }

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -18,6 +18,8 @@ extension Date {
     /// Returns a localized update string relative to the receiver if it's within one day of now *or*
     /// a medium datestyle + short timestyle string otherwise.
     ///
+    /// *Note:* if the receiver is a future date, "Updated moments ago" will be returned
+    ///
     /// - Example: Updated moments ago
     /// - Example: Updated 55 minutes ago
     /// - Example: Updated 1 hour ago

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -77,8 +77,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
 
     private var summaryDateUpdated: String {
         if let lastUpdatedDate = lastUpdatedDate {
-            return String.localizedStringWithFormat(NSLocalizedString("Updated %@",
-                                                                      comment: "Stats summary date"), lastUpdatedDate.mediumString())
+            return lastUpdatedDate.relativelyFormattedUpdateString
         } else {
             return ""
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7459A6C621B0680300F83A78 /* RequirementsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7459A6C521B0680300F83A78 /* RequirementsChecker.swift */; };
 		746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791622108D7C0007CF1DC /* WooAnalyticsTests.swift */; };
 		746791662108D87B007CF1DC /* MockupAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */; };
+		746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746FC23C2200A62B00C3096C /* DateWooTests.swift */; };
 		747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747AA0882107CEC60047A89B /* AnalyticsProvider.swift */; };
 		747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747AA08A2107CF8D0047A89B /* TracksProvider.swift */; };
 		748AD087219F481B00023535 /* UIView+Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748AD086219F481B00023535 /* UIView+Animation.swift */; };
@@ -337,6 +338,7 @@
 		7459A6C521B0680300F83A78 /* RequirementsChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequirementsChecker.swift; sourceTree = "<group>"; };
 		746791622108D7C0007CF1DC /* WooAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalyticsTests.swift; sourceTree = "<group>"; };
 		746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockupAnalyticsProvider.swift; sourceTree = "<group>"; };
+		746FC23C2200A62B00C3096C /* DateWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateWooTests.swift; sourceTree = "<group>"; };
 		747AA0882107CEC60047A89B /* AnalyticsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsProvider.swift; sourceTree = "<group>"; };
 		747AA08A2107CF8D0047A89B /* TracksProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksProvider.swift; sourceTree = "<group>"; };
 		748AD086219F481B00023535 /* UIView+Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Animation.swift"; sourceTree = "<group>"; };
@@ -951,6 +953,7 @@
 			children = (
 				B5980A6621AC91AA00EBF596 /* BundleWooTests.swift */,
 				B57C5C9821B80E7100FF82B2 /* DataWooTests.swift */,
+				746FC23C2200A62B00C3096C /* DateWooTests.swift */,
 				B57C5C9721B80E7100FF82B2 /* DictionaryWooTests.swift */,
 				748C7783211E2D8400814F2C /* DoubleWooTests.swift */,
 				B5980A6421AC905C00EBF596 /* UIDeviceWooTests.swift */,
@@ -1914,6 +1917,7 @@
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
+				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -63,12 +63,12 @@ class DateWooTests: XCTestCase {
         // Oct 10,2018
         let dateComponents1 = DateComponents(calendar: Calendar.current, year: 2018, month: 10, day: 10)
         let specificPastDate1 = Calendar.current.date(from: dateComponents1)!
-        XCTAssertTrue(specificPastDate1.relativelyFormattedUpdateString.contains("Updated Oct 10, 2018"))
+        XCTAssertTrue(specificPastDate1.relativelyFormattedUpdateString.contains("Updated on Oct 10, 2018"))
 
         // Feb 2, 2016
         let dateComponents2 = DateComponents(calendar: Calendar.current, year: 2016, month: 2, day: 2)
         let specificPastDate2 = Calendar.current.date(from: dateComponents2)!
-        XCTAssertTrue(specificPastDate2.relativelyFormattedUpdateString.contains("Updated Feb 2, 2016"))
+        XCTAssertTrue(specificPastDate2.relativelyFormattedUpdateString.contains("Updated on Feb 2, 2016"))
     }
 
     func testUpdateStringWorksForFutureIntervals() {

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -32,8 +32,12 @@ class DateWooTests: XCTestCase {
         XCTAssertEqual(twoMinutesAgo.relativelyFormattedUpdateString, "Updated 2 minutes ago")
 
         // 2 minutes, 3 seconds
-        let twoPlusMinutesAgo = Calendar.current.date(byAdding: .minute, value: -2, to: Date())!
+        let twoPlusMinutesAgo = Calendar.current.date(byAdding: .second, value: -123, to: Date())!
         XCTAssertEqual(twoPlusMinutesAgo.relativelyFormattedUpdateString, "Updated 2 minutes ago")
+
+        // 59 minutes
+        let twoFiftyNineMinutesAgo = Calendar.current.date(byAdding: .minute, value: -59, to: Date())!
+        XCTAssertEqual(twoFiftyNineMinutesAgo.relativelyFormattedUpdateString, "Updated 59 minutes ago")
 
         // 1 hour
         let oneHourAgo = Calendar.current.date(byAdding: .hour, value: -1, to: Date())!
@@ -42,6 +46,10 @@ class DateWooTests: XCTestCase {
         /// 9 hours
         let nineHoursAgo = Calendar.current.date(byAdding: .hour, value: -9, to: Date())!
         XCTAssertEqual(nineHoursAgo.relativelyFormattedUpdateString, "Updated 9 hours ago")
+
+        /// 23 hours, 59 minutes
+        let underOneDayAgo = Calendar.current.date(byAdding: .minute, value: -1439, to: Date())!
+        XCTAssertEqual(underOneDayAgo.relativelyFormattedUpdateString, "Updated 23 hours ago")
 
         // 1 day
         let oneDayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import WooCommerce
+
+
+/// Date+Woo: Unit Tests
+///
+class DateWooTests: XCTestCase {
+
+    func testUpdateStringWorksForIntervalsUnderTwoMinutes() {
+
+        // 1 second
+        let oneSecondAgo = Calendar.current.date(byAdding: .second, value: -1, to: Date())!
+        XCTAssertEqual(oneSecondAgo.relativelyFormattedUpdateString, "Updated moments ago")
+
+        // 12 seconds
+        let twelveSecondsAgo = Calendar.current.date(byAdding: .second, value: -12, to: Date())!
+        XCTAssertEqual(twelveSecondsAgo.relativelyFormattedUpdateString, "Updated moments ago")
+
+        // 1 minute, 59 seconds
+        let almostTwoMinutesAgo = Calendar.current.date(byAdding: .second, value: -119, to: Date())!
+        XCTAssertEqual(almostTwoMinutesAgo.relativelyFormattedUpdateString, "Updated moments ago")
+
+        // 2 minutes
+        let twoMinutesAgo = Calendar.current.date(byAdding: .minute, value: -2, to: Date())!
+        XCTAssertNotEqual(twoMinutesAgo.relativelyFormattedUpdateString, "Updated moments ago")
+    }
+
+    func testUpdateStringWorksForIntervalsOneDayOrLess() {
+
+        // 2 minutes
+        let twoMinutesAgo = Calendar.current.date(byAdding: .minute, value: -2, to: Date())!
+        XCTAssertEqual(twoMinutesAgo.relativelyFormattedUpdateString, "Updated 2 minutes ago")
+
+        // 2 minutes, 3 seconds
+        let twoPlusMinutesAgo = Calendar.current.date(byAdding: .minute, value: -2, to: Date())!
+        XCTAssertEqual(twoPlusMinutesAgo.relativelyFormattedUpdateString, "Updated 2 minutes ago")
+
+        // 1 hour
+        let oneHourAgo = Calendar.current.date(byAdding: .hour, value: -1, to: Date())!
+        XCTAssertEqual(oneHourAgo.relativelyFormattedUpdateString, "Updated 1 hour ago")
+
+        /// 9 hours
+        let nineHoursAgo = Calendar.current.date(byAdding: .hour, value: -9, to: Date())!
+        XCTAssertEqual(nineHoursAgo.relativelyFormattedUpdateString, "Updated 9 hours ago")
+
+        // 1 day
+        let oneDayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        XCTAssertNotEqual(oneDayAgo.relativelyFormattedUpdateString, "Updated 24 hours ago")
+    }
+
+    func testUpdateStringWorksForIntervalsOverOneDay() {
+
+        // Skip verifying the time part of the resulting string because of TZ madness
+
+        // Oct 10,2018
+        let dateComponents1 = DateComponents(calendar: Calendar.current, year: 2018, month: 10, day: 10)
+        let specificPastDate1 = Calendar.current.date(from: dateComponents1)!
+        XCTAssertTrue(specificPastDate1.relativelyFormattedUpdateString.contains("Updated Oct 10, 2018"))
+
+        // Feb 2, 2016
+        let dateComponents2 = DateComponents(calendar: Calendar.current, year: 2016, month: 2, day: 2)
+        let specificPastDate2 = Calendar.current.date(from: dateComponents2)!
+        XCTAssertTrue(specificPastDate2.relativelyFormattedUpdateString.contains("Updated Feb 2, 2016"))
+    }
+
+    func testUpdateStringWorksForFutureIntervals() {
+
+        // 1 second in future
+        let futureDate = Calendar.current.date(byAdding: .second, value: 1, to: Date())!
+        XCTAssertEqual(futureDate.relativelyFormattedUpdateString, "Updated moments ago")
+
+        // 1 year in future
+        let futureDate2 = Calendar.current.date(byAdding: .year, value: 1, to: Date())!
+        XCTAssertEqual(futureDate2.relativelyFormattedUpdateString, "Updated moments ago")
+    }
+}


### PR DESCRIPTION
This PR fixes the recency message on the dashboard:

<img width="882" alt="napkin 112 01-29-19 11 44 40 am" src="https://user-images.githubusercontent.com/154014/51928402-7c227400-23bb-11e9-81be-abdf74cbe902.png">

_(See the issue #600 for the design requirements)_

To accomplish this, a new extension var was added to `Date` — `relativelyFormattedUpdateString`.  This computed var takes the reciever's date value and re-formats as a localized "update" string.

Additionally, because of the insights provided by @naokomc in #620, all of the "Update" strings are exposed to the translators (including the "Updated moments ago" phrase). Prior to this PR we were using `TTTTimeIntervalFormatter` which was only localized in ~20 languages without much in terms of customization. Now these strings can be fully localized such that they make sense natively. 

Fixes: #600 

## Testing

* Make sure code makes sense
* Unit tests are ✅ 
* Build and run the app, verify the stats last updated date behaves as expected (note `Updated moments ago' appears for 1 minute, 59 seconds or under)

@mindgraffiti or @astralbodies could you review this? First :shipit: wins. 😃 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
