### PR TITLE
Hide the keyboard when attempting to commit a note to the backend.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -37,7 +37,7 @@ class NewNoteViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        tableView.firstSubview(ofType: UITextView.self)?.becomeFirstResponder()
+        showKeyboard()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -50,7 +50,7 @@ class NewNoteViewController: UIViewController {
     }
 
     @objc func addButtonTapped() {
-        switchRightButtonToProgressIndicator()
+        configureForCommittingNote()
 
         WooAnalytics.shared.track(.orderNoteAddButtonTapped)
         WooAnalytics.shared.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.order.orderID,
@@ -63,7 +63,7 @@ class NewNoteViewController: UIViewController {
                 WooAnalytics.shared.track(.orderNoteAddFailed, withError: error)
 
                 self?.displayErrorNotice()
-                self?.switchRightButtonToAddButton()
+                self?.configureForEditingNote()
                 return
             }
             WooAnalytics.shared.track(.orderNoteAddSuccess)
@@ -257,7 +257,8 @@ private extension NewNoteViewController {
         navigationItem.rightBarButtonItem?.isEnabled = false
     }
 
-    func switchRightButtonToProgressIndicator() {
+    func configureForCommittingNote() {
+        hideKeyboard()
         configureRightButtonItemAsSpinner()
         navigationItem.rightBarButtonItem?.isEnabled = false
     }
@@ -272,9 +273,17 @@ private extension NewNoteViewController {
         navigationItem.setRightBarButton(rightBarButton, animated: true)
     }
 
-    func switchRightButtonToAddButton() {
+    func configureForEditingNote() {
         configureRightButtonItemAsAdd()
         navigationItem.rightBarButtonItem?.isEnabled = true
+    }
+
+    func showKeyboard() {
+        tableView.firstSubview(ofType: UITextView.self)?.becomeFirstResponder()
+    }
+
+    func hideKeyboard() {
+        tableView.firstSubview(ofType: UITextView.self)?.resignFirstResponder()
     }
 }
 


### PR DESCRIPTION
Fix #728

The keyboard was covering the Notice being presented when there is an error submitting a new note to the backend.

The fix:
- The keyboard is dismissed as soon as users tap the Add button, by making the text view resign its focus.

A short gif, when there is no connection at all:
![screen recording 2019-03-04 at 8 45 27 am mov](https://user-images.githubusercontent.com/2722505/53722624-482ce980-3e66-11e9-8a43-535d28131b7b.gif)


## Testing
- Checkout the branch
- Follow the reproduction steps in the original issue #728 
- The Keyboards should be dismissed when tapping "Add", and in case of an error, the Notice should be visible.