### PR TITLE
Order Details: Display Address unless every field is empty

### DIFF
--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -16,13 +16,6 @@ public struct Address: Decodable {
     public let phone: String?
     public let email: String?
 
-    /// Make Address conform to Error protocol.
-    ///
-    enum AddressParseError: Error {
-        case missingCountry
-    }
-
-
     /// Designated Initializer.
     ///
     public init(firstName: String, lastName: String, company: String?, address1: String, address2: String?, city: String, state: String, postcode: String, country: String, phone: String?, email: String?) {
@@ -53,12 +46,6 @@ public struct Address: Decodable {
         let country = try container.decode(String.self, forKey: .country)
         let phone = try container.decodeIfPresent(String.self, forKey: .phone)
         let email = try container.decodeIfPresent(String.self, forKey: .email)
-
-        // Check for an empty country, because on Android that's how
-        // we determine if the shipping address should be considered empty.
-        if country.isEmpty {
-            throw AddressParseError.missingCountry
-        }
 
         self.init(firstName: firstName, lastName: lastName, company: company, address1: address1, address2: address2, city: city, state: state, postcode: postcode, country: country, phone: phone, email: email)
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,3 +6,4 @@
 - bugfix: Log out of the current account right after selecting "Try another account" in store picker
 - improvement: Use the store name for the title of the view in "My store" tab
 - improvement: Add an alert to let the user know about our new store switcher
+- improvement: Display Address in Order Details screen unless every field is empty


### PR DESCRIPTION
Fixes #688 

The implementation of the `Address` initialiser in conformance with `Decodable` was throwing an exception when the address does not contain a country.

This PR removes that exception. That guarantees that a valid instance of `Address` is initialised even if it does not have a country assigned, and therefore it will show up on the UI.

For this billing address:
<img width="180" alt="screenshot 2019-02-19 at 1 49 12 pm" src="https://user-images.githubusercontent.com/2722505/52993278-a6ad9d00-344e-11e9-8060-9ad209b406ee.png">
And this shipping address:
<img width="377" alt="screenshot 2019-02-19 at 1 49 24 pm" src="https://user-images.githubusercontent.com/2722505/52993302-b75e1300-344e-11e9-93ca-dc779561b3bb.png">

The result would be:
![simulator screen shot - iphone x - 2019-02-19 at 13 48 23](https://user-images.githubusercontent.com/2722505/52993331-ce046a00-344e-11e9-8f56-9e33e0eeefba.png)

For this shipping address (note none of the address fields are filled):
![simulator screen shot - iphone x - 2019-02-19 at 13 50 03](https://user-images.githubusercontent.com/2722505/52993387-fab88180-344e-11e9-8d23-0d4256f51901.png)

## Testing
* In your store's site, edit an order and delete the country from the shipping and billing addresses. Add anything to the Address line 1 or 2. Note the order number.
* Go to the app and navigate to Orders > {order number}
* Under the Customer Information section, find the Shipping Address heading. It should report an address as long as any of the address fields are filled.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.