### PR TITLE
Dashboard: total sales fixes

### DIFF
--- a/WooCommerce/Classes/Model/OrderStats+Woo.swift
+++ b/WooCommerce/Classes/Model/OrderStats+Woo.swift
@@ -15,13 +15,4 @@ extension OrderStats {
 
         return currencyCode
     }
-
-    /// Returns the sum of total sales this stats period. This value is typically used in the dashboard for revenue reporting.
-    ///
-    /// *Note:* The value returned here is an aggregation of all the `OrderStatsItem.totalSales` values and
-    /// _not_ `OrderStats.totalGrossSales` or `OrderStats.totalNetSales`.
-    ///
-    var totalSales: Double {
-        return items?.map({ $0.totalSales }).reduce(0.0, +) ?? 0.0
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -444,7 +444,7 @@ private extension PeriodDataViewController {
         var totalRevenueText = Constants.placeholderText
         if let orderStats = orderStats {
             totalOrdersText = Double(orderStats.totalOrders).friendlyString()
-            let totalRevenue = orderStats.totalSales.friendlyString()
+            let totalRevenue = orderStats.totalGrossSales.friendlyString()
             totalRevenueText = CurrencyFormatter().formatCurrency(using: totalRevenue,
                                                                   at: CurrencySettings.shared.currencyPosition,
                                                                   with: currencySymbol)
@@ -495,8 +495,8 @@ private extension PeriodDataViewController {
         var barColors: [UIColor] = []
         var dataEntries: [BarChartDataEntry] = []
         statItems.forEach { (item) in
-            let entry = BarChartDataEntry(x: Double(barCount), y: item.totalSales)
-            let formattedAmount = CurrencyFormatter().formatCurrency(using: item.totalSales.friendlyString(),
+            let entry = BarChartDataEntry(x: Double(barCount), y: item.grossSales)
+            let formattedAmount = CurrencyFormatter().formatCurrency(using: item.grossSales.friendlyString(),
                                                                      at: CurrencySettings.shared.currencyPosition,
                                                                      with: currencySymbol)
             entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"


### PR DESCRIPTION
**Note: This is targeting the 1.1 release.**

This PR fixes #653:

![3](https://user-images.githubusercontent.com/154014/52152687-ded67280-263c-11e9-9858-ff2e15f25221.png)

In short, from the order stats response JSON, we are now using:
1.  `grossSales` instead of ~~`totalSales`~~ for each bar item in the chart
2. `totalGrossSales` in the response JSON instead of calculating this value "manually" (via `OrderStats+Woo.swift`) for the "Revenue" field under each tab

## Testing

* Make sure the unit tests are ✅ 
* Build and run the app
    - [ ] Verify the values for each bar in the chart is what you expect (aka matches the web)
    - [ ] Verify the "Revenue" field under each period tab is what you expect

@astralbodies could you take a look at this?

/cc @loremattei  