### PR TITLE
Fixed CocoaLumberjack preventing an archive from being created

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -957,7 +957,7 @@
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-NetworkingTests/Pods-NetworkingTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-Default-Swift/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/Networking/Networking/Network/Tools/Loader.swift
+++ b/Networking/Networking/Network/Tools/Loader.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 
 /// File-Loading Tools: Only for Unit Testing purposes.
 ///

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Alamofire
-import CocoaLumberjack
 
 
 /// Represents a collection of Remote Endpoints

--- a/Podfile
+++ b/Podfile
@@ -36,6 +36,7 @@ target 'WooCommerce' do
   pod 'Alamofire', '~> 4.7'
   pod 'Crashlytics', '~> 3.10'
   pod 'KeychainAccess', '~> 3.1'
+  pod 'CocoaLumberjack', '~> 3.4'
   pod 'CocoaLumberjack/Swift', '~> 3.4'
   pod 'XLPagerTabStrip', '~> 8.1'
   pod 'Charts', '~> 3.2'
@@ -62,6 +63,7 @@ target 'Yosemite' do
   # ==================
   #
   pod 'Alamofire', '~> 4.7'
+  pod 'CocoaLumberjack', '~> 3.4'
   pod 'CocoaLumberjack/Swift', '~> 3.4'
 
   # Unit Tests
@@ -86,6 +88,7 @@ target 'Networking' do
   # ==================
   #
   pod 'Alamofire', '~> 4.7'
+  pod 'CocoaLumberjack', '~> 3.4'
   pod 'CocoaLumberjack/Swift', '~> 3.4'
 
 
@@ -107,6 +110,7 @@ target 'Storage' do
   # External Libraries
   # ==================
   #
+  pod 'CocoaLumberjack', '~> 3.4'
   pod 'CocoaLumberjack/Swift', '~> 3.4'
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -82,6 +82,7 @@ DEPENDENCIES:
   - Alamofire (~> 4.7)
   - Automattic-Tracks-iOS (= 0.2.4)
   - Charts (~> 3.2)
+  - CocoaLumberjack (~> 3.4)
   - CocoaLumberjack/Swift (~> 3.4)
   - Crashlytics (~> 3.10)
   - Gridicons (~> 0.18-beta)
@@ -147,6 +148,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 22d4c58200d7c105e0e407ab6bfd01a5d85014be
   ZendeskSDK: af6509ad7968d367f95b2645713802712152f879
 
-PODFILE CHECKSUM: bdc38e652c093973c639f51205241e2c3cdd7946
+PODFILE CHECKSUM: fa8c6b74d405866b108f16b75b24a6ea7154b198
 
 COCOAPODS: 1.5.3

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -510,7 +510,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-Default-Swift/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -1,6 +1,5 @@
 import Foundation
 import CoreData
-import CocoaLumberjack
 
 
 /// CoreDataManager: Manages the entire CoreData Stack. Conforms to the StorageManager API.

--- a/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
+++ b/Storage/Storage/Extensions/NSManagedObjectContext+Storage.swift
@@ -1,6 +1,5 @@
 import Foundation
 import CoreData
-import CocoaLumberjack
 
 /// NSManagedObjectContext Storage Conformance
 ///

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Yosemite
 import AutomatticTracks
-import CocoaLumberjack
 
 
 public class TracksProvider: AnalyticsProvider {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UserNotifications
-import CocoaLumberjack
 import AutomatticTracks
 import Yosemite
 

--- a/WooCommerce/Classes/Tools/Fabric/FabricManager.swift
+++ b/WooCommerce/Classes/Tools/Fabric/FabricManager.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 
-import CocoaLumberjack
 import Crashlytics
 import Fabric
 import Yosemite

--- a/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
+++ b/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Yosemite
 import UIKit
-import CocoaLumberjack
 
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Gridicons
-import CocoaLumberjack
 import WordPressUI
 import Yosemite
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Yosemite
-import CocoaLumberjack
 
 protocol NewOrdersDelegate {
     func didUpdateNewOrdersData(hasNewOrders: Bool)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Yosemite
 import Charts
 import XLPagerTabStrip
-import CocoaLumberjack
 
 
 class PeriodDataViewController: UIViewController, IndicatorInfoProvider {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Yosemite
-import CocoaLumberjack
 import XLPagerTabStrip
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Yosemite
 import Charts
 import XLPagerTabStrip
-import CocoaLumberjack
 import WordPressUI
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Yosemite
-import CocoaLumberjack
 import XLPagerTabStrip
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import CocoaLumberjack
 
 import Yosemite
 import Gridicons

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import Yosemite
 import Gridicons
-import CocoaLumberjack
 
 class NewNoteViewController: UIViewController {
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -3,7 +3,6 @@ import Gridicons
 import Contacts
 import MessageUI
 import Yosemite
-import CocoaLumberjack
 import SafariServices
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import Gridicons
 import Yosemite
 import WordPressUI
-import CocoaLumberjack
 import SafariServices
 import StoreKit
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -290,16 +290,16 @@
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
 		D8023EE3221547D400D2DC30 /* FancyAlertViewController+SwitchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8023EE2221547D400D2DC30 /* FancyAlertViewController+SwitchStore.swift */; };
+		D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */; };
 		D81D9228222E7F0800FFA585 /* OrderStatusListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D9226222E7F0800FFA585 /* OrderStatusListViewController.swift */; };
 		D81D9229222E7F0800FFA585 /* OrderStatusListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D81D9227222E7F0800FFA585 /* OrderStatusListViewController.xib */; };
