### PR TITLE
Force a logout when users tap “Try another account”  in the store picker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 - bugfix: Allows for decimal quantities which some extensions have
 - new feature: quick site select. Navigate to Settings > select row with store website.
 - improvement: Updated the colors of the bars in the charts for better readability
+- bugfix: Log out of the current account right after selecting "Try another account" in store picker

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -265,12 +265,14 @@ private extension StorePickerViewController {
         tableView.reloadRows(at: rowsToReload, with: .none)
     }
 
-    /// Re-initializes the Login Flow. This may be required if the WordPress.com Account has no Stores available.
+    /// Re-initializes the Login Flow, forcing a logout. This may be required if the WordPress.com Account has no Stores available.
     ///
     func restartAuthentication() {
         guard StoresManager.shared.needsDefaultStore, let navigationController = navigationController else {
             return
         }
+
+        StoresManager.shared.deauthenticate()
 
         let loginViewController = AppDelegate.shared.authenticationManager.loginForWordPressDotCom()
         navigationController.setViewControllers([loginViewController], animated: true)


### PR DESCRIPTION
Fixes #597 

Deauthenticate from StoreManager when "Try another account" is selected in the Store picker.

## Testing
* Log into a WordPress.com account that has no WooCommerce stores associated with it.
* Verify you get the notification that no stores are present.
* Tap the button to try a different account.
* Force kill the app.
* Restart the app.
* User should be at the beginning of the login flow.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.