### PR TITLE
Changes to support the latest authenticator pod version.

### DIFF
--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -20,6 +20,18 @@ public struct Credentials: Equatable {
         self.username = username
         self.authToken = authToken
     }
+
+    /// Convenience initializer. Assigns a UUID as a placeholder for the username.
+    ///
+    public init(authToken: String) {
+        self.init(username: UUID().uuidString, authToken: authToken)
+    }
+
+    /// Returns true if the username is a UUID placeholder.
+    ///
+    public func hasPlaceholderUsername() -> Bool {
+        return UUID(uuidString: username) != nil
+    }
 }
 
 

--- a/Podfile
+++ b/Podfile
@@ -19,8 +19,7 @@ target 'WooCommerce' do
 
   # Use the latest bugfix for coretelephony
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
-  #pod 'Automattic-Tracks-iOS', '0.2.4'
-  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.3.2'
+  pod 'Automattic-Tracks-iOS', '0.3.2-beta.1'
 
   pod 'Gridicons', '~> 0.18-beta'
   

--- a/Podfile
+++ b/Podfile
@@ -19,12 +19,14 @@ target 'WooCommerce' do
 
   # Use the latest bugfix for coretelephony
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
-  pod 'Automattic-Tracks-iOS', '0.2.4'
+  #pod 'Automattic-Tracks-iOS', '0.2.4'
+  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.3.2'
 
   pod 'Gridicons', '~> 0.18-beta'
   
   # allow pod to pick up beta versions, such as 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.1-beta'
+  #pod 'WordPressAuthenticator', '~> 1.1-beta'
+  pod 'WordPressAuthenticator', '~> 1.2.0-beta.1'
 
   pod 'WordPressShared', '~> 1.1'
   pod 'WordPressUI', '~> 1.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - 1PasswordExtension (1.8.5)
   - Alamofire (4.7.3)
-  - Automattic-Tracks-iOS (0.3.2):
+  - Automattic-Tracks-iOS (0.3.2-beta.1):
     - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 1.1.4)
