### PR TITLE
Notifications: Gridicon update .menus to .filter

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -27,7 +27,7 @@ class NotificationsViewController: UIViewController {
     /// Filter nav bar button
     ///
     private lazy var rightBarButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: Gridicon.iconOfType(.menus),
+        return UIBarButtonItem(image: Gridicon.iconOfType(.filter),
                                style: .plain,
                                target: self,
                                action: #selector(displayFiltersAlert))


### PR DESCRIPTION
Title has it.

![3](https://user-images.githubusercontent.com/154014/52448035-315dd600-2af8-11e9-8af0-3226bb4074d1.png)

Fixes #667 

## Testing

Build and run the app. Verify the notification filter icon is correct.

@mindgraffiti would you mind taking a 👀?
