### PR TITLE
Switch Add button to a spinner in notes editor screen 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -45,43 +45,12 @@ class NewNoteViewController: UIViewController {
         view.endEditing(true)
     }
 
-    func configureNavigation() {
-        configureTitle()
-        configureDismissButton()
-        configureAddButton()
-    }
-
-    private func configureTitle() {
-        title = NSLocalizedString("Order #\(viewModel.order.number)", comment: "Add a note screen - title. Example: Order #15")
-    }
-
-    private func configureDismissButton() {
-        let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Add a note screen - button title for closing the view")
-        let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
-                                            style: .plain,
-                                            target: self,
-                                            action: #selector(dismissButtonTapped))
-        leftBarButton.tintColor = .white
-        navigationItem.setLeftBarButton(leftBarButton, animated: false)
-    }
-
-    private func configureAddButton() {
-        let addButtonTitle = NSLocalizedString("Add", comment: "Add a note screen - button title to send the note")
-        let rightBarButton = UIBarButtonItem(title: addButtonTitle,
-                                             style: .done,
-                                             target: self,
-                                             action: #selector(addButtonTapped))
-        rightBarButton.tintColor = .white
-        navigationItem.setRightBarButton(rightBarButton, animated: false)
-        navigationItem.rightBarButtonItem?.isEnabled = false
-    }
-
     @objc func dismissButtonTapped() {
         dismiss(animated: true, completion: nil)
     }
 
     @objc func addButtonTapped() {
-        navigationItem.rightBarButtonItem?.isEnabled = false
+        switchRightButtonToProgressIndicator()
 
         WooAnalytics.shared.track(.orderNoteAddButtonTapped)
         WooAnalytics.shared.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.order.orderID,
@@ -94,7 +63,7 @@ class NewNoteViewController: UIViewController {
                 WooAnalytics.shared.track(.orderNoteAddFailed, withError: error)
 
                 self?.displayErrorNotice()
-                self?.navigationItem.rightBarButtonItem?.isEnabled = true
+                self?.switchRightButtonToAddButton()
                 return
             }
             WooAnalytics.shared.track(.orderNoteAddSuccess)
@@ -248,6 +217,62 @@ private extension NewNoteViewController {
         }
 
         noticePresenter.enqueue(notice: notice)
+    }
+}
+
+
+// MARK: - Navigation bar
+//
+private extension NewNoteViewController {
+    func configureNavigation() {
+        configureTitle()
+        configureDismissButton()
+        configureRightButtonItemAsAdd()
+    }
+
+    func configureTitle() {
+        title = NSLocalizedString("Order #\(viewModel.order.number)", comment: "Add a note screen - title. Example: Order #15")
+    }
+
+    func configureDismissButton() {
+        let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Add a note screen - button title for closing the view")
+        let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(dismissButtonTapped))
+        leftBarButton.tintColor = .white
+        navigationItem.setLeftBarButton(leftBarButton, animated: false)
+    }
+
+    func configureRightButtonItemAsAdd() {
+        let addButtonTitle = NSLocalizedString("Add", comment: "Add a note screen - button title to send the note")
+        let rightBarButton = UIBarButtonItem(title: addButtonTitle,
+                                             style: .done,
+                                             target: self,
+                                             action: #selector(addButtonTapped))
+        rightBarButton.tintColor = .white
+        navigationItem.setRightBarButton(rightBarButton, animated: false)
+        navigationItem.rightBarButtonItem?.isEnabled = false
+    }
+
+    func switchRightButtonToProgressIndicator() {
+        configureRightButtonItemAsSpinner()
+        navigationItem.rightBarButtonItem?.isEnabled = false
+    }
+
+    func configureRightButtonItemAsSpinner() {
+        let activityIndicator = UIActivityIndicatorView(style: .white)
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.startAnimating()
+
+        let rightBarButton = UIBarButtonItem(customView: activityIndicator)
+
+        navigationItem.setRightBarButton(rightBarButton, animated: true)
+    }
+
+    func switchRightButtonToAddButton() {
+        configureRightButtonItemAsAdd()
+        navigationItem.rightBarButtonItem?.isEnabled = true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -46,8 +46,16 @@ class NewNoteViewController: UIViewController {
     }
 
     func configureNavigation() {
-        title = NSLocalizedString("Order #\(viewModel.order.number)", comment: "Add a note screen - title. Example: Order #15")
+        configureTitle()
+        configureDismissButton()
+        configureAddButton()
+    }
 
+    private func configureTitle() {
+        title = NSLocalizedString("Order #\(viewModel.order.number)", comment: "Add a note screen - title. Example: Order #15")
+    }
+
+    private func configureDismissButton() {
         let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Add a note screen - button title for closing the view")
         let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
                                             style: .plain,
@@ -55,7 +63,9 @@ class NewNoteViewController: UIViewController {
                                             action: #selector(dismissButtonTapped))
         leftBarButton.tintColor = .white
         navigationItem.setLeftBarButton(leftBarButton, animated: false)
+    }
 
+    private func configureAddButton() {
         let addButtonTitle = NSLocalizedString("Add", comment: "Add a note screen - button title to send the note")
         let rightBarButton = UIBarButtonItem(title: addButtonTitle,
                                              style: .done,

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -220,7 +220,6 @@ private extension NewNoteViewController {
     }
 }
 
-
 // MARK: - Navigation bar
 //
 private extension NewNoteViewController {
@@ -231,11 +230,13 @@ private extension NewNoteViewController {
     }
 
     func configureTitle() {
-        title = NSLocalizedString("Order #\(viewModel.order.number)", comment: "Add a note screen - title. Example: Order #15")
+        title = NSLocalizedString("Order #\(viewModel.order.number)",
+            comment: "Add a note screen - title. Example: Order #15")
     }
 
     func configureDismissButton() {
-        let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Add a note screen - button title for closing the view")
+        let dismissButtonTitle = NSLocalizedString("Dismiss",
+                                                   comment: "Add a note screen - button title for closing the view")
         let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
                                             style: .plain,
                                             target: self,
@@ -245,7 +246,8 @@ private extension NewNoteViewController {
     }
 
     func configureRightButtonItemAsAdd() {
-        let addButtonTitle = NSLocalizedString("Add", comment: "Add a note screen - button title to send the note")
+        let addButtonTitle = NSLocalizedString("Add",
+                                               comment: "Add a note screen - button title to send the note")
         let rightBarButton = UIBarButtonItem(title: addButtonTitle,
                                              style: .done,
                                              target: self,


### PR DESCRIPTION
Fix #698 

This PR switches the Add button in the notes editor screen to a progress indicator, when users tap Add to create a new note, to prevent a slight hang in the UI while the note is being created.

I tried to solve this by dismissing the view controller immediately and adding the progress indicator to the notes list in the `OrderDetailsViewController` but that seemed to add a lot of complexity.

![screen recording 2019-02-28 at 11 30 07 am mov](https://user-images.githubusercontent.com/2722505/53540589-1dcee980-3b51-11e9-955f-c3416ea7d277.gif)

## Testing
- Checkout the branch
- Create a new note. Notice the Add button switching to a spinner
- Attempt to create a new note, but make it fail (for example, activating 100% Loss in Network Conditioner). when the Error Notice is presented, the spinner should switch back to the Add button.
