### PR TITLE
Update secrets placeholders so that build & tests can pass without credentials

### DIFF
--- a/WooCommerce/Credentials/Templates/ApiCredentials-Template.swift
+++ b/WooCommerce/Credentials/Templates/ApiCredentials-Template.swift
@@ -3,41 +3,41 @@ struct ApiCredentials {
 
     /// WordPress.com AppID
     ///
-    static let dotcomAppId: String =  <#Wordpress.com App ID#>
+    static let dotcomAppId: String =  "<#Wordpress.com App ID#>"
 
     /// WordPress.com Secret
     ///
-    static let dotcomSecret: String = <#Wordpress.com App Secret#>
+    static let dotcomSecret: String = "<#Wordpress.com App Secret#>"
 
     /// WordPress.com Magic Link Scheme
     ///
-    static let dotcomAuthScheme: String = <#Wordpress.com Auth Scheme#>
+    static let dotcomAuthScheme: String = "<#Wordpress.com Auth Scheme#>"
 
     /// Google SDK's ClientID
     ///
-    static let googleClientId: String = <#Google Client ID#>
+    static let googleClientId: String = "<#Google Client ID#>"
 
     /// Google SDK's ServerID
     ///
-    static let googleServerId: String = <#Google Server ID#>
+    static let googleServerId: String = "<#Google Server ID#>"
 
     /// Google SDK's Auth Scheme
     ///
-    static let googleAuthScheme: String = <#Google Auth Scheme#>
+    static let googleAuthScheme: String = "<#Google Auth Scheme#>"
 
     /// Tracks Prefix
     ///
-    static let tracksPrefix: String = <#Tracks Prefix#>
+    static let tracksPrefix: String = "<#Tracks Prefix#>"
 
     /// Zendesk App ID
     ///
-    static let zendeskAppId: String = <#Zendesk App ID#>
+    static let zendeskAppId: String = "<#Zendesk App ID#>"
 
     /// Zendesk URL
     ///
-    static let zendeskUrl: String = <#Zendesk URL#>
+    static let zendeskUrl: String = "<#Zendesk URL#>"
 
     /// Zendesk Client ID
     ///
-    static let zendeskClientId: String = <#Zendesk Client ID#>
+    static let zendeskClientId: String = "<#Zendesk Client ID#>"
 }

--- a/WooCommerce/Credentials/Templates/InfoPlist-Template.h
+++ b/WooCommerce/Credentials/Templates/InfoPlist-Template.h
@@ -7,12 +7,12 @@
 
 /// Google Auth Callback Scheme
 ///
-#define GOOGLE_AUTH_SCHEME <#Google Auth Scheme#>
+#define GOOGLE_AUTH_SCHEME com.googleusercontent.apps.AUTH_SCHEME
 
 /// WordPress.com Auth Callback Scheme (AKA Magic Link!)
 ///
-#define DOTCOM_AUTH_SCHEME <#Wordpress.com Auth Scheme#>
+#define DOTCOM_AUTH_SCHEME dotcom_auth_scheme
 
 /// Fabric / Crashlytics API key
 ///
-#define FABRIC_API_KEY <#Fabric API Key#>
+#define FABRIC_API_KEY fabric_api_key


### PR DESCRIPTION
Currently, if you check out this repo and try to build, it immediately fails. This means that even unit tests can't be run without the secrets being set up.

This is a very small change to the template files so that tests can be run without the full secret set up. This will be useful for CI.

Here is an example failing on CircleCI without this change: https://circleci.com/gh/woocommerce/woocommerce-ios/59
And here is one passing with this change: https://circleci.com/gh/woocommerce/woocommerce-ios/66

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
