### PR TITLE
Add Retry functionality to failed order fulfilment and failed adding notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,5 @@
 - bugfix: Allows for decimal quantities which some extensions have
 - new feature: quick site select. Navigate to Settings > select row with store website.
 - improvement: Updated the colors of the bars in the charts for better readability
+- improvement: Present an error message with an option to retry when adding a note to an order fails
+- improvement: Present an error message with an option to retry when fulfilling an order fails

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -184,7 +184,7 @@ extension FulfillViewController {
     /// Displays the `Unable to Fulfill Order` Notice.
     ///
     func displayErrorNotice(orderID: Int) {
-        let title = NSLocalizedString("Unable to fulfill order #\(orderID)", comment: "Content of error presented when Fullfill Order Action Failed")
+        let title = NSLocalizedString("Unable to fulfill order #\(orderID)", comment: "Content of error presented when Fullfill Order Action Failed. It reads: Unable to fulfill order #{order number}")
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.fulfillWasPressed()

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -166,6 +166,8 @@ extension FulfillViewController {
 
             WooAnalytics.shared.track(.orderStatusChangeFailed, withError: error)
             DDLogError("⛔️ Order Update Failure: [\(orderID).status = \(status.rawValue)]. Error: \(error)")
+
+            self.displayErrorNotice(orderID: orderID)
         })
     }
 
@@ -175,6 +177,18 @@ extension FulfillViewController {
         let message = NSLocalizedString("Order marked as fulfilled", comment: "Order fulfillment success notice")
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
         let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle, actionHandler: onUndoAction)
+
+        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Displays the `Unable to Fulfill Order` Notice.
+    ///
+    func displayErrorNotice(orderID: Int) {
+        let title = NSLocalizedString("Unable to fulfill order #\(orderID)", comment: "Content of error presented when Fullfill Order Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            self?.fulfillWasPressed()
+        }
 
         AppDelegate.shared.noticePresenter.enqueue(notice: notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -17,6 +17,14 @@ class NewNoteViewController: UIViewController {
 
     private var noteText: String = ""
 
+    /// Dedicated NoticePresenter (use this here instead of AppDelegate.shared.noticePresenter)
+    ///
+    private lazy var noticePresenter: NoticePresenter = {
+        let noticePresenter = NoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     // MARK: - View Lifecycle
 
     override func viewDidLoad() {
@@ -74,7 +82,8 @@ class NewNoteViewController: UIViewController {
             if let error = error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
                 WooAnalytics.shared.track(.orderNoteAddFailed, withError: error)
-                // TODO: should this alert the user that there was an error?
+
+                self?.displayErrorNotice()
                 self?.navigationItem.rightBarButtonItem?.isEnabled = true
                 return
             }
@@ -215,6 +224,20 @@ extension NewNoteViewController: UITableViewDataSource {
 extension NewNoteViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)
+    }
+}
+
+// MARK: - Error Notice
+//
+private extension NewNoteViewController {
+    func displayErrorNotice() {
+        let title = NSLocalizedString("Unable to add note to order #\(viewModel.order.orderID)", comment: "Content of error presented when Add Note Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            self?.addButtonTapped()
+        }
+
+        noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -231,7 +231,7 @@ extension NewNoteViewController: UITableViewDelegate {
 //
 private extension NewNoteViewController {
     func displayErrorNotice() {
-        let title = NSLocalizedString("Unable to add note to order #\(viewModel.order.orderID)", comment: "Content of error presented when Add Note Action Failed")
+        let title = NSLocalizedString("Unable to add note to order #\(viewModel.order.orderID)", comment: "Content of error presented when Add Note Action Failed. It reads: Unable to add note to order #{order number}")
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.addButtonTapped()


### PR DESCRIPTION
Fixes #256 

Add a Notice with retry functionality when:
- Fulfilling an order fails 
- Adding a note to an order fails

In the case of fulfilling orders, we are presenting the success Notice immediately after users tap "Mark Order Completed", without waiting for the StoresManager to actually complete the fulfilment operation. That, in my opinion, provides better feedback to users (as the Notice incorporates an Undo button) that waiting until the operation is completed, but in the case there is an error we would present a Notice advising of the success of the operation followed by another prompt notifying that the operation failed, which I don't know if it is the expected behaviour.

This is how the Notices look:
- Adding a Note failed:
![simulator screen shot - iphone x - 2019-02-14 at 18 30 55](https://user-images.githubusercontent.com/2722505/52782781-d5142c80-308a-11e9-8e8f-907d4bd6abab.png)

- Fulfilling an Order failed:
![simulator screen shot - iphone x - 2019-02-14 at 18 54 15](https://user-images.githubusercontent.com/2722505/52782807-e3624880-308a-11e9-9a07-62f70607b595.png)

## Testing
The best way I've found to force an error is using the Network Link Conditioner (100% Loss). 
### When adding a note:
- Navigate to Orders > Any order
- Scroll down and tap "Add a note"
- Type some text.
- Activate the Network Link Conditioner.
- Tap Add.
- Wait for the operation to fail and notice the error message. Tap Retry on it.

### When fulfilling an order:
- Navigate to Orders > Any order
- Tap "Fulfill Order"
- Activate the Network Link Conditioner.
- Tap "Mark Order Completed"
- Wait for the operation to fail and notice the error message. Tap Retry on it.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.