### PR TITLE
Fix genstrings issues

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -401,10 +401,7 @@ private extension StorePickerViewController {
     func displayVersionCheckErrorNotice(siteID: Int, siteName: String) {
         let message = String.localizedStringWithFormat(
             NSLocalizedString("Unable to successfully connect to %@",
-                              comment: """
-                                  On the site picker screen, the error displayed when connecting to a site fails. \
-                                  It reads: Unable to successfully connect to {site name}
-                                  """
+                              comment: "On the site picker screen, the error displayed when connecting to a site fails. It reads: Unable to successfully connect to {site name}"
             ),
             siteName
         )

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -153,15 +153,7 @@ private extension LoginPrologueViewController {
     ///
     var disclaimerAttributedText: NSAttributedString {
         let disclaimerText = NSLocalizedString("This app requires Jetpack to connect to your Store. <br /> Read the <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
-                             comment: """
-                                 Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to \
-                                 your Store. Read the configuration instructions.' and it links to a web page on the words \
-                                 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, \
-                                 'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. \
-                                 If a literal translation of 'Read the configuration instructions' does not make sense in your language, \
-                                 please use a contextually appropriate substitution. For example, you can translate it to say \
-                                 'See: instructions' or any alternative that sounds natural in your language.
-                                 """
+                             comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, \'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'Read the configuration instructions' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language."
         )
         let disclaimerAttributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.font(forStyle: .caption1, weight: .thin),

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -78,38 +78,23 @@ private extension Date {
         )
         static let singularMinuteUpdateStatment = NSLocalizedString(
             "Updated %ld minute ago",
-            comment: """
-                Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. \
-                Usage example: Updated 1 minute ago
-                """
+            comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. Usage example: Updated 1 minute ago"
         )
         static let pluralMinuteUpdateStatment = NSLocalizedString(
             "Updated %ld minutes ago",
-            comment: """
-                Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. \
-                Usage example: Updated 55 minutes ago
-                """
+            comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago"
         )
         static let singularHourUpdateStatment = NSLocalizedString(
             "Updated %ld hour ago",
-            comment: """
-                Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. \
-                Usage example: Updated 1 hour ago
-                """
+            comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago"
         )
         static let pluralHourUpdateStatment = NSLocalizedString(
             "Updated %ld hours ago",
-            comment: """
-                Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. \
-                Usage example: Updated 14 hours ago
-                """
+            comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago"
         )
         static let longFormUpdateStatement = NSLocalizedString(
             "Updated on %@",
-            comment: """
-                A specific date and time string which represents when the data was last updated. \
-                Usage example: Updated on Jan 22, 2019 3:31PM
-                """
+            comment: "A specific date and time string which represents when the data was last updated. Usage example: Updated on Jan 22, 2019 3:31PM"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -367,10 +367,7 @@ private extension PeriodDataViewController {
         yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
             NSLocalizedString(
                 "Minimum value %@, maximum value %@",
-                comment: """
-                    VoiceOver accessibility value, informs the user about the Y-axis min/max values. \
-                    It reads: Minimum value {value}, maximum value {value}.
-                    """
+                comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."
             ),
             yAxisMinimum,
             yAxisMaximum
@@ -405,10 +402,7 @@ private extension PeriodDataViewController {
             chartSummaryString += String.localizedStringWithFormat(
                 NSLocalizedString(
                     "Bar number %i, %@, ",
-                    comment: """
-                        VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. \
-                        It reads: Bar number {bar number} {summary of bar}.
-                        """
+                    comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."
                 ),
                 i+1,
                 entrySummaryString

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -120,10 +120,7 @@ private extension SettingsViewController {
     func configureSections() {
         let selectedStoreTitle = NSLocalizedString(
             "Selected Store",
-            comment: """
-                My Store > Settings > Selected Store information section. This is the heading listed above the information row that \
-                displays the store website and their username.
-                """
+            comment: "My Store > Settings > Selected Store information section. This is the heading listed above the information row that displays the store website and their username."
             ).uppercased()
         let improveTheAppTitle = NSLocalizedString("Help Improve The App", comment: "My Store > Settings > Privacy settings section").uppercased()
         let aboutSettingsTitle = NSLocalizedString("About the app", comment: "My Store > Settings > About app section").uppercased()

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -213,10 +213,7 @@ private extension NotificationsViewController {
         rightBarButton.accessibilityTraits = .button
         rightBarButton.accessibilityLabel = NSLocalizedString("Filter notifications", comment: "Accessibility label for the Filter notifications button.")
         rightBarButton.accessibilityHint = NSLocalizedString("Filters the notifications list by notification type.",
-                                                             comment: """
-                                                                 VoiceOver accessibility hint, \
-                                                                 informing the user the button can be used to filter the notifications list.
-                                                                 """
+                                                             comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the notifications list."
         )
         navigationItem.rightBarButtonItem = rightBarButton
     }
@@ -250,10 +247,7 @@ private extension NotificationsViewController {
         guard currentTypeFilter != .all else {
             navigationItem.title = NSLocalizedString(
                 "Notifications",
-                comment: """
-                    Title that appears on top of the main Notifications screen when there is no filter \
-                    applied to the list (plural form of the word Notification).
-                    """
+                comment: "Title that appears on top of the main Notifications screen when there is no filter applied to the list (plural form of the word Notification)."
             )
             return
         }
@@ -882,17 +876,11 @@ private extension NotificationsViewController {
                 )
             case .orders:
                 return NSLocalizedString("Orders",
-                                         comment: """
-                                             Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. \
-                                             Plural form of the word Order.
-                                             """
+                                         comment: "Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. Plural form of the word Order."
                 )
             case .reviews:
                 return NSLocalizedString("Reviews",
-                                         comment: """
-                                             Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. \
-                                             Plural form of the word Review.
-                                             """
+                                         comment: "Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. Plural form of the word Review."
                 )
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -317,10 +317,7 @@ private extension OrderDetailsViewController {
         let message = String.localizedStringWithFormat(
             NSLocalizedString(
                 "Order %@ has been deleted from your store",
-                comment: """
-                    Displayed whenever the Details for an Order that just got deleted was onscreen. \
-                    It reads: Order {order number} has been deleted from your store
-                    """
+                comment: "Displayed whenever the Details for an Order that just got deleted was onscreen. It reads: Order {order number} has been deleted from your store."
             ),
             viewModel.order.number
         )
@@ -455,10 +452,7 @@ private extension OrderDetailsViewController {
 
         cell.accessibilityHint = NSLocalizedString(
             "Prompts with the option to call or message the billing customer.",
-            comment: """
-                VoiceOver accessibility hint, informing the user that the row can be tapped to get to a \
-                prompt that lets them call or message the billing customer.
-                """
+            comment: "VoiceOver accessibility hint, informing the user that the row can be tapped to get to a prompt that lets them call or message the billing customer."
         )
     }
 


### PR DESCRIPTION
This PR reverts some multi line comments to single line. Hound won't be happy at all, but `genstrings` will :-)  

I looked for some updates/replacements to `genstrings`, but I couldn't find anything official, and the two projects that claimed to be drop-in replacement failed to work with various errors. 

I think it's worth to start to look for an updated toolchain, but the lack of good drop-in replacement mean that we'll need to do some migration and validation work.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
