### PR TITLE
Settings: Change text from "Log out account" to "Log Out"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -209,7 +209,7 @@ private extension SettingsViewController {
         cell.selectionStyle = .default
         cell.textLabel?.textAlignment = .center
         cell.textLabel?.textColor = StyleManager.destructiveActionColor
-        cell.textLabel?.text = NSLocalizedString("Log out account", comment: "Log out button title")
+        cell.textLabel?.text = NSLocalizedString("Log Out", comment: "Log out button title")
     }
 }
 

--- a/WooCommerce/Resources/ar.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ar.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "سجِّل الدخول باستخدام عنوان البريد الإلكتروني لحساب وردبرس.كوم الخاص بك لإدارة متاجر WooCommerce الخاصة بك.";
 
 /* Log out button title */
-"Log out account" = "تسجيل الخروج من الحساب";
+"Log Out" = "تسجيل الخروج من الحساب";
 
 /* Title of a button. */
 "Lost your password?" = "هل فقدت كلمة مرورك؟";

--- a/WooCommerce/Resources/de.lproj/Localizable.strings
+++ b/WooCommerce/Resources/de.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Melde dich mit der E-Mail-Adresse deines WordPress.com-Kontos an, um deine WooCommerce-Shops zu verwalten.";
 
 /* Log out button title */
-"Log out account" = "Von Konto abmelden";
+"Log Out" = "Von Konto abmelden";
 
 /* Title of a button. */
 "Lost your password?" = "Passwort vergessen?";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿/* Title for an untitled post, should match WP core */
+/* Title for an untitled post, should match WP core */
 "(no title)" = "(no title)";
 
 /* An error message. */
@@ -430,7 +430,7 @@
 "Log Out" = "Log Out";
 
 /* Log out button title */
-"Log out account" = "Log out account";
+"Log Out" = "Log Out";
 
 /* Title of a button.  */
 "Lost your password?" = "Lost your password?";

--- a/WooCommerce/Resources/es.lproj/Localizable.strings
+++ b/WooCommerce/Resources/es.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Accede con la dirección de correo electrónico de tu cuenta de WordPress.com para gestionar tus tiendas de WooCommerce.";
 
 /* Log out button title */
-"Log out account" = "Salir de la cuenta";
+"Log Out" = "Salir de la cuenta";
 
 /* Title of a button. */
 "Lost your password?" = "¿Has perdido tu contraseña?";

--- a/WooCommerce/Resources/fr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/fr.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Connectez-vous avec l’adresse e-mail de votre compte WordPress.com afin de gérer toutes vos boutiques WooCommerce.";
 
 /* Log out button title */
-"Log out account" = "Déconnecter le compte";
+"Log Out" = "Déconnecter le compte";
 
 /* Title of a button. */
 "Lost your password?" = "Mot de passe oublié ?";

--- a/WooCommerce/Resources/he.lproj/Localizable.strings
+++ b/WooCommerce/Resources/he.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "עליך להתחבר באמצעות כתובת האימייל של החשבון ב-WordPress.com כדי לנהל את החנויות שלך ב-WooCommerce.";
 
 /* Log out button title */
-"Log out account" = "ניתוק החשבון";
+"Log Out" = "ניתוק החשבון";
 
 /* Title of a button. */
 "Lost your password?" = "שחזור סיסמה";

--- a/WooCommerce/Resources/id.lproj/Localizable.strings
+++ b/WooCommerce/Resources/id.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Login dengan alamat email akun WordPress.com Anda untuk mengelola toko WooCommerce.";
 
 /* Log out button title */
-"Log out account" = "Logout dari akun";
+"Log Out" = "Logout dari akun";
 
 /* Title of a button. */
 "Lost your password?" = "Lupa sandi Anda?";

--- a/WooCommerce/Resources/it.lproj/Localizable.strings
+++ b/WooCommerce/Resources/it.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Accedi con l'indirizzo e-mail dell'account WordPress.com per gestire i negozi WooCommerce.";
 
 /* Log out button title */
-"Log out account" = "Disconnetti account";
+"Log Out" = "Disconnetti account";
 
 /* Title of a button. */
 "Lost your password?" = "Password persa?";

