### PR TITLE
Present a Notice after switching a store, informing users that they will only receive notifications from the active store

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -366,10 +366,10 @@ extension StorePickerViewController {
         guard let newStoreName = StoresManager.shared.sessionManager.defaultSite?.name else {
             return
         }
-        let message = NSLocalizedString("Now you will only receive notifications related to \(newStoreName)",
-            comment: "Message presented after users switch to a new store. "
-                + " Reads like: Now you will only receive notifications related to A Store")
 
+        let message = NSLocalizedString("Switched to \(newStoreName). You will only receive notifications from this store.",
+            comment: "Message presented after users switch to a new store. "
+                + "Reads like: Switched to {store name}. You will only receive notifications from this store.")
         let notice = Notice(title: message, feedbackType: .success)
 
         AppDelegate.shared.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -353,11 +353,26 @@ extension StorePickerViewController {
             WooAnalytics.shared.track(.sitePickerContinueTapped,
                                       withProperties: ["selected_store_id": StoresManager.shared.sessionManager.defaultStoreID ?? String()])
 
+            presentStoreSwitchedNotice()
+
             dismiss(animated: true) {
                 AppDelegate.shared.authenticatorWasDismissed()
                 MainTabBarController.switchToMyStoreTab(animated: true)
             }
         }
+    }
+
+    private func presentStoreSwitchedNotice() {
+        guard let newStoreName = StoresManager.shared.sessionManager.defaultSite?.name else {
+            return
+        }
+        let message = NSLocalizedString("Now you will only receive notifications related to \(newStoreName)",
+            comment: "Message presented after users switch to a new store. "
+                + " Reads like: Now you will only receive notifications related to A Store")
+
+        let notice = Notice(title: message, feedbackType: .success)
+
+        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
     }
 }
 


### PR DESCRIPTION
Fixes #729 

Present a Notice after users switch a store, with a message informing that only notifications from the newly selected stores will be received.

![screen recording 2019-03-04 at 10 55 22 am mov](https://user-images.githubusercontent.com/2722505/53725719-d310e280-3e6c-11e9-9d9e-a301ea91383f.gif)

## Testing
- Checkout the branch
- Switch stores. The Notice should be visible.

@kyleaparker I am not sure about the wording. Space in the Notice is limited, so I tried to make it as short as possible, leaving the store name at the end of it.