### PR TITLE
OrderStatus refresh not implemented on pull-to-refresh

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.5
 -----
+- bugfix: order status refreshes upon pull-to-refresh in Order Details
 - improvement: change top performers text from "Total Product Order" to "Total orders" for clarity
 
 1.4

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -622,7 +622,8 @@ private extension OrderDetailsViewController {
                 return
             }
 
-            self.viewModel = OrderDetailsViewModel(order: order, orderStatus: nil)
+            let orderStatus = self.lookUpOrderStatus(for: order)
+            self.viewModel = OrderDetailsViewModel(order: order, orderStatus: orderStatus)
             onCompletion?(nil)
         }
 


### PR DESCRIPTION
Fixes #790 

May also fix the pull-to-refresh broken UI layout (Ref. #789)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
