### PR TITLE
Make Tracks a lazy init rather than an implied dispatch once

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -5,16 +5,19 @@ import AutomatticTracks
 
 public class TracksProvider: AnalyticsProvider {
 
-    private let contextManager: TracksContextManager
-    private let tracksService: TracksService
+    lazy private var contextManager: TracksContextManager = {
+        return TracksContextManager()
+    }()
+    lazy private var tracksService: TracksService = {
+        let tracksService = TracksService(contextManager: contextManager)!
+        tracksService.eventNamePrefix = Constants.eventNamePrefix
+        return tracksService
+    }()
 
 
     /// Designated Initializer
     ///
     init() {
-        self.contextManager = TracksContextManager()
-        self.tracksService = TracksService(contextManager: contextManager)
-        self.tracksService.eventNamePrefix = Constants.eventNamePrefix
     }
 }
 


### PR DESCRIPTION
Fixes #567 

This is a stab in the dark to eliminate the crash we're seeing once in a while. By making the Tracks service properties lazy it prevents Swift from initializing them during the implied dispatch once call from the `static let` initialization of `WooAnalytics` shared instance. I'm not entirely sure this will fix anything; we don't really know the reason the persistent store coordinator isn't able to be brought up.

If the crash persists after this fix then my next suggestion is to move as much as possible in the `AppDelegate` into `application(_:didFinishLaunchingWithOptions:)` that doesn't need to be there. Technically willFinish is reserved for state restoration and a few other things. There could be some strange lifecycle problem with the file system.

Testing? Just make sure Tracks works?