+		D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */; };
+		D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */; };
 		D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B8331222FABD1002168F3 /* StatusListTableViewCell.swift */; };
 		D85B8334222FABD1002168F3 /* StatusListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D85B8332222FABD1002168F3 /* StatusListTableViewCell.xib */; };
 		D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */; };
-		D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */; };
-		D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */; };
-		D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */; };
-		D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */; };
 		D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833C2230DC9D002168F3 /* StringWooTests.swift */; };
+		D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -636,16 +636,16 @@
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
 		D8023EE2221547D400D2DC30 /* FancyAlertViewController+SwitchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertViewController+SwitchStore.swift"; sourceTree = "<group>"; };
+		D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTrackingTableViewCellTests.swift; sourceTree = "<group>"; };
 		D81D9226222E7F0800FFA585 /* OrderStatusListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusListViewController.swift; sourceTree = "<group>"; };
 		D81D9227222E7F0800FFA585 /* OrderStatusListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderStatusListViewController.xib; sourceTree = "<group>"; };
+		D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderTrackingTableViewCell.xib; sourceTree = "<group>"; };
+		D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderTrackingTableViewCell.swift; sourceTree = "<group>"; };
 		D85B8331222FABD1002168F3 /* StatusListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusListTableViewCell.swift; sourceTree = "<group>"; };
 		D85B8332222FABD1002168F3 /* StatusListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusListTableViewCell.xib; sourceTree = "<group>"; };
 		D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StatusListTableViewCellTests.swift; path = WooCommerceTests/Views/StatusListTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
-		D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SummaryTableViewCellTests.swift; path = WooCommerceTests/Views/SummaryTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
-		D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTrackingTableViewCellTests.swift; sourceTree = "<group>"; };
-		D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderTrackingTableViewCell.xib; sourceTree = "<group>"; };
-		D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderTrackingTableViewCell.swift; sourceTree = "<group>"; };
 		D85B833C2230DC9D002168F3 /* StringWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringWooTests.swift; path = WooCommerceTests/Extensions/StringWooTests.swift; sourceTree = SOURCE_ROOT; };
+		D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SummaryTableViewCellTests.swift; path = WooCommerceTests/Views/SummaryTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1706,7 +1706,7 @@
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Automattic-Tracks-iOS/AutomatticTracks.framework",
 				"${BUILT_PRODUCTS_DIR}/Charts/Charts.framework",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack.default-Swift/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
 				"${PODS_ROOT}/GoogleSignInRepacked/Frameworks/GoogleSignIn.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-Default-Swift/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/Yosemite/Yosemite/Stores/OrderNoteStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderNoteStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Networking
 import Storage
-import CocoaLumberjack
 
 // MARK: - OrderNoteStore
 //

--- a/Yosemite/Yosemite/Stores/OrderStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStatusStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Networking
 import Storage
-import CocoaLumberjack
 
 
 // MARK: - OrderStatusStore

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Networking
 import Storage
-import CocoaLumberjack
 
 
 // MARK: - SettingStore

--- a/Yosemite/Yosemite/Stores/ShipmentStore.swift
+++ b/Yosemite/Yosemite/Stores/ShipmentStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Networking
 import Storage
-import CocoaLumberjack
 
 
 // MARK: - ShipmentStore

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Storage
 import CoreData
-import CocoaLumberjack
 
 
 


### PR DESCRIPTION
Closes #765 

This PR fixes a problem with not being able to produce an archive because of an error with CocoaLumberjack. This resolves that problem by also specifying CoocaLumberjack as a dependency, not just CocoaLumberjack/Swift. CocoaPods was creating a second target with a slightly different name but the same artifact name. Eventually the right solution is to remove CocoaLumberjack as a dependency entirely from all of our Podspecs and conditionally support a custom logging solution if the consuming target has it (like a weak linking).