### PR TITLE
Reduce number of conflicts in RELEASE-NOTES.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+RELEASE-NOTES.txt merge=union


### PR DESCRIPTION
This updates the merge strategy for `RELEASE-NOTES.txt`

Related to https://github.com/wordpress-mobile/WordPress-iOS/pull/10842

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
