### PR TITLE
Product settings fetch

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		7412A8EE21B6E335005D182A /* ReportOrderMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7412A8ED21B6E335005D182A /* ReportOrderMapperTests.swift */; };
 		7412A8F021B6E416005D182A /* report-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = 7412A8EF21B6E415005D182A /* report-orders.json */; };
 		7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */; };
+		74159623224D2C86003C21CF /* settings-product.json in Resources */ = {isa = PBXBuildFile; fileRef = 74159622224D2C86003C21CF /* settings-product.json */; };
 		741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */; };
 		7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */; };
 		7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */; };
@@ -236,6 +237,7 @@
 		7412A8ED21B6E335005D182A /* ReportOrderMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportOrderMapperTests.swift; sourceTree = "<group>"; };
 		7412A8EF21B6E415005D182A /* report-orders.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-orders.json"; sourceTree = "<group>"; };
 		7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRemoteTests.swift; sourceTree = "<group>"; };
+		74159622224D2C86003C21CF /* settings-product.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "settings-product.json"; sourceTree = "<group>"; };
 		741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCouponLine.swift; sourceTree = "<group>"; };
 		7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteAPIRemote.swift; sourceTree = "<group>"; };
 		7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteAPI.swift; sourceTree = "<group>"; };
@@ -717,6 +719,7 @@
 				7412A8EF21B6E415005D182A /* report-orders.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
+				74159622224D2C86003C21CF /* settings-product.json */,
 				743E84F022172D0900FAC9D7 /* shipment_tracking_empty.json */,
 				743E84F522172D3E00FAC9D7 /* shipment_tracking_single.json */,
 				743E84F122172D0900FAC9D7 /* shipment_tracking_multiple.json */,
@@ -1016,6 +1019,7 @@
 				74A1D264211898F000931DFA /* site-visits-week.json in Resources */,
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				74A1D265211898F000931DFA /* site-visits-month.json in Resources */,
+				74159623224D2C86003C21CF /* settings-product.json in Resources */,
 				74A1D266211898F000931DFA /* site-visits-year.json in Resources */,
 				743BF8BE21191B63008A9D87 /* site-visits.json in Resources */,
 				CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */; };
 		74159623224D2C86003C21CF /* settings-product.json in Resources */ = {isa = PBXBuildFile; fileRef = 74159622224D2C86003C21CF /* settings-product.json */; };
 		74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74159624224D4045003C21CF /* SiteSettingGroup.swift */; };
+		74159628224D63CE003C21CF /* settings-product-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 74159627224D63CE003C21CF /* settings-product-alt.json */; };
 		741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */; };
 		7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */; };
 		7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */; };
@@ -240,6 +241,7 @@
 		7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRemoteTests.swift; sourceTree = "<group>"; };
 		74159622224D2C86003C21CF /* settings-product.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "settings-product.json"; sourceTree = "<group>"; };
 		74159624224D4045003C21CF /* SiteSettingGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingGroup.swift; sourceTree = "<group>"; };
+		74159627224D63CE003C21CF /* settings-product-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-product-alt.json"; sourceTree = "<group>"; };
 		741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCouponLine.swift; sourceTree = "<group>"; };
 		7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteAPIRemote.swift; sourceTree = "<group>"; };
 		7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteAPI.swift; sourceTree = "<group>"; };
@@ -723,6 +725,7 @@
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
 				74159622224D2C86003C21CF /* settings-product.json */,
+				74159627224D63CE003C21CF /* settings-product-alt.json */,
 				743E84F022172D0900FAC9D7 /* shipment_tracking_empty.json */,
 				743E84F522172D3E00FAC9D7 /* shipment_tracking_single.json */,
 				743E84F122172D0900FAC9D7 /* shipment_tracking_multiple.json */,
@@ -1035,6 +1038,7 @@
 				74ABA1C9213F19FE00FFAD30 /* top-performers-month.json in Resources */,
 				743E84F622172D3E00FAC9D7 /* shipment_tracking_single.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
+				74159628224D63CE003C21CF /* settings-product-alt.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		7412A8F021B6E416005D182A /* report-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = 7412A8EF21B6E415005D182A /* report-orders.json */; };
 		7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */; };
 		74159623224D2C86003C21CF /* settings-product.json in Resources */ = {isa = PBXBuildFile; fileRef = 74159622224D2C86003C21CF /* settings-product.json */; };
+		74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74159624224D4045003C21CF /* SiteSettingGroup.swift */; };
 		741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */; };
 		7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */; };
 		7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */; };
@@ -238,6 +239,7 @@
 		7412A8EF21B6E415005D182A /* report-orders.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-orders.json"; sourceTree = "<group>"; };
 		7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportRemoteTests.swift; sourceTree = "<group>"; };
 		74159622224D2C86003C21CF /* settings-product.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "settings-product.json"; sourceTree = "<group>"; };
+		74159624224D4045003C21CF /* SiteSettingGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSettingGroup.swift; sourceTree = "<group>"; };
 		741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCouponLine.swift; sourceTree = "<group>"; };
 		7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteAPIRemote.swift; sourceTree = "<group>"; };
 		7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteAPI.swift; sourceTree = "<group>"; };
@@ -677,6 +679,7 @@
 				B56C1EB720EA76F500D749F9 /* Site.swift */,
 				7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */,
 				74046E1C217A6989007DD7BF /* SiteSetting.swift */,
+				74159624224D4045003C21CF /* SiteSettingGroup.swift */,
 				CE50345F21B5799F007573C6 /* SitePlan.swift */,
 			);
 			path = Model;
@@ -1150,6 +1153,7 @@
 				7412A8EC21B6E286005D182A /* ReportOrderTotalsMapper.swift in Sources */,
 				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
+				74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */,
 				D823D905223746CE00C90817 /* NewShipmentTrackingMapper.swift in Sources */,
 				743057B5218B6ACD00441A76 /* Queue.swift in Sources */,
 				74A1D26821189A7100931DFA /* SiteVisitStats.swift in Sources */,

