### PR TITLE
Update to the latest release-toolkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,13 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a569711c6bdd4026f1c3e929f743a42189bfba0c
-  tag: 0.1.1
+  revision: a7f414b31dc383075d3489b3d9d4ec039529ef67
+  tag: 0.1.9
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.1)
+    fastlane-plugin-wpmreleasetoolkit (0.1.9)
+      diffy
+      git
+      nokogiri
+      octokit
 
 GEM
   remote: https://rubygems.org/
@@ -63,6 +67,7 @@ GEM
     concurrent-ruby (1.0.5)
     declarative (0.0.10)
     declarative-option (0.1.0)
+    diffy (3.3.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
@@ -116,6 +121,7 @@ GEM
     fourflusher (2.0.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
+    git (1.5.0)
     google-api-client (0.21.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
@@ -143,6 +149,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mini_magick (4.5.1)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     molinillo (0.6.5)
     multi_json (1.13.1)
@@ -152,6 +159,10 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     os (1.0.0)
     plist (3.4.0)
     public_suffix (2.0.5)
@@ -164,6 +175,9 @@ GEM
     rouge (1.11.1)
     ruby-macho (1.1.0)
     rubyzip (1.2.2)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.1.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.1.9'


### PR DESCRIPTION
This PR updates the release tools to the latest version of release-toolkit in order to fix an issue with missing gems (octokit).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
