### PR TITLE
Update hound to allow 160 characters for a line length, instead of 120.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,7 +69,7 @@ whitelist_rules:
   # - legacy_constructor
 
   # Lines should not span too many characters.
-  # - line_length
+  line_length: 160
 
   # MARK comment should be in valid format.
   - mark

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,7 +69,7 @@ whitelist_rules:
   # - legacy_constructor
 
   # Lines should not span too many characters.
-  line_length: 160
+  - line_length
 
   # MARK comment should be in valid format.
   - mark
@@ -135,6 +135,8 @@ whitelist_rules:
 vertical_whitespace:
   max_empty_lines: 3
   severity: error
+
+line_length: 160
 
 control_statement:
   severity: error


### PR DESCRIPTION
Configuration via [Swiftlint configuration docs](https://github.com/realm/SwiftLint#configuration)

First reviewer wins 😀 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
