### PR TITLE
Remove feature flag for app ratings

### DIFF
--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -1,13 +1,15 @@
 /// FeatureFlag exposes a series of features to be conditionally enabled on
 /// different builds.
 enum FeatureFlag: Int {
-    case appReviewPrompt
+    /// Throwaway case, to prevent a compiler error:
+    /// `An enum with no cases cannot declare a raw type`
+    case null
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
         switch self {
-        case .appReviewPrompt:
-            return BuildConfiguration.current == .localDeveloper
+        default:
+            return true
         }
     }
 }

--- a/WooCommerce/Classes/Tools/AppRatings/AppRatingManager.swift
+++ b/WooCommerce/Classes/Tools/AppRatings/AppRatingManager.swift
@@ -25,9 +25,7 @@ public class AppRatingManager {
 
     private let defaults: UserDefaults
     private var sections = [String: Section]()
-    private var promptingDisabledViaFeatureFlag: Bool {
-        return FeatureFlag.appReviewPrompt.enabled == false
-    }
+
     /// Don't prompt for reviews for internal builds
     /// http://stackoverflow.com/questions/26081543/how-to-tell-at-runtime-whether-an-ios-app-is-running-through-a-testflight-beta-i?noredirect=1&lq=1
     ///
@@ -39,7 +37,7 @@ public class AppRatingManager {
     }()
 
     private var promptingDisabled: Bool {
-        return promptingDisabledViaFeatureFlag || promptingDisabledLocal
+        return promptingDisabledLocal
     }
 
     static let shared = AppRatingManager(defaults: .standard)

--- a/WooCommerce/WooCommerceTests/System/FeatureFlagTests.swift
+++ b/WooCommerce/WooCommerceTests/System/FeatureFlagTests.swift
@@ -2,22 +2,4 @@ import XCTest
 @testable import WooCommerce
 
 class FeatureFlagTests: XCTestCase {
-
-    /// App review prompt is enabled for dev builds
-    ///
-    func testFeatureFlagForAppReviewPromptIsEnabledForLocalDeveloperBuildConfiguration() {
-        BuildConfiguration.localDeveloper.test {
-            let actualValue = FeatureFlag.appReviewPrompt.enabled
-            XCTAssertTrue(actualValue, "App Review Prompt should be enabled for .localDeveloper BuildConfiguration")
-        }
-    }
-
-    /// App review prompt is disabled for app store builds
-    ///
-    func testFeatureFlagForAppReviewPromptIsDisabledForAppStoreBuildConfiguration() {
-        BuildConfiguration.appStore.test {
-            let actualValue = FeatureFlag.appReviewPrompt.enabled
-            XCTAssertFalse(actualValue, "App Review Prompt should be disabled for .appStore BuildConfiguration")
-        }
-    }
 }


### PR DESCRIPTION
Fixes #682 

Remove the feature flag for the App Review prompt, introduced in #582 

![simulator screen shot - iphone x - 2019-02-19 at 15 37 18](https://user-images.githubusercontent.com/2722505/52997993-0a3ec700-345d-11e9-92fd-bd32abd3581e.png)
![simulator screen shot - iphone x - 2019-02-19 at 15 20 06](https://user-images.githubusercontent.com/2722505/52997997-10cd3e80-345d-11e9-984a-b638c9b49cb8.png)


## Testing
Testing instructions taken from #582 with some slight tweaks:
- [x] Verify the unit tests are green
- [x] Delete the app from your simulator and run it. View notification details 6 times. The prompt should be visible.
- [x] Delete the app from your simulator and run it. Find a processing order and "Mark as Complete" 11 times. Return to the list of orders. The prompt should be visible.

I have not added an item to the `RELEASE_NOTES` file.