### PR TITLE
Update localize.py script to handle multiple comments

### DIFF
--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -34,7 +34,17 @@ class LocalizedString():
         self.key, self.value = re_translation.match(self.translation).groups()
 
     def __unicode__(self):
-        return u'%s%s\n' % (u''.join(self.comments), self.translation)
+        try:
+            for idx, val in enumerate(self.comments):
+                if (idx > 0) and (idx < (len(self.comments) - 1)):
+                    self.comments[idx] = self.comments[idx].replace('\n',' - ')
+                    self.comments[idx + 1] = self.comments[idx + 1].lstrip()
+        except:
+            exit(-1)
+            print "Couldn't strip comments"
+
+        joined_comments = u''.join(self.comments)
+        return u'%s%s\n' % (joined_comments, self.translation)
 
 class LocalizedFile():
     def __init__(self, fname=None, auto_read=False):


### PR DESCRIPTION
This PR fixes an issue with comments in GlotPress where the upload of source files fails when they contain comments that span more than two lines. 

In order to fix it, the script now shrinks the comments to two lines, by concatenating multiple lines.

## To Test:
1. Run the previous version of `Scripts/localize.py`  and save the updated `en.lproj/Localizable.strings`.
2. Run the `Scripts/localize.py` contained in this PR and save the updated `en.lproj/Localizable.strings`.
3. Compare the two versions of `en.lproj/Localizable.strings` and make sure that both files contain the same strings and that comments have been shrunk to 2 lines in the second one. 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
