### PR TITLE
Bugfix: background color appears outside of payment status labels

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.5
 -----
+- bugfix: payment status label background color showing up beyond rounded border
 - improvement: change top performers text from "Total Product Order" to "Total orders" for clarity
 
 1.4

--- a/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
@@ -18,6 +18,7 @@ extension UILabel {
     /// Setup: Layer
     ///
     private func applyLayerSettings() {
+        layer.masksToBounds = true
         layer.borderWidth = OrderStatusSettings.borderWidth
         layer.cornerRadius = OrderStatusSettings.cornerRadius
     }


### PR DESCRIPTION
Fixes #791.

<img width="700" alt="Screen Shot 2019-03-15 at 3 48 00 PM" src="https://user-images.githubusercontent.com/1062444/54461278-2111ca00-473a-11e9-8d40-4632f5d8aa6b.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
