### PR TITLE
Update copy of Clear Log Button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -216,7 +216,7 @@ private extension ApplicationLogViewController {
         cell.selectionStyle = .default
         cell.textLabel?.textAlignment = .center
         cell.textLabel?.textColor = StyleManager.destructiveActionColor
-        cell.textLabel?.text = NSLocalizedString("Clear old activity logs", comment: "Deletes all activity logs except for the marked 'Current'.")
+        cell.textLabel?.text = NSLocalizedString("Reset Activity Log", comment: "Deletes all activity logs except for the marked 'Current'.")
     }
 }
 

--- a/WooCommerce/Resources/ar.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ar.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "خطأ في الشهادة";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "مسح سجلات النشاط القديمة";
+"Reset Activity Log" = "مسح سجلات النشاط القديمة";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "جمع المعلومات";

--- a/WooCommerce/Resources/de.lproj/Localizable.strings
+++ b/WooCommerce/Resources/de.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Zertifikatsfehler";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Alte Aktivitätsprotokolle löschen";
+"Reset Activity Log" = "Alte Aktivitätsprotokolle löschen";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Informationen erfassen";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -133,7 +133,7 @@
 "Certificate error" = "Certificate error";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Clear old activity logs";
+"Reset Activity Log" = "Reset Activity Log";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Collect Information";

--- a/WooCommerce/Resources/es.lproj/Localizable.strings
+++ b/WooCommerce/Resources/es.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Error del certificado";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Borrar registros de actividad antiguos";
+"Reset Activity Log" = "Borrar registros de actividad antiguos";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Recopilar información";

--- a/WooCommerce/Resources/fr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/fr.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Erreur de certificat";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Effacer vos anciens journaux d'activités";
+"Reset Activity Log" = "Effacer vos anciens journaux d'activités";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Recueil d’information";

--- a/WooCommerce/Resources/he.lproj/Localizable.strings
+++ b/WooCommerce/Resources/he.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "שגיאה בתעודה";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "ניקוי פעילויות ישנות";
+"Reset Activity Log" = "ניקוי פעילויות ישנות";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "איסוף מידע";

--- a/WooCommerce/Resources/id.lproj/Localizable.strings
+++ b/WooCommerce/Resources/id.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Kesalahan sertifikat";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Hapus log aktivitas lama";
+"Reset Activity Log" = "Hapus log aktivitas lama";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Kumpulkan informasi";

--- a/WooCommerce/Resources/it.lproj/Localizable.strings
+++ b/WooCommerce/Resources/it.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Errore di certificato";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Cancella i log delle vecchie attività";
+"Reset Activity Log" = "Cancella i log delle vecchie attività";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Raccogli informazioni";

--- a/WooCommerce/Resources/ja.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ja.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "証明書エラー";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "古いアクティビティログをクリア";
+"Reset Activity Log" = "古いアクティビティログをクリア";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "情報を収集";

--- a/WooCommerce/Resources/ko.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ko.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "인증서 오류";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "이전 활동 기록 지우기";
+"Reset Activity Log" = "이전 활동 기록 지우기";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "정보 수집";

--- a/WooCommerce/Resources/nl.lproj/Localizable.strings
+++ b/WooCommerce/Resources/nl.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Certificaat fout";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Oude activiteitenlogs wissen";
+"Reset Activity Log" = "Oude activiteitenlogs wissen";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Verzamel informatie";

--- a/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pt-BR.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Erro do certificado";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Limpar logs de atividades antigos";
+"Reset Activity Log" = "Limpar logs de atividades antigos";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Coletar informação";

--- a/WooCommerce/Resources/ru.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ru.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Ошибка сертификата";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Очистить старые журналы активности";
+"Reset Activity Log" = "Очистить старые журналы активности";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Сбор информации";

--- a/WooCommerce/Resources/sv.lproj/Localizable.strings
+++ b/WooCommerce/Resources/sv.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Certifikat-fel";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Rensa gamla aktivitetsloggar";
+"Reset Activity Log" = "Rensa gamla aktivitetsloggar";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Samla in information";

--- a/WooCommerce/Resources/tr.lproj/Localizable.strings
+++ b/WooCommerce/Resources/tr.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "Sertifika hatası";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Eski etkinlik günlüklerini temizle";
+"Reset Activity Log" = "Eski etkinlik günlüklerini temizle";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "Bilgi topla";

--- a/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hans.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "证书错误";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "清除旧活动日志";
+"Reset Activity Log" = "清除旧活动日志";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "收集信息";

--- a/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WooCommerce/Resources/zh-Hant.lproj/Localizable.strings
@@ -135,7 +135,7 @@
 "Certificate error" = "憑證錯誤";
 
 /* Deletes all activity logs except for the marked 'Current'. */
-"Clear old activity logs" = "Clear old activity logs";
+"Reset Activity Log" = "Reset Activity Log";
 
 /* Settings > Privacy Settings > collect info section. Label for the `Collect Information` toggle. */
 "Collect Information" = "收集資訊";


### PR DESCRIPTION
Fixes #740 

Update the copy of the `Clear old activity logs` button to `Reset Activity Log`

Before and after:
![clear_log](https://user-images.githubusercontent.com/2722505/53874899-bb1f9700-4003-11e9-8f07-82d60af1f7ec.jpg)

## Testing
- Checkout the branch, navigate to Help & Support > View Application Log and notice the copy of the reset button. The button should remain localised for non-English locales.