### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+
+orbs:
+  # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
+  ios: wordpress-mobile/ios@0.0.18
+  danger: wordpress-mobile/danger@0.0.18
+
+workflows:
+  woocommerce_ios:
+    jobs:
+      - ios/test:
+          name: Test
+          workspace: WooCommerce.xcworkspace
+          scheme: WooCommerce
+          device: iPhone XS
+          ios-version: "12.1"
+      - danger/danger-ruby:
+          name: Danger


### PR DESCRIPTION
Adding a CircleCI config for this repo. It re-uses the configuration from https://github.com/wordpress-mobile/circleci-orbs.

To test:

- CircleCI checks are ✅ 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
