### PR TITLE
Fixed DateFormatter dateFormat string typo.

### DIFF
--- a/Networking/Networking/Extensions/DateFormatter+Woo.swift
+++ b/Networking/Networking/Extensions/DateFormatter+Woo.swift
@@ -26,7 +26,7 @@ public extension DateFormatter {
         public static let yearMonthDayDateFormatter: DateFormatter = {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
-            formatter.dateFormat = "yyyy'-'MM'-'DD'"
+            formatter.dateFormat = "yyyy'-'MM'-'dd"
             return formatter
         }()
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - improvement: Filtering by custom order status now supported!
 - new feature: You can now manually change the status of an order on the order details screen
 - bugfix: correctly flips chevron on Dashboard > New Orders, to support RTL languages.
+- bugfix: fixed an issue on the order details screen where the shipment tracking dates were incorrect
 
 1.3
 -----


### PR DESCRIPTION
This PR introduces a `DateFormatter`[ patch from `develop`](https://github.com/woocommerce/woocommerce-ios/pull/794) into `release/1.4`. 

> ... fixes an issue where the shipment tracking dates on order details was incorrect. 

![3](https://user-images.githubusercontent.com/154014/54463270-7ea91500-4740-11e9-8442-28b977404a30.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
