### PR TITLE
Add prepareForReuse to Basic cell

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.5
 -----
+- bugfix: Sometimes Settings would style all the options like "Log Out". No longer happens now.
 
 1.4
 -----

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
@@ -7,4 +7,11 @@ class BasicTableViewCell: UITableViewCell {
 
         textLabel?.applyBodyStyle()
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        textLabel?.applyBodyStyle()
+        textLabel?.textAlignment = .left
+    }
 }


### PR DESCRIPTION
Fixes #785.

This bug was happening because the BasicTableViewCell is used for normal Settings cells and then customized for destructive Settings cells, such as "Log Out". When the cell was reused, there was no "prepareForReuse" method to override and reset the destructive styles.

## To test:
It takes quite a while to reproduce the bug because a destructive-styled cell has to get re-used. 

1. On the My store tab, tap the gear icon to open Settings.
2. Scroll down on the settings screen.
3. Open the Privacy Settings section repeatedly (Settings > Privacy Settings > Back to Settings > Privacy Settings, etc.).
(Eventually, some or all of the cells would pick up the wrong formatting.)

**Before**
<img src="https://user-images.githubusercontent.com/8658164/54434607-97a4cc80-4726-11e9-9871-9146caf767d9.png" width="350" />

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