@@ -78,7 +78,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.3.2`)
+  - Automattic-Tracks-iOS (= 0.3.2-beta.1)
   - Charts (~> 3.2)
   - CocoaLumberjack (~> 3.4)
   - CocoaLumberjack/Swift (~> 3.4)
@@ -95,6 +95,7 @@ SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - 1PasswordExtension
     - Alamofire
+    - Automattic-Tracks-iOS
     - Charts
     - CocoaLumberjack
     - Crashlytics
@@ -118,20 +119,10 @@ SPEC REPOS:
     - XLPagerTabStrip
     - ZendeskSDK
 
-EXTERNAL SOURCES:
-  Automattic-Tracks-iOS:
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.3.2
-
-CHECKOUT OPTIONS:
-  Automattic-Tracks-iOS:
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.3.2
-
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  Automattic-Tracks-iOS: cedc19fcfc1e5b3be48dbc313a548d2e38565265
+  Automattic-Tracks-iOS: 7678d30a5e2dfe75ff93e6496024790eefcf441d
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: 07fb167b1694128c1c9a5a5cc319b0e9c3ca0933
@@ -155,6 +146,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 63166e21c9844fa30f2d95d30f335e73be5caf22
   ZendeskSDK: af6509ad7968d367f95b2645713802712152f879
 
-PODFILE CHECKSUM: ef454a3545d82acb3fcb6791ea5cd43fd2f0b644
+PODFILE CHECKSUM: bf75f789f6e5e8094ed2dabed6424536a3a718ef
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - 1PasswordExtension (1.8.5)
   - Alamofire (4.7.3)
-  - Automattic-Tracks-iOS (0.2.4):
+  - Automattic-Tracks-iOS (0.3.2):
     - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
-    - UIDeviceIdentifier (~> 0.4)
-  - Charts (3.2.1):
-    - Charts/Core (= 3.2.1)
-  - Charts/Core (3.2.1)
+    - UIDeviceIdentifier (~> 1.1.4)
+  - Charts (3.2.2):
+    - Charts/Core (= 3.2.2)
+  - Charts/Core (3.2.2)
   - CocoaLumberjack (3.4.2):
     - CocoaLumberjack/Default (= 3.4.2)
     - CocoaLumberjack/Extensions (= 3.4.2)
@@ -25,49 +25,47 @@ PODS:
   - GoogleSignInRepacked (4.1.2):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
-  - GoogleToolboxForMac/DebugUtils (2.1.4):
-    - GoogleToolboxForMac/Defines (= 2.1.4)
-  - GoogleToolboxForMac/Defines (2.1.4)
-  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.1.4)":
-    - GoogleToolboxForMac/DebugUtils (= 2.1.4)
-    - GoogleToolboxForMac/Defines (= 2.1.4)
-    - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
-  - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
+  - GoogleToolboxForMac/DebugUtils (2.2.0):
+    - GoogleToolboxForMac/Defines (= 2.2.0)
+  - GoogleToolboxForMac/Defines (2.2.0)
+  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.2.0)":
+    - GoogleToolboxForMac/DebugUtils (= 2.2.0)
+    - GoogleToolboxForMac/Defines (= 2.2.0)
+    - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.0)"
+  - "GoogleToolboxForMac/NSString+URLArguments (2.2.0)"
   - Gridicons (0.18)
   - KeychainAccess (3.1.2)
-  - lottie-ios (2.5.0)
+  - lottie-ios (2.5.2)
   - NSObject-SafeExpectations (0.0.3)
   - "NSURL+IDN (0.3)"
   - Reachability (3.2)
   - SVProgressHUD (2.2.5)
-  - UIDeviceIdentifier (0.5.0)
-  - WordPressAuthenticator (1.1.7-beta.1):
+  - UIDeviceIdentifier (1.1.4)
+  - WordPressAuthenticator (1.2.0-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
-    - CocoaLumberjack (= 3.4.2)
+    - CocoaLumberjack (~> 3.4)
     - GoogleSignInRepacked (= 4.1.2)
     - Gridicons (~> 0.15)
-    - lottie-ios (= 2.5.0)
+    - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - UIDeviceIdentifier (~> 0.4)
-    - WordPressKit (~> 1.4)
+    - WordPressKit (~> 3.1.1)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-    - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.5.1):
+  - WordPressKit (3.1.1):
     - Alamofire (~> 4.7.3)
-    - CocoaLumberjack (= 3.4.2)
+    - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
-    - UIDeviceIdentifier (~> 0.4)
+    - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
-    - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.6.0):
+    - wpxmlrpc (= 0.8.4)
+  - WordPressShared (1.7.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
-  - wpxmlrpc (0.8.3)
-  - XLPagerTabStrip (8.1.0)
+  - wpxmlrpc (0.8.4)
+  - XLPagerTabStrip (8.1.1)
   - ZendeskSDK (2.3.0):
     - ZendeskSDK/Providers (= 2.3.0)
     - ZendeskSDK/UI (= 2.3.0)
@@ -80,14 +78,14 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
-  - Automattic-Tracks-iOS (= 0.2.4)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.3.2`)
   - Charts (~> 3.2)
   - CocoaLumberjack (~> 3.4)
   - CocoaLumberjack/Swift (~> 3.4)
   - Crashlytics (~> 3.10)
   - Gridicons (~> 0.18-beta)
   - KeychainAccess (~> 3.1)
-  - WordPressAuthenticator (~> 1.1-beta)
+  - WordPressAuthenticator (~> 1.2.0-beta.1)
   - WordPressShared (~> 1.1)
   - WordPressUI (~> 1.2)
   - XLPagerTabStrip (~> 8.1)
@@ -97,7 +95,6 @@ SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - 1PasswordExtension
     - Alamofire
-    - Automattic-Tracks-iOS
     - Charts
     - CocoaLumberjack
     - Crashlytics
@@ -121,33 +118,43 @@ SPEC REPOS:
     - XLPagerTabStrip
     - ZendeskSDK
 
+EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
+    :tag: 0.3.2
+
+CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
+    :tag: 0.3.2
+
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  Automattic-Tracks-iOS: c1e1ef6f3e9daf79e6e411666ccc71503604bef9
-  Charts: f122fb70b19847fa5817d018b77d6c5a2296ab25
+  Automattic-Tracks-iOS: cedc19fcfc1e5b3be48dbc313a548d2e38565265
+  Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: 07fb167b1694128c1c9a5a5cc319b0e9c3ca0933
   Fabric: f988e33c97f08930a413e08123064d2e5f68d655
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
-  GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
+  GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
   Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
   KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
-  lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
+  lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressAuthenticator: ef9169f1d8c7ee06c731c39c6acc9c015228b0bf
-  WordPressKit: b0d9838a874a2ea126da17965d939f0422d94581
-  WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
+  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
+  WordPressAuthenticator: 835ec46e30bae522929eed826eb8a997ed746a36
+  WordPressKit: 9af12361492d12c6c5512d3d7de594aa415ad670
+  WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
-  wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
-  XLPagerTabStrip: 22d4c58200d7c105e0e407ab6bfd01a5d85014be
+  wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
+  XLPagerTabStrip: 63166e21c9844fa30f2d95d30f335e73be5caf22
   ZendeskSDK: af6509ad7968d367f95b2645713802712152f879
 
-PODFILE CHECKSUM: fa8c6b74d405866b108f16b75b24a6ea7154b198
+PODFILE CHECKSUM: ef454a3545d82acb3fcb6791ea5cd43fd2f0b644
 
 COCOAPODS: 1.5.3

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -183,8 +183,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             fatalError("Self Hosted sites are not supported. Please review the Authenticator settings!")
         }
 
-        let tempUsername = UUID().uuidString
-        StoresManager.shared.authenticate(credentials: .init(username: tempUsername, authToken: authToken))
+        StoresManager.shared.authenticate(credentials: .init(authToken: authToken))
         let action = AccountAction.synchronizeAccount { (account, error) in
             if let account = account {
                 StoresManager.shared

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -51,8 +51,9 @@ struct SessionManager {
                 return
             }
 
+            removeCredentials()
+
             guard let credentials = newValue else {
-                removeCredentials()
                 return
             }
 

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -160,7 +160,7 @@ private extension StoresManager {
             guard let `self` = self, let account = account else {
                 return
             }
-
+            self.replaceTempCredentialsIfNecessary(account: account)
             self.sessionManager.defaultAccount = account
         }
 
@@ -180,6 +180,20 @@ private extension StoresManager {
         }
 
         dispatch(action)
+    }
+
+    /// Replaces the temporary UUID username in default credentials with the
+    /// actual username from the passed account.  This *shouldn't* be necessary
+    /// under normal conditions but is a safety net incase there is an error
+    /// preventing the temp username from being updated during login.
+    ///
+    func replaceTempCredentialsIfNecessary(account: Account) {
+        guard
+            let credentials = sessionManager.defaultCredentials,
+            UUID(uuidString: credentials.username) != nil else {
+                return
+        }
+        authenticate(credentials: .init(username: account.username, authToken: credentials.authToken))
     }
 
     /// Synchronizes the WordPress.com Sites, associated with the current credentials.

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -190,7 +190,7 @@ private extension StoresManager {
     func replaceTempCredentialsIfNecessary(account: Account) {
         guard
             let credentials = sessionManager.defaultCredentials,
-            UUID(uuidString: credentials.username) != nil else {
+            credentials.hasPlaceholderUsername() else {
                 return
         }
         authenticate(credentials: .init(username: account.username, authToken: credentials.authToken))


### PR DESCRIPTION
This PR is an update to support the latest version of WordPressAuthenticator-iOS. 

The credentials returned from the authenticator pod no longer include a username, just an auth token.  Its the responsibility of the client to fetch the user name for the auth token.  To accommodate the change I've modified `sync(credentials:, onCompletion:)` to use a temporary username (a uuid) to fetch account information, and then proceed with the rest of the login flow.  I'm not too sure what to do about failures to fetch account information and error handling in this PR is rudimentary.  I'd appreciate suggestions.

@bummytime @mindgraffiti what do y'all think? 