### PR TITLE
Fix some strings that break genstrings

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -152,10 +152,7 @@ private extension LoginPrologueViewController {
     /// Returns the Disclaimer Attributed Text (which contains a link to the Jetpack Setup URL).
     ///
     var disclaimerAttributedText: NSAttributedString {
-        let disclaimerText = NSLocalizedString("""
-                                 This app requires Jetpack to connect to your Store. <br /> Read the \
-                                 <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.
-                                 """,
+        let disclaimerText = NSLocalizedString("This app requires Jetpack to connect to your Store. <br /> Read the <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
                              comment: """
                                  Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to \
                                  your Store. Read the configuration instructions.' and it links to a web page on the words \

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -101,7 +101,7 @@ private extension Date {
             "Updated %ld hours ago",
             comment: """
                 Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. \
-                Usage example: Updated 14 hours ago"
+                Usage example: Updated 14 hours ago
                 """
         )
         static let longFormUpdateStatement = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -149,10 +149,8 @@ private extension PrivacySettingsViewController {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
         cell.imageView?.image = Gridicon.iconOfType(.image)
         cell.imageView?.tintColor = .white
-        cell.textLabel?.text = NSLocalizedString("""
-                                    This information helps us improve our products, make marketing to you more relevant, \
-                                    personalize your WordPress.com experience, and more as detailed in our privacy policy.
-                                    """,
+        cell.textLabel?.text = NSLocalizedString(
+            "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.",
             comment: "Settings > Privacy Settings > privacy info section. Explains what we do with the information we collect."
         )
     }


### PR DESCRIPTION
This PR fixes some strings that break genstrings.

# To Test
1. Run `./Script/localize.py` and verify that it doesn't fail and that `en.lporj/Localizable.strings` is updated.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
