### PR TITLE
Present a notice when loading the dashboard data fails

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -39,9 +39,9 @@ class NewOrdersViewController: UIViewController {
 //
 extension NewOrdersViewController {
 
-    func syncNewOrders(onCompletion: (() -> Void)? = nil) {
+    func syncNewOrders(onCompletion: ((Error?) -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
-            onCompletion?()
+            onCompletion?(nil)
             return
         }
 
@@ -50,12 +50,12 @@ extension NewOrdersViewController {
                 if let error = error {
                     DDLogError("⛔️ Dashboard (New Orders) — Error synchronizing pending orders: \(error)")
                 }
-                onCompletion?()
+                onCompletion?(error)
                 return
             }
 
             self.updateNewOrdersIfNeeded(orderCount: processingOrderCount)
-            onCompletion?()
+            onCompletion?(nil)
         }
 
         StoresManager.shared.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -87,9 +87,9 @@ class TopPerformerDataViewController: UIViewController, IndicatorInfoProvider {
 //
 extension TopPerformerDataViewController {
 
-    func syncTopPerformers(onCompletion: (() -> Void)? = nil) {
+    func syncTopPerformers(onCompletion: ((Error?) -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
-            onCompletion?()
+            onCompletion?(nil)
             return
         }
 
@@ -106,7 +106,7 @@ extension TopPerformerDataViewController {
             } else {
                 WooAnalytics.shared.track(.dashboardTopPerformersLoaded, withProperties: ["granularity": self.granularity.rawValue])
             }
-            onCompletion?()
+            onCompletion?(error)
         }
 
         StoresManager.shared.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -59,21 +59,26 @@ class TopPerformersViewController: ButtonBarPagerTabStripViewController {
 //
 extension TopPerformersViewController {
 
-    func syncTopPerformers(onCompletion: (() -> Void)? = nil) {
+    func syncTopPerformers(onCompletion: ((Error?) -> Void)? = nil) {
         let group = DispatchGroup()
+
+        var syncError: Error? = nil
 
         ensureGhostContentIsDisplayed()
 
         dataVCs.forEach { vc in
             group.enter()
-            vc.syncTopPerformers() {
+            vc.syncTopPerformers() { error in
+                if let error = error {
+                    syncError = error
+                }
                 group.leave()
             }
         }
 
         group.notify(queue: .main) { [weak self] in
             self?.removeGhostContent()
-            onCompletion?()
+            onCompletion?(syncError)
         }
     }
 }


### PR DESCRIPTION
Fixes #180 

Present a Notice when any of the sections in "My store" fails to load data. 

In this implementation there is no granularity: if any data loading operation fails, we present a Notice, with a generic message that does not indicate neither which operation failed, nor the cause of the error (i.e. network down or data inconsistency)

![simulator screen shot - iphone x - 2019-02-13 at 14 51 40](https://user-images.githubusercontent.com/2722505/52692664-79b94000-2f9f-11e9-82f9-676454f8c7f1.png)

## Testing
The only way I figured I could test this was by triggering a network failure (in my case using the Network Link Conditioner)
- Checkout and build the branch
- Assuming the Network Link Conditioner is installed in the development machine, activate it and set it up to prevent network requests  (i.e. 100% Loss)
- Pull to refresh in My store.
- Wait for the Notice to appear.