### PR TITLE
Run SwiftLint on sub projects

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ included:
   - WooCommerce
   - Networking
   - Storage
+  - Yosemite
 
 # Rules
 whitelist_rules:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 # Project configuration
 included:
   - WooCommerce
+  - Networking
 
 # Rules
 whitelist_rules:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@
 included:
   - WooCommerce
   - Networking
+  - Storage
 
 # Rules
 whitelist_rules:

--- a/Networking/Networking/Extensions/KeyedDecodingContainer+Woo.swift
+++ b/Networking/Networking/Extensions/KeyedDecodingContainer+Woo.swift
@@ -10,7 +10,7 @@ extension KeyedDecodingContainer {
     /// This method *does NOT throw*. We want this behavior so that if a malformed entity is received, we just skip it, rather
     /// than breaking the entire parsing chain.
     ///
-    func failsafeDecodeIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) -> T? where T : Decodable {
+    func failsafeDecodeIfPresent<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) -> T? where T: Decodable {
         do {
             return try decodeIfPresent(type, forKey: key)
         } catch {

--- a/Networking/Networking/Logging.swift
+++ b/Networking/Networking/Logging.swift
@@ -24,22 +24,92 @@ internal func resetDefaultDebugLevel() {
     defaultDebugLevel = CocoaLumberjack.defaultDebugLevel
 }
 
-internal func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogDebug(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0, file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line, tag: Any? = nil,
+                         asynchronous async: Bool = true,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogDebug(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }
 
-internal func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogInfo(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0, file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line, tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogInfo(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogWarn(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0, file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line, tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogWarn(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogVerbose(_ message: @autoclosure () -> String,
+                           level: DDLogLevel = defaultDebugLevel,
+                           context: Int = 0, file: StaticString = #file,
+                           function: StaticString = #function,
+                           line: UInt = #line, tag: Any? = nil,
+                           asynchronous async: Bool = true,
+                           ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogVerbose(message,
+                                 level: level,
+                                 context: context,
+                                 file: file,
+                                 function: function,
+                                 line: line,
+                                 tag: tag,
+                                 asynchronous: async,
+                                 ddlog: ddlog)
 }
 
-internal func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogError(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0, file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line, tag: Any? = nil,
+                         asynchronous async: Bool = false,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogError(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }

--- a/Networking/Networking/Mapper/CommentResultMapper.swift
+++ b/Networking/Networking/Mapper/CommentResultMapper.swift
@@ -15,7 +15,7 @@ struct CommentResultMapper: Mapper {
     }
 }
 
-private extension CommentResultMapper{
+private extension CommentResultMapper {
     enum Constants {
         static let statusKey: String = "status"
     }

--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -18,7 +18,17 @@ public struct Address: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(firstName: String, lastName: String, company: String?, address1: String, address2: String?, city: String, state: String, postcode: String, country: String, phone: String?, email: String?) {
+    public init(firstName: String,
+                lastName: String,
+                company: String?,
+                address1: String,
+                address2: String?,
+                city: String,
+                state: String,
+                postcode: String,
+                country: String,
+                phone: String?,
+                email: String?) {
         self.firstName = firstName
         self.lastName = lastName
         self.company = company
@@ -47,7 +57,17 @@ public struct Address: Decodable {
         let phone = try container.decodeIfPresent(String.self, forKey: .phone)
         let email = try container.decodeIfPresent(String.self, forKey: .email)
 
-        self.init(firstName: firstName, lastName: lastName, company: company, address1: address1, address2: address2, city: city, state: state, postcode: postcode, country: country, phone: phone, email: email)
+        self.init(firstName: firstName,
+                  lastName: lastName,
+                  company: company,
+                  address1: address1,
+                  address2: address2,
+                  city: city,
+                  state: state,
+                  postcode: postcode,
+                  country: country,
+                  phone: phone,
+                  email: email)
     }
 }
 
@@ -96,4 +116,3 @@ extension Address: Comparable {
         (lhs.city == rhs.city && lhs.state == rhs.state && lhs.postcode == rhs.postcode && lhs.lastName < rhs.lastName)
     }
 }
-

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -123,7 +123,28 @@ public struct Order: Decodable {
 
         let coupons = try container.decode([OrderCouponLine].self, forKey: .couponLines)
 
-        self.init(siteID: siteID, orderID: orderID, parentID: parentID, customerID: customerID, number: number, statusKey: statusKey, currency: currency, customerNote: customerNote, dateCreated: dateCreated, dateModified: dateModified, datePaid: datePaid, discountTotal: discountTotal, discountTax: discountTax, shippingTotal: shippingTotal, shippingTax: shippingTax, total: total, totalTax: totalTax, paymentMethodTitle: paymentMethodTitle, items: items, billingAddress: billingAddress, shippingAddress: shippingAddress, coupons: coupons)
+        self.init(siteID: siteID,
+                  orderID: orderID,
+                  parentID: parentID,
+                  customerID: customerID,
+                  number: number,
+                  statusKey: statusKey,
+                  currency: currency,
+                  customerNote: customerNote,
+                  dateCreated: dateCreated,
+                  dateModified: dateModified,
+                  datePaid: datePaid,
+                  discountTotal: discountTotal,
+                  discountTax: discountTax,
+                  shippingTotal: shippingTotal,
+                  shippingTax: shippingTax,
+                  total: total,
+                  totalTax: totalTax,
+                  paymentMethodTitle: paymentMethodTitle,
+                  items: items,
+                  billingAddress: billingAddress,
+                  shippingAddress: shippingAddress,
+                  coupons: coupons)
     }
 }
 

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -19,7 +19,18 @@ public struct OrderItem: Decodable {
 
     /// OrderItem struct initializer.
     ///
-    public init(itemID: Int, name: String, productID: Int, quantity: NSDecimalNumber, price: NSDecimalNumber, sku: String?, subtotal: String, subtotalTax: String, taxClass: String, total: String, totalTax: String, variationID: Int) {
+    public init(itemID: Int,
+                name: String,
+                productID: Int,
+                quantity: NSDecimalNumber,
+                price: NSDecimalNumber,
+                sku: String?,
+                subtotal: String,
+                subtotalTax: String,
+                taxClass: String,
+                total: String,
+                totalTax: String,
+                variationID: Int) {
         self.itemID = itemID
         self.name = name
         self.productID = productID

--- a/Networking/Networking/Model/Stats/MIContainer.swift
+++ b/Networking/Networking/Model/Stats/MIContainer.swift
@@ -32,8 +32,8 @@ import Foundation
 public struct MIContainer {
     let data: [Any]
     let fieldNames: [String]
-    
-    func fetchStringValue<T : RawRepresentable>(for field: T) -> String where T.RawValue == String {
+
+    func fetchStringValue<T: RawRepresentable>(for field: T) -> String where T.RawValue == String {
         guard let index = fieldNames.index(of: field.rawValue) else {
             return ""
         }
@@ -50,7 +50,7 @@ public struct MIContainer {
         }
     }
 
-    func fetchIntValue<T : RawRepresentable>(for field: T) -> Int where T.RawValue == String {
+    func fetchIntValue<T: RawRepresentable>(for field: T) -> Int where T.RawValue == String {
         guard let index = fieldNames.index(of: field.rawValue),
             let returnValue = self.data[index] as? Int else {
                 return 0
@@ -58,7 +58,7 @@ public struct MIContainer {
         return returnValue
     }
 
-    func fetchDoubleValue<T : RawRepresentable>(for field: T) -> Double where T.RawValue == String {
+    func fetchDoubleValue<T: RawRepresentable>(for field: T) -> Double where T.RawValue == String {
         guard let index = fieldNames.index(of: field.rawValue) else {
             return 0
         }

--- a/Networking/Networking/Model/Stats/OrderStats.swift
+++ b/Networking/Networking/Model/Stats/OrderStats.swift
@@ -60,13 +60,35 @@ public struct OrderStats: Decodable {
                                                            avgProductsPerOrder: $0.fetchDoubleValue(for: ItemFieldNames.avgProductsPerOrder)) })
 
 
-        self.init(date: date, granularity: granularity, quantity: quantity, items: items, totalGrossSales: totalGrossSales, totalNetSales: totalNetSales, totalOrders: totalOrders, totalProducts: totalProducts, averageGrossSales: averageGrossSales, averageNetSales: averageNetSales, averageOrders: averageOrders, averageProducts: averageProducts)
+        self.init(date: date,
+                  granularity: granularity,
+                  quantity: quantity,
+                  items: items,
+                  totalGrossSales: totalGrossSales,
+                  totalNetSales: totalNetSales,
+                  totalOrders: totalOrders,
+                  totalProducts: totalProducts,
+                  averageGrossSales: averageGrossSales,
+                  averageNetSales: averageNetSales,
+                  averageOrders: averageOrders,
+                  averageProducts: averageProducts)
     }
 
 
     /// OrderStats struct initializer.
     ///
-    public init(date: String, granularity: StatGranularity, quantity: String, items: [OrderStatsItem]?, totalGrossSales: Double, totalNetSales: Double, totalOrders: Int, totalProducts: Int, averageGrossSales: Double, averageNetSales: Double, averageOrders: Double, averageProducts: Double) {
+    public init(date: String,
+                granularity: StatGranularity,
+                quantity: String,
+                items: [OrderStatsItem]?,
+                totalGrossSales: Double,
+                totalNetSales: Double,
+                totalOrders: Int,
+                totalProducts: Int,
+                averageGrossSales: Double,
+                averageNetSales: Double,
+                averageOrders: Double,
+                averageProducts: Double) {
         self.date = date
         self.granularity = granularity
         self.quantity = quantity

--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -43,4 +43,3 @@ extension StatGranularity: CustomStringConvertible {
         }
     }
 }
-

--- a/Networking/Networking/Network/Tools/AnyCodable.swift
+++ b/Networking/Networking/Network/Tools/AnyCodable.swift
@@ -20,7 +20,7 @@ import Foundation
  */
 public struct AnyCodable: Codable {
     public let value: Any
-    
+
     public init<T>(_ value: T?) {
         self.value = value ?? ()
     }
@@ -95,4 +95,10 @@ extension AnyCodable: CustomDebugStringConvertible {
     }
 }
 
-extension AnyCodable: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral, ExpressibleByStringLiteral, ExpressibleByArrayLiteral, ExpressibleByDictionaryLiteral {}
+extension AnyCodable: ExpressibleByNilLiteral,
+                      ExpressibleByBooleanLiteral,
+                      ExpressibleByIntegerLiteral,
+                      ExpressibleByFloatLiteral,
+                      ExpressibleByStringLiteral,
+                      ExpressibleByArrayLiteral,
+                      ExpressibleByDictionaryLiteral {}

--- a/Networking/Networking/Network/Tools/AnyDecodable.swift
+++ b/Networking/Networking/Network/Tools/AnyDecodable.swift
@@ -35,7 +35,7 @@ import Foundation
  */
 public struct AnyDecodable: Decodable {
     public let value: Any
-    
+
     public init<T>(_ value: T?) {
         self.value = value ?? ()
     }
@@ -51,7 +51,7 @@ extension AnyDecodable: _AnyDecodable {}
 extension _AnyDecodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        
+
         if container.decodeNil() {
             self.init(())
         } else if let bool = try? container.decode(Bool.self) {

--- a/Networking/Networking/Network/Tools/AnyEncodable.swift
+++ b/Networking/Networking/Network/Tools/AnyEncodable.swift
@@ -33,7 +33,7 @@ import Foundation
  */
 public struct AnyEncodable: Encodable {
     public let value: Any
-    
+
     public init<T>(_ value: T?) {
         self.value = value ?? ()
     }
@@ -52,7 +52,7 @@ extension AnyEncodable: _AnyEncodable {}
 extension _AnyEncodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        
+
         switch self.value {
         case is Void:
             try container.encodeNil()
@@ -166,7 +166,13 @@ extension AnyEncodable: CustomDebugStringConvertible {
     }
 }
 
-extension AnyEncodable: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, ExpressibleByIntegerLiteral, ExpressibleByFloatLiteral, ExpressibleByStringLiteral, ExpressibleByArrayLiteral, ExpressibleByDictionaryLiteral {}
+extension AnyEncodable: ExpressibleByNilLiteral,
+                        ExpressibleByBooleanLiteral,
+                        ExpressibleByIntegerLiteral,
+                        ExpressibleByFloatLiteral,
+                        ExpressibleByStringLiteral,
+                        ExpressibleByArrayLiteral,
+                        ExpressibleByDictionaryLiteral {}
 
 extension _AnyEncodable {
     public init(nilLiteral: ()) {
@@ -188,7 +194,7 @@ extension _AnyEncodable {
     public init(extendedGraphemeClusterLiteral value: String) {
         self.init(value)
     }
-    
+
     public init(stringLiteral value: String) {
         self.init(value)
     }

--- a/Networking/Networking/Remote/DevicesRemote.swift
+++ b/Networking/Networking/Remote/DevicesRemote.swift
@@ -15,7 +15,11 @@ public class DevicesRemote: Remote {
     ///     - defaultStoreID: Active Store ID.
     ///     - completion: Closure to be executed on commpletion.
     ///
-    public func registerDevice(device: APNSDevice, applicationId: String, applicationVersion: String, defaultStoreID: Int, completion: @escaping (DotcomDevice?, Error?) -> Void) {
+    public func registerDevice(device: APNSDevice,
+                               applicationId: String,
+                               applicationVersion: String,
+                               defaultStoreID: Int,
+                               completion: @escaping (DotcomDevice?, Error?) -> Void) {
         var parameters = [
             ParameterKeys.applicationId: applicationId,
             ParameterKeys.applicationVersion: applicationVersion,

--- a/Networking/Networking/Remote/OrderStatsRemote.swift
+++ b/Networking/Networking/Remote/OrderStatsRemote.swift
@@ -11,11 +11,16 @@ public class OrderStatsRemote: Remote {
     /// - Parameters:
     ///   - siteID: The site ID
     ///   - unit: Defines the granularity of the stats we are fetching (one of 'day', 'week', 'month', or 'year')
-    ///   - latestDateToInclude: The latest date to include in the results. This string should match the `unit`, e.g.: 'day':'1955-11-05', 'week':'1955-W44', 'month':'1955-11', 'year':'1955'.
+    ///   - latestDateToInclude: The latest date to include in the results.
+    ///     This string should match the `unit`, e.g.: 'day':'1955-11-05', 'week':'1955-W44', 'month':'1955-11', 'year':'1955'.
     ///   - quantity: How many `unit`s to fetch
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadOrderStats(for siteID: Int, unit: StatGranularity, latestDateToInclude: String, quantity: Int, completion: @escaping (OrderStats?, Error?) -> Void) {
+    public func loadOrderStats(for siteID: Int,
+                               unit: StatGranularity,
+                               latestDateToInclude: String,
+                               quantity: Int,
+                               completion: @escaping (OrderStats?, Error?) -> Void) {
         let path = "\(Constants.sitesPath)/\(siteID)/\(Constants.orderStatsPath)/"
         let parameters = [ParameterKeys.unit: unit.rawValue,
                           ParameterKeys.date: latestDateToInclude,

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -19,8 +19,7 @@ public class OrdersRemote: Remote {
                               statusKey: String? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
-                              completion: @escaping ([Order]?, Error?) -> Void)
-    {
+                              completion: @escaping ([Order]?, Error?) -> Void) {
         let parameters = [
             ParameterKeys.page: String(pageNumber),
             ParameterKeys.perPage: String(pageSize),
@@ -77,8 +76,7 @@ public class OrdersRemote: Remote {
                              keyword: String,
                              pageNumber: Int = Defaults.pageNumber,
                              pageSize: Int = Defaults.pageSize,
-                             completion: @escaping ([Order]?, Error?) -> Void)
-    {
+                             completion: @escaping ([Order]?, Error?) -> Void) {
         let parameters = [
             ParameterKeys.keyword: keyword,
             ParameterKeys.page: String(pageNumber),

--- a/Networking/Networking/Remote/SiteVisitStatsRemote.swift
+++ b/Networking/Networking/Remote/SiteVisitStatsRemote.swift
@@ -15,7 +15,11 @@ public class SiteVisitStatsRemote: Remote {
     ///   - quantity: How many `unit`s to fetch
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadSiteVisitorStats(for siteID: Int, unit: StatGranularity, latestDateToInclude: Date, quantity: Int, completion: @escaping (SiteVisitStats?, Error?) -> Void) {
+    public func loadSiteVisitorStats(for siteID: Int,
+                                     unit: StatGranularity,
+                                     latestDateToInclude: Date,
+                                     quantity: Int,
+                                     completion: @escaping (SiteVisitStats?, Error?) -> Void) {
         let path = "\(Constants.sitesPath)/\(siteID)/\(Constants.siteVisitStatsPath)/"
         let parameters = [ParameterKeys.unit: unit.rawValue,
                           ParameterKeys.date: DateFormatter.Stats.statsDayFormatter.string(from: latestDateToInclude),

--- a/Networking/Networking/Remote/TopEarnersStatsRemote.swift
+++ b/Networking/Networking/Remote/TopEarnersStatsRemote.swift
@@ -6,7 +6,8 @@ import Alamofire
 ///
 public class TopEarnersStatsRemote: Remote {
 
-    /// Fetch the top earner (aka Top Performer) stats ( stats for a given site for the current day, week, month, or year (depends on the given granularity of the `unit` parameter).
+    /// Fetch the top earner (aka Top Performer) stats for a given site for the current day, week, month, or year
+    /// (depends on the given granularity of the `unit` parameter).
     ///
     /// - Parameters:
     ///   - siteID: The site ID
@@ -15,9 +16,13 @@ public class TopEarnersStatsRemote: Remote {
     ///   - limit: Maximum number of `unit`s to fetch
     ///   - completion: Closure to be executed upon completion.
     ///
-    /// Note: `latestDateToInclude` date string must be formatted appropriately given the `unit` param. See: `DateFormatter.Stats` extension for some helper funcs.
+    /// Note: `latestDateToInclude` string must be formatted appropriately given the `unit` param. See: `DateFormatter.Stats` extension for some helper funcs.
     ///
-    public func loadTopEarnersStats(for siteID: Int, unit: StatGranularity, latestDateToInclude: String, limit: Int, completion: @escaping (TopEarnerStats?, Error?) -> Void) {
+    public func loadTopEarnersStats(for siteID: Int,
+                                    unit: StatGranularity,
+                                    latestDateToInclude: String,
+                                    limit: Int,
+                                    completion: @escaping (TopEarnerStats?, Error?) -> Void) {
         let path = "\(Constants.sitesPath)/\(siteID)/\(Constants.topEarnersStatsPath)/"
         let parameters = [ParameterKeys.unit: unit.rawValue,
                           ParameterKeys.date: latestDateToInclude,

--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -83,9 +83,9 @@ private extension JetpackRequest {
     ///
     var dotcomParams: [String: String] {
         var output = [
-            "_method"   : method.rawValue.lowercased(),
-            "path"      : jetpackPath + jetpackQueryParams,
-            "json"      : "true"
+            "_method": method.rawValue.lowercased(),
+            "path": jetpackPath + jetpackQueryParams,
+            "json": "true"
         ]
 
         if let jetpackBodyParams = jetpackBodyParams {

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -28,7 +28,8 @@ class SiteSettingsMapperTests: XCTestCase {
         XCTAssertNotNil(currencySetting)
         XCTAssertEqual(currencySetting.siteID, dummySiteID)
         XCTAssertEqual(currencySetting.settingID, "woocommerce_currency")
-        XCTAssertEqual(currencySetting.settingDescription, "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.")
+        XCTAssertEqual(currencySetting.settingDescription,
+                       "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.")
         XCTAssertEqual(currencySetting.label, "Currency")
         XCTAssertEqual(currencySetting.value, "USD")
 

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -183,14 +183,24 @@ private extension CoreDataIterativeMigrator {
 //
 private extension CoreDataIterativeMigrator {
 
-    static func migrateStore(at url: URL, storeType: String, fromModel: NSManagedObjectModel, toModel: NSManagedObjectModel, with mappingModel: NSMappingModel) -> Bool {
+    static func migrateStore(at url: URL,
+                             storeType: String,
+                             fromModel: NSManagedObjectModel,
+                             toModel: NSManagedObjectModel,
+                             with mappingModel: NSMappingModel) -> Bool {
         let tempDestinationURL = createTemporaryFolder(at: url)
 
         // Migrate from the source model to the target model using the mapping,
         // and store the resulting data at the temporary path.
         let migrator = NSMigrationManager(sourceModel: fromModel, destinationModel: toModel)
         do {
-            try migrator.migrateStore(from: url, sourceType: storeType, options: nil, with: mappingModel, toDestinationURL: tempDestinationURL, destinationType: storeType, destinationOptions: nil)
+            try migrator.migrateStore(from: url,
+                                      sourceType: storeType,
+                                      options: nil,
+                                      with: mappingModel,
+                                      toDestinationURL: tempDestinationURL,
+                                      destinationType: storeType,
+                                      destinationOptions: nil)
         } catch {
             return false
         }
@@ -206,21 +216,21 @@ private extension CoreDataIterativeMigrator {
         return true
     }
 
-    static func metadataForPersistentStore(storeType: String, at url: URL) throws -> [String : Any]? {
+    static func metadataForPersistentStore(storeType: String, at url: URL) throws -> [String: Any]? {
 
         guard let sourceMetadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: url, options: nil) else {
             let description = "Failed to find source metadata for store: \(url)"
-            throw NSError(domain: "IterativeMigrator", code: 102, userInfo: [NSLocalizedDescriptionKey : description])
+            throw NSError(domain: "IterativeMigrator", code: 102, userInfo: [NSLocalizedDescriptionKey: description])
         }
 
         return sourceMetadata
     }
 
-    static func model(for metadata: [String : Any]) throws -> NSManagedObjectModel? {
+    static func model(for metadata: [String: Any]) throws -> NSManagedObjectModel? {
         let bundle = Bundle(for: CoreDataManager.self)
         guard let sourceModel = NSManagedObjectModel.mergedModel(from: [bundle], forStoreMetadata: metadata) else {
             let description = "Failed to find source model for metadata: \(metadata)"
-            throw NSError(domain: "IterativeMigrator", code: 100, userInfo: [NSLocalizedDescriptionKey : description])
+            throw NSError(domain: "IterativeMigrator", code: 100, userInfo: [NSLocalizedDescriptionKey: description])
         }
 
         return sourceModel
@@ -231,7 +241,7 @@ private extension CoreDataIterativeMigrator {
             guard let url = urlForModel(name: name, in: nil),
                 let model = NSManagedObjectModel(contentsOf: url) else {
                 let description = "No model found for \(name)"
-                throw NSError(domain: "IterativeMigrator", code: 110, userInfo: [NSLocalizedDescriptionKey : description])
+                throw NSError(domain: "IterativeMigrator", code: 110, userInfo: [NSLocalizedDescriptionKey: description])
             }
 
             return model

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -158,7 +158,10 @@ public class CoreDataManager: StorageManagerType {
         }
 
         do {
-            let migrateResult = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL, storeType: NSSQLiteStoreType, to: objectModel, using: sortedKeys)
+            let migrateResult = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL,
+                                                                               storeType: NSSQLiteStoreType,
+                                                                               to: objectModel,
+                                                                               using: sortedKeys)
             if migrateResult == false {
                 DDLogError("☠️ [CoreDataManager] Unable to migrate store.")
             }

--- a/Storage/Storage/Logging.swift
+++ b/Storage/Storage/Logging.swift
@@ -24,22 +24,102 @@ internal func resetDefaultDebugLevel() {
     defaultDebugLevel = CocoaLumberjack.defaultDebugLevel
 }
 
-internal func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogDebug(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = true,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogDebug(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogInfo(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogInfo(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogWarn(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogWarn(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogVerbose(_ message: @autoclosure () -> String,
+                           level: DDLogLevel = defaultDebugLevel,
+                           context: Int = 0,
+                           file: StaticString = #file,
+                           function: StaticString = #function,
+                           line: UInt = #line,
+                           tag: Any? = nil,
+                           asynchronous async: Bool = true,
+                           ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogVerbose(message,
+                                 level: level,
+                                 context: context,
+                                 file: file,
+                                 function: function,
+                                 line: line,
+                                 tag: tag,
+                                 asynchronous: async,
+                                 ddlog: ddlog)
 }
 
-internal func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogError(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = false,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogError(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -17,7 +17,7 @@ class CoreDataIterativeMigratorTests: XCTestCase {
         let model0URL = urlForModel(name: "Model")
         let model10URL = urlForModel(name: "Model 10")
         let storeURL = urlForStore(withName: "Woo Test 10.sqlite", deleteIfExists: true)
-        let options = [NSInferMappingModelAutomaticallyOption : false, NSMigratePersistentStoresAutomaticallyOption : false]
+        let options = [NSInferMappingModelAutomaticallyOption: false, NSMigratePersistentStoresAutomaticallyOption: false]
 
         var model = NSManagedObjectModel(contentsOf: model0URL)
         XCTAssertNotNil(model)
@@ -41,7 +41,7 @@ class CoreDataIterativeMigratorTests: XCTestCase {
         let model0URL = urlForModel(name: "Model")
         let model10URL = urlForModel(name: "Model 10")
         let storeURL = urlForStore(withName: "Woo Test 10.sqlite", deleteIfExists: true)
-        let options = [NSInferMappingModelAutomaticallyOption : false, NSMigratePersistentStoresAutomaticallyOption : false]
+        let options = [NSInferMappingModelAutomaticallyOption: false, NSMigratePersistentStoresAutomaticallyOption: false]
 
         var model = NSManagedObjectModel(contentsOf: model0URL)
         XCTAssertNotNil(model)
@@ -56,7 +56,8 @@ class CoreDataIterativeMigratorTests: XCTestCase {
         XCTAssertNotNil(model)
 
         do {
-            let result = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL, storeType: NSSQLiteStoreType, to: model!, using: ["Model", "Model 2", "Model 3", "Model 4", "Model 5", "Model 6", "Model 7", "Model 8", "Model 9", "Model 10"])
+            let modelNames = ["Model", "Model 2", "Model 3", "Model 4", "Model 5", "Model 6", "Model 7", "Model 8", "Model 9", "Model 10"]
+            let result = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL, storeType: NSSQLiteStoreType, to: model!, using: modelNames)
             XCTAssertTrue(result)
         } catch {
             XCTFail("Error when attempting to migrate: \(error)")
@@ -91,7 +92,7 @@ extension CoreDataIterativeMigratorTests {
         if deleteIfExists {
             try? FileManager.default.removeItem(at: storeURL)
         }
-        
+
         try? FileManager.default.createDirectory(at: URL(fileURLWithPath: documentsDirectory), withIntermediateDirectories: true, attributes: nil)
 
         return storeURL

--- a/Yosemite/Yosemite/Actions/NotificationAction.swift
+++ b/Yosemite/Yosemite/Actions/NotificationAction.swift
@@ -9,7 +9,11 @@ public enum NotificationAction: Action {
 
     /// Registers a device for Push Notifications Delivery.
     ///
-    case registerDevice(device: APNSDevice, applicationId: String, applicationVersion: String, defaultStoreID: Int, onCompletion: (DotcomDevice?, Error?) -> Void)
+    case registerDevice(device: APNSDevice,
+                        applicationId: String,
+                        applicationVersion: String,
+                        defaultStoreID: Int,
+                        onCompletion: (DotcomDevice?, Error?) -> Void)
 
     /// Unregisters a device for Push Notifications Delivery.
     ///

--- a/Yosemite/Yosemite/Internal/Logging.swift
+++ b/Yosemite/Yosemite/Internal/Logging.swift
@@ -24,22 +24,102 @@ internal func resetDefaultDebugLevel() {
     defaultDebugLevel = CocoaLumberjack.defaultDebugLevel
 }
 
-internal func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogDebug(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogDebug(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = true,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogDebug(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }
 
-internal func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogInfo(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogInfo(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogInfo(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogWarn(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogWarn(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogWarn(message,
+                              level: level,
+                              context: context,
+                              file: file,
+                              function: function,
+                              line: line,
+                              tag: tag,
+                              asynchronous: async,
+                              ddlog: ddlog)
 }
 
-internal func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogVerbose(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogVerbose(_ message: @autoclosure () -> String,
+                        level: DDLogLevel = defaultDebugLevel,
+                        context: Int = 0,
+                        file: StaticString = #file,
+                        function: StaticString = #function,
+                        line: UInt = #line,
+                        tag: Any? = nil,
+                        asynchronous async: Bool = true,
+                        ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogVerbose(message,
+                                 level: level,
+                                 context: context,
+                                 file: file,
+                                 function: function,
+                                 line: line,
+                                 tag: tag,
+                                 asynchronous: async,
+                                 ddlog: ddlog)
 }
 
-internal func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
-    CocoaLumberjack.DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+internal func DDLogError(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = defaultDebugLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = false,
+                         ddlog: DDLog = DDLog.sharedInstance) {
+    CocoaLumberjack.DDLogError(message,
+                               level: level,
+                               context: context,
+                               file: file,
+                               function: function,
+                               line: line,
+                               tag: tag,
+                               asynchronous: async,
+                               ddlog: ddlog)
 }

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -96,7 +96,7 @@ extension Storage.Order: ReadOnlyConvertible {
         guard let billingCountry = billingCountry else {
             return nil
         }
-        
+
         return Address(firstName: billingFirstName ?? "",
                        lastName: billingLastName ?? "",
                        company: billingCompany ?? "",

--- a/Yosemite/Yosemite/Model/Storage/OrderStatus+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatus+ReadOnlyConvertible.swift
@@ -21,4 +21,3 @@ extension Storage.OrderStatus: ReadOnlyConvertible {
         return OrderStatus(name: name, siteID: Int(siteID), slug: slug, total: Int(total))
     }
 }
-

--- a/Yosemite/Yosemite/Stores/NotificationStore.swift
+++ b/Yosemite/Yosemite/Stores/NotificationStore.swift
@@ -31,7 +31,11 @@ public class NotificationStore: Store {
 
         switch action {
         case .registerDevice(let device, let applicationId, let applicationVersion, let defaultStoreID, let onCompletion):
-            registerDevice(device: device, applicationId: applicationId, applicationVersion: applicationVersion, defaultStoreID: defaultStoreID, onCompletion: onCompletion)
+            registerDevice(device: device,
+                           applicationId: applicationId,
+                           applicationVersion: applicationVersion,
+                           defaultStoreID: defaultStoreID,
+                           onCompletion: onCompletion)
         case .synchronizeNotifications(let onCompletion):
             synchronizeNotifications(onCompletion: onCompletion)
         case .synchronizeNotification(let noteId, let onCompletion):
@@ -57,9 +61,17 @@ private extension NotificationStore {
 
     /// Registers an APNS Device in the WordPress.com Delivery Subsystem.
     ///
-    func registerDevice(device: APNSDevice, applicationId: String, applicationVersion: String, defaultStoreID: Int, onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
+    func registerDevice(device: APNSDevice,
+                        applicationId: String,
+                        applicationVersion: String,
+                        defaultStoreID: Int,
+                        onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         let remote = DevicesRemote(network: network)
-        remote.registerDevice(device: device, applicationId: applicationId, applicationVersion: applicationVersion, defaultStoreID: defaultStoreID, completion: onCompletion)
+        remote.registerDevice(device: device,
+                              applicationId: applicationId,
+                              applicationVersion: applicationVersion,
+                              defaultStoreID: defaultStoreID,
+                              completion: onCompletion)
     }
 
 

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -56,7 +56,7 @@ private extension SettingStore {
     ///
     func retrieveSiteAPI(siteID: Int, onCompletion: @escaping (SiteAPI?, Error?) -> Void) {
         let remote = SiteAPIRemote(network: network)
-        remote.loadAPIInformation(for: siteID) { (siteAPI, error) in            
+        remote.loadAPIInformation(for: siteID) { (siteAPI, error) in
             onCompletion(siteAPI, error)
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -25,9 +25,17 @@ public class StatsStore: Store {
         case .resetStoredStats(let onCompletion):
             resetStoredStats(onCompletion: onCompletion)
         case .retrieveOrderStats(let siteID, let granularity, let latestDateToInclude, let quantity, let onCompletion):
-            retrieveOrderStats(siteID: siteID, granularity: granularity, latestDateToInclude: latestDateToInclude,  quantity: quantity, onCompletion: onCompletion)
+            retrieveOrderStats(siteID: siteID,
+                               granularity: granularity,
+                               latestDateToInclude: latestDateToInclude,
+                               quantity: quantity,
+                               onCompletion: onCompletion)
         case .retrieveSiteVisitStats(let siteID, let granularity, let latestDateToInclude, let quantity, let onCompletion):
-            retrieveSiteVisitStats(siteID: siteID, granularity: granularity, latestDateToInclude: latestDateToInclude,  quantity: quantity, onCompletion: onCompletion)
+            retrieveSiteVisitStats(siteID: siteID,
+                                   granularity: granularity,
+                                   latestDateToInclude: latestDateToInclude,
+                                   quantity: quantity,
+                                   onCompletion: onCompletion)
         case .retrieveTopEarnerStats(let siteID, let granularity, let latestDateToInclude, let onCompletion):
             retrieveTopEarnerStats(siteID: siteID, granularity: granularity, latestDateToInclude: latestDateToInclude, onCompletion: onCompletion)
         case .retrieveOrderTotals(let siteID, let status, let onCompletion):
@@ -39,7 +47,7 @@ public class StatsStore: Store {
 
 // MARK: - Public Helpers
 //
-public extension StatsStore  {
+public extension StatsStore {
 
     /// Converts a Date into the appropriately formatted string based on the `OrderStatGranularity`
     ///
@@ -60,7 +68,7 @@ public extension StatsStore  {
 
 // MARK: - Services!
 //
-private extension StatsStore  {
+private extension StatsStore {
 
     /// Deletes all of the Stats data.
     ///
@@ -99,7 +107,10 @@ private extension StatsStore  {
 
         let remote = SiteVisitStatsRemote(network: network)
 
-        remote.loadSiteVisitorStats(for: siteID, unit: granularity, latestDateToInclude: latestDateToInclude, quantity: quantity) { [weak self] (siteVisitStats, error) in
+        remote.loadSiteVisitorStats(for: siteID,
+                                    unit: granularity,
+                                    latestDateToInclude: latestDateToInclude,
+                                    quantity: quantity) { [weak self] (siteVisitStats, error) in
             guard let siteVisitStats = siteVisitStats else {
                 onCompletion(error)
                 return
@@ -118,7 +129,10 @@ private extension StatsStore  {
         let remote = TopEarnersStatsRemote(network: network)
         let formattedDateString = StatsStore.buildDateString(from: latestDateToInclude, with: granularity)
 
-        remote.loadTopEarnersStats(for: siteID, unit: granularity, latestDateToInclude: formattedDateString, limit: Constants.defaultTopEarnerStatsLimit) { [weak self] (topEarnerStats, error) in
+        remote.loadTopEarnersStats(for: siteID,
+                                   unit: granularity,
+                                   latestDateToInclude: formattedDateString,
+                                   limit: Constants.defaultTopEarnerStatsLimit) { [weak self] (topEarnerStats, error) in
             guard let topEarnerStats = topEarnerStats else {
                 onCompletion(error)
                 return
@@ -159,7 +173,9 @@ extension StatsStore {
 
     /// Updates the provided StorageTopEarnerStats items using the provided read-only TopEarnerStats items
     ///
-    private func handleTopEarnerStatsItems(_ readOnlyStats: Networking.TopEarnerStats, _ storageTopEarnerStats: Storage.TopEarnerStats, _ storage: StorageType) {
+    private func handleTopEarnerStatsItems(_ readOnlyStats: Networking.TopEarnerStats,
+                                           _ storageTopEarnerStats: Storage.TopEarnerStats,
+                                           _ storage: StorageType) {
 
         // Since we are treating the items in core data like a dumb cache, start by nuking all of the existing stored TopEarnerStatsItems
         storageTopEarnerStats.items?.forEach {
@@ -189,7 +205,9 @@ extension StatsStore {
 
     /// Updates the provided StorageSiteVisitStats items using the provided read-only SiteVisitStats items
     ///
-    private func handleSiteVisitStatsItems(_ readOnlyStats: Networking.SiteVisitStats, _ storageSiteVisitStats: Storage.SiteVisitStats, _ storage: StorageType) {
+    private func handleSiteVisitStatsItems(_ readOnlyStats: Networking.SiteVisitStats,
+                                           _ storageSiteVisitStats: Storage.SiteVisitStats,
+                                           _ storage: StorageType) {
 
         // Since we are treating the items in core data like a dumb cache, start by nuking all of the existing stored SiteVisitStatsItems
         storageSiteVisitStats.items?.forEach {

--- a/Yosemite/Yosemite/Tools/EntityListener.swift
+++ b/Yosemite/Yosemite/Tools/EntityListener.swift
@@ -80,8 +80,7 @@ private extension EntityListener {
         /// Scenario: Upsert (Insert + Update + Refresh)
         ///
         if let storageEntity = readOnlyConvertible(from: note.upsertedObjects, representing: readOnlyEntity),
-            let updatedEntity = storageEntity.toTypeErasedReadOnly() as? T
-        {
+            let updatedEntity = storageEntity.toTypeErasedReadOnly() as? T {
             readOnlyEntity = updatedEntity
             onUpsert?(readOnlyEntity)
         }

--- a/Yosemite/Yosemite/Tools/Internal/FetchedResultsControllerDelegateWrapper.swift
+++ b/Yosemite/Yosemite/Tools/Internal/FetchedResultsControllerDelegateWrapper.swift
@@ -37,11 +37,18 @@ extension FetchedResultsControllerDelegateWrapper: NSFetchedResultsControllerDel
         onDidChangeContent?()
     }
 
-    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>,
+                    didChange anObject: Any,
+                    at indexPath: IndexPath?,
+                    for type: NSFetchedResultsChangeType,
+                    newIndexPath: IndexPath?) {
         onDidChangeObject?(anObject, indexPath, type, newIndexPath)
     }
 
-    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange sectionInfo: NSFetchedResultsSectionInfo, atSectionIndex sectionIndex: Int, for type: NSFetchedResultsChangeType) {
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>,
+                    didChange sectionInfo: NSFetchedResultsSectionInfo,
+                    atSectionIndex sectionIndex: Int,
+                    for type: NSFetchedResultsChangeType) {
         onDidChangeSection?(sectionInfo, sectionIndex, type)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -56,7 +56,7 @@ class NotificationStoreTests: XCTestCase {
                 XCTAssertEqual(note.noteId, 100036)
                 XCTAssertEqual(note.hash, 987654)
                 XCTAssertEqual(note.read, false)
-                XCTAssertEqual(note.icon,"https://s.wp.com/wp-content/mu-plugins/achievements/likeable-blog-5-2x.png")
+                XCTAssertEqual(note.icon, "https://s.wp.com/wp-content/mu-plugins/achievements/likeable-blog-5-2x.png")
                 XCTAssertEqual(note.noticon, "\u{f806}")
                 XCTAssertEqual(note.timestamp, "2018-10-10T01:52:46+00:00")
                 XCTAssertEqual(note.type, "like_milestone_achievement")
@@ -362,7 +362,10 @@ class NotificationStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "new", filename: "device-settings")
 
-        let action = NotificationAction.registerDevice(device: sampleAPNSDevice(), applicationId: sampleApplicationID, applicationVersion: sampleApplicationVersion, defaultStoreID: sampleDefaultStoreID) { (device, error) in
+        let action = NotificationAction.registerDevice(device: sampleAPNSDevice(),
+                                                       applicationId: sampleApplicationID,
+                                                       applicationVersion: sampleApplicationVersion,
+                                                       defaultStoreID: sampleDefaultStoreID) { (device, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(device)
             XCTAssertEqual(device?.deviceID, "12345678")
@@ -383,7 +386,10 @@ class NotificationStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "new", filename: "generic_error")
 
-        let action = NotificationAction.registerDevice(device: sampleAPNSDevice(), applicationId: sampleApplicationID, applicationVersion: sampleApplicationVersion, defaultStoreID: sampleDefaultStoreID) { (device, error) in
+        let action = NotificationAction.registerDevice(device: sampleAPNSDevice(),
+                                                       applicationId: sampleApplicationID,
+                                                       applicationVersion: sampleApplicationVersion,
+                                                       defaultStoreID: sampleDefaultStoreID) { (device, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(device)
 

--- a/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
@@ -315,4 +315,3 @@ private extension OrderNoteStoreTests {
         return date
     }
 }
-

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -97,7 +97,8 @@ class OrderStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    /// Verifies that `OrderAction.synchronizeOrders` effectively persists all of the order fields correctly across all of the related Order objects (items, coupons, etc).
+    /// Verifies that `OrderAction.synchronizeOrders` effectively persists all of the order fields
+    /// correctly across all of the related Order objects (items, coupons, etc).
     ///
     func testRetrieveOrdersEffectivelyPersistsOrderFieldsAndRelatedObjects() {
         let expectation = self.expectation(description: "Persist order list")
@@ -192,7 +193,10 @@ class OrderStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
 
-        let action = OrderAction.searchOrders(siteID: sampleSiteID, keyword: defaultSearchKeyword, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let action = OrderAction.searchOrders(siteID: sampleSiteID,
+                                              keyword: defaultSearchKeyword,
+                                              pageNumber: defaultPageNumber,
+                                              pageSize: defaultPageSize) { error in
             let readOnlyOrder = self.viewStorage.loadOrder(orderID: expectedOrder.orderID)?.toReadOnly()
             XCTAssertEqual(readOnlyOrder, expectedOrder)
             XCTAssertNil(error)
@@ -213,7 +217,10 @@ class OrderStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
 
-        let action = OrderAction.searchOrders(siteID: sampleSiteID, keyword: defaultSearchKeyword, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let action = OrderAction.searchOrders(siteID: sampleSiteID,
+                                              keyword: defaultSearchKeyword,
+                                              pageNumber: defaultPageNumber,
+                                              pageSize: defaultPageSize) { error in
             let searchResults = self.viewStorage.loadOrderSearchResults(keyword: self.defaultSearchKeyword)
 
             XCTAssertEqual(searchResults?.keyword, self.defaultSearchKeyword)
@@ -236,7 +243,10 @@ class OrderStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
 
-        let nestedAction = OrderAction.searchOrders(siteID: sampleSiteID, keyword: defaultSearchKeyword, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let nestedAction = OrderAction.searchOrders(siteID: sampleSiteID,
+                                                    keyword: defaultSearchKeyword,
+                                                    pageNumber: defaultPageNumber,
+                                                    pageSize: defaultPageSize) { error in
             let orders = context.allObjects(ofType: Storage.Order.self, matching: nil, sortedBy: nil)
             for order in orders {
                 XCTAssertEqual(order.searchResults?.count, 1)
@@ -250,7 +260,10 @@ class OrderStoreTests: XCTestCase {
             expectation.fulfill()
         }
 
-        let firstAction = OrderAction.searchOrders(siteID: sampleSiteID, keyword: defaultSearchKeyword, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let firstAction = OrderAction.searchOrders(siteID: sampleSiteID,
+                                                   keyword: defaultSearchKeyword,
+                                                   pageNumber: defaultPageNumber,
+                                                   pageSize: defaultPageSize) { error in
             orderStore.onAction(nestedAction)
         }
 
@@ -280,7 +293,8 @@ class OrderStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    /// Verifies that `OrderAction.retrieveOrder` effectively persists all of the remote order fields correctly across all of the related `Order` objects (items, coupons, etc).
+    /// Verifies that `OrderAction.retrieveOrder` effectively persists all of the remote order fields
+    /// correctly across all of the related `Order` objects (items, coupons, etc).
     ///
     func testRetrieveSingleOrderEffectivelyPersistsOrderFieldsAndRelatedObjects() {
         let expectation = self.expectation(description: "Persist order")
@@ -331,7 +345,7 @@ class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 3)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 2)
-        
+
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrderMutated2(), in: viewStorage)
         let storageOrder2 = viewStorage.loadOrder(orderID: sampleOrderMutated2().orderID)
         XCTAssertEqual(storageOrder2?.toReadOnly(), sampleOrderMutated2())

--- a/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
@@ -57,19 +57,27 @@ class ShipmentStoreTests: XCTestCase {
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ShipmentTracking.self), 4)
 
-            let storageTracking1 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID, orderID: self.sampleOrderID, trackingID: self.sampleShipmentTracking1().trackingID)
+            let storageTracking1 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID,
+                                                                         orderID: self.sampleOrderID,
+                                                                         trackingID: self.sampleShipmentTracking1().trackingID)
             XCTAssertNotNil(storageTracking1)
             XCTAssertEqual(storageTracking1?.toReadOnly(), self.sampleShipmentTracking1())
 
-            let storageTracking2 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID, orderID: self.sampleOrderID, trackingID: self.sampleShipmentTracking2().trackingID)
+            let storageTracking2 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID,
+                                                                         orderID: self.sampleOrderID,
+                                                                         trackingID: self.sampleShipmentTracking2().trackingID)
             XCTAssertNotNil(storageTracking2)
             XCTAssertEqual(storageTracking2?.toReadOnly(), self.sampleShipmentTracking2())
 
-            let storageTracking3 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID, orderID: self.sampleOrderID, trackingID: self.sampleShipmentTracking3().trackingID)
+            let storageTracking3 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID,
+                                                                         orderID: self.sampleOrderID,
+                                                                         trackingID: self.sampleShipmentTracking3().trackingID)
             XCTAssertNotNil(storageTracking3)
             XCTAssertEqual(storageTracking3?.toReadOnly(), self.sampleShipmentTracking3())
 
-            let storageTracking4 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID, orderID: self.sampleOrderID, trackingID: self.sampleShipmentTracking4().trackingID)
+            let storageTracking4 = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID,
+                                                                         orderID: self.sampleOrderID,
+                                                                         trackingID: self.sampleShipmentTracking4().trackingID)
             XCTAssertNotNil(storageTracking4)
             XCTAssertEqual(storageTracking4?.toReadOnly(), self.sampleShipmentTracking4())
 
@@ -126,13 +134,17 @@ class ShipmentStoreTests: XCTestCase {
         let group = DispatchGroup()
 
         group.enter()
-        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID, orderID: sampleOrderID, readOnlyShipmentTrackingData: sampleShipmentTrackingList()) {
+        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID,
+                                                             orderID: sampleOrderID,
+                                                             readOnlyShipmentTrackingData: sampleShipmentTrackingList()) {
             XCTAssertTrue(Thread.isMainThread)
             group.leave()
         }
 
         group.enter()
-        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID, orderID: sampleOrderID, readOnlyShipmentTrackingData: sampleShipmentTrackingListMutated()) {
+        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID,
+                                                             orderID: sampleOrderID,
+                                                             readOnlyShipmentTrackingData: sampleShipmentTrackingListMutated()) {
             XCTAssertTrue(Thread.isMainThread)
             group.leave()
         }
@@ -141,7 +153,9 @@ class ShipmentStoreTests: XCTestCase {
         group.notify(queue: .main) {
             let originalShipmentTracking = self.sampleShipmentTracking1()
             let expectedShipmentTracking = self.sampleShipmentTracking1Mutated()
-            let storageShipmentTracking = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID, orderID: self.sampleOrderID, trackingID: expectedShipmentTracking.trackingID)
+            let storageShipmentTracking = self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID,
+                                                                                orderID: self.sampleOrderID,
+                                                                                trackingID: expectedShipmentTracking.trackingID)
             XCTAssertNotEqual(storageShipmentTracking?.toReadOnly(), originalShipmentTracking)
             XCTAssertEqual(storageShipmentTracking?.toReadOnly(), expectedShipmentTracking)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ShipmentTracking.self), 4)
@@ -161,13 +175,17 @@ class ShipmentStoreTests: XCTestCase {
         let group = DispatchGroup()
 
         group.enter()
-        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID, orderID: sampleOrderID, readOnlyShipmentTrackingData: sampleShipmentTrackingList()) {
+        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID,
+                                                             orderID: sampleOrderID,
+                                                             readOnlyShipmentTrackingData: sampleShipmentTrackingList()) {
             XCTAssertTrue(Thread.isMainThread)
             group.leave()
         }
 
         group.enter()
-        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID, orderID: sampleOrderID, readOnlyShipmentTrackingData: sampleShipmentTrackingListDeleted()) {
+        shipmentStore.upsertShipmentTrackingDataInBackground(siteID: sampleSiteID,
+                                                             orderID: sampleOrderID,
+                                                             readOnlyShipmentTrackingData: sampleShipmentTrackingListDeleted()) {
             XCTAssertTrue(Thread.isMainThread)
             group.leave()
         }
@@ -175,7 +193,9 @@ class ShipmentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Delete item from shipment tracking list")
         group.notify(queue: .main) {
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ShipmentTracking.self), 3)
-            XCTAssertNil(self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID, orderID: self.sampleOrderID, trackingID: self.sampleShipmentTracking3().trackingID))
+            XCTAssertNil(self.viewStorage.loadShipmentTracking(siteID: self.sampleSiteID,
+                                                               orderID: self.sampleOrderID,
+                                                               trackingID: self.sampleShipmentTracking3().trackingID))
 
             expectation.fulfill()
         }
@@ -189,7 +209,7 @@ class ShipmentStoreTests: XCTestCase {
 //
 private extension ShipmentStoreTests {
 
-    //  MARK: - ShipmentTracking Samples
+    // MARK: - ShipmentTracking Samples
 
     func sampleShipmentTracking1() -> Networking.ShipmentTracking {
         return ShipmentTracking(siteID: sampleSiteID,

--- a/Yosemite/YosemiteTests/Stores/StatsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreTests.swift
@@ -170,7 +170,10 @@ class StatsStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "site-visits")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 0)
 
-        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID, granularity: .day, latestDateToInclude: date(with: "2018-08-06T17:06:55"), quantity: 2) { (error) in
+        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID,
+                                                        granularity: .day,
+                                                        latestDateToInclude: date(with: "2018-08-06T17:06:55"),
+                                                        quantity: 2) { (error) in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 1)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
@@ -196,7 +199,10 @@ class StatsStoreTests: XCTestCase {
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "site-visits-alt")
-        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID, granularity: .year, latestDateToInclude: date(with: "2018-08-06T17:06:55"), quantity: 2) { (error) in
+        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID,
+                                                        granularity: .year,
+                                                        latestDateToInclude: date(with: "2018-08-06T17:06:55"),
+                                                        quantity: 2) { (error) in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteVisitStats.self), 1)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteVisitStatsItem.self), 2)
@@ -217,7 +223,10 @@ class StatsStoreTests: XCTestCase {
         let statsStore = StatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "generic_error")
-        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID, granularity: .year, latestDateToInclude: date(with: "2018-08-06T17:06:55"), quantity: 2) { (error) in
+        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID,
+                                                        granularity: .year,
+                                                        latestDateToInclude: date(with: "2018-08-06T17:06:55"),
+                                                        quantity: 2) { (error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -232,7 +241,10 @@ class StatsStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve site visit stats empty response")
         let statsStore = StatsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID, granularity: .year, latestDateToInclude: date(with: "2018-08-06T17:06:55"), quantity: 2) { (error) in
+        let action = StatsAction.retrieveSiteVisitStats(siteID: sampleSiteID,
+                                                        granularity: .year,
+                                                        latestDateToInclude: date(with: "2018-08-06T17:06:55"),
+                                                        quantity: 2) { (error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -448,7 +460,7 @@ class StatsStoreTests: XCTestCase {
 //
 private extension StatsStoreTests {
 
-    //  MARK: - Order Stats Sample
+    // MARK: - Order Stats Sample
 
     func sampleOrderStats() -> Networking.OrderStats {
         return OrderStats(date: "2018-06-02",
@@ -564,7 +576,7 @@ private extension StatsStoreTests {
                               avgProductsPerOrder: 10)
     }
 
-    //  MARK: - Site Visit Stats Sample
+    // MARK: - Site Visit Stats Sample
 
     func sampleSiteVisitStats() -> Networking.SiteVisitStats {
         return SiteVisitStats(date: "2015-08-06",

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -78,7 +78,9 @@ class ResultsControllerTests: XCTestCase {
     ///
     func testResultsControllerGroupSectionsBySectionNameKeypath() {
         let sectionNameKeyPath = "userID"
-        let resultsController = ResultsController<Storage.Account>(viewContext: viewContext, sectionNameKeyPath: sectionNameKeyPath, sortedBy: [sampleSortDescriptor])
+        let resultsController = ResultsController<Storage.Account>(viewContext: viewContext,
+                                                                   sectionNameKeyPath: sectionNameKeyPath,
+                                                                   sortedBy: [sampleSortDescriptor])
         try? resultsController.performFetch()
 
         let numberOfAccounts = 100
@@ -100,7 +102,9 @@ class ResultsControllerTests: XCTestCase {
     ///
     func testObjectAtIndexPathReturnsExpectedEntity() {
         let sectionNameKeyPath = "userID"
-        let resultsController = ResultsController<Storage.Account>(viewContext: viewContext, sectionNameKeyPath: sectionNameKeyPath, sortedBy: [sampleSortDescriptor])
+        let resultsController = ResultsController<Storage.Account>(viewContext: viewContext,
+                                                                   sectionNameKeyPath: sectionNameKeyPath,
+                                                                   sortedBy: [sampleSortDescriptor])
         try? resultsController.performFetch()
 
         let mutableAccount = storage.insertSampleAccount()
@@ -187,7 +191,9 @@ class ResultsControllerTests: XCTestCase {
     ///
     func testOnDidChangeSectionIsCalledWheneverNewSectionsAreAdded() {
         let sectionNameKeyPath = "userID"
-        let resultsController = ResultsController<Storage.Account>(viewContext: viewContext, sectionNameKeyPath: sectionNameKeyPath, sortedBy: [sampleSortDescriptor])
+        let resultsController = ResultsController<Storage.Account>(viewContext: viewContext,
+                                                                   sectionNameKeyPath: sectionNameKeyPath,
+                                                                   sortedBy: [sampleSortDescriptor])
         try? resultsController.performFetch()
 
         let expectation = self.expectation(description: "OnDidChange")


### PR DESCRIPTION
Lint isn't currently being run on the subprojects (`Networking`, `Storage` and `Yosemite`). This adds them to the config and fixes existing violations. There are still 6 line length violations that I was unsure how to fix (mostly long nil coalescing statements).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.