### PR TITLE
Product Variations Mark1: Storage Fun!

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -45,6 +45,14 @@
 		7499FA45221C7A60004EC0B4 /* ShipmentTracking+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7499FA43221C7A60004EC0B4 /* ShipmentTracking+CoreDataProperties.swift */; };
 		74B7D6AD20F90CBB002667AC /* OrderNote+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B7D6AB20F90CBB002667AC /* OrderNote+CoreDataClass.swift */; };
 		74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B7D6AC20F90CBB002667AC /* OrderNote+CoreDataProperties.swift */; };
+		74E218F22252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E218EE2252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataClass.swift */; };
+		74E218F32252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E218EF2252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataProperties.swift */; };
+		74E218F42252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E218F02252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataClass.swift */; };
+		74E218F52252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E218F12252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataProperties.swift */; };
+		74E218F72252BB7800E4B0D7 /* ProductVariation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E218F62252BB7800E4B0D7 /* ProductVariation+CoreDataProperties.swift */; };
+		74E218F92252BB9E00E4B0D7 /* ProductVariation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E218F82252BB9E00E4B0D7 /* ProductVariation+CoreDataClass.swift */; };
+		74ED52332252EF2C0076D28E /* ProductVariationImage+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74ED52312252EF2C0076D28E /* ProductVariationImage+CoreDataClass.swift */; };
+		74ED52342252EF2C0076D28E /* ProductVariationImage+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74ED52322252EF2C0076D28E /* ProductVariationImage+CoreDataProperties.swift */; };
 		74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F009BE2183B99B002B4566 /* Note+CoreDataClass.swift */; };
 		74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F009BF2183B99B002B4566 /* Note+CoreDataProperties.swift */; };
 		9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9302E3A5220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift */; };
@@ -141,6 +149,14 @@
 		74B053702153090F0068EB85 /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
 		74B7D6AB20F90CBB002667AC /* OrderNote+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderNote+CoreDataClass.swift"; sourceTree = "<group>"; };
 		74B7D6AC20F90CBB002667AC /* OrderNote+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderNote+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		74E218EE2252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationAttribute+CoreDataClass.swift"; sourceTree = "<group>"; };
+		74E218EF2252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationAttribute+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		74E218F02252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationDimensions+CoreDataClass.swift"; sourceTree = "<group>"; };
+		74E218F12252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationDimensions+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		74E218F62252BB7800E4B0D7 /* ProductVariation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		74E218F82252BB9E00E4B0D7 /* ProductVariation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataClass.swift"; sourceTree = "<group>"; };
+		74ED52312252EF2C0076D28E /* ProductVariationImage+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationImage+CoreDataClass.swift"; sourceTree = "<group>"; };
+		74ED52322252EF2C0076D28E /* ProductVariationImage+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationImage+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		74F009BE2183B99B002B4566 /* Note+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+CoreDataClass.swift"; sourceTree = "<group>"; };
 		74F009BF2183B99B002B4566 /* Note+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Note+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7C81935EDD982072BBDCC837 /* Pods-Storage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.release.xcconfig"; sourceTree = "<group>"; };
@@ -397,6 +413,14 @@
 				747453942242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift */,
 				747453972242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift */,
 				747453982242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift */,
+				74E218F82252BB9E00E4B0D7 /* ProductVariation+CoreDataClass.swift */,
+				74E218F62252BB7800E4B0D7 /* ProductVariation+CoreDataProperties.swift */,
+				74E218EE2252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataClass.swift */,
+				74E218EF2252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataProperties.swift */,
+				74E218F02252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataClass.swift */,
+				74E218F12252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataProperties.swift */,
+				74ED52312252EF2C0076D28E /* ProductVariationImage+CoreDataClass.swift */,
+				74ED52322252EF2C0076D28E /* ProductVariationImage+CoreDataProperties.swift */,
 				747453992242C85E00E0B5EE /* ProductTag+CoreDataClass.swift */,
 				7474539A2242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift */,
 				7499FA42221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift */,
