### PR TITLE
Replace BuddyBuild status badge with CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5b2b904eaa674400010e975e&branch=develop&build=latest)](https://dashboard.buddybuild.com/apps/5b2b904eaa674400010e975e/build/latest?branch=develop) 
+[![CircleCI](https://circleci.com/gh/woocommerce/woocommerce-ios.svg?style=svg)](https://circleci.com/gh/woocommerce/woocommerce-ios)
 
 # woocommerce-ios
 A Jetpack-powered companion app for WooCommerce.


### PR DESCRIPTION
BuddyBuild will be turned off soon so this replaces the badge in the README.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
