### PR TITLE
Swift linting

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -148,13 +148,25 @@ private extension WooAnalytics {
             return
         }
 
-        NotificationCenter.default.addObserver(self, selector: #selector(trackApplicationOpened), name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(trackApplicationClosed), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(trackApplicationOpened),
+                                               name: UIApplication.didBecomeActiveNotification,
+                                               object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(trackApplicationClosed),
+                                               name: UIApplication.didEnterBackgroundNotification,
+                                               object: nil)
     }
 
     func stopObservingNotifications() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UIApplication.didBecomeActiveNotification,
+                                                  object: nil)
+
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UIApplication.didEnterBackgroundNotification,
+                                                  object: nil)
     }
 
     @objc func trackApplicationOpened() {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -116,17 +116,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         pushNotesManager.registrationDidFail(with: error)
     }
 
-    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+    func application(_ application: UIApplication,
+                     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         pushNotesManager.handleNotification(userInfo, completionHandler: completionHandler)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+        // Sent when the application is about to move from active to inactive state.
+        // This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message)
+        // or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
+        // Games should use this method to pause the game.
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // Use this method to release shared resources, save user data, invalidate timers,
+        // and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
@@ -135,7 +141,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        // Restart any tasks that were paused (or not yet started) while the application was inactive.
+        // If the application was previously in the background, optionally refresh the user interface.
 
         RequirementsChecker.checkMinimumWooVersionForDefaultStore()
     }