--- a/Networking/Networking/Extensions/CodingUserInfoKey+Woo.swift
+++ b/Networking/Networking/Extensions/CodingUserInfoKey+Woo.swift
@@ -9,6 +9,10 @@ extension CodingUserInfoKey {
     ///
     public static let siteID = CodingUserInfoKey(rawValue: "siteID")!
 
+    /// Used to store the SettingGroupKey within a Coder/Decoder's userInfo dictionary.
+    ///
+    public static let settingGroupKey = CodingUserInfoKey(rawValue: "settingGroupKey")!
+
     /// Used to store the SiteID within a Coder/Decoder's userInfo dictionary.
     ///
     public static let orderID = CodingUserInfoKey(rawValue: "orderID")!

--- a/Networking/Networking/Mapper/SiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingsMapper.swift
@@ -14,7 +14,7 @@ struct SiteSettingsMapper: Mapper {
     /// Group name associated to the settings that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the group in any of the setting endpoints.
     ///
-    let settingsGroup: String
+    let settingsGroup: SiteSettingGroup
 
     /// (Attempts) to convert a dictionary into [SiteSetting].
     ///
@@ -23,7 +23,7 @@ struct SiteSettingsMapper: Mapper {
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [
             .siteID: siteID,
-            .settingGroupKey: settingsGroup
+            .settingGroupKey: settingsGroup.rawValue
         ]
 
         return try decoder.decode(SiteSettingsEnvelope.self, from: response).settings

--- a/Networking/Networking/Mapper/SiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingsMapper.swift
@@ -11,6 +11,10 @@ struct SiteSettingsMapper: Mapper {
     ///
     let siteID: Int
 
+    /// Group name associated to the settings that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the group in any of the setting endpoints.
+    ///
+    let settingsGroup: String
 
     /// (Attempts) to convert a dictionary into [SiteSetting].
     ///
@@ -18,7 +22,8 @@ struct SiteSettingsMapper: Mapper {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [
-            .siteID: siteID
+            .siteID: siteID,
+            .settingGroupKey: settingsGroup
         ]
 
         return try decoder.decode(SiteSettingsEnvelope.self, from: response).settings

--- a/Networking/Networking/Model/SiteSetting.swift
+++ b/Networking/Networking/Model/SiteSetting.swift
@@ -9,15 +9,23 @@ public struct SiteSetting: Decodable {
     public let label: String
     public let settingDescription: String
     public let value: String
+    public let settingGroupKey: String
+
+    // MARK: Computed Properties
+
+    public var settingGroup: SiteSettingGroup {
+        return SiteSettingGroup(rawValue: settingGroupKey)
+    }
 
     /// OrderNote struct initializer.
     ///
-    public init(siteID: Int, settingID: String, label: String, description: String, value: String) {
+    public init(siteID: Int, settingID: String, label: String, description: String, value: String, settingGroupKey: String) {
         self.siteID = siteID
         self.settingID = settingID
         self.label = label
         self.settingDescription = description
         self.value = value
+        self.settingGroupKey = settingGroupKey
     }
 
     /// The public initializer for SiteSetting.
@@ -25,6 +33,9 @@ public struct SiteSetting: Decodable {
     public init(from decoder: Decoder) throws {
         guard let siteID = decoder.userInfo[.siteID] as? Int else {
             throw SiteSettingError.missingSiteID
+        }
+        guard let settingGroupKey = decoder.userInfo[.settingGroupKey] as? String else {
+            throw SiteSettingError.missingSettingGroupKey
         }
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -42,7 +53,7 @@ public struct SiteSetting: Decodable {
             DDLogWarn("⚠️ Could not successfully decode SiteSetting value for \(settingID)")
         }
 
-        self.init(siteID: siteID, settingID: settingID, label: label, description: settingDescription, value: value) // initialize the struct
+        self.init(siteID: siteID, settingID: settingID, label: label, description: settingDescription, value: value, settingGroupKey: settingGroupKey)
     }
 }
 
@@ -67,7 +78,9 @@ extension SiteSetting: Comparable {
         return lhs.settingID == rhs.settingID &&
             lhs.label == rhs.label &&
             lhs.settingDescription == rhs.settingDescription &&
-            lhs.value == rhs.value
+            lhs.value == rhs.value &&
+            lhs.settingGroupKey == rhs.settingGroupKey
+
     }
 
     public static func < (lhs: SiteSetting, rhs: SiteSetting) -> Bool {
@@ -86,4 +99,5 @@ extension SiteSetting: Comparable {
 //
 enum SiteSettingError: Error {
     case missingSiteID
+    case missingSettingGroupKey
 }

--- a/Networking/Networking/Model/SiteSettingGroup.swift
+++ b/Networking/Networking/Model/SiteSettingGroup.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+
+/// Represents a SiteSettingGroup Entity.
+///
+public enum SiteSettingGroup: Decodable, Hashable {
+    case general
+    case product
+    case custom(String) // catch-all
+}
+
+
+/// RawRepresentable Conformance
+///
+extension SiteSettingGroup: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.general:
+            self = .general
+        case Keys.product:
+            self = .product
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .general: return Keys.general
+        case .product: return Keys.product
+        case .custom(let payload):  return payload
+        }
+    }
+}
+
+
+/// Enum containing the SiteSettingGroup keys the app currently uses
+///
+private enum Keys {
+    static let general = "general"
+    static let product = "product"
+}

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -13,9 +13,9 @@ public class SiteSettingsRemote: Remote {
     ///   - completion: Closure to be executed upon completion.
     ///
     public func loadGeneralSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
-        let path = Constants.generalSettingsPath
+        let path = Constants.siteSettingsPath + Constants.generalSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
-        let mapper = SiteSettingsMapper(siteID: siteID)
+        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: Constants.generalSettingsGroup)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -27,9 +27,9 @@ public class SiteSettingsRemote: Remote {
     ///   - completion: Closure to be executed upon completion.
     ///
     public func loadProductSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
-        let path = Constants.productSettingsPath
+        let path = Constants.siteSettingsPath + Constants.productSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
-        let mapper = SiteSettingsMapper(siteID: siteID)
+        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: Constants.productSettingsGroup)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -40,7 +40,8 @@ public class SiteSettingsRemote: Remote {
 //
 private extension SiteSettingsRemote {
     enum Constants {
-        static let generalSettingsPath: String   = "settings/general"
-        static let productSettingsPath: String   = "settings/products"
+        static let siteSettingsPath: String       = "settings/"
+        static let generalSettingsGroup: String   = "general"
+        static let productSettingsGroup: String   = "products"
     }
 }

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -19,6 +19,20 @@ public class SiteSettingsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Retrieves all of the product `SiteSetting`s for a given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll fetch the product settings.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadProductSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
+        let path = Constants.productSettingsPath
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = SiteSettingsMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -27,5 +41,6 @@ public class SiteSettingsRemote: Remote {
 private extension SiteSettingsRemote {
     enum Constants {
         static let generalSettingsPath: String   = "settings/general"
+        static let productSettingsPath: String   = "settings/products"
     }
 }

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -15,7 +15,7 @@ public class SiteSettingsRemote: Remote {
     public func loadGeneralSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.siteSettingsPath + Constants.generalSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
-        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: Constants.generalSettingsGroup)
+        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -29,7 +29,7 @@ public class SiteSettingsRemote: Remote {
     public func loadProductSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.siteSettingsPath + Constants.productSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
-        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: Constants.productSettingsGroup)
+        let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.product)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -13,7 +13,7 @@ class SiteSettingsMapperTests: XCTestCase {
     /// Verifies the SiteSetting fields are parsed correctly.
     ///
     func testSiteSettingFieldsAreProperlyParsed() {
-        let settings = mapLoadAllSiteSettingsResponse()
+        let settings = mapLoadGeneralSiteSettingsResponse()
         XCTAssertEqual(settings.count, 20)
 
         let firstSetting = settings[0]
@@ -45,7 +45,7 @@ class SiteSettingsMapperTests: XCTestCase {
     /// Verifies that a SiteSetting in a broken state gets default values
     ///
     func testSiteSettingsAreProperlyParsedWhenNullsReceived() {
-        let settings = mapLoadBrokenSiteSettingsResponse()
+        let settings = mapLoadBrokenGeneralSiteSettingsResponse()
         XCTAssertEqual(settings.count, 1)
 
         let firstSetting = settings[0]
@@ -65,23 +65,23 @@ private extension SiteSettingsMapperTests {
 
     /// Returns the OrderNotesMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapSettings(from filename: String) -> [SiteSetting] {
+    func mapGeneralSettings(from filename: String) -> [SiteSetting] {
         guard let response = Loader.contentsOf(filename) else {
             return []
         }
 
-        return try! SiteSettingsMapper(siteID: dummySiteID).map(response: response)
+        return try! SiteSettingsMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general.rawValue).map(response: response)
     }
 
-    /// Returns the OrderNotesMapper output upon receiving `orders-load-all`
+    /// Returns the OrderNotesMapper output upon receiving `settings-general`
     ///
-    func mapLoadAllSiteSettingsResponse() -> [SiteSetting] {
-        return mapSettings(from: "settings-general")
+    func mapLoadGeneralSiteSettingsResponse() -> [SiteSetting] {
+        return mapGeneralSettings(from: "settings-general")
     }
 
-    /// Returns the OrderNotesMapper output upon receiving `broken-order`
+    /// Returns the OrderNotesMapper output upon receiving `broken-settings-general`
     ///
-    func mapLoadBrokenSiteSettingsResponse() -> [SiteSetting] {
-        return mapSettings(from: "broken-settings-general")
+    func mapLoadBrokenGeneralSiteSettingsResponse() -> [SiteSetting] {
+        return mapGeneralSettings(from: "broken-settings-general")
     }
 }

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -70,7 +70,7 @@ private extension SiteSettingsMapperTests {
             return []
         }
 
-        return try! SiteSettingsMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general.rawValue).map(response: response)
+        return try! SiteSettingsMapper(siteID: dummySiteID, settingsGroup: SiteSettingGroup.general).map(response: response)
     }
 
     /// Returns the OrderNotesMapper output upon receiving `settings-general`

--- a/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -20,6 +20,8 @@ class SiteSettingsRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
+    // MARK: - Load general settings tests
+
     /// Verifies that loadGeneralSettings properly parses the sample response.
     ///
     func testLoadGeneralSettingsProperlyReturnsParsedSettings() {
@@ -44,6 +46,40 @@ class SiteSettingsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load site settings contains errors")
 
         remote.loadGeneralSettings(for: sampleSiteID) { (siteSettings, error) in
+            XCTAssertNil(siteSettings)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    // MARK: - Load product settings tests
+
+    /// Verifies that `loadProductSettings` properly parses the sample response.
+    ///
+    func testLoadProductSettingsProperlyReturnsParsedSettings() {
+        let remote = SiteSettingsRemote(network: network)
+        let expectation = self.expectation(description: "Load product settings")
+
+        network.simulateResponse(requestUrlSuffix: "settings/products", filename: "settings-product")
+        remote.loadProductSettings(for: sampleSiteID) { (siteSettings, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(siteSettings)
+            XCTAssertEqual(siteSettings?.count, 23)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `loadProductSettings` properly relays Networking Layer errors.
+    ///
+    func testLoadProductSettingsProperlyRelaysNetwokingErrors() {
+        let remote = SiteSettingsRemote(network: network)
+        let expectation = self.expectation(description: "Load product settings contains errors")
+
+        remote.loadProductSettings(for: sampleSiteID) { (siteSettings, error) in
             XCTAssertNil(siteSettings)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/Networking/NetworkingTests/Responses/settings-general-alt.json
+++ b/Networking/NetworkingTests/Responses/settings-general-alt.json
@@ -2743,26 +2743,6 @@
 					}
 				]
 			}
-		},
-		{
-			"id": "woocommerce_bookings_tz_calculation",
-			"label": "Enable Bookings Timezone calculation",
-			"description": "Schedule Bookings events, such as reminder emails and auto-completions of bookings, using your site’s configured timezone.",
-			"type": "checkbox",
-			"default": "no",
-			"value": "no",
-			"_links": {
-				"self": [
-					{
-						"href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general/woocommerce_bookings_tz_calculation"
-					}
-				],
-				"collection": [
-					{
-						"href": "https://jamosova3.mystagingwebsite.com/wp-json/wc/v2/settings/general"
-					}
-				]
-			}
 		}
 	]
 }

--- a/Networking/NetworkingTests/Responses/settings-product-alt.json
+++ b/Networking/NetworkingTests/Responses/settings-product-alt.json
@@ -1,0 +1,485 @@
+{
+    "data": [
+        {
+            "id": "woocommerce_shop_page_id",
+            "label": "Shop page",
+            "description": "<br\/>The base page can also be used in your <a href=\"https:\/\/paperairplane.store\/wp-admin\/options-permalink.php\">product permalinks<\/a>.",
+            "type": "select",
+            "default": "",
+            "tip": "This sets the base page of your shop - this is where your product archive will be.",
+            "value": "67",
+            "options": {
+                "37": "Welcome",
+                "38": "Blog",
+                "67": "Shop",
+                "68": "Cart",
+                "69": "Checkout",
+                "70": "My account",
+                "2": "Contact"
+            },
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_shop_page_id"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_cart_redirect_after_add",
+            "label": "Add to cart behaviour",
+            "description": "Redirect to the cart page after successful addition",
+            "type": "checkbox",
+            "default": "no",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_cart_redirect_after_add"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_enable_ajax_add_to_cart",
+            "label": "",
+            "description": "Enable AJAX add to cart buttons on archives",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_enable_ajax_add_to_cart"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_placeholder_image",
+            "label": "Placeholder image",
+            "description": "",
+            "type": "text",
+            "default": "",
+            "tip": "This is the attachment ID, or image URL, used for placeholder images in the product catalog. Products with no image will use this.",
+            "value": "",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_placeholder_image"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_weight_unit",
+            "label": "Animal unit",
+            "description": "This controls what animal you will define weights in.",
+            "type": "select",
+            "default": "kg",
+            "options": {
+                "kg": "kg",
+                "g": "g",
+                "lbs": "lbs",
+                "oz": "oz"
+            },
+            "tip": "This controls what unit you will define weights in.",
+            "value": "elephants",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_weight_unit"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_dimension_unit",
+            "label": "Dimension Fruit",
+            "description": "This controls what fruit you will define lengths in.",
+            "type": "select",
+            "default": "cm",
+            "options": {
+                "m": "m",
+                "cm": "cm",
+                "mm": "mm",
+                "in": "in",
+                "yd": "yd"
+            },
+            "tip": "This controls what unit you will define lengths in.",
+            "value": "Kumquat",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_dimension_unit"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_enable_reviews",
+            "label": "Enable reviews",
+            "description": "Enable product reviews",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_enable_reviews"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_review_rating_verification_label",
+            "label": "",
+            "description": "Show \"verified owner\" label on customer reviews",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_review_rating_verification_label"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_review_rating_verification_required",
+            "label": "",
+            "description": "Reviews can only be left by \"verified owners\"",
+            "type": "checkbox",
+            "default": "no",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_review_rating_verification_required"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_enable_review_rating",
+            "label": "Product ratings",
+            "description": "Enable star rating on reviews",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_enable_review_rating"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_review_rating_required",
+            "label": "",
+            "description": "Star ratings should be required, not optional",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_review_rating_required"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_manage_stock",
+            "label": "Manage stock",
+            "description": "Enable stock management",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_manage_stock"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_hold_stock_minutes",
+            "label": "Hold stock (minutes)",
+            "description": "Hold stock (for unpaid orders) for x minutes. When this limit is reached, the pending order will be cancelled. Leave blank to disable.",
+            "type": "number",
+            "default": "60",
+            "value": "60",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_hold_stock_minutes"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_low_stock",
+            "label": "Notifications",
+            "description": "Enable low stock notifications",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_low_stock"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_no_stock",
+            "label": "",
+            "description": "Enable out of stock notifications",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_no_stock"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_stock_email_recipient",
+            "label": "Notification recipient(s)",
+            "description": "Enter recipients (comma separated) that will receive this notification.",
+            "type": "text",
+            "default": "bummytime@yahoo.com",
+            "tip": "Enter recipients (comma separated) that will receive this notification.",
+            "value": "bummytime@yahoo.com",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_stock_email_recipient"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_low_stock_amount",
+            "label": "Low stock threshold",
+            "description": "When product stock reaches this amount you will be notified via email.",
+            "type": "number",
+            "default": "2",
+            "tip": "When product stock reaches this amount you will be notified via email.",
+            "value": "2",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_low_stock_amount"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_no_stock_amount",
+            "label": "Out of stock threshold",
+            "description": "When product stock reaches this amount the stock status will change to \"out of stock\" and you will be notified via email. This setting does not affect existing \"in stock\" products.",
+            "type": "number",
+            "default": "0",
+            "tip": "When product stock reaches this amount the stock status will change to \"out of stock\" and you will be notified via email. This setting does not affect existing \"in stock\" products.",
+            "value": "0",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_no_stock_amount"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_hide_out_of_stock_items",
+            "label": "Out of stock visibility",
+            "description": "Hide out of stock items from the catalog",
+            "type": "checkbox",
+            "default": "no",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_hide_out_of_stock_items"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_stock_format",
+            "label": "Stock display format",
+            "description": "This controls how stock quantities are displayed on the frontend.",
+            "type": "select",
+            "default": "",
+            "options": {
+                "low_amount": "Only show quantity remaining in stock when low e.g. \"Only 2 left in stock\"",
+                "no_amount": "Never show quantity remaining in stock"
+            },
+            "tip": "This controls how stock quantities are displayed on the frontend.",
+            "value": "",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_stock_format"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_file_download_method",
+            "label": "File download method",
+            "description": "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect<\/code> \/ <code>X-Sendfile<\/code> can be used to serve downloads instead (server requires <code>mod_xsendfile<\/code>).",
+            "type": "select",
+            "default": "force",
+            "options": {
+                "force": "Force downloads",
+                "xsendfile": "X-Accel-Redirect\/X-Sendfile",
+                "redirect": "Redirect only"
+            },
+            "tip": "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect<\/code> \/ <code>X-Sendfile<\/code> can be used to serve downloads instead (server requires <code>mod_xsendfile<\/code>).",
+            "value": "force",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_file_download_method"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_downloads_require_login",
+            "label": "Access restriction",
+            "description": "Downloads require login",
+            "type": "checkbox",
+            "default": "no",
+            "tip": "This setting does not apply to guest purchases.",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_downloads_require_login"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/settings-product.json
+++ b/Networking/NetworkingTests/Responses/settings-product.json
@@ -1,0 +1,506 @@
+{
+    "data": [
+        {
+            "id": "woocommerce_shop_page_id",
+            "label": "Shop page",
+            "description": "<br\/>The base page can also be used in your <a href=\"https:\/\/paperairplane.store\/wp-admin\/options-permalink.php\">product permalinks<\/a>.",
+            "type": "select",
+            "default": "",
+            "tip": "This sets the base page of your shop - this is where your product archive will be.",
+            "value": "67",
+            "options": {
+                "37": "Welcome",
+                "38": "Blog",
+                "67": "Shop",
+                "68": "Cart",
+                "69": "Checkout",
+                "70": "My account",
+                "2": "Contact"
+            },
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_shop_page_id"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_cart_redirect_after_add",
+            "label": "Add to cart behaviour",
+            "description": "Redirect to the cart page after successful addition",
+            "type": "checkbox",
+            "default": "no",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_cart_redirect_after_add"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_enable_ajax_add_to_cart",
+            "label": "",
+            "description": "Enable AJAX add to cart buttons on archives",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_enable_ajax_add_to_cart"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_placeholder_image",
+            "label": "Placeholder image",
+            "description": "",
+            "type": "text",
+            "default": "",
+            "tip": "This is the attachment ID, or image URL, used for placeholder images in the product catalog. Products with no image will use this.",
+            "value": "",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_placeholder_image"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_weight_unit",
+            "label": "Weight unit",
+            "description": "This controls what unit you will define weights in.",
+            "type": "select",
+            "default": "kg",
+            "options": {
+                "kg": "kg",
+                "g": "g",
+                "lbs": "lbs",
+                "oz": "oz"
+            },
+            "tip": "This controls what unit you will define weights in.",
+            "value": "kg",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_weight_unit"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_dimension_unit",
+            "label": "Dimensions unit",
+            "description": "This controls what unit you will define lengths in.",
+            "type": "select",
+            "default": "cm",
+            "options": {
+                "m": "m",
+                "cm": "cm",
+                "mm": "mm",
+                "in": "in",
+                "yd": "yd"
+            },
+            "tip": "This controls what unit you will define lengths in.",
+            "value": "m",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_dimension_unit"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_enable_reviews",
+            "label": "Enable reviews",
+            "description": "Enable product reviews",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_enable_reviews"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_review_rating_verification_label",
+            "label": "",
+            "description": "Show \"verified owner\" label on customer reviews",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_review_rating_verification_label"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_review_rating_verification_required",
+            "label": "",
+            "description": "Reviews can only be left by \"verified owners\"",
+            "type": "checkbox",
+            "default": "no",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_review_rating_verification_required"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_enable_review_rating",
+            "label": "Product ratings",
+            "description": "Enable star rating on reviews",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_enable_review_rating"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_review_rating_required",
+            "label": "",
+            "description": "Star ratings should be required, not optional",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_review_rating_required"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_manage_stock",
+            "label": "Manage stock",
+            "description": "Enable stock management",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_manage_stock"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_hold_stock_minutes",
+            "label": "Hold stock (minutes)",
+            "description": "Hold stock (for unpaid orders) for x minutes. When this limit is reached, the pending order will be cancelled. Leave blank to disable.",
+            "type": "number",
+            "default": "60",
+            "value": "60",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_hold_stock_minutes"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_low_stock",
+            "label": "Notifications",
+            "description": "Enable low stock notifications",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_low_stock"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_no_stock",
+            "label": "",
+            "description": "Enable out of stock notifications",
+            "type": "checkbox",
+            "default": "yes",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_no_stock"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_stock_email_recipient",
+            "label": "Notification recipient(s)",
+            "description": "Enter recipients (comma separated) that will receive this notification.",
+            "type": "text",
+            "default": "bummytime@yahoo.com",
+            "tip": "Enter recipients (comma separated) that will receive this notification.",
+            "value": "bummytime@yahoo.com",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_stock_email_recipient"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_low_stock_amount",
+            "label": "Low stock threshold",
+            "description": "When product stock reaches this amount you will be notified via email.",
+            "type": "number",
+            "default": "2",
+            "tip": "When product stock reaches this amount you will be notified via email.",
+            "value": "2",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_low_stock_amount"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_notify_no_stock_amount",
+            "label": "Out of stock threshold",
+            "description": "When product stock reaches this amount the stock status will change to \"out of stock\" and you will be notified via email. This setting does not affect existing \"in stock\" products.",
+            "type": "number",
+            "default": "0",
+            "tip": "When product stock reaches this amount the stock status will change to \"out of stock\" and you will be notified via email. This setting does not affect existing \"in stock\" products.",
+            "value": "0",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_notify_no_stock_amount"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_hide_out_of_stock_items",
+            "label": "Out of stock visibility",
+            "description": "Hide out of stock items from the catalog",
+            "type": "checkbox",
+            "default": "no",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_hide_out_of_stock_items"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_stock_format",
+            "label": "Stock display format",
+            "description": "This controls how stock quantities are displayed on the frontend.",
+            "type": "select",
+            "default": "",
+            "options": {
+                "low_amount": "Only show quantity remaining in stock when low e.g. \"Only 2 left in stock\"",
+                "no_amount": "Never show quantity remaining in stock"
+            },
+            "tip": "This controls how stock quantities are displayed on the frontend.",
+            "value": "",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_stock_format"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_file_download_method",
+            "label": "File download method",
+            "description": "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect<\/code> \/ <code>X-Sendfile<\/code> can be used to serve downloads instead (server requires <code>mod_xsendfile<\/code>).",
+            "type": "select",
+            "default": "force",
+            "options": {
+                "force": "Force downloads",
+                "xsendfile": "X-Accel-Redirect\/X-Sendfile",
+                "redirect": "Redirect only"
+            },
+            "tip": "Forcing downloads will keep URLs hidden, but some servers may serve large files unreliably. If supported, <code>X-Accel-Redirect<\/code> \/ <code>X-Sendfile<\/code> can be used to serve downloads instead (server requires <code>mod_xsendfile<\/code>).",
+            "value": "force",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_file_download_method"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_downloads_require_login",
+            "label": "Access restriction",
+            "description": "Downloads require login",
+            "type": "checkbox",
+            "default": "no",
+            "tip": "This setting does not apply to guest purchases.",
+            "value": "no",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_downloads_require_login"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "woocommerce_downloads_grant_access_after_payment",
+            "label": "",
+            "description": "Grant access to downloadable products after payment",
+            "type": "checkbox",
+            "default": "yes",
+            "tip": "Enable this option to grant access to downloads when orders are \"processing\", rather than \"completed\".",
+            "value": "yes",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products\/woocommerce_downloads_grant_access_after_payment"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/settings\/products"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 /* Begin PBXFileReference section */
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.debug.xcconfig"; sourceTree = "<group>"; };
+		74159626224D5644003C21CF /* Model 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 13.xcdatamodel"; sourceTree = "<group>"; };
 		7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCoupon+CoreDataClass.swift"; sourceTree = "<group>"; };
 		7426A04F20F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCoupon+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7426A05220F69DA4002A4E07 /* OrderItem+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItem+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -957,6 +958,7 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				74159626224D5644003C21CF /* Model 13.xcdatamodel */,
 				D82A61EF2239EB9900335D40 /* Model 12.xcdatamodel */,
 				CE3B7ACF2225E5CE0050FE4B /* Model 11.xcdatamodel */,
 				9302E3A7220DC69400DA5018 /* Model 10.xcdatamodel */,
@@ -970,7 +972,7 @@
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = D82A61EF2239EB9900335D40 /* Model 12.xcdatamodel */;
+			currentVersion = 74159626224D5644003C21CF /* Model 13.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,10 @@
 
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 13 (Release 1.6.0.0)
+- @bummytime 2019-03-28
+    - Added  `settingGroupKey` attribute on `SiteSetting` entity
+
 ## Model 12 (Release 1.5.0.0)
 - @bummytime 2019-03-20
     - New `Product` entity

--- a/Storage/Storage/Model/SiteSetting+CoreDataProperties.swift
+++ b/Storage/Storage/Model/SiteSetting+CoreDataProperties.swift
@@ -13,5 +13,5 @@ extension SiteSetting {
     @NSManaged public var label: String?
     @NSManaged public var settingDescription: String?
     @NSManaged public var value: String?
-
+    @NSManaged public var settingGroupKey: String?
 }

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 12.xcdatamodel</string>
+	<string>Model 13.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18E226" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="subtype" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timestamp" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="number" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem" syncable="YES"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote" syncable="YES"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults" syncable="YES"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="note" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String" syncable="YES"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderStats" representedClassName="OrderStats" syncable="YES">
+        <attribute name="averageGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageNetSales" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageOrders" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageProducts" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalNetSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderStatsItem" inverseName="stats" inverseEntity="OrderStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsItem" representedClassName="OrderStatsItem" syncable="YES">
+        <attribute name="avgOrderValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="avgProductsPerOrder" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="grossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="netSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShipping" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStats" inverseName="items" inverseEntity="OrderStats" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String" syncable="YES"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersKey" attributeType="String" syncable="YES"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="catalogVisibilityKey" attributeType="String" syncable="YES"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="permalink" attributeType="String" syncable="YES"/>
+        <attribute name="price" attributeType="String" syncable="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productTypeKey" attributeType="String" syncable="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="stockStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductCategory" inverseName="product" inverseEntity="ProductCategory" syncable="YES"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute" syncable="YES"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions" syncable="YES"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage" syncable="YES"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag" syncable="YES"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="categories" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String" syncable="YES"/>
+        <attribute name="length" attributeType="String" syncable="YES"/>
+        <attribute name="width" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="src" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="trackingID" attributeType="String" syncable="YES"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider" syncable="YES"/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="plan" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="limit" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
+        <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
+        <element name="Order" positionX="-20" positionY="27" width="128" height="720"/>
+        <element name="OrderCoupon" positionX="-206.01953125" positionY="379.74609375" width="128" height="120"/>
+        <element name="OrderItem" positionX="-364.890625" positionY="379.453125" width="128" height="240"/>
+        <element name="OrderNote" positionX="-365.16796875" positionY="630.2109375" width="128" height="135"/>
+        <element name="OrderSearchResults" positionX="144.44140625" positionY="743.43359375" width="128" height="75"/>
+        <element name="OrderStats" positionX="137.859375" positionY="388.33203125" width="128" height="225"/>
+        <element name="OrderStatsItem" positionX="321.74609375" positionY="425.51171875" width="128" height="330"/>
+        <element name="OrderStatus" positionX="-29.671875" positionY="781.29296875" width="128" height="105"/>
+        <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="883"/>
+        <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
+        <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
+        <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
+        <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
+        <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
+        <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
+        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="150"/>
+        <element name="SiteSetting" positionX="-362.54296875" positionY="217.9921875" width="128" height="135"/>
+        <element name="SiteVisitStats" positionX="134.515625" positionY="224.62109375" width="128" height="90"/>
+        <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
+        <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
+        <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+    </elements>
+</model>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -97,9 +97,9 @@ public extension StorageType {
         return firstObject(ofType: OrderStatus.self, matching: predicate)
     }
 
-    /// Retrieves all of the Stored SiteSettings for the provided siteID.
+    /// Retrieves **all** of the Stored SiteSettings for the provided siteID.
     ///
-    public func loadSiteSettings(siteID: Int) -> [SiteSetting]? {
+    public func loadAllSiteSettings(siteID: Int) -> [SiteSetting]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -97,13 +97,22 @@ public extension StorageType {
         return firstObject(ofType: OrderStatus.self, matching: predicate)
     }
 
-    /// Retrieves **all** of the Stored SiteSettings for the provided siteID.
+    /// Retrieves **all** of the stored SiteSettings for the provided siteID.
     ///
     public func loadAllSiteSettings(siteID: Int) -> [SiteSetting]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
     }
+
+    /// Retrieves stored SiteSettings for the provided siteID and settingGroupKey.
+    ///
+    public func loadSiteSettings(siteID: Int, settingGroupKey: String) -> [SiteSetting]? {
+        let predicate = NSPredicate(format: "siteID = %ld AND settingGroupKey ==[c] %@", siteID, settingGroupKey)
+        let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
+        return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
+    }
+
 
     /// Retrieves the Stored SiteSetting.
     ///

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -113,7 +113,6 @@ public extension StorageType {
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
     }
 
-
     /// Retrieves the Stored SiteSetting.
     ///
     public func loadSiteSetting(siteID: Int, settingID: String) -> SiteSetting? {

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -225,12 +225,19 @@ private extension StoresManager {
 
         CurrencySettings.shared.beginListeningToSiteSettingsUpdates()
 
-        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { error in
+        let generalSettingsAction = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { error in
             if let error = error {
                 DDLogError("⛔️ Could not successfully synchronize general settings for siteID \(siteID): \(error)")
             }
         }
-        dispatch(action)
+        dispatch(generalSettingsAction)
+
+        let productSettingsAction = SettingAction.synchronizeProductSiteSettings(siteID: siteID) { error in
+            if let error = error {
+                DDLogError("⛔️ Could not successfully synchronize product settings for siteID \(siteID): \(error)")
+            }
+        }
+        dispatch(productSettingsAction)
     }
 
     /// Synchronizes the order statuses, if possible.

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -225,9 +225,9 @@ private extension StoresManager {
 
         CurrencySettings.shared.beginListeningToSiteSettingsUpdates()
 
-        let action = SettingAction.retrieveSiteSettings(siteID: siteID) { error in
+        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { error in
             if let error = error {
-                DDLogError("⛔️ Could not successfully fetch settings for siteID \(siteID): \(error)")
+                DDLogError("⛔️ Could not successfully synchronize general settings for siteID \(siteID): \(error)")
             }
         }
         dispatch(action)

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -280,7 +280,7 @@ private extension StoresManager {
 
         restoreSessionSite(with: siteID)
         synchronizeSettings(with: siteID) {
-            CurrencySettings.shared.beginListeningToSiteSettingsUpdates()
+            CurrencySettings.shared.refresh()
         }
         retrieveOrderStatus(with: siteID)
     }

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -37,11 +37,16 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithSiteSettings() {
-        let wooCurrencyCode = SiteSetting(siteID: 1, settingID: "woocommerce_currency", label: "", description: "", value: "SHP")
-        let wooCurrencyPosition = SiteSetting(siteID: 1, settingID: "woocommerce_currency_pos", label: "", description: "", value: "right")
-        let thousandsSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_thousand_sep", label: "", description: "", value: "X")
-        let decimalSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_decimal_sep", label: "", description: "", value: "Y")
-        let numberOfDecimals = SiteSetting(siteID: 1, settingID: "woocommerce_price_num_decimals", label: "", description: "", value: "3")
+        let wooCurrencyCode = SiteSetting(siteID: 1, settingID: "woocommerce_currency", label: "", description: "",
+                                          value: "SHP", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let wooCurrencyPosition = SiteSetting(siteID: 1, settingID: "woocommerce_currency_pos", label: "", description: "",
+                                              value: "right", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let thousandsSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_thousand_sep", label: "", description: "",
+                                             value: "X", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let decimalSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_decimal_sep", label: "", description: "",
+                                           value: "Y", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let numberOfDecimals = SiteSetting(siteID: 1, settingID: "woocommerce_price_num_decimals", label: "", description: "",
+                                           value: "3", settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let siteSettings = [wooCurrencyCode, wooCurrencyPosition, thousandsSeparator, decimalSeparator, numberOfDecimals]
         let moneyFormat = CurrencySettings(siteSettings: siteSettings)
@@ -54,10 +59,14 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithIncompleteSiteSettings() {
-        let wooCurrencyCode = SiteSetting(siteID: 1, settingID: "woocommerce_currency", label: "", description: "", value: "SHP")
-        let wooCurrencyPosition = SiteSetting(siteID: 1, settingID: "woocommerce_currency_pos", label: "", description: "", value: "right")
-        let thousandsSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_thousand_sep", label: "", description: "", value: "X")
-        let decimalSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_decimal_sep", label: "", description: "", value: "Y")
+        let wooCurrencyCode = SiteSetting(siteID: 1, settingID: "woocommerce_currency", label: "", description: "",
+                                          value: "SHP", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let wooCurrencyPosition = SiteSetting(siteID: 1, settingID: "woocommerce_currency_pos", label: "", description: "",
+                                              value: "right", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let thousandsSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_thousand_sep", label: "", description: "",
+                                             value: "X", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let decimalSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_decimal_sep", label: "", description: "",
+                                           value: "Y", settingGroupKey: SiteSettingGroup.general.rawValue)
         // Missing number of decimals; should default to MoneyFormatSettings()
 
         let siteSettings = [wooCurrencyCode, wooCurrencyPosition, thousandsSeparator, decimalSeparator]

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -2,9 +2,19 @@ import Foundation
 import Networking
 
 
-// MARK: - SettingAction: Defines all of the Actions supported by the SettingStore.
-//
+/// SettingAction: Defines all of the Actions supported by the SettingStore.
+///
 public enum SettingAction: Action {
-    case retrieveSiteSettings(siteID: Int, onCompletion: (Error?) -> Void)
+
+    /// Synchronizes the site's general settings
+    ///
+    case synchronizeGeneralSiteSettings(siteID: Int, onCompletion: (Error?) -> Void)
+
+    /// Synchronizes the site's product settings
+    ///
+    case synchronizeProductSiteSettings(siteID: Int, onCompletion: (Error?) -> Void)
+
+    /// Retrieves the site API details (used to determine the WC version)
+    ///
     case retrieveSiteAPI(siteID: Int, onCompletion: (SiteAPI?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -40,6 +40,7 @@ public typealias ShipmentTrackingProviderGroup = Networking.ShipmentTrackingProv
 public typealias Site = Networking.Site
 public typealias SiteAPI = Networking.SiteAPI
 public typealias SiteSetting = Networking.SiteSetting
+public typealias SiteSettingGroup = Networking.SiteSettingGroup
 public typealias SiteVisitStats = Networking.SiteVisitStats
 public typealias SiteVisitStatsItem = Networking.SiteVisitStatsItem
 public typealias TopEarnerStats = Networking.TopEarnerStats

--- a/Yosemite/Yosemite/Model/ReadOnly/SiteSetting+ReadOnlyType.swift
+++ b/Yosemite/Yosemite/Model/ReadOnly/SiteSetting+ReadOnlyType.swift
@@ -14,6 +14,7 @@ extension Yosemite.SiteSetting: ReadOnlyType {
         }
 
         return siteID == Int(storageSiteSiteSetting.siteID) &&
-            storageSiteSiteSetting.settingID == settingID
+            storageSiteSiteSetting.settingID == settingID &&
+            storageSiteSiteSetting.settingGroupKey == settingGroupKey
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
@@ -23,6 +23,7 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
                            settingID: settingID ?? "",
                            label: label ?? "",
                            description: settingDescription ?? "",
-                           value: value ?? "")
+                           value: value ?? "",
+                           settingGroupKey: "") // FIXME: Add the setting group here
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
@@ -14,6 +14,7 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
         label = setting.label
         settingDescription = setting.settingDescription
         value = setting.value
+        settingGroupKey = setting.settingGroupKey
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -24,6 +25,6 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
                            label: label ?? "",
                            description: settingDescription ?? "",
                            value: value ?? "",
-                           settingGroupKey: "") // FIXME: Add the setting group here
+                           settingGroupKey: settingGroupKey ?? SiteSettingGroup.general.rawValue) // Default to general group
     }
 }

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -22,8 +22,10 @@ public class SettingStore: Store {
         }
 
         switch action {
-        case .retrieveSiteSettings(let siteID, let onCompletion):
-            retrieveSiteSettings(siteID: siteID, onCompletion: onCompletion)
+        case .synchronizeGeneralSiteSettings(let siteID, let onCompletion):
+            synchronizeGeneralSiteSettings(siteID: siteID, onCompletion: onCompletion)
+        case .synchronizeProductSiteSettings(let siteID, let onCompletion):
+            synchronizeProductSiteSettings(siteID: siteID, onCompletion: onCompletion)
         case .retrieveSiteAPI(let siteID, let onCompletion):
             retrieveSiteAPI(siteID: siteID, onCompletion: onCompletion)
         }
@@ -35,9 +37,9 @@ public class SettingStore: Store {
 //
 private extension SettingStore {
 
-    /// Retrieves the site settings associated with the provided Site ID (if any!).
+    /// Synchronizes the general site settings associated with the provided Site ID (if any!).
     ///
-    func retrieveSiteSettings(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeGeneralSiteSettings(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = SiteSettingsRemote(network: network)
         remote.loadGeneralSettings(for: siteID) { [weak self] (settings, error) in
             guard let settings = settings else {
@@ -45,13 +47,28 @@ private extension SettingStore {
                 return
             }
 
-            self?.upsertStoredSiteSettings(siteID: siteID, readOnlySiteSettings: settings)
+            self?.upsertStoredGeneralSiteSettings(siteID: siteID, readOnlySiteSettings: settings)
+            onCompletion(nil)
+        }
+    }
+
+    /// Synchronizes the product site settings associated with the provided Site ID (if any!).
+    ///
+    func synchronizeProductSiteSettings(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
+        let remote = SiteSettingsRemote(network: network)
+        remote.loadProductSettings(for: siteID) { [weak self] (settings, error) in
+            guard let settings = settings else {
+                onCompletion(error)
+                return
+            }
+
+            self?.upsertStoredProductSiteSettings(siteID: siteID, readOnlySiteSettings: settings)
             onCompletion(nil)
         }
     }
 
     /// Retrieves the site API information associated with the provided Site ID (if any!).
-    /// This call does NOT persist anything in the Storage layer.
+    /// This call does NOT persist returned data into the Storage layer.
     ///
     func retrieveSiteAPI(siteID: Int, onCompletion: @escaping (SiteAPI?, Error?) -> Void) {
         let remote = SiteAPIRemote(network: network)
@@ -66,9 +83,37 @@ private extension SettingStore {
 //
 extension SettingStore {
 
-    /// Updates (OR Inserts) the specified ReadOnly SiteSetting Entities into the Storage Layer.
+    /// Updates (OR Inserts) the specified general ReadOnly SiteSetting Entities into the Storage Layer.
     ///
-    func upsertStoredSiteSettings(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting]) {
+    func upsertStoredGeneralSiteSettings(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting]) {
+        assert(Thread.isMainThread)
+        let storage = storageManager.viewStorage
+
+        // Upsert the settings from the read-only site settings
+        for readOnlyItem in readOnlySiteSettings {
+            if let existingStorageItem = storage.loadSiteSetting(siteID: siteID, settingID: readOnlyItem.settingID) {
+                existingStorageItem.update(with: readOnlyItem)
+            } else {
+                let newStorageItem = storage.insertNewObject(ofType: Storage.SiteSetting.self)
+                newStorageItem.update(with: readOnlyItem)
+            }
+        }
+
+        // Now, remove any objects that exist in storageSiteSettings but not in readOnlySiteSettings
+        if let storageSiteSettings = storage.loadSiteSettings(siteID: siteID) {
+            storageSiteSettings.forEach({ storageItem in
+                if readOnlySiteSettings.first(where: { $0.settingID == storageItem.settingID } ) == nil {
+                    storage.deleteObject(storageItem)
+                }
+            })
+        }
+
+        storage.saveIfNeeded()
+    }
+
+    /// Updates (OR Inserts) the specified product ReadOnly SiteSetting Entities into the Storage Layer.
+    ///
+    func upsertStoredProductSiteSettings(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting]) {
         assert(Thread.isMainThread)
         let storage = storageManager.viewStorage
 

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -116,9 +116,8 @@ private extension SettingStore {
             }
         }
 
-        // Now, remove any objects that exist in storageSiteSettings but not in readOnlySiteSettings
-        // FIXME: 🚨 Only fetch/prune the general settings! 🚨
-        if let storageSiteSettings = storage.loadAllSiteSettings(siteID: siteID) {
+        // Now, remove any objects that exist in (general) storageSiteSettings but not in readOnlySiteSettings
+        if let storageSiteSettings = storage.loadSiteSettings(siteID: siteID, settingGroupKey: SiteSettingGroup.general.rawValue) {
             storageSiteSettings.forEach({ storageItem in
                 if readOnlySiteSettings.first(where: { $0.settingID == storageItem.settingID } ) == nil {
                     storage.deleteObject(storageItem)
@@ -154,9 +153,8 @@ private extension SettingStore {
             }
         }
 
-        // Now, remove any objects that exist in storageSiteSettings but not in readOnlySiteSettings
-        // FIXME: 🚨 Only fetch/prune the product settings! 🚨
-        if let storageSiteSettings = storage.loadAllSiteSettings(siteID: siteID) {
+        // Now, remove any objects that exist in (product) storageSiteSettings but not in readOnlySiteSettings
+        if let storageSiteSettings = storage.loadSiteSettings(siteID: siteID, settingGroupKey: SiteSettingGroup.product.rawValue) {
             storageSiteSettings.forEach({ storageItem in
                 if readOnlySiteSettings.first(where: { $0.settingID == storageItem.settingID } ) == nil {
                     storage.deleteObject(storageItem)

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -156,4 +156,3 @@ extension SettingStore {
         upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
     }
 }
-

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -41,7 +41,6 @@ class SettingStoreTests: XCTestCase {
 
     // MARK: - SettingAction.synchronizeGeneralSiteSettings
 
-
     /// Verifies that `SettingAction.synchronizeGeneralSiteSettings` effectively persists any retrieved SiteSettings.
     ///
     func testRetrieveSiteSettingsEffectivelyPersistsRetrievedSettings() {
@@ -75,7 +74,9 @@ class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
 
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "settings-general-alt")
@@ -126,6 +127,9 @@ class SettingStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+
+    // MARK: - SettingStore.upsertStoredGeneralSiteSettings
+
     /// Verifies that `upsertStoredGeneralSiteSettings` effectively inserts a new SiteSetting, with the specified payload.
     ///
     func testUpsertStoredSiteSettingsEffectivelyPersistsNewSiteSettings() {
@@ -133,9 +137,9 @@ class SettingStoreTests: XCTestCase {
         let remoteSiteSettings = [sampleSiteSetting(), sampleSiteSetting2()].sorted()
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()], in: viewStorage)
 
-        let storageSiteSettings = viewStorage.loadSiteSettings(siteID: sampleSiteID)
+        let storageSiteSettings = viewStorage.loadAllSiteSettings(siteID: sampleSiteID)
         XCTAssertNotNil(storageSiteSettings)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
         XCTAssertEqual(storageSiteSettings?.map({ $0.toReadOnly() }).sorted(), remoteSiteSettings)
@@ -147,13 +151,21 @@ class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSetting()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 1)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSettingMutated()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSettingMutated()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 1)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSettingMutated(), sampleSiteSetting2()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSettingMutated(), sampleSiteSetting2()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSettingMutated(), sampleSiteSetting2Mutated()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSettingMutated(), sampleSiteSetting2Mutated()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
 
         let expectedSiteSetting = sampleSiteSettingMutated()
@@ -171,9 +183,13 @@ class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting2Mutated()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSetting2Mutated()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 1)
 
         let expectedSiteSetting = sampleSiteSetting2Mutated()
@@ -187,15 +203,18 @@ class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [])
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [],
+                                                     in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
     }
 
 
     // MARK: - SettingAction.retrieveSiteAPI
-
 
     /// Verifies that `SettingAction.retrieveSiteAPI` returns the expected API information.
     ///
@@ -272,7 +291,7 @@ class SettingStoreTests: XCTestCase {
 //
 private extension SettingStoreTests {
 
-    // MARK: - SiteSetting Samples
+    // MARK: - General SiteSetting Samples
 
     func sampleSiteSetting() -> Networking.SiteSetting {
         return SiteSetting(siteID: sampleSiteID,

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -54,11 +54,11 @@ class SettingStoreTests: XCTestCase {
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 20)
 
-            let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleSiteSetting().settingID)
-            XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleSiteSetting())
+            let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleGeneralSiteSetting().settingID)
+            XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleGeneralSiteSetting())
 
-            let readOnlySiteSetting2 = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleSiteSetting2().settingID)
-            XCTAssertEqual(readOnlySiteSetting2?.toReadOnly(), self.sampleSiteSetting2())
+            let readOnlySiteSetting2 = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleGeneralSiteSetting2().settingID)
+            XCTAssertEqual(readOnlySiteSetting2?.toReadOnly(), self.sampleGeneralSiteSetting2())
 
             expectation.fulfill()
         }
@@ -75,7 +75,7 @@ class SettingStoreTests: XCTestCase {
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSetting(), sampleGeneralSiteSetting2()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
 
@@ -84,11 +84,11 @@ class SettingStoreTests: XCTestCase {
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 20)
 
-            let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleSiteSetting().settingID)
-            XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleSiteSettingMutated())
+            let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleGeneralSiteSetting().settingID)
+            XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleGeneralSiteSettingMutated())
 
-            let readOnlySiteSetting2 = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleSiteSetting2().settingID)
-            XCTAssertEqual(readOnlySiteSetting2?.toReadOnly(), self.sampleSiteSetting2Mutated())
+            let readOnlySiteSetting2 = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleGeneralSiteSetting2().settingID)
+            XCTAssertEqual(readOnlySiteSetting2?.toReadOnly(), self.sampleGeneralSiteSetting2Mutated())
             expectation.fulfill()
         }
 
@@ -134,10 +134,12 @@ class SettingStoreTests: XCTestCase {
     ///
     func testUpsertStoredSiteSettingsEffectivelyPersistsNewSiteSettings() {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let remoteSiteSettings = [sampleSiteSetting(), sampleSiteSetting2()].sorted()
+        let remoteSiteSettings = [sampleGeneralSiteSetting(), sampleGeneralSiteSetting2()].sorted()
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
-        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID, readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()], in: viewStorage)
+        settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleGeneralSiteSetting(), sampleGeneralSiteSetting2()],
+                                                     in: viewStorage)
 
         let storageSiteSettings = viewStorage.loadAllSiteSettings(siteID: sampleSiteID)
         XCTAssertNotNil(storageSiteSettings)
@@ -152,28 +154,28 @@ class SettingStoreTests: XCTestCase {
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSetting()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSetting()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 1)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSettingMutated()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSettingMutated()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 1)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSettingMutated(), sampleSiteSetting2()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSettingMutated(), sampleGeneralSiteSetting2()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSettingMutated(), sampleSiteSetting2Mutated()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSettingMutated(), sampleGeneralSiteSetting2Mutated()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
 
-        let expectedSiteSetting = sampleSiteSettingMutated()
-        let storageSiteSetting = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: sampleSiteSettingMutated().settingID)
+        let expectedSiteSetting = sampleGeneralSiteSettingMutated()
+        let storageSiteSetting = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: sampleGeneralSiteSettingMutated().settingID)
         XCTAssertEqual(storageSiteSetting?.toReadOnly(), expectedSiteSetting)
 
-        let expectedSiteSetting2 = sampleSiteSetting2Mutated()
-        let storageSiteSetting2 = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: sampleSiteSetting2Mutated().settingID)
+        let expectedSiteSetting2 = sampleGeneralSiteSetting2Mutated()
+        let storageSiteSetting2 = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: sampleGeneralSiteSetting2Mutated().settingID)
         XCTAssertEqual(storageSiteSetting2?.toReadOnly(), expectedSiteSetting2)
     }
 
@@ -184,16 +186,16 @@ class SettingStoreTests: XCTestCase {
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSetting(), sampleGeneralSiteSetting2()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSetting2Mutated()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSetting2Mutated()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 1)
 
-        let expectedSiteSetting = sampleSiteSetting2Mutated()
-        let storageSiteSetting = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: sampleSiteSetting2Mutated().settingID)
+        let expectedSiteSetting = sampleGeneralSiteSetting2Mutated()
+        let storageSiteSetting = viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: sampleGeneralSiteSetting2Mutated().settingID)
         XCTAssertEqual(storageSiteSetting?.toReadOnly(), expectedSiteSetting)
     }
 
@@ -204,7 +206,7 @@ class SettingStoreTests: XCTestCase {
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
-                                                     readOnlySiteSettings: [sampleSiteSetting(), sampleSiteSetting2()],
+                                                     readOnlySiteSettings: [sampleGeneralSiteSetting(), sampleGeneralSiteSetting2()],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
         settingStore.upsertStoredGeneralSiteSettings(siteID: sampleSiteID,
@@ -293,36 +295,40 @@ private extension SettingStoreTests {
 
     // MARK: - General SiteSetting Samples
 
-    func sampleSiteSetting() -> Networking.SiteSetting {
+    func sampleGeneralSiteSetting() -> Networking.SiteSetting {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_currency",
                            label: "Currency",
                            description: "This controls what currency prices are listed at in the catalog and which currency gateways will take payments in.",
-                           value: "USD")
+                           value: "USD",
+                           settingGroupKey: SiteSettingGroup.general.rawValue)
     }
 
-    func sampleSiteSettingMutated() -> Networking.SiteSetting {
+    func sampleGeneralSiteSettingMutated() -> Networking.SiteSetting {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_currency",
                            label: "Currency!",
                            description: "This controls what currency prices are listed!",
-                           value: "GBP")
+                           value: "GBP",
+                           settingGroupKey: SiteSettingGroup.general.rawValue)
     }
 
-    func sampleSiteSetting2() -> Networking.SiteSetting {
+    func sampleGeneralSiteSetting2() -> Networking.SiteSetting {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_price_thousand_sep",
                            label: "Thousand separator",
                            description: "This sets the thousand separator of displayed prices.",
-                           value: ",")
+                           value: ",",
+                           settingGroupKey: SiteSettingGroup.general.rawValue)
     }
 
-    func sampleSiteSetting2Mutated() -> Networking.SiteSetting {
+    func sampleGeneralSiteSetting2Mutated() -> Networking.SiteSetting {
         return SiteSetting(siteID: sampleSiteID,
                            settingID: "woocommerce_price_thousand_sep",
                            label: "Thousand separator!!",
                            description: "This sets the thousand separator!!",
-                           value: "~")
+                           value: "~",
+                           settingGroupKey: SiteSettingGroup.general.rawValue)
     }
 
     // MARK: - SiteAPI Samples

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -43,8 +43,8 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `SettingAction.synchronizeGeneralSiteSettings` effectively persists any retrieved SiteSettings.
     ///
-    func testRetrieveSiteSettingsEffectivelyPersistsRetrievedSettings() {
-        let expectation = self.expectation(description: "Persist site settings")
+    func testRetrieveGerneralSiteSettingsEffectivelyPersistsRetrievedSettings() {
+        let expectation = self.expectation(description: "Persist general site settings")
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "settings-general")
@@ -69,8 +69,8 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `SettingAction.synchronizeGeneralSiteSettings` effectively persists any updated SiteSettings.
     ///
-    func testRetrieveSiteSettingsEffectivelyPersistsUpdatedSettings() {
-        let expectation = self.expectation(description: "Persist updated site settings")
+    func testRetrieveGeneralSiteSettingsEffectivelyPersistsUpdatedSettings() {
+        let expectation = self.expectation(description: "Persist updated general site settings")
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
@@ -82,7 +82,7 @@ class SettingStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "settings-general-alt")
         let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { (error) in
             XCTAssertNil(error)
-            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 20)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 19)
 
             let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleGeneralSiteSetting().settingID)
             XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleGeneralSiteSettingMutated())
@@ -98,8 +98,8 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `SettingAction.synchronizeGeneralSiteSettings` returns an error whenever there is an error response from the backend.
     ///
-    func testRetrieveSiteSettingsReturnsErrorUponReponseError() {
-        let expectation = self.expectation(description: "Retrieve site settings error response")
+    func testRetrieveGeneralSiteSettingsReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve general site settings error response")
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "generic_error")
@@ -114,8 +114,8 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `SettingAction.synchronizeGeneralSiteSettings` returns an error whenever there is no backend response.
     ///
-    func testRetrieveSiteSettingsReturnsErrorUponEmptyResponse() {
-        let expectation = self.expectation(description: "Retrieve site settings empty response")
+    func testRetrieveGeneralSiteSettingsReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve general site settings empty response")
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { (error) in
@@ -132,7 +132,7 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `upsertStoredGeneralSiteSettings` effectively inserts a new SiteSetting, with the specified payload.
     ///
-    func testUpsertStoredSiteSettingsEffectivelyPersistsNewSiteSettings() {
+    func testUpsertStoredGeneralSiteSettingsEffectivelyPersistsNewSiteSettings() {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let remoteSiteSettings = [sampleGeneralSiteSetting(), sampleGeneralSiteSetting2()].sorted()
 
@@ -149,7 +149,7 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `upsertStoredGeneralSiteSettings` does not produce duplicate entries.
     ///
-    func testUpsertStoredSiteSettingsEffectivelyUpdatesPreexistantSiteSettings() {
+    func testUpsertStoredGeneralSiteSettingsEffectivelyUpdatesPreexistantSiteSettings() {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
@@ -181,7 +181,7 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `upsertStoredGeneralSiteSettings` removes previously stored SiteSettings correctly.
     ///
-    func testUpsertStoredSiteSettingsEffectivelyRemovesInvalidSiteSettings() {
+    func testUpsertStoredGeneralSiteSettingsEffectivelyRemovesInvalidSiteSettings() {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
@@ -201,7 +201,7 @@ class SettingStoreTests: XCTestCase {
 
     /// Verifies that `upsertStoredGeneralSiteSettings` removes previously stored SiteSettings correctly if an empty read-only array is passed in.
     ///
-    func testUpsertStoredSiteSettingsEffectivelyRemovesSiteSettings() {
+    func testUpsertStoredGeneralSiteSettingsEffectivelyRemovesSiteSettings() {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
@@ -213,6 +213,95 @@ class SettingStoreTests: XCTestCase {
                                                      readOnlySiteSettings: [],
                                                      in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
+    }
+
+
+    // MARK: - SettingAction.synchronizeProductSiteSettings
+
+    /// Verifies that `SettingAction.synchronizeProductSiteSettings` effectively persists any retrieved SiteSettings.
+    ///
+    func testRetrieveProductSiteSettingsEffectivelyPersistsRetrievedSettings() {
+        let expectation = self.expectation(description: "Persist product site settings")
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "settings/products", filename: "settings-product")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
+
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+            XCTAssertNil(error)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 23)
+
+            let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleProductSiteSetting().settingID)
+            XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleProductSiteSetting())
+
+            let readOnlySiteSetting2 = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleProductSiteSetting2().settingID)
+            XCTAssertEqual(readOnlySiteSetting2?.toReadOnly(), self.sampleProductSiteSetting2())
+
+            expectation.fulfill()
+        }
+
+        settingStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `SettingAction.synchronizeProductSiteSettings` effectively persists any updated SiteSettings.
+    ///
+    func testRetrieveProductSiteSettingsEffectivelyPersistsUpdatedSettings() {
+        let expectation = self.expectation(description: "Persist updated product site settings")
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
+        settingStore.upsertStoredProductSiteSettings(siteID: sampleSiteID,
+                                                     readOnlySiteSettings: [sampleProductSiteSetting(), sampleProductSiteSetting2()],
+                                                     in: viewStorage)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
+
+        network.simulateResponse(requestUrlSuffix: "settings/products", filename: "settings-product-alt")
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+            XCTAssertNil(error)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 22)
+
+            let readOnlySiteSetting = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleProductSiteSetting().settingID)
+            XCTAssertEqual(readOnlySiteSetting?.toReadOnly(), self.sampleProductSiteSettingMutated())
+
+            let readOnlySiteSetting2 = self.viewStorage.loadSiteSetting(siteID: self.sampleSiteID, settingID: self.sampleProductSiteSetting2().settingID)
+            XCTAssertEqual(readOnlySiteSetting2?.toReadOnly(), self.sampleProductSiteSetting2Mutated())
+            expectation.fulfill()
+        }
+
+        settingStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `SettingAction.synchronizeProductSiteSettings` returns an error whenever there is an error response from the backend.
+    ///
+    func testRetrieveProductSiteSettingsReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve product site settings error response")
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "settings/products", filename: "generic_error")
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        settingStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `SettingAction.synchronizeProductSiteSettings` returns an error whenever there is no backend response.
+    ///
+    func testRetrieveProductSiteSettingsReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve product site settings empty response")
+        let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        settingStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
 
@@ -329,6 +418,44 @@ private extension SettingStoreTests {
                            description: "This sets the thousand separator!!",
                            value: "~",
                            settingGroupKey: SiteSettingGroup.general.rawValue)
+    }
+
+    // MARK: - Product SiteSetting Samples
+
+    func sampleProductSiteSetting() -> Networking.SiteSetting {
+        return SiteSetting(siteID: sampleSiteID,
+                           settingID: "woocommerce_dimension_unit",
+                           label: "Dimensions unit",
+                           description: "This controls what unit you will define lengths in.",
+                           value: "m",
+                           settingGroupKey: SiteSettingGroup.product.rawValue)
+    }
+
+    func sampleProductSiteSettingMutated() -> Networking.SiteSetting {
+        return SiteSetting(siteID: sampleSiteID,
+                           settingID: "woocommerce_dimension_unit",
+                           label: "Dimension Fruit",
+                           description: "This controls what fruit you will define lengths in.",
+                           value: "Kumquat",
+                           settingGroupKey: SiteSettingGroup.product.rawValue)
+    }
+
+    func sampleProductSiteSetting2() -> Networking.SiteSetting {
+        return SiteSetting(siteID: sampleSiteID,
+                           settingID: "woocommerce_weight_unit",
+                           label: "Weight unit",
+                           description: "This controls what unit you will define weights in.",
+                           value: "kg",
+                           settingGroupKey: SiteSettingGroup.product.rawValue)
+    }
+
+    func sampleProductSiteSetting2Mutated() -> Networking.SiteSetting {
+        return SiteSetting(siteID: sampleSiteID,
+                           settingID: "woocommerce_weight_unit",
+                           label: "Animal unit",
+                           description: "This controls what animal you will define weights in.",
+                           value: "elephants",
+                           settingGroupKey: SiteSettingGroup.product.rawValue)
     }
 
     // MARK: - SiteAPI Samples


### PR DESCRIPTION
This PR updates the `SiteSettings` logic to now also download + cache the **product** settings values from the API. We were previously only fetching general settings, but now need the product settings so we can display the appropriate weight and length labels on the Product Details screen.

First off, please don't be scared by the diff size here 😄 The bulk of the changes (~1778 lines of 2,062) are the result of new test JSON files, XCode-generated updates to `WooCommerce.xcdatamodeld`, and boilerplate tests. Additionally, this is basically an all-or-nothing kind of change. Let me walk you through everything going on here:

### Networking
* A new `SiteSettingGroup` enum was added to the models
* `SiteSetting` has a new prop → `SiteSettingGroup` (used to classify a setting...right now it's just product and general)
* `SiteSettingsMapper` now requires a`SiteSettingGroup` during `init()`
* `SiteSettingsRemote` has a new `loadProductSettings` func
* Unit test additions (boilerplate)

### Storage
**There is a new CD model in this PR → v13**. The only change here is the addition of an optional `settingGroupKey` attribute on the existing `SiteSetting` entity. 

### Yosemite
* `SettingAction` and `SettingStore` now support fetching product _and_ general settings
* `StoresManager.synchronizeSettings()` has been lightly refactored to accommodate fetching multiple setting groups.
* Typical updates to `SiteSetting+ReadOnlyConvertible` and `SiteSetting+ReadOnlyType.swift`
* Unit test additions (boilerplate)

### WooCommerce
The only update in the app is to `CurrencySettings` in order to accommodate the new setting groups **and** also adding a `predicate` to the `resultsController` so we are fetching the correct store's settings (I think this was an undiscovered 🐛).

Fixes #807 

## Testing
* Review the updated code mentioned in the section above ☝️ 
* Make sure all of the unit tests are ✅ 
* Verify migrating from the `v12` to `v13` model is ✅  (this is a lightweight migration)
* Build and run the app:
    * Log out/in — verify the current store's currency settings are still fetched and applied correctly. 
    * Switch stores — verify the current store's currency settings are still fetched and applied correctly.
    * Using a SQLite browser verify the `SiteSetting` table contains `product` or `general` groups for each record.

