### PR TITLE
Don't track stats loaded events if user is not authed

### DIFF
--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -44,7 +44,6 @@ class RequirementsChecker {
     ///
     static func checkMinimumWooVersionForDefaultStore() {
         guard StoresManager.shared.isAuthenticated else {
-            DDLogWarn("⚠️ Cannot check WC version on default store — user is not authenticated.")
             return
         }
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID, siteID != 0 else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -80,7 +80,7 @@ extension StoreStatsViewController {
                     DDLogError("⛔️ Error synchronizing order stats: \(error)")
                     syncError = error
                 } else {
-                    self?.trackStatsLoaded(for: vc.granularity.rawValue)
+                    self?.trackStatsLoaded(for: vc.granularity)
                 }
                 group.leave()
             }
@@ -195,7 +195,6 @@ private extension StoreStatsViewController {
 
     func syncVisitorStats(for granularity: StatGranularity, onCompletion: ((Error?) -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
-            DDLogWarn("⚠️ Tried to sync order stats without a current defaultStoreID")
             onCompletion?(nil)
             return
         }
@@ -214,7 +213,6 @@ private extension StoreStatsViewController {
 
     func syncOrderStats(for granularity: StatGranularity, onCompletion: ((Error?) -> Void)? = nil) {
         guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
-            DDLogWarn("⚠️ Tried to sync order stats without a current defaultStoreID")
             onCompletion?(nil)
             return
         }
@@ -254,15 +252,12 @@ private extension StoreStatsViewController {
         }
     }
 
-    func trackStatsLoaded(for granularityString: String) {
+    func trackStatsLoaded(for granularity: StatGranularity) {
         guard StoresManager.shared.isAuthenticated else {
             return
         }
-        guard granularityString.isEmpty == false else {
-            return
-        }
 
-        WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularityString])
+        WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -75,12 +75,12 @@ extension StoreStatsViewController {
         periodVCs.forEach { (vc) in
             group.enter()
 
-            syncOrderStats(for: vc.granularity) { error in
+            syncOrderStats(for: vc.granularity) { [weak self] error in
                 if let error = error {
                     DDLogError("⛔️ Error synchronizing order stats: \(error)")
                     syncError = error
                 } else {
-                    WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": vc.granularity.rawValue])
+                    self?.trackStatsLoaded(for: vc.granularity.rawValue)
                 }
                 group.leave()
             }
@@ -252,6 +252,17 @@ private extension StoreStatsViewController {
         case .year:
             return Constants.quantityDefaultForYear
         }
+    }
+
+    func trackStatsLoaded(for granularityString: String) {
+        guard StoresManager.shared.isAuthenticated else {
+            return
+        }
+        guard granularityString.isEmpty == false else {
+            return
+        }
+
+        WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularityString])
     }
 }
 


### PR DESCRIPTION
Just a tiny PR to clean up tracking for stats data loads. In short, if the user is not auth'ed, don't send the tracks events.

Events fired on a clean install, now look like this:

![clean_stats](https://user-images.githubusercontent.com/154014/55257152-060c8300-522d-11e9-96ff-9c873821174a.gif)

Fixes: #822 

## Testing

1. In the dev console, filter log activity to 🔵 Tracked
2. Launch a fresh install
3. Verify you don't see anything like this in the console:

```
2019-03-28 14:29:46.365205-0500 WooCommerce[35547:37317216] 🔵 Tracked dashboard_main_stats_loaded, properties: [AnyHashable("granularity"): "day"]
2019-03-28 14:29:46.366467-0500 WooCommerce[35547:37317215] 🔵 Tracked dashboard_main_stats_loaded, properties: [AnyHashable("granularity"): "week"]
2019-03-28 14:29:46.367760-0500 WooCommerce[35547:37317190] 🔵 Tracked dashboard_main_stats_loaded, properties: [AnyHashable("granularity"): "month"]
2019-03-28 14:29:46.368957-0500 WooCommerce[35547:37317190] 🔵 Tracked dashboard_main_stats_loaded, properties: [AnyHashable("granularity"): "year"]
```

@astralbodies would you mind giving this a quick 👀 ?