--- a/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationConstants.swift
@@ -6,13 +6,22 @@ struct AuthenticationConstants {
 
     /// Email login instructions.
     ///
-    static let emailInstructions = NSLocalizedString("Log in with your WordPress.com account email address to manage your WooCommerce stores.", comment: "Sign in instructions on the 'log in using email' screen.")
+    static let emailInstructions = NSLocalizedString(
+        "Log in with your WordPress.com account email address to manage your WooCommerce stores.",
+        comment: "Sign in instructions on the 'log in using email' screen."
+    )
 
     /// Login with Jetpack instructions.
     ///
-    static let jetpackInstructions = NSLocalizedString("Log in with your WordPress.com account email address to manage your WooCommerce stores.", comment: "Sign in instructions on the 'log in using email' screen.")
+    static let jetpackInstructions = NSLocalizedString(
+        "Log in with your WordPress.com account email address to manage your WooCommerce stores.",
+        comment: "Sign in instructions on the 'log in using email' screen."
+    )
 
     /// Login with site URL instructions.
     ///
-    static let siteInstructions = NSLocalizedString("Enter the address of your WooCommerce store you'd like to connect.", comment: "Sign in instructions for logging in with a URL.")
+    static let siteInstructions = NSLocalizedString(
+        "Enter the address of your WooCommerce store you'd like to connect.",
+        comment: "Sign in instructions for logging in with a URL."
+    )
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -314,8 +314,13 @@ private extension StorePickerViewController {
     /// Displays the Error Notice for the version check.
     ///
     func displayVersionCheckErrorNotice(siteID: Int, siteName: String) {
-        let message = String.localizedStringWithFormat(NSLocalizedString("Unable to successfully connect to %@",
-                                                                         comment: "On the site picker screen, the error displayed when connecting to a site fails. It reads: Unable to successfully connect to {site name}"), siteName)
+        let message = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Unable to successfully connect to %@",
+                comment: "On the site picker screen, the error displayed when connecting to a site fails. It reads: Unable to successfully connect to {site name}"
+            ),
+            siteName
+        )
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.displaySiteWCRequirementWarningIfNeeded(siteID: siteID, siteName: siteName)

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -152,7 +152,10 @@ private extension LoginPrologueViewController {
     /// Returns the Disclaimer Attributed Text (which contains a link to the Jetpack Setup URL).
     ///
     var disclaimerAttributedText: NSAttributedString {
-        let disclaimerText = NSLocalizedString("This app requires Jetpack to connect to your Store. <br /> Read the <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.", comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, 'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'Read the configuration instructions' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language.")
+        let disclaimerText = NSLocalizedString(
+            "This app requires Jetpack to connect to your Store. <br /> Read the <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
+            comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, 'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'Read the configuration instructions' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language."
+        )
         let disclaimerAttributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.font(forStyle: .caption1, weight: .thin),
             .foregroundColor: UIColor.white

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -72,11 +72,29 @@ extension Date {
 private extension Date {
 
     enum Strings {
-        static let presentDeicticExpression     = NSLocalizedString("Updated moments ago", comment: "Deictic expression for a data update that occurred in the very recent past - similar to 'Updated just now'")
-        static let singularMinuteUpdateStatment = NSLocalizedString("Updated %ld minute ago", comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. Usage example: Updated 1 minute ago")
-        static let pluralMinuteUpdateStatment   = NSLocalizedString("Updated %ld minutes ago", comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago")
-        static let singularHourUpdateStatment   = NSLocalizedString("Updated %ld hour ago", comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago")
-        static let pluralHourUpdateStatment     = NSLocalizedString("Updated %ld hours ago", comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago")
-        static let longFormUpdateStatement      = NSLocalizedString("Updated on %@", comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated on Jan 22, 2019 3:31PM")
+        static let presentDeicticExpression = NSLocalizedString(
+            "Updated moments ago",
+            comment: "Deictic expression for a data update that occurred in the very recent past - similar to 'Updated just now'"
+        )
+        static let singularMinuteUpdateStatment = NSLocalizedString(
+            "Updated %ld minute ago",
+            comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. Usage example: Updated 1 minute ago"
+        )
+        static let pluralMinuteUpdateStatment = NSLocalizedString(
+            "Updated %ld minutes ago",
+            comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago"
+        )
+        static let singularHourUpdateStatment = NSLocalizedString(
+            "Updated %ld hour ago",
+            comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago"
+        )
+        static let pluralHourUpdateStatment = NSLocalizedString(
+            "Updated %ld hours ago",
+            comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago"
+        )
+        static let longFormUpdateStatement = NSLocalizedString(
+            "Updated on %@",
+            comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated on Jan 22, 2019 3:31PM"
+        )
     }
 }

--- a/WooCommerce/Classes/Extensions/String+HTML.swift
+++ b/WooCommerce/Classes/Extensions/String+HTML.swift
@@ -31,7 +31,10 @@ extension String {
     var htmlToAttributedString: NSAttributedString {
         guard let data = data(using: .utf8) else { return NSAttributedString() }
         do {
-            return try NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue], documentAttributes: nil)
+            return try NSAttributedString(data: data,
+                                          options: [.documentType: NSAttributedString.DocumentType.html,
+                                                    .characterEncoding: String.Encoding.utf8.rawValue],
+                                          documentAttributes: nil)
         } catch {
             DDLogError("Error: unable to convert HTML data to an attributed string")
             return NSAttributedString()

--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -95,7 +95,7 @@ public class CurrencyFormatter {
     /// For our purposes here, a "small number" is anything in-between -1000 and 1000 (exclusive).
     ///
     /// - Note: This func leverages the formatter from our `NSDecimalNumber` extension.
-    ///         See: [NSDecimalNumber+Helpers.swift](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Extensions/NSDecimalNumber%2BHelpers.swift) for more details.
+    ///         See: `NSDecimalNumber+Helpers.swift` for more details.
     ///
     /// Examples with currency code of "USD" (`roundSmallNumbers` is set to `true`):
     ///  - 0 becomes "$0"
@@ -113,7 +113,9 @@ public class CurrencyFormatter {
     ///  - 1000 becomes "$1.0k"
     ///  - 5800199.56 becomes "$5.8m"
     ///
-    func formatHumanReadableAmount(_ amount: String, with currency: String = CurrencySettings.shared.currencyCode.rawValue, roundSmallNumbers: Bool = true) -> String? {
+    func formatHumanReadableAmount(_ amount: String,
+                                   with currency: String = CurrencySettings.shared.currencyCode.rawValue,
+                                   roundSmallNumbers: Bool = true) -> String? {
         guard let decimalAmount = convertToDecimal(from: amount) else {
             return nil
         }

--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -14,7 +14,58 @@ public class CurrencySettings {
     /// The 3-letter country code for supported currencies
     ///
     public enum CurrencyCode: String, CaseIterable {
-        case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN, BAM, BBD, BDT, BGN, BHD, BIF, BMD, BND, BOB, BRL, BSD, BTC, BTN, BWP, BYR, BYN, BZD, CAD, CDF, CHF, CLP, CNY, COP, CRC, CUC, CUP, CVE, CZK, DJF, DKK, DOP, DZD, EGP, ERN, ETB, EUR, FJD, FKP, GBP, GEL, GGP, GHS, GIP, GMD, GNF, GTQ, GYD, HKD, HNL, HRK, HTG, HUF, IDR, ILS, IMP, INR, IQD, IRR, IRT, ISK, JEP, JMD, JOD, JPY, KES, KGS, KHR, KMF, KPW, KRW, KWD, KYD, KZT, LAK, LBP, LKR, LRD, LSL, LYD, MAD, MDL, MGA, MKD, MMK, MNT, MOP, MRO, MUR, MVR, MWK, MXN, MYR, MZN, NAD, NGN, NIO, NOK, NPR, NZD, OMR, PAB, PEN, PGK, PHP, PKR, PLN, PRB, PYG, QAR, RMB, RON, RSD, RUB, RWF, SAR, SBD, SCR, SDG, SEK, SGD, SHP, SLL, SOS, SRD, SSP, STD, SYP, SZL, THB, TJS, TMT, TND, TOP, TRY, TTD, TWD, TZS, UAH, UGX, USD, UYU, UZS, VEF, VND, VUV, WST, XAF, XCD, XOF, XPF, YER, ZAR, ZMW
+        // A
+        case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN,
+        // B
+        BAM, BBD, BDT, BGN, BHD, BIF, BMD, BND, BOB, BRL, BSD, BTC, BTN, BWP, BYR, BYN, BZD,
+        // C
+        CAD, CDF, CHF, CLP, CNY, COP, CRC, CUC, CUP, CVE, CZK,
+        // D
+        DJF, DKK, DOP, DZD,
+        // E
+        EGP, ERN, ETB, EUR, FJD,
+        // F
+        FKP,
+        // G
+        GBP, GEL, GGP, GHS, GIP, GMD, GNF, GTQ, GYD,
+        // H
+        HKD, HNL, HRK, HTG, HUF,
+        // I
+        IDR, ILS, IMP, INR, IQD, IRR, IRT, ISK,
+        // J
+        JEP, JMD, JOD, JPY,
+        // K
+        KES, KGS, KHR, KMF, KPW, KRW, KWD, KYD, KZT,
+        // L
+        LAK, LBP, LKR, LRD, LSL, LYD,
+        // M
+        MAD, MDL, MGA, MKD, MMK, MNT, MOP, MRO, MUR, MVR, MWK, MXN, MYR, MZN,
+        // N
+        NAD, NGN, NIO, NOK, NPR, NZD,
+        // O
+        OMR,
+        // P
+        PAB, PEN, PGK, PHP, PKR, PLN, PRB, PYG,
+        // Q
+        QAR,
+        // R
+        RMB, RON, RSD, RUB, RWF,
+        // S
+        SAR, SBD, SCR, SDG, SEK, SGD, SHP, SLL, SOS, SRD, SSP, STD, SYP, SZL,
+        // T
+        THB, TJS, TMT, TND, TOP, TRY, TTD, TWD, TZS,
+        // U
+        UAH, UGX, USD, UYU, UZS,
+        // V
+        VEF, VND, VUV,
+        // W
+        WST,
+        // X
+        XAF, XCD, XOF, XPF,
+        // Y
+        YER,
+        // Z
+        ZAR, ZMW
     }
 
     /// Designates where the currency symbol is located on a formatted price

--- a/WooCommerce/Classes/Tools/Logging/Logging.swift
+++ b/WooCommerce/Classes/Tools/Logging/Logging.swift
@@ -24,22 +24,107 @@ internal func resetDefaultDebugLevel() {
     defaultDebugLevel = CocoaLumberjack.defaultDebugLevel
 }
 
-internal func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogDebug(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = true,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+
+    CocoaLumberjack.DDLogDebug(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }
 
-internal func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogInfo(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+
+    CocoaLumberjack.DDLogInfo(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogWarn(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+
+    CocoaLumberjack.DDLogWarn(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogVerbose(_ message: @autoclosure () -> String,
+                           level: DDLogLevel = defaultDebugLevel,
+                           context: Int = 0,
+                           file: StaticString = #file,
+                           function: StaticString = #function,
+                           line: UInt = #line,
+                           tag: Any? = nil,
+                           asynchronous async: Bool = true,
+                           ddlog: DDLog = DDLog.sharedInstance) {
+
+    CocoaLumberjack.DDLogVerbose(message,
+                                 level: level,
+                                 context: context,
+                                 file: file,
+                                 function: function,
+                                 line: line,
+                                 tag: tag,
+                                 asynchronous: async,
+                                 ddlog: ddlog)
 }
 
-internal func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogError(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = false,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+
+    CocoaLumberjack.DDLogError(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }

--- a/WooCommerce/Classes/Tools/Notices/Notice.swift
+++ b/WooCommerce/Classes/Tools/Notices/Notice.swift
@@ -34,7 +34,12 @@ struct Notice {
 
     /// Designated Initializer
     ///
-    init(title: String, message: String? = nil, feedbackType: UINotificationFeedbackGenerator.FeedbackType? = nil, notificationInfo: NoticeNotificationInfo? = nil, actionTitle: String? = nil, actionHandler: ((() -> Void))? = nil) {
+    init(title: String,
+         message: String? = nil,
+         feedbackType: UINotificationFeedbackGenerator.FeedbackType? = nil,
+         notificationInfo: NoticeNotificationInfo? = nil,
+         actionTitle: String? = nil,
+         actionHandler: ((() -> Void))? = nil) {
         self.title = title
         self.message = message
         self.feedbackType = feedbackType

--- a/WooCommerce/Classes/Tools/StringFormatter/StringStyles.swift
+++ b/WooCommerce/Classes/Tools/StringFormatter/StringStyles.swift
@@ -101,13 +101,31 @@ extension StringStyles {
     /// Styles: Notification Defailts / Body Blocks
     ///
     static let body: StringStyles = {
-        let regular: Style      = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body, .foregroundColor: StyleManager.defaultTextColor]
-        let bold: Style         = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.bold, .foregroundColor: StyleManager.defaultTextColor]
-        let blockquote: Style   = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.italics, .foregroundColor: StyleManager.defaultTextColor]
-        let match: Style        = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.bold, .foregroundColor: StyleManager.defaultTextColor]
-        let noticon: Style      = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.noticon(forStyle: .body), .foregroundColor: StyleManager.defaultTextColor]
-        let italic: Style       = [.paragraphStyle: NSParagraphStyle.body, .font: UIFont.body.italics, .foregroundColor: StyleManager.defaultTextColor]
-        let link: Style         = [.foregroundColor: StyleManager.wooCommerceBrandColor]
+        let regular: Style = [.paragraphStyle: NSParagraphStyle.body,
+                              .font: UIFont.body,
+                              .foregroundColor: StyleManager.defaultTextColor]
+
+        let bold: Style = [.paragraphStyle: NSParagraphStyle.body,
+                           .font: UIFont.body.bold,
+                           .foregroundColor: StyleManager.defaultTextColor]
+
+        let blockquote: Style = [.paragraphStyle: NSParagraphStyle.body,
+                                 .font: UIFont.body.italics,
+                                 .foregroundColor: StyleManager.defaultTextColor]
+
+        let match: Style = [.paragraphStyle: NSParagraphStyle.body,
+                            .font: UIFont.body.bold,
+                            .foregroundColor: StyleManager.defaultTextColor]
+
+        let noticon: Style = [.paragraphStyle: NSParagraphStyle.body,
+                              .font: UIFont.noticon(forStyle: .body),
+                              .foregroundColor: StyleManager.defaultTextColor]
+
+        let italic: Style = [.paragraphStyle: NSParagraphStyle.body,
+                             .font: UIFont.body.italics,
+                             .foregroundColor: StyleManager.defaultTextColor]
+
+        let link: Style = [.foregroundColor: StyleManager.wooCommerceBrandColor]
 
         return StringStyles(regular: regular, bold: bold, blockquote: blockquote, match: match, noticon: noticon, link: link)
     }()

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -292,10 +292,13 @@ extension ZendeskManager: SupportManagerAdapter {
         }
 
         // navigate thru the stack
-        let settingsVC = UIStoryboard.dashboard.instantiateViewController(withIdentifier: SettingsViewController.classNameWithoutNamespaces) as! SettingsViewController
+        let dashboard = UIStoryboard.dashboard
+        let settingsID = SettingsViewController.classNameWithoutNamespaces
+        let settingsVC = dashboard.instantiateViewController(withIdentifier: settingsID) as! SettingsViewController
         navController.pushViewController(settingsVC, animated: false)
 
-        let helpAndSupportVC = UIStoryboard.dashboard.instantiateViewController(withIdentifier: HelpAndSupportViewController.classNameWithoutNamespaces) as! HelpAndSupportViewController
+        let helpID = HelpAndSupportViewController.classNameWithoutNamespaces
+        let helpAndSupportVC = dashboard.instantiateViewController(withIdentifier: helpID) as! HelpAndSupportViewController
         navController.pushViewController(helpAndSupportVC, animated: false)
 
         // show the single ticket view instead of the ticket list
@@ -793,7 +796,10 @@ private extension ZendeskManager {
         static let articleLabel = "iOS"
         static let platformTag = "iOS"
         static let sdkTag = "woo-mobile-sdk"
-        static let ticketSubject = NSLocalizedString("WooCommerce for iOS Support", comment: "Subject of new Zendesk ticket.")
+        static let ticketSubject = NSLocalizedString(
+            "WooCommerce for iOS Support",
+            comment: "Subject of new Zendesk ticket."
+        )
         static let blogSeperator = "\n----------\n"
         static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"
@@ -827,12 +833,30 @@ private extension ZendeskManager {
     }
 
     struct LocalizedText {
-        static let alertMessageWithName = NSLocalizedString("Please enter your email address and username:", comment: "Instructions for alert asking for email and name.")
-        static let alertMessage = NSLocalizedString("Please enter your email address:", comment: "Instructions for alert asking for email.")
-        static let alertSubmit = NSLocalizedString("OK", comment: "Submit button on prompt for user information.")
-        static let alertCancel = NSLocalizedString("Cancel", comment: "Cancel prompt for user information.")
-        static let emailPlaceholder = NSLocalizedString("Email", comment: "Email address text field placeholder")
-        static let namePlaceholder = NSLocalizedString("Name", comment: "Name text field placeholder")
+        static let alertMessageWithName = NSLocalizedString(
+            "Please enter your email address and username:",
+            comment: "Instructions for alert asking for email and name."
+        )
+        static let alertMessage = NSLocalizedString(
+            "Please enter your email address:",
+            comment: "Instructions for alert asking for email."
+        )
+        static let alertSubmit = NSLocalizedString(
+            "OK",
+            comment: "Submit button on prompt for user information."
+        )
+        static let alertCancel = NSLocalizedString(
+            "Cancel",
+            comment: "Cancel prompt for user information."
+        )
+        static let emailPlaceholder = NSLocalizedString(
+            "Email",
+            comment: "Email address text field placeholder"
+        )
+        static let namePlaceholder = NSLocalizedString(
+            "Name",
+            comment: "Name text field placeholder"
+        )
     }
 
     struct PushKey {

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
@@ -26,8 +26,12 @@ class OrderDetailsViewModel {
         shortFormat.dateFormat = "HH:mm:ss"
         shortFormat.timeStyle = .short
         let time = shortFormat.string(from: order.dateModified)
-        return String.localizedStringWithFormat(NSLocalizedString("Updated %@ at %@",
-                                                                  comment: "Order updated summary date. It reads: Updated {medium formatted date} at {short style time}"), order.dateModified.mediumString(), time)
+        return String.localizedStringWithFormat(
+            NSLocalizedString("Updated %@ at %@",
+                              comment: "Order updated summary date. It reads: Updated {medium formatted date} at {short style time}"),
+            order.dateModified.mediumString(),
+            time
+        )
     }
 
     var items: [OrderItem] {
@@ -132,7 +136,10 @@ class OrderDetailsViewModel {
             return nil
         }
 
-        return NSLocalizedString("Payment of \(totalValue) received via \(order.paymentMethodTitle)", comment: "Payment of <currency symbol><payment total> received via (payment method title)")
+        return NSLocalizedString(
+            "Payment of \(totalValue) received via \(order.paymentMethodTitle)",
+            comment: "Payment of <currency symbol><payment total> received via (payment method title)"
+        )
     }
 
     /// Order Notes Button

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -80,13 +80,19 @@ private extension DashboardViewController {
     }
 
     private func configureTitle() {
-        let myStore = NSLocalizedString("My store", comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard")
+        let myStore = NSLocalizedString(
+            "My store",
+            comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
+        )
         title = StoresManager.shared.sessionManager.defaultSite?.name ?? myStore
         tabBarItem.title = myStore
     }
 
     private func resetTitle() {
-        let myStore = NSLocalizedString("My store", comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard")
+        let myStore = NSLocalizedString(
+            "My store",
+            comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
+        )
         title = myStore
         tabBarItem.title = myStore
     }
@@ -99,7 +105,10 @@ private extension DashboardViewController {
         rightBarButton.tintColor = .white
         rightBarButton.accessibilityLabel = NSLocalizedString("Settings", comment: "Accessibility label for the Settings button.")
         rightBarButton.accessibilityTraits = .button
-        rightBarButton.accessibilityHint = NSLocalizedString("Navigates to Settings.", comment: "VoiceOver accessibility hint, informing the user the button can be used to navigate to the Settings screen.")
+        rightBarButton.accessibilityHint = NSLocalizedString(
+            "Navigates to Settings.",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to navigate to the Settings screen."
+        )
         navigationItem.setRightBarButton(rightBarButton, animated: false)
 
         // Don't show the Dashboard title in the next-view's back button

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/NoPeriodDataTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/NoPeriodDataTableViewCell.swift
@@ -12,7 +12,10 @@ class NoPeriodDataTableViewCell: UITableViewCell {
     @IBOutlet private var legendLabel: UILabel! {
         didSet {
             legendLabel.applySubheadlineStyle()
-            legendLabel.text = NSLocalizedString("No activity this period", comment: "Default text for Top Performers section when no data exists for a given period.")
+            legendLabel.text = NSLocalizedString(
+                "No activity this period",
+                comment: "Default text for Top Performers section when no data exists for a given period."
+            )
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -53,7 +53,11 @@ class ProductTableViewCell: UITableViewCell {
 extension ProductTableViewCell {
     func configure(_ statsItem: TopEarnerStatsItem?) {
         nameText = statsItem?.productName
-        detailText = String.localizedStringWithFormat( NSLocalizedString("Total Product Order: %ld", comment: "Top performers — label for the total number of products ordered"), statsItem?.quantity ?? 0)
+        detailText = String.localizedStringWithFormat(
+            NSLocalizedString("Total Product Order: %ld",
+                              comment: "Top performers — label for the total number of products ordered"),
+            statsItem?.quantity ?? 0
+        )
         priceText = statsItem?.formattedTotalString
 
         if let productURLString = statsItem?.imageUrl {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -75,8 +75,10 @@ private extension NewOrdersViewController {
         titleLabel.textInsets = Constants.newOrdersTitleLabelInsets
         descriptionLabel.applyBodyStyle()
         descriptionLabel.textInsets = Constants.newOrdersDescriptionLabelInsets
-        descriptionLabel.text = NSLocalizedString("Review, prepare, and ship these pending orders",
-                                                  comment: "Description text used on the UI element displayed when a user has pending orders to process.")
+        descriptionLabel.text = NSLocalizedString(
+            "Review, prepare, and ship these pending orders",
+            comment: "Description text used on the UI element displayed when a user has pending orders to process."
+        )
         chevronImageView.image = UIImage.chevronImage
     }
 }
@@ -151,9 +153,15 @@ private extension UIButton {
 private extension NewOrdersViewController {
 
     func updateNewOrdersIfNeeded(orderCount: Int) {
-        titleLabel.text = String.pluralize(orderCount,
-                                           singular: NSLocalizedString("You have %ld order to fulfill", comment: "Title text used on the My Store UI when a user has a _single_ pending order to process."),
-                                           plural: NSLocalizedString("You have %ld orders to fulfill", comment: "Title text used on the My Store UI when a user has _multiple_ pending orders to process."))
+        let singular = NSLocalizedString(
+            "You have %ld order to fulfill",
+            comment: "Title text used on the My Store UI when a user has a _single_ pending order to process."
+        )
+        let plural = NSLocalizedString(
+            "You have %ld orders to fulfill",
+            comment: "Title text used on the My Store UI when a user has _multiple_ pending orders to process."
+        )
+        titleLabel.text = String.pluralize(orderCount, singular: singular, plural: plural)
         delegate?.didUpdateNewOrdersData(hasNewOrders: orderCount > 0)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -237,15 +237,21 @@ private extension PeriodDataViewController {
         // Accessibility elements
         xAxisAccessibilityView.isAccessibilityElement = true
         xAxisAccessibilityView.accessibilityTraits = .staticText
-        xAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: X Axis", comment: "VoiceOver accessibility label for the store revenue chart's X-axis.")
+        xAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: X Axis",
+                                                                      comment: "VoiceOver accessibility label for the store revenue chart's X-axis.")
         yAxisAccessibilityView.isAccessibilityElement = true
         yAxisAccessibilityView.accessibilityTraits = .staticText
-        yAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: Y Axis", comment: "VoiceOver accessibility label for the store revenue chart's Y-axis.")
+        yAxisAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart: Y Axis",
+                                                                      comment: "VoiceOver accessibility label for the store revenue chart's Y-axis.")
         chartAccessibilityView.isAccessibilityElement = true
         chartAccessibilityView.accessibilityTraits = .image
-        chartAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart", comment: "VoiceOver accessibility label for the store revenue chart.")
-        chartAccessibilityView.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Store revenue chart %@",
-                                                                                                       comment: "VoiceOver accessibility label for the store revenue chart. It reads: Store revenue chart {chart granularity}."), granularity.pluralizedString)
+        chartAccessibilityView.accessibilityLabel = NSLocalizedString("Store revenue chart",
+                                                                      comment: "VoiceOver accessibility label for the store revenue chart.")
+        chartAccessibilityView.accessibilityLabel = String.localizedStringWithFormat(
+            NSLocalizedString("Store revenue chart %@",
+                              comment: "VoiceOver accessibility label for the store revenue chart. It reads: Store revenue chart {chart granularity}."),
+            granularity.pluralizedString
+        )
     }
 
     func configureBarChart() {
@@ -359,10 +365,24 @@ extension PeriodDataViewController: IAxisValueFormatter {
 private extension PeriodDataViewController {
 
     func updateChartAccessibilityValues() {
-        yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Minimum value %@, maximum value %@",
-                                                                                                       comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."), yAxisMinimum, yAxisMaximum)
-        xAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(NSLocalizedString("Starting period %@, ending period %@",
-                                                                                                       comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."), xAxisMinimum, xAxisMaximum)
+        yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Minimum value %@, maximum value %@",
+                comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."
+            ),
+            yAxisMinimum,
+            yAxisMaximum
+        )
+
+        xAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Starting period %@, ending period %@",
+                comment: "VoiceOver accessibility value, informs the user about the X-axis min/max values. It reads: Starting date {date}, ending date {date}."
+            ),
+            xAxisMinimum,
+            xAxisMaximum
+        )
+
         chartAccessibilityView.accessibilityValue = chartSummaryString()
     }
 
@@ -380,8 +400,14 @@ private extension PeriodDataViewController {
             }
 
             let entrySummaryString = (entry.accessibilityValue ?? String(entry.y))
-            chartSummaryString += String.localizedStringWithFormat(NSLocalizedString("Bar number %i, %@, ",
-                                                                                     comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."), i+1, entrySummaryString)
+            chartSummaryString += String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "Bar number %i, %@, ",
+                    comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."
+                ),
+                i+1,
+                entrySummaryString
+            )
         }
         return chartSummaryString
     }
@@ -431,7 +457,16 @@ private extension PeriodDataViewController {
         reloadSiteFields()
         reloadChart(animateChart: animateChart)
         reloadLastUpdatedField()
-        view.accessibilityElements = [visitorsTitle, visitorsData, ordersTitle, ordersData, revenueTitle, revenueData, lastUpdated, yAxisAccessibilityView, xAxisAccessibilityView, chartAccessibilityView]
+        view.accessibilityElements = [visitorsTitle,
+                                      visitorsData,
+                                      ordersTitle,
+                                      ordersData,
+                                      revenueTitle,
+                                      revenueData,
+                                      lastUpdated,
+                                      yAxisAccessibilityView,
+                                      xAxisAccessibilityView,
+                                      chartAccessibilityView]
     }
 
     func reloadOrderFields() {
@@ -492,7 +527,9 @@ private extension PeriodDataViewController {
         var dataEntries: [BarChartDataEntry] = []
         statItems.forEach { (item) in
             let entry = BarChartDataEntry(x: Double(barCount), y: item.grossSales)
-            let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String(item.grossSales), with: orderStats.currencyCode, roundSmallNumbers: false) ?? String()
+            let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String(item.grossSales),
+                                                                                with: orderStats.currencyCode,
+                                                                                roundSmallNumbers: false) ?? String()
             entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"
             barColors.append(StyleManager.wooGreyMid)
             dataEntries.append(entry)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -181,7 +181,7 @@ private extension StoreStatsViewController {
             progressPercentage: CGFloat,
             changeCurrentIndex: Bool,
             animated: Bool) -> Void in
-            
+
             guard changeCurrentIndex == true else { return }
             oldCell?.label.textColor = StyleManager.defaultTextColor
             newCell?.label.textColor = StyleManager.wooCommerceBrandColor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -175,7 +175,13 @@ private extension StoreStatsViewController {
         settings.style.buttonBarItemsShouldFillAvailableWidth = false
         settings.style.buttonBarItemLeftRightMargin = TabStrip.buttonLeftRightMargin
 
-        changeCurrentIndexProgressive = { (oldCell: ButtonBarViewCell?, newCell: ButtonBarViewCell?, progressPercentage: CGFloat, changeCurrentIndex: Bool, animated: Bool) -> Void in
+        changeCurrentIndexProgressive = {
+            (oldCell: ButtonBarViewCell?,
+            newCell: ButtonBarViewCell?,
+            progressPercentage: CGFloat,
+            changeCurrentIndex: Bool,
+            animated: Bool) -> Void in
+            
             guard changeCurrentIndex == true else { return }
             oldCell?.label.textColor = StyleManager.defaultTextColor
             newCell?.label.textColor = StyleManager.wooCommerceBrandColor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -275,7 +275,8 @@ private extension TopPerformerDataViewController {
 //
 private extension TopPerformerDataViewController {
     enum Text {
-        static let sectionDescription = NSLocalizedString("Gain insights into how products are performing on your store", comment: "Description for Top Performers section of My Store tab.")
+        static let sectionDescription = NSLocalizedString("Gain insights into how products are performing on your store",
+                                                          comment: "Description for Top Performers section of My Store tab.")
         static let sectionLeftColumn = NSLocalizedString("Product", comment: "Description for Top Performers left column header")
         static let sectionRightColumn = NSLocalizedString("Total Spend", comment: "Description for Top Performers right column header")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -158,7 +158,13 @@ private extension TopPerformersViewController {
         settings.style.buttonBarItemsShouldFillAvailableWidth = false
         settings.style.buttonBarItemLeftRightMargin = TabStrip.buttonLeftRightMargin
 
-        changeCurrentIndexProgressive = { (oldCell: ButtonBarViewCell?, newCell: ButtonBarViewCell?, progressPercentage: CGFloat, changeCurrentIndex: Bool, animated: Bool) -> Void in
+        changeCurrentIndexProgressive = {
+            (oldCell: ButtonBarViewCell?,
+            newCell: ButtonBarViewCell?,
+            progressPercentage: CGFloat,
+            changeCurrentIndex: Bool,
+            animated: Bool) -> Void in
+            
             guard changeCurrentIndex == true else { return }
             oldCell?.label.textColor = StyleManager.defaultTextColor
             newCell?.label.textColor = StyleManager.wooCommerceBrandColor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -164,7 +164,7 @@ private extension TopPerformersViewController {
             progressPercentage: CGFloat,
             changeCurrentIndex: Bool,
             animated: Bool) -> Void in
-            
+
             guard changeCurrentIndex == true else { return }
             oldCell?.label.textColor = StyleManager.defaultTextColor
             newCell?.label.textColor = StyleManager.wooCommerceBrandColor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -17,8 +17,14 @@ class AboutViewController: UIViewController {
     ///
     private lazy var footerTitleText: String = {
         let year = Calendar.current.component(.year, from: Date()).description
-        let localizedTitleTextLine1 = String.localizedStringWithFormat(NSLocalizedString("Version %@", comment: "Displays the version of the App"), Bundle.main.detailedVersionNumber())
-        let localizedTitleTextLine2 = String.localizedStringWithFormat(NSLocalizedString("© %@ Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year"), year)
+        let localizedTitleTextLine1 = String.localizedStringWithFormat(
+            NSLocalizedString("Version %@", comment: "Displays the version of the App"),
+            Bundle.main.detailedVersionNumber()
+        )
+        let localizedTitleTextLine2 = String.localizedStringWithFormat(
+            NSLocalizedString("© %@ Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year"),
+            year
+        )
         return String(format: localizedTitleTextLine1, year) + "\n" + localizedTitleTextLine2
     }()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -64,7 +64,10 @@ class ApplicationLogViewController: UIViewController {
     /// Style the back button, add the title to nav bar.
     ///
     func configureNavigation() {
-        title = NSLocalizedString("Application Logs", comment: "Application Logs navigation bar title - this screen is where users view the list of application logs available to them.")
+        title = NSLocalizedString(
+            "Application Logs",
+            comment: "Application Logs navigation bar title - this screen is where users view the list of application logs available to them."
+        )
 
         // Don't show the Help & Support title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
@@ -93,8 +96,14 @@ class ApplicationLogViewController: UIViewController {
     /// Define section data.
     ///
     func configureSections() {
-        let logFileTitle = NSLocalizedString("Log files by created date", comment: "Explains that the files are sorted by LIFO date: most recent day listed first.")
-        let logFileFooter = NSLocalizedString("Up to seven days՚ worth of logs are saved.", comment: "Footer text below the list of logs explaining the maximum number of logs saved.")
+        let logFileTitle = NSLocalizedString(
+            "Log files by created date",
+            comment: "Explains that the files are sorted by LIFO date: most recent day listed first."
+        )
+        let logFileFooter = NSLocalizedString(
+            "Up to seven days՚ worth of logs are saved.",
+            comment: "Footer text below the list of logs explaining the maximum number of logs saved."
+        )
 
         var logFileRows = [Row]()
         for _ in logFiles {
@@ -197,7 +206,8 @@ private extension ApplicationLogViewController {
         let logFileInfo: DDLogFileInfo = logFiles[indexPath.row]
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = indexPath.row == 0 ? NSLocalizedString("Current", comment: "Cell title: the current date.") : dateFormatter.string(from: logFileInfo.creationDate)
+        cell.textLabel?.text = indexPath.row == 0 ?
+            NSLocalizedString("Current", comment: "Cell title: the current date.") : dateFormatter.string(from: logFileInfo.creationDate)
     }
 
     /// Clear application logs cell.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -121,7 +121,9 @@ private extension HelpAndSupportViewController {
             return
         }
 
-        let alert = UIAlertController(title: "Warning", message: "Developer email account detected. Please log in with a non-Automattic email to submit or view support tickets.", preferredStyle: .alert)
+        let alert = UIAlertController(title: "Warning",
+                                      message: "Developer email account detected. Please log in with a non-Automattic email to submit or view support tickets.",
+                                      preferredStyle: .alert)
         let cancel = UIAlertAction(title: "Dismiss", style: .cancel, handler: nil)
         alert.addAction(cancel)
 
@@ -162,7 +164,10 @@ private extension HelpAndSupportViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Contact Support", comment: "Contact Support title")
-        cell.detailTextLabel?.text = NSLocalizedString("Reach our happiness engineers who can help answer tough questions", comment: "Subtitle for Contact Support")
+        cell.detailTextLabel?.text = NSLocalizedString(
+            "Reach our happiness engineers who can help answer tough questions",
+            comment: "Subtitle for Contact Support"
+        )
     }
 
     /// My Tickets cell.
@@ -189,7 +194,10 @@ private extension HelpAndSupportViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("View Application Log", comment: "View application log cell title")
-        cell.detailTextLabel?.text = NSLocalizedString("Advanced tool to review the app status", comment: "Cell subtitle explaining why you might want to navigate to view the application log.")
+        cell.detailTextLabel?.text = NSLocalizedString(
+            "Advanced tool to review the app status",
+            comment: "Cell subtitle explaining why you might want to navigate to view the application log."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -115,7 +115,10 @@ private extension PrivacySettingsViewController {
         cell.imageView?.tintColor = StyleManager.defaultTextColor
 
         // text
-        cell.title = NSLocalizedString("Collect Information", comment: "Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle.")
+        cell.title = NSLocalizedString(
+            "Collect Information",
+            comment: "Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle."
+        )
 
         // switch
         cell.isOn = collectInfo
@@ -128,7 +131,10 @@ private extension PrivacySettingsViewController {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString("Share information with our analytics tool about your use of services while logged in to your WordPress.com account.", comment: "Settings > Privacy Settings > collect info section. Explains what the 'collect information' toggle is collecting")
+        cell.textLabel?.text = NSLocalizedString(
+            "Share information with our analytics tool about your use of services while logged in to your WordPress.com account.",
+            comment: "Settings > Privacy Settings > collect info section. Explains what the 'collect information' toggle is collecting"
+        )
     }
 
     func configureCookiePolicy(cell: BasicTableViewCell) {
@@ -143,14 +149,20 @@ private extension PrivacySettingsViewController {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString("This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.", comment: "Settings > Privacy Settings > privacy info section. Explains what we do with the information we collect.")
+        cell.textLabel?.text = NSLocalizedString(
+            "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.",
+            comment: "Settings > Privacy Settings > privacy info section. Explains what we do with the information we collect."
+        )
     }
 
     func configurePrivacyPolicy(cell: BasicTableViewCell) {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString("Read privacy policy", comment: "Settings > Privacy Settings > privacy policy info section. A text link to the privacy policy.")
+        cell.textLabel?.text = NSLocalizedString(
+            "Read privacy policy",
+            comment: "Settings > Privacy Settings > privacy policy info section. A text link to the privacy policy."
+        )
         cell.textLabel?.textColor = StyleManager.wooCommerceBrandColor
     }
 
@@ -158,7 +170,10 @@ private extension PrivacySettingsViewController {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString("We use other tracking tools, including some from third parties. Read about these and how to control them.", comment: "Settings > Privacy Settings > cookie info section. Explains what we do with the cookie information we collect.")
+        cell.textLabel?.text = NSLocalizedString(
+            "We use other tracking tools, including some from third parties. Read about these and how to control them.",
+            comment: "Settings > Privacy Settings > cookie info section. Explains what we do with the cookie information we collect."
+        )
     }
 
     func configureReportCrashes(cell: SwitchTableViewCell) {
@@ -167,7 +182,10 @@ private extension PrivacySettingsViewController {
         cell.imageView?.tintColor = StyleManager.defaultTextColor
 
         // text
-        cell.title = NSLocalizedString("Report Crashes", comment: "Settings > Privacy Settings > report crashes section. Label for the `Report Crashes` toggle.")
+        cell.title = NSLocalizedString(
+            "Report Crashes",
+            comment: "Settings > Privacy Settings > report crashes section. Label for the `Report Crashes` toggle."
+        )
 
         // switch
         cell.isOn = reportCrashes
@@ -180,7 +198,10 @@ private extension PrivacySettingsViewController {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString("To help us improve the app’s performance and fix the occasional bug, enable automatic crash reports.", comment: "Settings > Privacy Settings > report crashes section. Explains what the 'report crashes' toggle does")
+        cell.textLabel?.text = NSLocalizedString(
+            "To help us improve the app’s performance and fix the occasional bug, enable automatic crash reports.",
+            comment: "Settings > Privacy Settings > report crashes section. Explains what the 'report crashes' toggle does"
+        )
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -99,14 +99,20 @@ private extension SettingsViewController {
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
         footerView.iconImage = Gridicon.iconOfType(.heartOutline)
         footerView.iconColor = StyleManager.wooGreyMid
-        footerView.footnoteText = NSLocalizedString("Made with love by Automattic", comment: "Tagline after the heart icon, displayed to the user")
+        footerView.footnoteText = NSLocalizedString(
+            "Made with love by Automattic",
+            comment: "Tagline after the heart icon, displayed to the user"
+        )
         footerView.footnoteColor = StyleManager.wooGreyMid
         tableView.tableFooterView = footerContainer
         footerContainer.addSubview(footerView)
     }
 
     func configureSections() {
-        let selectedStoreTitle = NSLocalizedString("Selected Store", comment: "My Store > Settings > Selected Store information section. This is the heading listed above the information row that displays the store website and their username.").uppercased()
+        let selectedStoreTitle = NSLocalizedString(
+            "Selected Store",
+            comment: "My Store > Settings > Selected Store information section. This is the heading listed above the information row that displays the store website and their username."
+            ).uppercased()
         let improveTheAppTitle = NSLocalizedString("Help Improve The App", comment: "My Store > Settings > Privacy settings section").uppercased()
         let aboutSettingsTitle = NSLocalizedString("About the app", comment: "My Store > Settings > About app section").uppercased()
         let otherTitle = NSLocalizedString("Other", comment: "My Store > Settings > Other app section").uppercased()
@@ -166,7 +172,10 @@ private extension SettingsViewController {
     func configureSwitchStore(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Switch Store", comment: "This action allows the user to change stores without logging out and logging back in again.")
+        cell.textLabel?.text = NSLocalizedString(
+            "Switch Store",
+            comment: "This action allows the user to change stores without logging out and logging back in again."
+        )
     }
 
     func configureSupport(cell: BasicTableViewCell) {
@@ -230,7 +239,10 @@ private extension SettingsViewController {
 
     func logoutWasPressed() {
         WooAnalytics.shared.track(.settingsLogoutTapped)
-        let messageUnformatted = NSLocalizedString("Are you sure you want to log out of the account %@?", comment: "Alert message to confirm a user meant to log out.")
+        let messageUnformatted = NSLocalizedString(
+            "Are you sure you want to log out of the account %@?",
+            comment: "Alert message to confirm a user meant to log out."
+        )
         let messageFormatted = String(format: messageUnformatted, accountName)
         let alertController = UIAlertController(title: "", message: messageFormatted, preferredStyle: .alert)
 

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+SwitchStore.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+SwitchStore.swift
@@ -105,14 +105,26 @@ private extension FancyAlertViewController {
 
     struct Strings {
         // Title
-        static let titleText = NSLocalizedString("Running multiple stores?",
-                                                          comment: "Title of alert informing users that it is possible to switch stores in Settings.")
+        static let titleText = NSLocalizedString(
+            "Running multiple stores?",
+            comment: "Title of alert informing users that it is possible to switch stores in Settings."
+        )
+
         // Body
-        static let bodyText = NSLocalizedString("You can now switch between stores by tapping the selected store in Settings.",
-                                                          comment: "Body text of alert informing users that it is possible to switch stores in Settings.")
+        static let bodyText = NSLocalizedString(
+            "You can now switch between stores by tapping the selected store in Settings.",
+            comment: "Body text of alert informing users that it is possible to switch stores in Settings."
+        )
 
         // UI Elements
-        static let dismissButtonText = NSLocalizedString("Got It", comment: "Dismiss button in alert informing users that it is possible to switch stores in settings.")
-        static let tryNowButtonText = NSLocalizedString("Try It Now", comment: "Primary button in alert informing users that it is possible to switch stores in settings and inviting them to do so.")
+        static let dismissButtonText = NSLocalizedString(
+            "Got It",
+            comment: "Dismiss button in alert informing users that it is possible to switch stores in settings."
+        )
+
+        static let tryNowButtonText = NSLocalizedString(
+            "Try It Now",
+            comment: "Primary button in alert informing users that it is possible to switch stores in settings and inviting them to do so."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Upgrade.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Upgrade.swift
@@ -83,19 +83,33 @@ private extension FancyAlertViewController {
 
     struct Strings {
         // Titles
-        static let titleText          = NSLocalizedString("Update to WooCommerce 3.5 to keep using this app",
-                                                          comment: "Title of alert warning users to upgrade to WC 3.5.")
-        static let titleTextForSite   = NSLocalizedString("Update %@ to WooCommerce 3.5",
-                                                          comment: "Title of alert warning users to upgrade to WC 3.5 WITH a site name. It reads: Update {site name} to WooCommerce 3.5 to use this app")
+        static let titleText = NSLocalizedString(
+            "Update to WooCommerce 3.5 to keep using this app",
+            comment: "Title of alert warning users to upgrade to WC 3.5."
+        )
+
+        static let titleTextForSite = NSLocalizedString(
+            "Update %@ to WooCommerce 3.5",
+            comment: "Title of alert warning users to upgrade to WC 3.5 WITH a site name. It reads: Update {site name} to WooCommerce 3.5 to use this app"
+        )
 
         // Body
-        static let bodyText           = NSLocalizedString("This app requires that you install WooCommerce 3.5 on your server, and won't work properly without it. Update as soon as possible to continue using this app.",
-                                                         comment: "Body text of alert warning users to upgrade to WC 3.5.")
+        static let bodyText = NSLocalizedString(
+            "This app requires that you install WooCommerce 3.5 on your server, and won't work properly without it. Update as soon as possible to continue using this app.",
+            comment: "Body text of alert warning users to upgrade to WC 3.5."
+        )
 
         // UI Elements
-        static let moreInfoButtonText = NSLocalizedString("Update Instructions",
-                                                          comment: "Update instructions button title shown in alert warning users to upgrade to WC 3.5.")
-        static let moreInfoURLString  = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
-        static let dismissButtonText  = NSLocalizedString("Dismiss", comment: "Dismiss button title shown in alert warning users to upgrade to WC 3.5.")
+        static let moreInfoButtonText = NSLocalizedString(
+            "Update Instructions",
+            comment: "Update instructions button title shown in alert warning users to upgrade to WC 3.5."
+        )
+
+        static let moreInfoURLString = "https://docs.woocommerce.com/document/how-to-update-woocommerce/"
+
+        static let dismissButtonText = NSLocalizedString(
+            "Dismiss",
+            comment: "Dismiss button title shown in alert warning users to upgrade to WC 3.5."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -93,7 +93,9 @@ class MainTabBarController: UITabBarController {
 // MARK: - UIViewControllerTransitioningDelegate
 //
 extension MainTabBarController: UIViewControllerTransitioningDelegate {
-    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+    func presentationController(forPresented presented: UIViewController,
+                                presenting: UIViewController?,
+                                source: UIViewController) -> UIPresentationController? {
         guard presented is FancyAlertViewController else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.swift
@@ -139,8 +139,12 @@ private extension NoteTableViewCell {
 private extension NoteTableViewCell {
 
     enum Star {
-        static let size   = Double(13)
-        static let filledImage = Gridicon.iconOfType(.star, withSize: CGSize(width: Star.size, height: Star.size)).imageWithTintColor(StyleManager.defaultTextColor)
-        static let emptyImage  = Gridicon.iconOfType(.star, withSize: CGSize(width: Star.size, height: Star.size)).imageWithTintColor(.clear)
+        static let size = Double(13)
+        static let filledImage = Gridicon.iconOfType(.star,
+                                                     withSize: CGSize(width: Star.size, height: Star.size)
+                                                    ).imageWithTintColor(StyleManager.defaultTextColor)
+        static let emptyImage = Gridicon.iconOfType(.star,
+                                                    withSize: CGSize(width: Star.size, height: Star.size)
+                                                    ).imageWithTintColor(.clear)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -181,8 +181,13 @@ private extension NotificationDetailsViewController {
     /// Displays the Error Notice.
     ///
     static func displayModerationErrorNotice(failedStatus: CommentStatus) {
-        let message = String.localizedStringWithFormat(NSLocalizedString("Unable to mark review as %@",
-                                                                         comment: "Review error notice message. It reads: Unable to mark review as {attempted status}"), failedStatus.description)
+        let message = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Unable to mark review as %@",
+                comment: "Review error notice message. It reads: Unable to mark review as {attempted status}"
+            ),
+            failedStatus.description
+        )
         let notice = Notice(title: message, feedbackType: .error)
 
         AppDelegate.shared.noticePresenter.enqueue(notice: notice)
@@ -195,8 +200,13 @@ private extension NotificationDetailsViewController {
             return
         }
 
-        let message = String.localizedStringWithFormat(NSLocalizedString("Review marked as %@",
-                                                                         comment: "Review moderation success notice message. It reads: Review marked as {new status}"), newStatus.description)
+        let message = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Review marked as %@",
+                comment: "Review moderation success notice message. It reads: Review marked as {new status}"
+            ),
+            newStatus.description
+        )
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
         let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle, actionHandler: onUndoAction)
 
@@ -408,21 +418,39 @@ private extension NotificationDetailsViewController {
 
         switch status {
         case .approved:
-            return [CommentAction.updateApprovalStatus(siteID: siteID, commentID: commentID, isApproved: true, onCompletion: { (_, error) in onCompletion(error) })]
+            return [CommentAction.updateApprovalStatus(siteID: siteID,
+                                                       commentID: commentID,
+                                                       isApproved: true,
+                                                       onCompletion: { (_, error) in onCompletion(error) })]
         case .unapproved:
-            return [CommentAction.updateApprovalStatus(siteID: siteID, commentID: commentID, isApproved: false, onCompletion: { (_, error) in onCompletion(error) })]
+            return [CommentAction.updateApprovalStatus(siteID: siteID,
+                                                       commentID: commentID,
+                                                       isApproved: false,
+                                                       onCompletion: { (_, error) in onCompletion(error) })]
         case .spam:
             return [locallyDeletedStatusAction(noteID: noteID, deleteInProgress: true),
-                    CommentAction.updateSpamStatus(siteID: siteID, commentID: commentID, isSpam: true, onCompletion: { (_, error) in onCompletion(error) })]
+                    CommentAction.updateSpamStatus(siteID: siteID,
+                                                   commentID: commentID,
+                                                   isSpam: true,
+                                                   onCompletion: { (_, error) in onCompletion(error) })]
         case .unspam:
             return [locallyDeletedStatusAction(noteID: noteID, deleteInProgress: false),
-                    CommentAction.updateSpamStatus(siteID: siteID, commentID: commentID, isSpam: false, onCompletion: { (_, error) in onCompletion(error) })]
+                    CommentAction.updateSpamStatus(siteID: siteID,
+                                                   commentID: commentID,
+                                                   isSpam: false,
+                                                   onCompletion: { (_, error) in onCompletion(error) })]
         case .trash:
             return [locallyDeletedStatusAction(noteID: noteID, deleteInProgress: true),
-                    CommentAction.updateTrashStatus(siteID: siteID, commentID: commentID, isTrash: true, onCompletion: { (_, error) in onCompletion(error) })]
+                    CommentAction.updateTrashStatus(siteID: siteID,
+                                                    commentID: commentID,
+                                                    isTrash: true,
+                                                    onCompletion: { (_, error) in onCompletion(error) })]
         case .untrash:
             return [locallyDeletedStatusAction(noteID: noteID, deleteInProgress: false),
-                    CommentAction.updateTrashStatus(siteID: siteID, commentID: commentID, isTrash: false, onCompletion: { (_, error) in onCompletion(error) })]
+                    CommentAction.updateTrashStatus(siteID: siteID,
+                                                    commentID: commentID,
+                                                    isTrash: false,
+                                                    onCompletion: { (_, error) in onCompletion(error) })]
         case .unknown:
             DDLogError("⛔️ Comment moderation failure: attempted to update comment with unknown status.")
             return nil

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -242,13 +242,20 @@ private extension NotificationsViewController {
 
     func refreshTitle() {
         guard currentTypeFilter != .all else {
-            navigationItem.title = NSLocalizedString("Notifications",
-                                                     comment: "Title that appears on top of the main Notifications screen when there is no filter applied to the list (plural form of the word Notification).")
+            navigationItem.title = NSLocalizedString(
+                "Notifications",
+                comment: "Title that appears on top of the main Notifications screen when there is no filter applied to the list (plural form of the word Notification)."
+            )
             return
         }
 
-        let title = String.localizedStringWithFormat(NSLocalizedString("Notifications: %@",
-                                                                       comment: "Title that appears on top of the Notifications screen when a filter is applied. It reads: Notifications: {name of filter}"), currentTypeFilter.description.capitalized)
+        let title = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Notifications: %@",
+                comment: "Title that appears on top of the Notifications screen when a filter is applied. It reads: Notifications: {name of filter}"
+            ),
+            currentTypeFilter.description.capitalized
+        )
         navigationItem.title = title
     }
 }
@@ -861,11 +868,20 @@ private extension NotificationsViewController {
         var description: String {
             switch self {
             case .all:
-                return NSLocalizedString("All", comment: "Name of the All filter on the Notifications screen - it means all notifications will be displayed.")
+                return NSLocalizedString(
+                    "All",
+                    comment: "Name of the All filter on the Notifications screen - it means all notifications will be displayed."
+                )
             case .orders:
-                return NSLocalizedString("Orders", comment: "Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. Plural form of the word Order.")
+                return NSLocalizedString(
+                    "Orders",
+                    comment: "Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. Plural form of the word Order."
+                )
             case .reviews:
-                return NSLocalizedString("Reviews", comment: "Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. Plural form of the word Review.")
+                return NSLocalizedString(
+                    "Reviews",
+                    comment: "Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. Plural form of the word Review."
+                )
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductListViewController.swift
@@ -48,7 +48,8 @@ extension ProductListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = itemAtIndexPath(indexPath)
         let itemViewModel = OrderItemViewModel(item: item, currency: viewModel.order.currency)
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductDetailsTableViewCell.reuseIdentifier, for: indexPath) as? ProductDetailsTableViewCell else {
+        let cellID = ProductDetailsTableViewCell.reuseIdentifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? ProductDetailsTableViewCell else {
             fatalError()
         }
         cell.configure(item: itemViewModel, with: viewModel)
@@ -56,7 +57,8 @@ extension ProductListViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: TwoColumnSectionHeaderView.reuseIdentifier) as? TwoColumnSectionHeaderView else {
+        let headerID = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? TwoColumnSectionHeaderView else {
             fatalError()
         }
         headerView.leftText = viewModel.productLeftTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -184,7 +184,10 @@ extension FulfillViewController {
     /// Displays the `Unable to Fulfill Order` Notice.
     ///
     func displayErrorNotice(orderID: Int) {
-        let title = NSLocalizedString("Unable to fulfill order #\(orderID)", comment: "Content of error presented when Fullfill Order Action Failed. It reads: Unable to fulfill order #{order number}")
+        let title = NSLocalizedString(
+            "Unable to fulfill order #\(orderID)",
+            comment: "Content of error presented when Fullfill Order Action Failed. It reads: Unable to fulfill order #{order number}"
+        )
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.fulfillWasPressed()
@@ -223,7 +226,8 @@ extension FulfillViewController: UITableViewDataSource {
             return nil
         }
 
-        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: TwoColumnSectionHeaderView.reuseIdentifier) as? TwoColumnSectionHeaderView else {
+        let headerID = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? TwoColumnSectionHeaderView else {
             fatalError()
         }
 
@@ -281,7 +285,12 @@ private extension FulfillViewController {
         cell.labelText = note
 
         cell.isAccessibilityElement = true
-        cell.accessibilityHint = NSLocalizedString("Adds a note to an order", comment: "VoiceOver accessibility hint, informing the user that the button can be used to add an order note.")
+
+        cell.accessibilityHint = NSLocalizedString(
+            "Adds a note to an order",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to add an order note."
+        )
+
         cell.accessibilityLabel = note
         cell.accessibilityTraits = .button
     }
@@ -295,7 +304,11 @@ private extension FulfillViewController {
 
         guard let address = order.shippingAddress ?? order.billingAddress else {
             cell.title = NSLocalizedString("Shipping details", comment: "Shipping title for customer info cell")
-            cell.address = NSLocalizedString("No address specified.", comment: "Fulfill order > customer info > where the physical shipping address would normally display.")
+            cell.address = NSLocalizedString(
+                "No address specified.",
+                comment: "Fulfill order > customer info > where the physical shipping address would normally display."
+            )
+            
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -308,7 +308,7 @@ private extension FulfillViewController {
                 "No address specified.",
                 comment: "Fulfill order > customer info > where the physical shipping address would normally display."
             )
-            
+
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -234,7 +234,7 @@ private extension NewNoteViewController {
             "Unable to add note to order #\(viewModel.order.orderID)",
             comment: "Content of error presented when Add Note Action Failed. It reads: Unable to add note to order #{order number}"
         )
-        
+
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.addButtonTapped()

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -57,7 +57,10 @@ class NewNoteViewController: UIViewController {
                                                                   "status": viewModel.order.statusKey.rawValue,
                                                                   "type": isCustomerNote ? "customer" : "private"])
 
-        let action = OrderNoteAction.addOrderNote(siteID: viewModel.order.siteID, orderID: viewModel.order.orderID, isCustomerNote: isCustomerNote, note: noteText) { [weak self] (orderNote, error) in
+        let action = OrderNoteAction.addOrderNote(siteID: viewModel.order.siteID,
+                                                  orderID: viewModel.order.orderID,
+                                                  isCustomerNote: isCustomerNote,
+                                                  note: noteText) { [weak self] (orderNote, error) in
             if let error = error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
                 WooAnalytics.shared.track(.orderNoteAddFailed, withError: error)
@@ -127,7 +130,11 @@ private extension NewNoteViewController {
 
         cell.iconImage = Gridicon.iconOfType(.aside)
         cell.iconTint = isCustomerNote ? StyleManager.statusPrimaryBoldColor : StyleManager.wooGreyMid
-        cell.iconImage?.accessibilityLabel = isCustomerNote ? NSLocalizedString("Note to customer", comment: "Spoken accessibility label for an icon image that indicates it's a note to the customer.") :  NSLocalizedString("Private note", comment: "Spoken accessibility label for an icon image that indicates it's a private note and is not seen by the customer.")
+        cell.iconImage?.accessibilityLabel = isCustomerNote ?
+            NSLocalizedString("Note to customer",
+                              comment: "Spoken accessibility label for an icon image that indicates it's a note to the customer.") :
+            NSLocalizedString("Private note",
+                              comment: "Spoken accessibility label for an icon image that indicates it's a private note and is not seen by the customer.")
 
         cell.onTextChange = { [weak self] (text) in
             self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
@@ -143,8 +150,16 @@ private extension NewNoteViewController {
         cell.title = NSLocalizedString("Email note to customer", comment: "Label for yes/no switch - emailing the note to customer.")
         cell.subtitle = NSLocalizedString("If disabled the note will be private", comment: "Detail label for yes/no switch.")
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Email note to customer %@", comment: ""), isCustomerNote ? NSLocalizedString("On", comment: "Spoken label to indicate switch control is turned on") : NSLocalizedString("Off", comment: "Spoken label to indicate switch control is turned off."))
-        cell.accessibilityHint = NSLocalizedString("Double tap to toggle setting.", comment: "VoiceOver accessibility hint, informing the user that double-tapping will toggle the switch off and on.")
+        cell.accessibilityLabel = String.localizedStringWithFormat(
+            NSLocalizedString("Email note to customer %@", comment: ""),
+            isCustomerNote ?
+                NSLocalizedString("On", comment: "Spoken label to indicate switch control is turned on") :
+                NSLocalizedString("Off", comment: "Spoken label to indicate switch control is turned off.")
+        )
+        cell.accessibilityHint = NSLocalizedString(
+            "Double tap to toggle setting.",
+            comment: "VoiceOver accessibility hint, informing the user that double-tapping will toggle the switch off and on."
+        )
 
         cell.onChange = { [weak self] newValue in
             guard let `self` = self else {
@@ -154,7 +169,12 @@ private extension NewNoteViewController {
             self.isCustomerNote = newValue
             self.refreshTextViewCell()
 
-            cell.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Email note to customer %@", comment: ""), newValue ? NSLocalizedString("On", comment: "Spoken label to indicate switch control is turned on") : NSLocalizedString("Off", comment: "Spoken label to indicate switch control is turned off."))
+            cell.accessibilityLabel = String.localizedStringWithFormat(
+                NSLocalizedString("Email note to customer %@", comment: ""),
+                newValue ?
+                    NSLocalizedString("On", comment: "Spoken label to indicate switch control is turned on") :
+                    NSLocalizedString("Off", comment: "Spoken label to indicate switch control is turned off.")
+            )
 
             let stateValue = newValue ? "on" : "off"
             WooAnalytics.shared.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
@@ -210,7 +230,11 @@ extension NewNoteViewController: UITableViewDelegate {
 //
 private extension NewNoteViewController {
     func displayErrorNotice() {
-        let title = NSLocalizedString("Unable to add note to order #\(viewModel.order.orderID)", comment: "Content of error presented when Add Note Action Failed. It reads: Unable to add note to order #{order number}")
+        let title = NSLocalizedString(
+            "Unable to add note to order #\(viewModel.order.orderID)",
+            comment: "Content of error presented when Add Note Action Failed. It reads: Unable to add note to order #{order number}"
+        )
+        
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title, message: nil, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
             self?.addButtonTapped()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -244,8 +244,13 @@ private extension OrderDetailsViewController {
     /// Displays a Notice onscreen, indicating that the current Order has been deleted from the Store.
     ///
     func displayOrderDeletedNotice() {
-        let message = String.localizedStringWithFormat(NSLocalizedString("Order %@ has been deleted from your store",
-                                                                         comment: "Displayed whenever the Details for an Order that just got deleted was onscreen. It reads: Order {order number} has been deleted from your store"), viewModel.order.number)
+        let message = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Order %@ has been deleted from your store",
+                comment: "Displayed whenever the Details for an Order that just got deleted was onscreen. It reads: Order {order number} has been deleted from your store"
+            ),
+            viewModel.order.number
+        )
 
         let notice = Notice(title: message, feedbackType: .error)
         AppDelegate.shared.noticePresenter.enqueue(notice: notice)
@@ -314,7 +319,9 @@ private extension OrderDetailsViewController {
 
         cell.title = NSLocalizedString("Billing details", comment: "Billing title for customer info cell")
         cell.name = billingAddress?.fullNameWithCompany
-        cell.address = billingAddress?.formattedPostalAddress ?? NSLocalizedString("No address specified.", comment: "Order details > customer info > billing details. This is where the address would normally display.")
+        cell.address = billingAddress?.formattedPostalAddress ??
+            NSLocalizedString("No address specified.",
+                              comment: "Order details > customer info > billing details. This is where the address would normally display.")
     }
 
     func configureBillingEmail(cell: BillingDetailsTableViewCell) {
@@ -332,8 +339,16 @@ private extension OrderDetailsViewController {
 
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Email: %@", comment: "Accessibility label that lets the user know the billing customer's email address"), email)
-        cell.accessibilityHint = NSLocalizedString("Composes a new email message to the billing customer.", comment: "VoiceOver accessibility hint, informing the user that the row can be tapped and an email composer view will appear.")
+        cell.accessibilityLabel = String.localizedStringWithFormat(
+            NSLocalizedString("Email: %@",
+                              comment: "Accessibility label that lets the user know the billing customer's email address"),
+            email
+        )
+
+        cell.accessibilityHint = NSLocalizedString(
+            "Composes a new email message to the billing customer.",
+            comment: "VoiceOver accessibility hint, informing the user that the row can be tapped and an email composer view will appear."
+        )
     }
 
     func configureBillingPhone(cell: BillingDetailsTableViewCell) {
@@ -350,8 +365,18 @@ private extension OrderDetailsViewController {
 
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Phone number: %@", comment: "Accessibility label that lets the user know the data is a phone number before speaking the phone number."), phoneNumber)
-        cell.accessibilityHint = NSLocalizedString("Prompts with the option to call or message the billing customer.", comment: "VoiceOver accessibility hint, informing the user that the row can be tapped to get to a prompt that lets them call or message the billing customer.")
+        cell.accessibilityLabel = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Phone number: %@",
+                comment: "Accessibility label that lets the user know the data is a phone number before speaking the phone number."
+            ),
+            phoneNumber
+        )
+
+        cell.accessibilityHint = NSLocalizedString(
+            "Prompts with the option to call or message the billing customer.",
+            comment: "VoiceOver accessibility hint, informing the user that the row can be tapped to get to a prompt that lets them call or message the billing customer."
+        )
     }
 
     func configureCustomerNote(cell: CustomerNoteTableViewCell) {
@@ -363,8 +388,15 @@ private extension OrderDetailsViewController {
         cell.labelText = viewModel.addNoteText
 
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = NSLocalizedString("Add a note button", comment: "Accessibility label for the 'Add a note' button")
-        cell.accessibilityHint = NSLocalizedString("Composes a new order note.", comment: "VoiceOver accessibility hint, informing the user that the button can be used to create a new order note.")
+        cell.accessibilityLabel = NSLocalizedString(
+            "Add a note button",
+            comment: "Accessibility label for the 'Add a note' button"
+        )
+
+        cell.accessibilityHint = NSLocalizedString(
+            "Composes a new order note.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to create a new order note."
+        )
     }
 
     func configureOrderNote(cell: OrderNoteTableViewCell, at indexPath: IndexPath) {
@@ -398,7 +430,16 @@ private extension OrderDetailsViewController {
 
         cell.footerText = viewModel.paymentSummary
 
-        cell.accessibilityElements = [cell.subtotalLabel, cell.subtotalValue, cell.discountLabel, cell.discountValue, cell.shippingLabel, cell.shippingValue, cell.taxesLabel, cell.taxesValue, cell.totalLabel, cell.totalValue]
+        cell.accessibilityElements = [cell.subtotalLabel,
+                                      cell.subtotalValue,
+                                      cell.discountLabel,
+                                      cell.discountValue,
+                                      cell.shippingLabel,
+                                      cell.shippingValue,
+                                      cell.taxesLabel,
+                                      cell.taxesValue,
+                                      cell.totalLabel,
+                                      cell.totalValue]
 
         if let footerText = cell.footerText {
             cell.accessibilityElements?.append(footerText)
@@ -436,7 +477,11 @@ private extension OrderDetailsViewController {
 
         cell.title = NSLocalizedString("Shipping details", comment: "Shipping title for customer info cell")
         cell.name = shippingAddress?.fullNameWithCompany
-        cell.address = shippingAddress?.formattedPostalAddress ?? NSLocalizedString("No address specified.", comment: "Order details > customer info > shipping details. This is where the address would normally display.")
+        cell.address = shippingAddress?.formattedPostalAddress ??
+            NSLocalizedString(
+                "No address specified.",
+                comment: "Order details > customer info > shipping details. This is where the address would normally display."
+        )
     }
 
     func configureSummary(cell: SummaryTableViewCell) {
@@ -539,7 +584,8 @@ extension OrderDetailsViewController: UITableViewDataSource {
             return nil
         }
 
-        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: TwoColumnSectionHeaderView.reuseIdentifier) as? TwoColumnSectionHeaderView else {
+        let headerID = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? TwoColumnSectionHeaderView else {
             fatalError()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -137,11 +137,22 @@ private extension OrdersViewController {
     ///
     func refreshTitle() {
         guard let filter = statusKeyFilter?.description.capitalized else {
-            navigationItem.title = NSLocalizedString("Orders", comment: "Title that appears on top of the Order List screen when there is no filter applied to the list (plural form of the word Order).")
+            navigationItem.title = NSLocalizedString(
+                "Orders",
+                comment: "Title that appears on top of the Order List screen when there is no filter applied to the list (plural form of the word Order)."
+            )
+
             return
         }
 
-        let title = String.localizedStringWithFormat(NSLocalizedString("Orders: %@", comment: "Title that appears on top of the Order List screen when a filter is applied. It reads: Orders: {name of filter}"), filter)
+        let title = String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Orders: %@",
+                comment: "Title that appears on top of the Order List screen when a filter is applied. It reads: Orders: {name of filter}"
+            ),
+            filter
+        )
+
         navigationItem.title = title
     }
 
@@ -176,7 +187,11 @@ private extension OrdersViewController {
             button.tintColor = .white
             button.accessibilityTraits = .button
             button.accessibilityLabel = NSLocalizedString("Search orders", comment: "Search Orders")
-            button.accessibilityHint = NSLocalizedString("Retrieves a list of orders that contain a given keyword.", comment: "VoiceOver accessibility hint, informing the user the button can be used to search orders.")
+            button.accessibilityHint = NSLocalizedString(
+                "Retrieves a list of orders that contain a given keyword.",
+                comment: "VoiceOver accessibility hint, informing the user the button can be used to search orders."
+            )
+
             return button
         }()
 
@@ -188,7 +203,11 @@ private extension OrdersViewController {
             button.tintColor = .white
             button.accessibilityTraits = .button
             button.accessibilityLabel = NSLocalizedString("Filter orders", comment: "Filter the orders list.")
-            button.accessibilityHint = NSLocalizedString("Filters the order list by payment status.", comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the order list.")
+            button.accessibilityHint = NSLocalizedString(
+                "Filters the order list by payment status.",
+                comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the order list."
+            )
+
             return button
         }()
 
@@ -362,7 +381,10 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
 
         transitionToSyncingState()
 
-        let action = OrderAction.synchronizeOrders(siteID: siteID, statusKey: statusKeyFilter, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
+        let action = OrderAction.synchronizeOrders(siteID: siteID,
+                                                   statusKey: statusKeyFilter,
+                                                   pageNumber: pageNumber,
+                                                   pageSize: pageSize) { [weak self] error in
             guard let `self` = self else {
                 return
             }
@@ -681,7 +703,10 @@ private extension OrdersViewController {
 
     enum FilterAction {
         static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the action sheet")
-        static let displayAll = NSLocalizedString("All", comment: "Name of the All filter on the Order List screen - it means all orders will be displayed.")
+        static let displayAll = NSLocalizedString(
+            "All",
+            comment: "Name of the All filter on the Order List screen - it means all orders will be displayed."
+        )
     }
 
     enum Settings {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/StarRatingView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/StarRatingView.swift
@@ -90,15 +90,48 @@ class RatingView: UIView {
 
             if lastStarView != nil {
                 let relationalConstraints = [
-                    NSLayoutConstraint(item: starView, attribute: .left, relatedBy: .equal, toItem: lastStarView, attribute: .right, multiplier: 1.0, constant: Defaults.padding),
-                    NSLayoutConstraint(item: starView, attribute: .top, relatedBy: .equal, toItem: lastStarView, attribute: .top, multiplier: 1.0, constant: 0.0),
-                    NSLayoutConstraint(item: starView, attribute: .width, relatedBy: .equal, toItem: lastStarView, attribute: .width, multiplier: 1.0, constant: 0.0),
+                    NSLayoutConstraint(item: starView,
+                                       attribute: .left,
+                                       relatedBy: .equal,
+                                       toItem: lastStarView,
+                                       attribute: .right,
+                                       multiplier: 1.0,
+                                       constant: Defaults.padding),
+
+                    NSLayoutConstraint(item: starView,
+                                       attribute: .top,
+                                       relatedBy: .equal,
+                                       toItem: lastStarView,
+                                       attribute: .top,
+                                       multiplier: 1.0,
+                                       constant: 0.0),
+
+                    NSLayoutConstraint(item: starView,
+                                       attribute: .width,
+                                       relatedBy: .equal,
+                                       toItem: lastStarView,
+                                       attribute: .width,
+                                       multiplier: 1.0,
+                                       constant: 0.0),
                     ]
                 NSLayoutConstraint.activate(relationalConstraints)
             } else {
                 let leftEdgeConstraints = [
-                    NSLayoutConstraint(item: starView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0),
-                    NSLayoutConstraint(item: starView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0),
+                    NSLayoutConstraint(item: starView,
+                                       attribute: .left,
+                                       relatedBy: .equal,
+                                       toItem: self,
+                                       attribute: .left,
+                                       multiplier: 1.0,
+                                       constant: 0.0),
+
+                    NSLayoutConstraint(item: starView,
+                                       attribute: .top,
+                                       relatedBy: .equal,
+                                       toItem: self,
+                                       attribute: .top,
+                                       multiplier: 1.0,
+                                       constant: 0.0),
                     ]
                 NSLayoutConstraint.activate(leftEdgeConstraints)
             }

--- a/WooCommerce/WooCommerceTests/Extensions/NSDecimalNumberWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/NSDecimalNumberWooTests.swift
@@ -66,7 +66,7 @@ class NSDecimalNumberWooTests: XCTestCase {
     }
 
     func testRoundedHumanReadableStringWorksWithPositiveValuesAboveOneThousand() {
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(),expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000)) //"1.0m"
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"

--- a/WooCommerce/WooCommerceTests/Extensions/NSDecimalNumberWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/NSDecimalNumberWooTests.swift
@@ -48,8 +48,12 @@ class NSDecimalNumberWooTests: XCTestCase {
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999).humanReadableString(), "999")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999.99).humanReadableString(), "999")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999.99999).humanReadableString(), "999")
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
     }
 
     func testRoundedHumanReadableStringWorksWithNegativeValuesUnderOneThousand() {
@@ -61,69 +65,175 @@ class NSDecimalNumberWooTests: XCTestCase {
         XCTAssertEqual(NSDecimalNumber(floatLiteral: -999).humanReadableString(), "-999")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: -999.99).humanReadableString(), "-999")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: -999.99999).humanReadableString(), "-999")
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(), expectedLocalizedAbbreviation(for: -1000)) //"-1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -1000)) //"-1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1000)) //"-1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1000)) //"-1.0k"
     }
 
     func testRoundedHumanReadableStringWorksWithPositiveValuesAboveOneThousand() {
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(),expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000)) //"1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // // "1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_000_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 999_000_000_000_000)) // // "999.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_000_000_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: 9000_000_000_000_000)) // // "9000.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
 
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9880).humanReadableString(), expectedLocalizedAbbreviation(for: 9_900)) // "9.9k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9999).humanReadableString(), expectedLocalizedAbbreviation(for: 10_000)) // "10.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 44_999).humanReadableString(), expectedLocalizedAbbreviation(for: 45_000)) // "45.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 77_164).humanReadableString(), expectedLocalizedAbbreviation(for: 77_200)) // "77.2k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 100_101).humanReadableString(), expectedLocalizedAbbreviation(for: 100_100)) // "100.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 110_099).humanReadableString(), expectedLocalizedAbbreviation(for: 110_100)) // "110.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_899_999).humanReadableString(), expectedLocalizedAbbreviation(for: 9_900_000)) // "9.9m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 5_800_199).humanReadableString(), expectedLocalizedAbbreviation(for: 5_800_000)) // "5.8m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 998_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 999_000_000)) // "999.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999.9999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 99_899_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 99_900_000_000)) // "99.9b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000)) //"1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_000_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 999_000_000_000_000)) // "999.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_000_000_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 9000_000_000_000_000)) // "9000.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9880).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 9_900)) // "9.9k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 10_000)) // "10.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 44_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 45_000)) // "45.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 77_164).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 77_200)) // "77.2k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 100_101).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 100_100)) // "100.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 110_099).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 110_100)) // "110.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_899_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 9_900_000)) // "9.9m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 5_800_199).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 5_800_000)) // "5.8m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 998_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 999_000_000)) // "999.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999.9999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 99_899_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 99_900_000_000)) // "99.9b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
     }
 
     func testRoundedHumanReadableStringWorksWithNegativeValuesAboveOneThousand() {
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(), expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
 
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_880).humanReadableString(), expectedLocalizedAbbreviation(for: -9_900)) // "-9.9k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_999).humanReadableString(), expectedLocalizedAbbreviation(for: -10_000)) // "-10.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -44_999).humanReadableString(), expectedLocalizedAbbreviation(for: -45_000)) // "-45.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -77_164).humanReadableString(), expectedLocalizedAbbreviation(for: -77_200)) // "-77.2k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -100_101).humanReadableString(), expectedLocalizedAbbreviation(for: -100_100)) // "-100.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -110_099).humanReadableString(), expectedLocalizedAbbreviation(for: -110_100)) // "-110.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_899_999).humanReadableString(), expectedLocalizedAbbreviation(for: -9_900_000)) // "-9.9m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -5_800_199).humanReadableString(), expectedLocalizedAbbreviation(for: -5_800_000)) // "-5.8m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -998_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -999_000_000)) // "-999.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000))// "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -99_899_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -99_900_000_000)) // "-99.9b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_000_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -999_000_000_000_000)) // "-999.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_000_000_000_000_000.00001).humanReadableString(), expectedLocalizedAbbreviation(for: -9_000_000_000_000_000)) // "-9000.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_880).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -9_900)) // "-9.9k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -10_000)) // "-10.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -44_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -45_000)) // "-45.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -77_164).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -77_200)) // "-77.2k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -100_101).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -100_100)) // "-100.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -110_099).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -110_100)) // "-110.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_899_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -9_900_000)) // "-9.9m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -5_800_199).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -5_800_000)) // "-5.8m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -998_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -999_000_000)) // "-999.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000))// "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -99_899_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -99_900_000_000)) // "-99.9b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_000_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -999_000_000_000_000)) // "-999.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_000_000_000_000_000.00001).humanReadableString(),
+                       expectedLocalizedAbbreviation(for: -9_000_000_000_000_000)) // "-9000.0t"
     }
 
 
@@ -146,8 +256,11 @@ class NSDecimalNumberWooTests: XCTestCase {
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999).humanReadableString(roundSmallNumbers: false), "999")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999.99).humanReadableString(roundSmallNumbers: false), "999.99")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: 999.99999).humanReadableString(roundSmallNumbers: false), "999.99999")
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1000)) //"1.0k"
     }
 
     func testHumanReadableStringWorksWithNegativeValuesUnderOneThousand() {
@@ -159,69 +272,174 @@ class NSDecimalNumberWooTests: XCTestCase {
         XCTAssertEqual(NSDecimalNumber(floatLiteral: -999).humanReadableString(roundSmallNumbers: false), "-999")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: -999.99).humanReadableString(roundSmallNumbers: false), "-999.99")
         XCTAssertEqual(NSDecimalNumber(floatLiteral: -999.99999).humanReadableString(roundSmallNumbers: false), "-999.99999")
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
     }
 
     func testHumanReadableStringWorksWithPositiveValuesAboveOneThousand() {
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1000)) // "1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1000)) // "1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 999_000_000_000_000)) // "999.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_000_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 9_000_000_000_000_000)) // "9000.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1000)) // "1.0k"
 
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9880).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 9_900)) // "9.9k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 10_000)) // "10.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 44_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 45_000)) // "45.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 77_164).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 77_200)) // "77.2k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 100_101).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 100_100)) // "100.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 110_099).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 110_100)) // "110.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_899_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 9_900_000)) // "9.9m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 5_800_199).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 5_800_000)) // "5.8m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 998_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 999_000_000)) // "999.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999.9999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 99_899_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 99_900_000_000)) // "99.9b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1000)) // "1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000)) // "1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 999_000_000_000_000)) // "999.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_000_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 9_000_000_000_000_000)) // "9000.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9880).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 9_900)) // "9.9k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 10_000)) // "10.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 44_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 45_000)) // "45.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 77_164).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 77_200)) // "77.2k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 100_101).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 100_100)) // "100.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 110_099).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 110_100)) // "110.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 9_899_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 9_900_000)) // "9.9m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 5_800_199).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 5_800_000)) // "5.8m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 998_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 999_000_000)) // "999.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999.9999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 1_000_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000)) // "1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 99_899_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 99_900_000_000)) // "99.9b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: 999_999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: 1_000_000_000_000)) // "1.0t"
     }
 
     func testHumanReadableStringWorksWithNegativeValuesAboveOneThousand() {
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1000)) // "1.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000)) // "1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1000)) // "-1.0k"
 
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_880).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -9_900)) // "-9.9k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -10_000)) // "-10.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -44_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -45_000)) // "-45.0k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -77_164).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -77_200)) // "-77.2k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -100_101).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -100_100)) // "-100.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -110_099).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -110_100)) // "-110.1k"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_899_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -9_900_000)) // "-9.9m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -5_800_199).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -5_800_000)) // "-5.8m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -998_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -999_000_000)) // "-999.0m"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -99_899_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -99_900_000_000)) // "-99.9b"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -999_000_000_000_000)) // "-999.0t"
-        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_000_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false), expectedLocalizedAbbreviation(for: -9_000_000_000_000_000)) // "-9000.0t"
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1000)) // "1.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000)) // "1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000)) // "-1.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_880).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -9_900)) // "-9.9k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -10_000)) // "-10.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -44_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -45_000)) // "-45.0k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -77_164).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -77_200)) // "-77.2k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -100_101).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -100_100)) // "-100.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -110_099).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -110_100)) // "-110.1k"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_899_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -9_900_000)) // "-9.9m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -5_800_199).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -5_800_000)) // "-5.8m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -998_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -999_000_000)) // "-999.0m"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -1_000_000_000).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000)) // "-1.0b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -99_899_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -99_900_000_000)) // "-99.9b"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_999_999_999).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -1_000_000_000_000)) // "-1.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -999_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -999_000_000_000_000)) // "-999.0t"
+
+        XCTAssertEqual(NSDecimalNumber(floatLiteral: -9_000_000_000_000_000.00001).humanReadableString(roundSmallNumbers: false),
+                       expectedLocalizedAbbreviation(for: -9_000_000_000_000_000)) // "-9000.0t"
     }
 
     private func expectedLocalizedAbbreviation(for num: Double) -> String? {


### PR DESCRIPTION
Closes #731. All styles come from _[Swift Style, Second Edition: An Opinionated Guide to an Opinionated Language](https://pragprog.com/book/esswift2/swift-style-second-edition)_. If you have a style preference not found here, please comment below!

## To test
- check out this branch
- in the command line, `cd` into the repo
- run the `swiftlint` command

There will be 24 `line_length` violations. Every one of them are string localizations, and I'm not sure we _want_ to create concatenated multi-line comments for the translators.

Sorry about the size of the PR. Didn't want to break up styling into multiple reviews.

Update release notes:
- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
