### PR TITLE
Lint config updated for vertical_whitespace

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -99,6 +99,9 @@ whitelist_rules:
   # TODOs and FIXMEs should be avoided.
   # - todo
 
+  # Limit vertical whitespace to a three empty lines (rule configuration is below)
+  - vertical_whitespace
+
   # Files should have a single trailing newline.
   - trailing_newline
 
@@ -129,8 +132,12 @@ whitelist_rules:
 
 # Rules configuration
 
-control_statement: 
-  severity: error 
+vertical_whitespace:
+  max_empty_lines: 3
+  severity: error
+
+control_statement:
+  severity: error
 
 custom_rules:
 


### PR DESCRIPTION
We have an informal vertical whitespace standard that is causing linting to fail on Hound. Specifically:

* [2](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Model/Age.swift#L2-L3) or [3](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Notifications/PushNotificationsManager.swift#L6-L8) lines after import statements
* [2 lines](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Notifications/PushNotificationsManager.swift#L54-L55) before an extension (or its `MARK` comment)

The [`vertical_whitespace` rule in swiftlint is enabled by default](https://github.com/realm/SwiftLint/blob/master/Rules.md#vertical-whitespace) and limits vertical whitespace to a single empty line. This PR updates that rule's config to a maximum of 3 empty lines to accommodate the situations above ☝️ 

@mindgraffiti @ctarda @loremattei what do y'all think?