--- a/WooCommerce/Resources/ja.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ja.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "WooCommerce ストアを管理するには、WordPress.com アカウントのメールアドレスを使用してログインします。";
 
 /* Log out button title */
-"Log out account" = "アカウントからログアウト";
+"Log Out" = "アカウントからログアウト";
 
 /* Title of a button. */
 "Lost your password?" = "パスワードをお忘れですか ?";

--- a/WooCommerce/Resources/ko.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ko.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "WooCommerce 스토어를 관리하려면 워드프레스닷컴 계정 이메일 주소로 로그인합니다.";
 
 /* Log out button title */
-"Log out account" = "로그아웃 계정";
+"Log Out" = "로그아웃 계정";
 
 /* Title of a button. */
 "Lost your password?" = "비밀번호 분실?";

--- a/WooCommerce/Resources/nl.lproj/Localizable.strings
+++ b/WooCommerce/Resources/nl.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Log in met het e-mailadres van je WordPress.com-account om je WooCommerce-winkels te beheren.";
 
 /* Log out button title */
-"Log out account" = "Account uitloggen";
+"Log Out" = "Account uitloggen";
 
 /* Title of a button. */
 "Lost your password?" = "Wachtwoord vergeten?";

--- a/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Faça login com o seu endereço de e-mail da conta do WordPress.com para gerenciar suas lojas WooCommerce.";
 
 /* Log out button title */
-"Log out account" = "Fazer logout da conta";
+"Log Out" = "Fazer logout da conta";
 
 /* Title of a button. */
 "Lost your password?" = "Esqueceu sua senha?";

--- a/WooCommerce/Resources/ru.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ru.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Для управления магазинами WooCommerce выполните вход, указав адрес электронной почты своей учетной записи WordPress.com.";
 
 /* Log out button title */
-"Log out account" = "Выйти из учётной записи";
+"Log Out" = "Выйти из учётной записи";
 
 /* Title of a button. */
 "Lost your password?" = "Забыли пароль?";

--- a/WooCommerce/Resources/sv.lproj/Localizable.strings
+++ b/WooCommerce/Resources/sv.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "Logga in med e-postadressen för ditt WordPress.com-konto för att hantera dina WooCommerce-butiker.";
 
 /* Log out button title */
-"Log out account" = "Logga ut konto";
+"Log Out" = "Logga ut konto";
 
 /* Title of a button. */
 "Lost your password?" = "Glömt ditt lösenord?";

--- a/WooCommerce/Resources/tr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/tr.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "WooCommerce mağazalarınızı yönetmek için WordPress.com hesabınızın e-posta adresi ile oturum açın.";
 
 /* Log out button title */
-"Log out account" = "Hesaptan çıkış yap";
+"Log Out" = "Hesaptan çıkış yap";
 
 /* Title of a button. */
 "Lost your password?" = "Parolanızı mı unuttunuz?";

--- a/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "使用您的 WordPress.com 帐户电子邮件地址登录，管理您的 WooCommerce 商店。";
 
 /* Log out button title */
-"Log out account" = "注销帐户";
+"Log Out" = "注销帐户";
 
 /* Title of a button. */
 "Lost your password?" = "忘记密码？";

--- a/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "Log in with your WordPress.com account email address to manage your WooCommerce stores." = "使用 WordPress.com 帳號電子郵件地址登入，即可管理 WooCommerce 商店。";
 
 /* Log out button title */
-"Log out account" = "登出帳號";
+"Log Out" = "登出帳號";
 
 /* Title of a button. */
 "Lost your password?" = "忘記密碼？";


### PR DESCRIPTION
Fix: #714 

![simulator screen shot - iphone x - 2019-02-28 at 14 55 18](https://user-images.githubusercontent.com/2722505/53547581-60e98680-3b6a-11e9-8568-c603510e08d4.png)

I had a few minutes, so I took the liberty of taking this one. 

Change the title of the "Log out account" button in Settings to "Log Out". To preserve the previous translations, I have also updated the `Localizable.strings` files. 

## Testing
- Checkout the branch and build the project
- Navigate to Settings, notice the title of the Log Out button.
- Tap the button, check that logging out works.