### PR TITLE
Fixed deprecation warnings in PeriodDataVC

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -390,14 +390,14 @@ private extension PeriodDataViewController {
 
 
     func chartSummaryString() -> String {
-        guard let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet, dataSet.entryCount > 0 else {
+        guard let dataSet = barChartView.barData?.dataSets.first as? BarChartDataSet, dataSet.count > 0 else {
             return barChartView.noDataText
         }
 
         var chartSummaryString = ""
-        for i in 0..<dataSet.entryCount {
+        for i in 0..<dataSet.count {
             // We are not including zero value bars here to keep things shorter
-            guard let entry = dataSet.entryForIndex(i), entry.y != 0.0 else {
+            guard let entry = dataSet[safe: i], entry.y != 0.0 else {
                 continue
             }
 


### PR DESCRIPTION
Just a quick PR to address the deprecation warnings that popped up from a recent update to the Charts lib:

<img width="398" alt="Screen Shot 2019-03-25 at 10 06 45 AM" src="https://user-images.githubusercontent.com/154014/54931704-85c1e700-4ee7-11e9-87be-f4e23fbf1287.png">

@mindgraffiti would you mind giving this a quick 👀 ?

