### PR TITLE
Shipment tracking: dateFormat fix

### DIFF
--- a/Networking/Networking/Extensions/DateFormatter+Woo.swift
+++ b/Networking/Networking/Extensions/DateFormatter+Woo.swift
@@ -26,7 +26,7 @@ public extension DateFormatter {
         public static let yearMonthDayDateFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.dateFormat = "yyyy'-'MM'-'DD'"
+            formatter.dateFormat = "yyyy'-'MM'-'dd"
             return formatter
         }()
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.5
 -----
 - improvement: change top performers text from "Total Product Order" to "Total orders" for clarity
+- bugfix: fixed an issue on the order details screen where the shipment tracking dates were incorrect
 
 1.4
 -----


### PR DESCRIPTION
This PR fixes an issue where the shipment tracking dates on order details was incorrect. In short, I fat-fingered the `dateFormat` string 🙄 .

![3](https://user-images.githubusercontent.com/154014/54463270-7ea91500-4740-11e9-8442-28b977404a30.png)

Fixes: #784 

## Testing

1.  Build and run the app
2. Select a few orders that have shipment tracking information where the ship date is **not** in January
3.  Verify the correct date appears in the UI

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