@@ -604,6 +628,8 @@
 			files = (
 				B5B914C520EFF03500F2F832 /* Site+CoreDataClass.swift in Sources */,
 				74938EC9216FA9B200540BA1 /* OrderStatsItem+CoreDataProperties.swift in Sources */,
+				74E218F42252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataClass.swift in Sources */,
+				74ED52332252EF2C0076D28E /* ProductVariationImage+CoreDataClass.swift in Sources */,
 				747453A02242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift in Sources */,
 				B54CA5BB20A4BD2800F38CD1 /* NSManagedObject+Object.swift in Sources */,
 				D821645D2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift in Sources */,
@@ -617,10 +643,12 @@
 				B505F6DB20BEEA3200BB1B69 /* Account+CoreDataClass.swift in Sources */,
 				7426A05520F69DA4002A4E07 /* OrderItem+CoreDataProperties.swift in Sources */,
 				747453A72242C85E00E0B5EE /* ProductTag+CoreDataClass.swift in Sources */,
+				74E218F52252BA8400E4B0D7 /* ProductVariationDimensions+CoreDataProperties.swift in Sources */,
 				74938EC8216FA9B200540BA1 /* OrderStatsItem+CoreDataClass.swift in Sources */,
 				747453A32242C85E00E0B5EE /* Product+CoreDataClass.swift in Sources */,
 				D821645B2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataClass.swift in Sources */,
 				D821645C2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataProperties.swift in Sources */,
+				74E218F92252BB9E00E4B0D7 /* ProductVariation+CoreDataClass.swift in Sources */,
 				7499FA45221C7A60004EC0B4 /* ShipmentTracking+CoreDataProperties.swift in Sources */,
 				B5FD111E21D4046E00560344 /* OrderSearchResults+CoreDataProperties.swift in Sources */,
 				7471A515216CF0FE00219F7E /* SiteVisitStatsItem+CoreDataProperties.swift in Sources */,
@@ -631,6 +659,7 @@
 				746A9D21214078080013F6FF /* TopEarnerStats+CoreDataClass.swift in Sources */,
 				74B7D6AD20F90CBB002667AC /* OrderNote+CoreDataClass.swift in Sources */,
 				B52B0F7920AA287C00477698 /* StorageManagerType.swift in Sources */,
+				74ED52342252EF2C0076D28E /* ProductVariationImage+CoreDataProperties.swift in Sources */,
 				7471A517216CF0FE00219F7E /* SiteVisitStats+CoreDataProperties.swift in Sources */,
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
@@ -640,6 +669,8 @@
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
 				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
+				74E218F32252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataProperties.swift in Sources */,
+				74E218F72252BB7800E4B0D7 /* ProductVariation+CoreDataProperties.swift in Sources */,
 				74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */,
 				CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */,
 				747453A62242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift in Sources */,
@@ -648,6 +679,7 @@
 				B505F6DA20BEEA3200BB1B69 /* Account+CoreDataProperties.swift in Sources */,
 				7474539E2242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift in Sources */,
 				CE3B7AD22225E62C0050FE4B /* OrderStatus+CoreDataClass.swift in Sources */,
+				74E218F22252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataClass.swift in Sources */,
 				74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */,
 				CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */,
 				7474539B2242C85E00E0B5EE /* ProductDimensions+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -5,6 +5,12 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 ## Model 13 (Release 1.6.0.0)
 - @bummytime 2019-03-28
     - Added  `settingGroupKey` attribute on `SiteSetting` entity
+    
+- @bummytime 2019-04-01
+    - New `ProductVariation` entity
+    - New `ProductVariationAttribute` entity
+    - New `ProductVariationDimensions` entity
+    - New `ProductVariationImage` entity
 
 ## Model 12 (Release 1.5.0.0)
 - @bummytime 2019-03-20

--- a/Storage/Storage/Model/ProductVariation+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductVariation+CoreDataClass.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+
+@objc(ProductVariation)
+public class ProductVariation: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
@@ -1,0 +1,65 @@
+import Foundation
+import CoreData
+
+
+extension ProductVariation {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductVariation> {
+        return NSFetchRequest<ProductVariation>(entityName: "ProductVariation")
+    }
+
+    @NSManaged public var siteID: Int64
+    @NSManaged public var variationID: Int64
+    @NSManaged public var productID: Int64
+
+    @NSManaged public var backordered: Bool
+    @NSManaged public var backordersAllowed: Bool
+    @NSManaged public var backordersKey: String
+    @NSManaged public var dateCreated: Date
+    @NSManaged public var dateModified: Date?
+    @NSManaged public var dateOnSaleFrom: Date?
+    @NSManaged public var dateOnSaleTo: Date?
+    @NSManaged public var downloadable: Bool
+    @NSManaged public var downloadExpiry: Int64
+    @NSManaged public var downloadLimit: Int64
+    @NSManaged public var fullDescription: String?
+    @NSManaged public var manageStock: Bool
+    @NSManaged public var menuOrder: Int64
+    @NSManaged public var onSale: Bool
+    @NSManaged public var permalink: String?
+    @NSManaged public var price: String
+    @NSManaged public var purchasable: Bool
+    @NSManaged public var regularPrice: String?
+    @NSManaged public var salePrice: String?
+    @NSManaged public var shippingClass: String
+    @NSManaged public var shippingClassID: String
+    @NSManaged public var sku: String?
+    @NSManaged public var statusKey: String?
+    @NSManaged public var stockQuantity: Int64
+    @NSManaged public var stockStatusKey: String?
+    @NSManaged public var taxClass: String?
+    @NSManaged public var taxStatusKey: String?
+    @NSManaged public var virtual: Bool
+    @NSManaged public var weight: String?
+
+    @NSManaged public var dimensions: ProductVariationDimensions?
+    @NSManaged public var image: ProductImage?
+    @NSManaged public var attributes: Set<ProductVariationAttribute>?
+}
+
+// MARK: Generated accessors for attributes
+extension ProductVariation {
+
+    @objc(addAttributesObject:)
+    @NSManaged public func addToAttributes(_ value: ProductVariationAttribute)
+
+    @objc(removeAttributesObject:)
+    @NSManaged public func removeFromAttributes(_ value: ProductVariationAttribute)
+
+    @objc(addAttributes:)
+    @NSManaged public func addToAttributes(_ values: NSSet)
+
+    @objc(removeAttributes:)
+    @NSManaged public func removeFromAttributes(_ values: NSSet)
+
+}

--- a/Storage/Storage/Model/ProductVariationAttribute+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductVariationAttribute+CoreDataClass.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+
+@objc(ProductVariationAttribute)
+public class ProductVariationAttribute: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductVariationAttribute+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariationAttribute+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+
+extension ProductVariationAttribute {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductVariationAttribute> {
+        return NSFetchRequest<ProductVariationAttribute>(entityName: "ProductVariationAttribute")
+    }
+
+    @NSManaged public var attributeID: Int64
+    @NSManaged public var name: String?
+    @NSManaged public var option: String?
+    @NSManaged public var productVariation: ProductVariation?
+
+}

--- a/Storage/Storage/Model/ProductVariationDimensions+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductVariationDimensions+CoreDataClass.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+
+@objc(ProductVariationDimensions)
+public class ProductVariationDimensions: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductVariationDimensions+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariationDimensions+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+
+extension ProductVariationDimensions {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductVariationDimensions> {
+        return NSFetchRequest<ProductVariationDimensions>(entityName: "ProductVariationDimensions")
+    }
+
+    @NSManaged public var height: String
+    @NSManaged public var width: String
+    @NSManaged public var length: String
+    @NSManaged public var productVariation: ProductVariation?
+
+}

--- a/Storage/Storage/Model/ProductVariationImage+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductVariationImage+CoreDataClass.swift
@@ -1,0 +1,8 @@
+import Foundation
+import CoreData
+
+
+@objc(ProductVariationImage)
+public class ProductVariationImage: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductVariationImage+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariationImage+CoreDataProperties.swift
@@ -1,0 +1,19 @@
+import Foundation
+import CoreData
+
+
+extension ProductVariationImage {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductVariationImage> {
+        return NSFetchRequest<ProductVariationImage>(entityName: "ProductVariationImage")
+    }
+
+    @NSManaged public var alt: String?
+    @NSManaged public var dateCreated: NSDate
+    @NSManaged public var dateModified: NSDate?
+    @NSManaged public var imageID: Int64
+    @NSManaged public var name: String?
+    @NSManaged public var src: String
+    @NSManaged public var productVariation: Product?
+
+}

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
@@ -273,7 +273,7 @@
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="statusKey" attributeType="String" syncable="YES"/>
-        <attribute name="stockQuantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="stockQuantity" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="stockStatusKey" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="taxStatusKey" optional="YES" attributeType="String" syncable="YES"/>
@@ -291,9 +291,9 @@
         <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation" syncable="YES"/>
     </entity>
     <entity name="ProductVariationDimensions" representedClassName="ProductVariationDimensions" syncable="YES">
-        <attribute name="height" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="length" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="width" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="height" attributeType="String" syncable="YES"/>
+        <attribute name="length" attributeType="String" syncable="YES"/>
+        <attribute name="width" attributeType="String" syncable="YES"/>
         <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation" syncable="YES"/>
     </entity>
     <entity name="ProductVariationImage" representedClassName="ProductImage" syncable="YES">
@@ -386,6 +386,10 @@
         <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
         <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
         <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
+        <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="570"/>
+        <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="103"/>
+        <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="105"/>
+        <element name="ProductVariationImage" positionX="-1308.1953125" positionY="324.6328125" width="156.37890625" height="148"/>
         <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
         <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
         <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
@@ -395,9 +399,5 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
-        <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="568"/>
-        <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="103"/>
-        <element name="ProductVariationImage" positionX="-1308.1953125" positionY="324.6328125" width="156.37890625" height="148"/>
-        <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="103"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
@@ -247,7 +247,7 @@
         <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
     </entity>
-    <entity name="ProductVariation" representedClassName="Product" syncable="YES">
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
         <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="backordersKey" attributeType="String" syncable="YES"/>
@@ -296,7 +296,7 @@
         <attribute name="width" attributeType="String" syncable="YES"/>
         <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation" syncable="YES"/>
     </entity>
-    <entity name="ProductVariationImage" representedClassName="ProductImage" syncable="YES">
+    <entity name="ProductVariationImage" representedClassName="ProductVariationImage" syncable="YES">
         <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -386,7 +386,7 @@
         <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
         <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
         <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
-        <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="570"/>
+        <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="568"/>
         <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="103"/>
         <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="105"/>
         <element name="ProductVariationImage" positionX="-1308.1953125" positionY="324.6328125" width="156.37890625" height="148"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
@@ -247,6 +247,64 @@
         <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
     </entity>
+    <entity name="ProductVariation" representedClassName="Product" syncable="YES" codeGenerationType="class">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersKey" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateOnSaleFrom" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateOnSaleTo" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="permalink" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" attributeType="String" syncable="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClass" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClassID" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="stockStatusKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxStatusKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariationAttribute" inverseName="productVariation" inverseEntity="ProductVariationAttribute" syncable="YES"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductVariationDimensions" inverseName="productVariation" inverseEntity="ProductVariationDimensions" syncable="YES"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductVariationImage" inverseName="productVariation" inverseEntity="ProductVariationImage" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariationAttribute" representedClassName="ProductVariationAttribute" syncable="YES" codeGenerationType="class">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariationDimensions" representedClassName="ProductVariationDimensions" syncable="YES" codeGenerationType="class">
+        <attribute name="height" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="length" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="width" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariationImage" representedClassName="ProductImage" syncable="YES" codeGenerationType="class">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="src" attributeType="String" syncable="YES"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation" syncable="YES"/>
+    </entity>
     <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
         <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
@@ -337,5 +395,9 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+        <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="568"/>
+        <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="105"/>
+        <element name="ProductVariationImage" positionX="-1308.1953125" positionY="324.6328125" width="156.37890625" height="148"/>
+        <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="105"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 13.xcdatamodel/contents
@@ -247,7 +247,7 @@
         <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
     </entity>
-    <entity name="ProductVariation" representedClassName="Product" syncable="YES" codeGenerationType="class">
+    <entity name="ProductVariation" representedClassName="Product" syncable="YES">
         <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="backordersKey" attributeType="String" syncable="YES"/>
@@ -284,19 +284,19 @@
         <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductVariationDimensions" inverseName="productVariation" inverseEntity="ProductVariationDimensions" syncable="YES"/>
         <relationship name="image" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductVariationImage" inverseName="productVariation" inverseEntity="ProductVariationImage" syncable="YES"/>
     </entity>
-    <entity name="ProductVariationAttribute" representedClassName="ProductVariationAttribute" syncable="YES" codeGenerationType="class">
+    <entity name="ProductVariationAttribute" representedClassName="ProductVariationAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation" syncable="YES"/>
     </entity>
-    <entity name="ProductVariationDimensions" representedClassName="ProductVariationDimensions" syncable="YES" codeGenerationType="class">
+    <entity name="ProductVariationDimensions" representedClassName="ProductVariationDimensions" syncable="YES">
         <attribute name="height" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="length" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="width" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation" syncable="YES"/>
     </entity>
-    <entity name="ProductVariationImage" representedClassName="ProductImage" syncable="YES" codeGenerationType="class">
+    <entity name="ProductVariationImage" representedClassName="ProductImage" syncable="YES">
         <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -396,8 +396,8 @@
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
         <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="568"/>
-        <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="105"/>
+        <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="103"/>
         <element name="ProductVariationImage" positionX="-1308.1953125" positionY="324.6328125" width="156.37890625" height="148"/>
-        <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="105"/>
+        <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="103"/>
     </elements>
 </model>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -232,4 +232,19 @@ public extension StorageType {
         let predicate = NSPredicate(format: "tagID = %ld", tagID)
         return firstObject(ofType: ProductTag.self, matching: predicate)
     }
+
+    /// Retrieves all of the stored ProductVariations for the provided siteID and productID.
+    ///
+    public func loadProductVariations(siteID: Int, productID: Int) -> [ProductVariation]? {
+        let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld", siteID, productID)
+        let descriptor = NSSortDescriptor(keyPath: \ProductVariation.variationID, ascending: false)
+        return allObjects(ofType: ProductVariation.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Retrieves a stored ProductVariation for the provided siteID, productID, and variationID.
+    ///
+    public func loadProductVariation(siteID: Int, productID: Int, variationID: Int) -> ProductVariation? {
+        let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld AND variationID = %ld", siteID, productID, variationID)
+        return firstObject(ofType: ProductVariation.self, matching: predicate)
+    }
 }


### PR DESCRIPTION
In this PR, `Storage` support for product variations is added:

<img width="501" alt="Screen Shot 2019-04-01 at 8 57 00 PM" src="https://user-images.githubusercontent.com/154014/55370749-2d7b7e00-54c1-11e9-9e82-3a1ed8545a2d.png">

Updates here specifically include:
* **updating (the unreleased) Core Data model v13**
* Adding the `ProductVariation`, `ProductVariationAttribute`, `ProductVariationDimensions`, and `ProductVariationImage` `NSMO` subclasses
* Implementing some helper lookup functions in `StorageType+Extensions.swift`

It should be mentioned that I did consider reusing the existing `Product*` entities. However variations & products are different enough that attempting to use a single set of models/entities/etc would most likely cause subtle bugs. So just like our Android brethren, I separated variations out into their own entities.

Partially addresses: #818 

## Testing

**Note:** If you already have model v13 installed, be sure to completely reset your simulator before testing this PR (Hardware → Erase all content and settings)

There is not really much to test here. I only updated the data model in order to keep the PR sizes smaller. 😆 I would suggest:

* Making sure the data model + NSMO subs look ok
* Attempt a migration between v12 and v13 data models
* Verify the unit tests are ✅ 
