### PR TITLE
Set the chevron image to flip upon changing to a RTL language

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.4
 -----
+- bugfix: correctly flips chevron on Dashboard > New Orders, to support RTL languages.
 
 1.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -77,7 +77,7 @@ private extension NewOrdersViewController {
         descriptionLabel.textInsets = Constants.newOrdersDescriptionLabelInsets
         descriptionLabel.text = NSLocalizedString("Review, prepare, and ship these pending orders",
                                                   comment: "Description text used on the UI element displayed when a user has pending orders to process.")
-        chevronImageView.image = UIImage.chevronImage
+        chevronImageView.image = UIImage.chevronImage.imageFlippedForRightToLeftLayoutDirection()
     }
 }
 


### PR DESCRIPTION
Fixes #703. 

<img src="https://user-images.githubusercontent.com/1062444/53751168-4b79a280-3e71-11e9-925c-6b84d51d84c0.png" width="300" />


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
