### PR TITLE
Networking: NetworkRequestRetrier for Jetpack errors

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		7452387221124B7700A973CD /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452386F21124B7700A973CD /* AnyEncodable.swift */; };
 		7452387321124B7700A973CD /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452387021124B7700A973CD /* AnyCodable.swift */; };
 		7452387421124B7700A973CD /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7452387121124B7700A973CD /* AnyDecodable.swift */; };
+		745992EF222495CA00B878A9 /* WooURLRequestConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745992EE222495CA00B878A9 /* WooURLRequestConvertable.swift */; };
 		748D4248210F89ED00CF7D1B /* OrderStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D4247210F89ED00CF7D1B /* OrderStatsRemote.swift */; };
 		748D424A210F92EA00CF7D1B /* OrderStatsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D4249210F92EA00CF7D1B /* OrderStatsItem.swift */; };
 		748D424C210FA34400CF7D1B /* OrderStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D424B210FA34400CF7D1B /* OrderStatsMapper.swift */; };
@@ -234,6 +235,7 @@
 		7452386F21124B7700A973CD /* AnyEncodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		7452387021124B7700A973CD /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		7452387121124B7700A973CD /* AnyDecodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
+		745992EE222495CA00B878A9 /* WooURLRequestConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooURLRequestConvertable.swift; sourceTree = "<group>"; };
 		748D4247210F89ED00CF7D1B /* OrderStatsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemote.swift; sourceTree = "<group>"; };
 		748D4249210F92EA00CF7D1B /* OrderStatsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsItem.swift; sourceTree = "<group>"; };
 		748D424B210FA34400CF7D1B /* OrderStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsMapper.swift; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				B567AF2420A0CCA300AB6C62 /* AuthenticatedRequest.swift */,
 				B557DA0E20975E07005962F4 /* DotcomRequest.swift */,
 				B557D9FF209754FF005962F4 /* JetpackRequest.swift */,
+				745992EE222495CA00B878A9 /* WooURLRequestConvertable.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1047,6 +1050,7 @@
 				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
 				743057B5218B6ACD00441A76 /* Queue.swift in Sources */,
+				745992EF222495CA00B878A9 /* WooURLRequestConvertable.swift in Sources */,
 				74A1D26821189A7100931DFA /* SiteVisitStats.swift in Sources */,
 				B557DA0320975500005962F4 /* Remote.swift in Sources */,
 				748D424C210FA34400CF7D1B /* OrderStatsMapper.swift in Sources */,

--- a/Networking/Networking/Network/MockupNetwork.swift
+++ b/Networking/Networking/Network/MockupNetwork.swift
@@ -51,7 +51,7 @@ class MockupNetwork: Network {
     /// Whenever the Request's URL matches any of the "Mocked Up Patterns", we'll return the specified response file, loaded as *Data*.
     /// Otherwise, an error will be relayed back (.notFound!).
     ///
-    func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+    func responseData(for request: WooURLRequestConvertable, completion: @escaping (Data?, Error?) -> Void) {
         requestsForResponseData.append(request)
 
         if let error = error(for: request) {

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -20,5 +20,5 @@ public protocol Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void)
+    func responseData(for request: WooURLRequestConvertable, completion: @escaping (Data?, Error?) -> Void)
 }

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -29,7 +29,7 @@ public class Remote {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion. Will receive the JSON Parsed Response (if successful)
     ///
-    func enqueue(_ request: URLRequestConvertible, completion: @escaping (Any?, Error?) -> Void) {
+    func enqueue(_ request: WooURLRequestConvertable, completion: @escaping (Any?, Error?) -> Void) {
         network.responseData(for: request) { (data, networError) in
             guard let data = data else {
                 completion(nil, networError)
@@ -62,7 +62,7 @@ public class Remote {
     ///     - mapper: Mapper entitity that will be used to attempt to parse the Backend's Response.
     ///     - completion: Closure to be executed upon completion.
     ///
-    func enqueue<M: Mapper>(_ request: URLRequestConvertible, mapper: M, completion: @escaping (M.Output?, Error?) -> Void) {
+    func enqueue<M: Mapper>(_ request: WooURLRequestConvertable, mapper: M, completion: @escaping (M.Output?, Error?) -> Void) {
         network.responseData(for: request) { (data, networkError) in
             guard let data = data else {
                 completion(nil, networkError)

--- a/Networking/Networking/Requests/DotcomRequest.swift
+++ b/Networking/Networking/Requests/DotcomRequest.swift
@@ -4,7 +4,7 @@ import Alamofire
 
 /// Represents a WordPress.com Request
 ///
-struct DotcomRequest: URLRequestConvertible {
+struct DotcomRequest: WooURLRequestConvertable {
 
     /// WordPress.com Base URL
     ///
@@ -26,6 +26,9 @@ struct DotcomRequest: URLRequestConvertible {
     ///
     let parameters: [String: Any]?
 
+    /// WooURLRequestConvertable conformance — number of retry attempts upon error. Defaults to 0
+    ///
+    var retryAttempts: Int = 0
 
     /// Designated Initializer.
     ///

--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -4,7 +4,7 @@ import Alamofire
 
 /// Represents a Jetpack-Tunneled WordPress.com Endpoint
 ///
-struct JetpackRequest: URLRequestConvertible {
+struct JetpackRequest: WooURLRequestConvertable {
 
     /// WordPress.com API Version: By Default, we'll go thru Mark 1.1.
     ///
@@ -30,6 +30,9 @@ struct JetpackRequest: URLRequestConvertible {
     ///
     let parameters: [String: String]
 
+    /// WooURLRequestConvertable conformance — number of retry attempts upon error. Defaults to 2
+    ///
+    var retryAttempts: Int = 2
 
     /// Designated Initializer.
     ///

--- a/Networking/Networking/Requests/WooURLRequestConvertable.swift
+++ b/Networking/Networking/Requests/WooURLRequestConvertable.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Alamofire
+
+
+public protocol WooURLRequestConvertable: URLRequestConvertible {
+
+    /// Number of times to attempt a retry if this request recieves an error
+    ///
+    var retryAttempts: Int { get set }
+}


### PR DESCRIPTION
@mindgraffiti and @ctarda I wanted to get your thoughts on this idea before continuing too far.

I am working out a way to smartly address #161 in a similar way that WooAndroid did (automatic retry for JP timeout errors) without adding a lot of complexity to the codebase.

My thought here was that we could implement something in `Networking` such that no consumer of any `Remote` is aware of it. It turns out that [Alamofire offers a `RequestRetrier` protocol](https://github.com/Alamofire/Alamofire/blob/master/Documentation/AdvancedUsage.md#requestretrier) that allows us to define when/how many times a given request is retried if an error response is returned.

So in this PR, I extended Alamofire's `URLRequestConvertible` protocol as `WooURLRequestConvertable` and added a new var, `retryAttempts`, in it. Then, our two current adopters of `URLRequestConvertible` — `DotcomRequest` and `JetpackRequest` can define how many times they would like to retry a given request if it fails. In my example here I set JP requests to 2 and dotcom requests to 0.

Immediately before the network call is made we check to see if `retryAttempts > 0`. If so, we instantiate a `NetworkRequestRetrier`, assign it to the default Alamofire session, and fire off the request like normal. All of the retry logic is taken care of automagically.

Again, this is just a rough POC but it does work. Let me know any thoughts y'all have good or bad. 😄


