### PR TITLE
Default Dashboard title to "My Store" when the view controller is loaded without an available store

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -130,6 +130,8 @@ extension DashboardViewController {
             return
         }
 
+        configureTitle()
+
         storeStatsViewController.clearAllFields()
         applyHideAnimation(for: newOrdersContainerView)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -214,6 +214,7 @@ private extension DashboardViewController {
 
         group.notify(queue: .main) { [weak self] in
             self?.refreshControl.endRefreshing()
+            self?.configureTitle()
 
             if let error = reloadError {
                 DDLogError("⛔️ Error loading dashboard: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -80,8 +80,9 @@ private extension DashboardViewController {
     }
 
     private func configureTitle() {
-        title = StoresManager.shared.sessionManager.defaultSite?.name
-        tabBarItem.title = NSLocalizedString("My store", comment: "Title of the bottom tab item that presents the user's store dashboard")
+        let myStore = NSLocalizedString("My store", comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard")
+        title = StoresManager.shared.sessionManager.defaultSite?.name ?? myStore
+        tabBarItem.title = myStore
     }
 
     private func configureNavigationItem() {


### PR DESCRIPTION
Fix #699 

I haven't been able to reproduce the issue consistently, I have only been able to replicate it twice. I presume that would be because my dataset is not large enough yet, and therefore the migration happens too fast.

The solution I submit here is a bit of a shot in the dark.

- Default to "My store" as title if by the time the view appears on screen the `sessionManager` does not have a `defaultSite` yet.
- Assign the title again after data load (i.e. stats and orders) is completed. Not ideal, but it does not seem like a huge waste of resources. I assume there might be a more elegant way to be notified when the reload is going to begin, but I could not find it.
- Assign the title as well when the `defaultAccountWasUpdated` notification is received.

Worst case scenario, the title would read as "My store" until data is loaded, and it will change to the store name. @mindgraffiti @bummytime please let me know what you think

## Testing
1. In the simulator, perform a build + fresh install from the [`release/1.2` branch](https://github.com/woocommerce/woocommerce-ios/tree/release/1.2)
2. Log into any store all the way to the dashboard
3. Kill the app and switch to the `develop` branch
4. Build and run the app
5. The My Store navbar should not be blank. It might read as "My store" while the initial data is loaded