### PR TITLE
Lint fixes (primarily line length violations)

### DIFF
--- a/Networking/Networking/Model/NoteBlock.swift
+++ b/Networking/Networking/Model/NoteBlock.swift
@@ -70,7 +70,8 @@ extension NoteBlock: Decodable {
 extension NoteBlock {
 
     /// Returns the current Block's Kind. SORRY: Duck Typing code below.
-    /// Calypso Ref.: https://github.com/Automattic/wp-calypso/blob/823e0d6d0e5dc92ecafc8f4e09dbb88c7862e1b6/client/notifications/src/panel/templates/functions.jsx#L171
+    /// Calypso Ref.:
+    ///    https://github.com/Automattic/wp-calypso/blob/823e0d6d0e5dc92ecafc8f4e09dbb88c7862e1b6/client/notifications/src/panel/templates/functions.jsx#L171
     ///
     public var kind: Kind {
         if type == Kind.user.rawValue {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -400,9 +400,11 @@ private extension StorePickerViewController {
     ///
     func displayVersionCheckErrorNotice(siteID: Int, siteName: String) {
         let message = String.localizedStringWithFormat(
-            NSLocalizedString(
-                "Unable to successfully connect to %@",
-                comment: "On the site picker screen, the error displayed when connecting to a site fails. It reads: Unable to successfully connect to {site name}"
+            NSLocalizedString("Unable to successfully connect to %@",
+                              comment: """
+                                  On the site picker screen, the error displayed when connecting to a site fails. \
+                                  It reads: Unable to successfully connect to {site name}
+                                  """
             ),
             siteName
         )

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -152,9 +152,19 @@ private extension LoginPrologueViewController {
     /// Returns the Disclaimer Attributed Text (which contains a link to the Jetpack Setup URL).
     ///
     var disclaimerAttributedText: NSAttributedString {
-        let disclaimerText = NSLocalizedString(
-            "This app requires Jetpack to connect to your Store. <br /> Read the <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
-            comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, 'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'Read the configuration instructions' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language."
+        let disclaimerText = NSLocalizedString("""
+                                 This app requires Jetpack to connect to your Store. <br /> Read the \
+                                 <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.
+                                 """,
+                             comment: """
+                                 Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to \
+                                 your Store. Read the configuration instructions.' and it links to a web page on the words \
+                                 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, \
+                                 'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. \
+                                 If a literal translation of 'Read the configuration instructions' does not make sense in your language, \
+                                 please use a contextually appropriate substitution. For example, you can translate it to say \
+                                 'See: instructions' or any alternative that sounds natural in your language.
+                                 """
         )
         let disclaimerAttributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.font(forStyle: .caption1, weight: .thin),

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -78,23 +78,38 @@ private extension Date {
         )
         static let singularMinuteUpdateStatment = NSLocalizedString(
             "Updated %ld minute ago",
-            comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. Usage example: Updated 1 minute ago"
+            comment: """
+                Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. \
+                Usage example: Updated 1 minute ago
+                """
         )
         static let pluralMinuteUpdateStatment = NSLocalizedString(
             "Updated %ld minutes ago",
-            comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago"
+            comment: """
+                Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. \
+                Usage example: Updated 55 minutes ago
+                """
         )
         static let singularHourUpdateStatment = NSLocalizedString(
             "Updated %ld hour ago",
-            comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago"
+            comment: """
+                Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. \
+                Usage example: Updated 1 hour ago
+                """
         )
         static let pluralHourUpdateStatment = NSLocalizedString(
             "Updated %ld hours ago",
-            comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago"
+            comment: """
+                Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. \
+                Usage example: Updated 14 hours ago"
+                """
         )
         static let longFormUpdateStatement = NSLocalizedString(
             "Updated on %@",
-            comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated on Jan 22, 2019 3:31PM"
+            comment: """
+                A specific date and time string which represents when the data was last updated. \
+                Usage example: Updated on Jan 22, 2019 3:31PM
+                """
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -367,7 +367,10 @@ private extension PeriodDataViewController {
         yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
             NSLocalizedString(
                 "Minimum value %@, maximum value %@",
-                comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."
+                comment: """
+                    VoiceOver accessibility value, informs the user about the Y-axis min/max values. \
+                    It reads: Minimum value {value}, maximum value {value}.
+                    """
             ),
             yAxisMinimum,
             yAxisMaximum
@@ -402,7 +405,10 @@ private extension PeriodDataViewController {
             chartSummaryString += String.localizedStringWithFormat(
                 NSLocalizedString(
                     "Bar number %i, %@, ",
-                    comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."
+                    comment: """
+                        VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. \
+                        It reads: Bar number {bar number} {summary of bar}.
+                        """
                 ),
                 i+1,
                 entrySummaryString

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -149,8 +149,10 @@ private extension PrivacySettingsViewController {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString(
-            "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.",
+        cell.textLabel?.text = NSLocalizedString("""
+                                    This information helps us improve our products, make marketing to you more relevant, \
+                                    personalize your WordPress.com experience, and more as detailed in our privacy policy.
+                                    """,
             comment: "Settings > Privacy Settings > privacy info section. Explains what we do with the information we collect."
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -120,7 +120,10 @@ private extension SettingsViewController {
     func configureSections() {
         let selectedStoreTitle = NSLocalizedString(
             "Selected Store",
-            comment: "My Store > Settings > Selected Store information section. This is the heading listed above the information row that displays the store website and their username."
+            comment: """
+                My Store > Settings > Selected Store information section. This is the heading listed above the information row that \
+                displays the store website and their username.
+                """
             ).uppercased()
         let improveTheAppTitle = NSLocalizedString("Help Improve The App", comment: "My Store > Settings > Privacy settings section").uppercased()
         let aboutSettingsTitle = NSLocalizedString("About the app", comment: "My Store > Settings > About app section").uppercased()

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Upgrade.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Upgrade.swift
@@ -88,14 +88,17 @@ private extension FancyAlertViewController {
             comment: "Title of alert warning users to upgrade to WC 3.5."
         )
 
-        static let titleTextForSite = NSLocalizedString(
-            "Update %@ to WooCommerce 3.5",
-            comment: "Title of alert warning users to upgrade to WC 3.5 WITH a site name. It reads: Update {site name} to WooCommerce 3.5 to use this app"
+        static let titleTextForSite = NSLocalizedString("Update %@ to WooCommerce 3.5",
+            comment: """
+                Title of alert warning users to upgrade to WC 3.5 WITH a site name. It reads: Update {site name} to WooCommerce 3.5 to use this app
+                """
         )
 
         // Body
-        static let bodyText = NSLocalizedString(
-            "This app requires that you install WooCommerce 3.5 on your server, and won't work properly without it. Update as soon as possible to continue using this app.",
+        static let bodyText = NSLocalizedString("""
+                                  This app requires that you install WooCommerce 3.5 on your server, and won't work properly without it. \
+                                  Update as soon as possible to continue using this app.
+                                  """,
             comment: "Body text of alert warning users to upgrade to WC 3.5."
         )
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -205,13 +205,19 @@ private extension NotificationsViewController {
         leftBarButton.tintColor = .white
         leftBarButton.accessibilityTraits = .button
         leftBarButton.accessibilityLabel = NSLocalizedString("Mark All as Read", comment: "Accessibility label for the Mark All Notifications as Read Button")
-        leftBarButton.accessibilityHint = NSLocalizedString("Marks Every Notification as Read", comment: "VoiceOver accessibility hint for the Mark All Notifications as Read Action")
+        leftBarButton.accessibilityHint = NSLocalizedString("Marks Every Notification as Read",
+                                                            comment: "VoiceOver accessibility hint for the Mark All Notifications as Read Action")
         navigationItem.leftBarButtonItem = leftBarButton
 
         rightBarButton.tintColor = .white
         rightBarButton.accessibilityTraits = .button
         rightBarButton.accessibilityLabel = NSLocalizedString("Filter notifications", comment: "Accessibility label for the Filter notifications button.")
-        rightBarButton.accessibilityHint = NSLocalizedString("Filters the notifications list by notification type.", comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the notifications list.")
+        rightBarButton.accessibilityHint = NSLocalizedString("Filters the notifications list by notification type.",
+                                                             comment: """
+                                                                 VoiceOver accessibility hint, \
+                                                                 informing the user the button can be used to filter the notifications list.
+                                                                 """
+        )
         navigationItem.rightBarButtonItem = rightBarButton
     }
 
@@ -244,7 +250,10 @@ private extension NotificationsViewController {
         guard currentTypeFilter != .all else {
             navigationItem.title = NSLocalizedString(
                 "Notifications",
-                comment: "Title that appears on top of the main Notifications screen when there is no filter applied to the list (plural form of the word Notification)."
+                comment: """
+                    Title that appears on top of the main Notifications screen when there is no filter \
+                    applied to the list (plural form of the word Notification).
+                    """
             )
             return
         }
@@ -868,19 +877,22 @@ private extension NotificationsViewController {
         var description: String {
             switch self {
             case .all:
-                return NSLocalizedString(
-                    "All",
-                    comment: "Name of the All filter on the Notifications screen - it means all notifications will be displayed."
+                return NSLocalizedString("All",
+                                         comment: "Name of the All filter on the Notifications screen - it means all notifications will be displayed."
                 )
             case .orders:
-                return NSLocalizedString(
-                    "Orders",
-                    comment: "Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. Plural form of the word Order."
+                return NSLocalizedString("Orders",
+                                         comment: """
+                                             Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. \
+                                             Plural form of the word Order.
+                                             """
                 )
             case .reviews:
-                return NSLocalizedString(
-                    "Reviews",
-                    comment: "Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. Plural form of the word Review."
+                return NSLocalizedString("Reviews",
+                                         comment: """
+                                             Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. \
+                                             Plural form of the word Review.
+                                             """
                 )
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -317,7 +317,10 @@ private extension OrderDetailsViewController {
         let message = String.localizedStringWithFormat(
             NSLocalizedString(
                 "Order %@ has been deleted from your store",
-                comment: "Displayed whenever the Details for an Order that just got deleted was onscreen. It reads: Order {order number} has been deleted from your store"
+                comment: """
+                    Displayed whenever the Details for an Order that just got deleted was onscreen. \
+                    It reads: Order {order number} has been deleted from your store
+                    """
             ),
             viewModel.order.number
         )
@@ -452,7 +455,10 @@ private extension OrderDetailsViewController {
 
         cell.accessibilityHint = NSLocalizedString(
             "Prompts with the option to call or message the billing customer.",
-            comment: "VoiceOver accessibility hint, informing the user that the row can be tapped to get to a prompt that lets them call or message the billing customer."
+            comment: """
+                VoiceOver accessibility hint, informing the user that the row can be tapped to get to a \
+                prompt that lets them call or message the billing customer.
+                """
         )
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/StringFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/StringFormatterTests.swift
@@ -17,7 +17,14 @@ class StringFormatterTests: XCTestCase {
 
     /// Sample Long Text
     ///
-    private let sampleLongText = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry’s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+    private let sampleLongText = """
+                                 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry’s \
+                                 standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make \
+                                 a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, \
+                                 remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing \
+                                 Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions \
+                                 of Lorem Ipsum.
+                                 """
 
     /// Sample URL
     ///

--- a/Yosemite/Yosemite/Stores/ShipmentStore.swift
+++ b/Yosemite/Yosemite/Stores/ShipmentStore.swift
@@ -62,13 +62,15 @@ extension ShipmentStore {
     /// Updates (OR Inserts) the specified ReadOnly ShipmentTracking Entities into the Storage Layer *in a background thread*. onCompletion will be called
     /// on the main thread!
     ///
-    func upsertShipmentTrackingDataInBackground(siteID: Int, orderID: Int, readOnlyShipmentTrackingData: [Networking.ShipmentTracking], onCompletion: @escaping () -> Void) {
+    func upsertShipmentTrackingDataInBackground(siteID: Int,
+                                                orderID: Int,
+                                                readOnlyShipmentTrackingData: [Networking.ShipmentTracking],
+                                                onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             for readOnlyTracking in readOnlyShipmentTrackingData {
-                let storageTracking = derivedStorage.loadShipmentTracking(siteID: readOnlyTracking.siteID,
-                                                                          orderID: readOnlyTracking.orderID,
-                                                                          trackingID: readOnlyTracking.trackingID) ?? derivedStorage.insertNewObject(ofType: Storage.ShipmentTracking.self)
+                let storageTracking = derivedStorage.loadShipmentTracking(siteID: readOnlyTracking.siteID, orderID: readOnlyTracking.orderID,
+                    trackingID: readOnlyTracking.trackingID) ?? derivedStorage.insertNewObject(ofType: Storage.ShipmentTracking.self)
                 storageTracking.update(with: readOnlyTracking)
             }
 

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -165,7 +165,7 @@ extension StatsStore {
 
         let storage = storageManager.viewStorage
         let storageTopEarnerStats = storage.loadTopEarnerStats(date: readOnlyStats.date,
-                                                               granularity: readOnlyStats.granularity.rawValue) ?? storage.insertNewObject(ofType: Storage.TopEarnerStats.self)
+                                               granularity: readOnlyStats.granularity.rawValue) ?? storage.insertNewObject(ofType: Storage.TopEarnerStats.self)
         storageTopEarnerStats.update(with: readOnlyStats)
         handleTopEarnerStatsItems(readOnlyStats, storageTopEarnerStats, storage)
         storage.saveIfNeeded()
@@ -197,7 +197,8 @@ extension StatsStore {
         assert(Thread.isMainThread)
 
         let storage = storageManager.viewStorage
-        let storageSiteVisitStats = storage.loadSiteVisitStats(granularity: readOnlyStats.granularity.rawValue) ?? storage.insertNewObject(ofType: Storage.SiteVisitStats.self)
+        let storageSiteVisitStats = storage.loadSiteVisitStats(
+            granularity: readOnlyStats.granularity.rawValue) ?? storage.insertNewObject(ofType: Storage.SiteVisitStats.self)
         storageSiteVisitStats.update(with: readOnlyStats)
         handleSiteVisitStatsItems(readOnlyStats, storageSiteVisitStats, storage)
         storage.saveIfNeeded()
@@ -229,7 +230,8 @@ extension StatsStore {
         assert(Thread.isMainThread)
 
         let storage = storageManager.viewStorage
-        let storageOrderStats = storage.loadOrderStats(granularity: readOnlyStats.granularity.rawValue) ?? storage.insertNewObject(ofType: Storage.OrderStats.self)
+        let storageOrderStats = storage.loadOrderStats(
+            granularity: readOnlyStats.granularity.rawValue) ?? storage.insertNewObject(ofType: Storage.OrderStats.self)
         storageOrderStats.update(with: readOnlyStats)
         handleOrderStatsItems(readOnlyStats, storageOrderStats, storage)
         storage.saveIfNeeded()


### PR DESCRIPTION
This PR addresses the ~26 linter errors we had thanks to #769 😉 . Every single one was a line length violation (> 160chars). I resolved these issues by using swift's multiline string literal syntax for the most part.

## Testing
* Review the glorious multi-line syntax 🤣 
* run `rake lint` and make sure no errors appear
* Make sure the unit tests are still ✅ 
* Build and run the app, give a quick once-over to the login prologue, store picker, order detail, settings, and status screens — verify nothing looks out of wack.

@mindgraffiti or @ctarda → first :shipit: wins!
