### PR TITLE
Change text from "Total Product Order" to "Total orders"

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.5
 -----
+- improvement: change top performers text from "Total Product Order" to "Total orders" for clarity
 
 1.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -54,7 +54,7 @@ extension ProductTableViewCell {
     func configure(_ statsItem: TopEarnerStatsItem?) {
         nameText = statsItem?.productName
         detailText = String.localizedStringWithFormat(
-            NSLocalizedString("Total Product Order: %ld",
+            NSLocalizedString("Total orders: %ld",
                               comment: "Top performers — label for the total number of products ordered"),
             statsItem?.quantity ?? 0
         )


### PR DESCRIPTION
Fixes #709.

Per the i7 designs, the top performers list should say "Total orders" rather than "Total product order."

**Before:**
<img src="https://user-images.githubusercontent.com/1062444/53262120-6a22b100-369b-11e9-9e28-b59c204d509c.png" width="300" />

**After**
<img src="https://user-images.githubusercontent.com/1062444/54455298-7691ab00-4729-11e9-95fc-3a41cf8878d4.png" width="300" />


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
