### PR TITLE
Issue/751 crash on log out

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.4
 -----
+- bugfix: fix a crash happening on log out
 - new feature: Add shipment tracking to Order Details screen
 - improvement: The store switcher now allows you to go back to the previous screen without logging you out
 - improvement: Custom order status labels are now supported! Instead of just displaying the order status slug and capitalizing the slug, the custom order status label will now be fetched from the server and properly displayed.

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -12,6 +12,10 @@ extension NSNotification.Name {
     ///
     public static let defaultAccountWasUpdated = Foundation.Notification.Name(rawValue: "DefaultAccountWasUpdated")
 
+    /// Posted after a Log out event happens.
+    ///
+    public static let logOutEventReceived = Foundation.Notification.Name(rawValue: "LogOutEventReceived")
+
     /// Posted whenever the app is about to terminate.
     ///
     public static let applicationTerminating = Foundation.Notification.Name(rawValue: "ApplicationTerminating")

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -302,6 +302,16 @@ extension OrdersViewController {
     /// Runs whenever the default Account is updated.
     ///
     @objc func defaultAccountWasUpdated() {
+        // Bugfix for https://github.com/woocommerce/woocommerce-ios/issues/751.
+        // Because we are listening for default account changes,
+        // this will also fire upon logging out, when the account
+        // is set to nil. So let's protect against multi-threaded
+        // access attempts if the account is indeed nil.
+        guard StoresManager.shared.isAuthenticated,
+            StoresManager.shared.needsDefaultStore == false else {
+            return
+        }
+
         statusFilter = nil
         refreshStatusPredicate()
         syncingCoordinator.resetInternalState()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -204,7 +204,7 @@ private extension OrdersViewController {
             StoresManager.shared.needsDefaultStore == false else {
                 return
         }
-        
+
         statusResultsController.predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
     }
 

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -123,6 +123,8 @@ class StoresManager {
         ZendeskManager.shared.reset()
         AppDelegate.shared.storageManager.reset()
 
+        NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
+
         return self
     }
 


### PR DESCRIPTION
Fixes #751. 

This is not perfect. There are myriad of better ways to fix this. But this will stabilize the app.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
