### PR TITLE
Change selected bar color in charts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 - bugfix: Allows for decimal quantities which some extensions have
 - new feature: quick site select. Navigate to Settings > select row with store website.
+- improvement: Updated the colors of the bars in the charts for better readability

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -494,7 +494,7 @@ private extension PeriodDataViewController {
             let entry = BarChartDataEntry(x: Double(barCount), y: item.grossSales)
             let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String(item.grossSales), with: orderStats.currencyCode, roundSmallNumbers: false) ?? String()
             entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"
-            barColors.append(barColor(for: item.period))
+            barColors.append(StyleManager.wooGreyMid)
             dataEntries.append(entry)
             barCount += 1
         }
@@ -502,7 +502,7 @@ private extension PeriodDataViewController {
         let dataSet =  BarChartDataSet(values: dataEntries, label: "Data")
         dataSet.colors = barColors
         dataSet.highlightEnabled = true
-        dataSet.highlightColor = StyleManager.wooAccent
+        dataSet.highlightColor = StyleManager.wooCommerceBrandColor
         dataSet.highlightAlpha = Constants.chartHighlightAlpha
         dataSet.drawValuesEnabled = false // Do not draw value labels on the top of the bars
         return BarChartData(dataSet: dataSet)
@@ -552,16 +552,6 @@ private extension PeriodDataViewController {
             }
         }
         return dateString
-    }
-
-    func barColor(for period: String) -> UIColor {
-        guard granularity == .day,
-            let periodDate = DateFormatter.Stats.statsDayFormatter.date(from: period),
-            Calendar.current.isDateInWeekend(periodDate) else {
-                return StyleManager.wooCommerceBrandColor
-        }
-
-        return StyleManager.wooGreyMid
     }
 }
 


### PR DESCRIPTION
Fixes #386 

Turn the entire graph gray and highlight selected bar in purple. I am not 100 % sure this is the right solution, as I have removed all previous logic related to the bar colors, to hardcode a gray color.

Before and after (no bars selected)
![graph_gray](https://user-images.githubusercontent.com/2722505/52682702-4795e700-2f7b-11e9-9dc3-2c326203c936.jpg)

Before and after (bar selected)
![graph_selected](https://user-images.githubusercontent.com/2722505/52682707-4f558b80-2f7b-11e9-9c19-63730226fec8.jpg)

## Testing

- Check out the branch
- Navigate to My store. 
- Notice the bars in the graph. All of them should be in grab color.
- Select one bar. If should be highlighted in purple

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.