### PR TITLE
Tracks event name changed from `store` to `site`

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -103,7 +103,7 @@ public enum WooAnalyticsStat: String {
     // Settings View Events
     //
     case settingsTapped                         = "main_menu_settings_tapped"
-    case settingsSelectedStoreTapped            = "settings_selected_store_tapped"
+    case settingsSelectedStoreTapped            = "settings_selected_site_tapped"
     case settingsContactSupportTapped           = "main_menu_contact_support_tapped"
 
     case settingsPrivacySettingsTapped          = "settings_privacy_settings_tapped"


### PR DESCRIPTION
Originally the event discussed was to be named `settings_selected_store_tapped`. Per the [spreadsheet](https://docs.google.com/spreadsheets/d/17cKoFpHQpUMNo-stHSIyEyHbOZ30AIikTHWf9GKVwI0/edit#gid=86001244), Android is reporting `settings_selected_site_tapped`. This PR fixes the event that is reported, so that it matches the spreadsheet.


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
