### PR TITLE
Product Details: Update ProductStore to handle multiple sites better

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -198,8 +198,8 @@ public extension StorageType {
     ///
     /// Note: WC attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    public func loadProductAttribute(attributeID: Int, name: String) -> ProductAttribute? {
-        let predicate = NSPredicate(format: "attributeID = %ld AND name ==[c] %@", attributeID, name)
+    public func loadProductAttribute(siteID: Int, attributeID: Int, name: String) -> ProductAttribute? {
+        let predicate = NSPredicate(format: "product.siteID = %ld AND attributeID = %ld AND name ==[c] %@", siteID, attributeID, name)
         return firstObject(ofType: ProductAttribute.self, matching: predicate)
     }
 
@@ -207,29 +207,29 @@ public extension StorageType {
     ///
     /// Note: WC default attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    public func loadProductDefaultAttribute(defaultAttributeID: Int, name: String) -> ProductDefaultAttribute? {
-        let predicate = NSPredicate(format: "attributeID = %ld AND name ==[c] %@", defaultAttributeID, name)
+    public func loadProductDefaultAttribute(siteID: Int, defaultAttributeID: Int, name: String) -> ProductDefaultAttribute? {
+        let predicate = NSPredicate(format: "product.siteID = %ld AND attributeID = %ld AND name ==[c] %@", siteID, defaultAttributeID, name)
         return firstObject(ofType: ProductDefaultAttribute.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Image.
     ///
-    public func loadProductImage(imageID: Int) -> ProductImage? {
-        let predicate = NSPredicate(format: "imageID = %ld", imageID)
+    public func loadProductImage(siteID: Int, imageID: Int) -> ProductImage? {
+        let predicate = NSPredicate(format: "product.siteID = %ld AND imageID = %ld", siteID, imageID)
         return firstObject(ofType: ProductImage.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Category.
     ///
-    public func loadProductCategory(categoryID: Int) -> ProductCategory? {
-        let predicate = NSPredicate(format: "categoryID = %ld", categoryID)
+    public func loadProductCategory(siteID: Int, categoryID: Int) -> ProductCategory? {
+        let predicate = NSPredicate(format: "product.siteID = %ld AND categoryID = %ld", siteID, categoryID)
         return firstObject(ofType: ProductCategory.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Tag.
     ///
-    public func loadProductTag(tagID: Int) -> ProductTag? {
-        let predicate = NSPredicate(format: "tagID = %ld", tagID)
+    public func loadProductTag(siteID: Int, tagID: Int) -> ProductTag? {
+        let predicate = NSPredicate(format: "product.siteID = %ld AND tagID = %ld", siteID, tagID)
         return firstObject(ofType: ProductTag.self, matching: predicate)
     }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -96,6 +96,10 @@ private extension StorePickerCoordinator {
     func logOutOfCurrentStore(onCompletion: @escaping () -> Void) {
         StoresManager.shared.removeDefaultStore()
 
+        // Note: We are not deleting products here because products from multiple sites
+        // can exist in Storage simultaneously. Eventually we should make orders and stats
+        // behave this way. See https://github.com/woocommerce/woocommerce-ios/issues/279
+        // for more details.
         let group = DispatchGroup()
 
         group.enter()

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -157,9 +157,13 @@ private extension ProductStore {
     /// Updates, inserts, or prunes the provided StorageProduct's attributes using the provided read-only Product's attributes
     ///
     func handleProductAttributes(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        let siteID = readOnlyProduct.siteID
+
         // Upsert the attributes from the read-only product
         for readOnlyAttribute in readOnlyProduct.attributes {
-            if let existingStorageAttribute = storage.loadProductAttribute(attributeID: readOnlyAttribute.attributeID, name: readOnlyAttribute.name) {
+            if let existingStorageAttribute = storage.loadProductAttribute(siteID: siteID,
+                                                                           attributeID: readOnlyAttribute.attributeID,
+                                                                           name: readOnlyAttribute.name) {
                 existingStorageAttribute.update(with: readOnlyAttribute)
             } else {
                 let newStorageAttribute = storage.insertNewObject(ofType: Storage.ProductAttribute.self)
@@ -180,9 +184,12 @@ private extension ProductStore {
     /// Updates, inserts, or prunes the provided StorageProduct's default attributes using the provided read-only Product's default attributes
     ///
     func handleProductDefaultAttributes(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        let siteID = readOnlyProduct.siteID
+
         // Upsert the default attributes from the read-only product
         for readOnlyDefaultAttribute in readOnlyProduct.defaultAttributes {
-            if let existingStorageDefaultAttribute = storage.loadProductDefaultAttribute(defaultAttributeID: readOnlyDefaultAttribute.attributeID,
+            if let existingStorageDefaultAttribute = storage.loadProductDefaultAttribute(siteID: siteID,
+                                                                                         defaultAttributeID: readOnlyDefaultAttribute.attributeID,
                                                                                          name: readOnlyDefaultAttribute.name ?? "") {
                 existingStorageDefaultAttribute.update(with: readOnlyDefaultAttribute)
             } else {
@@ -205,9 +212,12 @@ private extension ProductStore {
     /// Updates, inserts, or prunes the provided StorageProduct's images using the provided read-only Product's images
     ///
     func handleProductImages(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        let siteID = readOnlyProduct.siteID
+
         // Upsert the images from the read-only product
         for readOnlyImage in readOnlyProduct.images {
-            if let existingStorageImage = storage.loadProductImage(imageID: readOnlyImage.imageID) {
+            if let existingStorageImage = storage.loadProductImage(siteID: siteID,
+                                                                   imageID: readOnlyImage.imageID) {
                 existingStorageImage.update(with: readOnlyImage)
             } else {
                 let newStorageImage = storage.insertNewObject(ofType: Storage.ProductImage.self)
@@ -228,9 +238,11 @@ private extension ProductStore {
     /// Updates, inserts, or prunes the provided StorageProduct's categories using the provided read-only Product's categories
     ///
     func handleProductCategories(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        let siteID = readOnlyProduct.siteID
+
         // Upsert the categories from the read-only product
         for readOnlyCategory in readOnlyProduct.categories {
-            if let existingStorageCategory = storage.loadProductCategory(categoryID: readOnlyCategory.categoryID) {
+            if let existingStorageCategory = storage.loadProductCategory(siteID: siteID, categoryID: readOnlyCategory.categoryID) {
                 existingStorageCategory.update(with: readOnlyCategory)
             } else {
                 let newStorageCategory = storage.insertNewObject(ofType: Storage.ProductCategory.self)
@@ -251,9 +263,11 @@ private extension ProductStore {
     /// Updates, inserts, or prunes the provided StorageProduct's tags using the provided read-only Product's tags
     ///
     func handleProductTags(_ readOnlyProduct: Networking.Product, _ storageProduct: Storage.Product, _ storage: StorageType) {
+        let siteID = readOnlyProduct.siteID
+
         // Upsert the tags from the read-only product
         for readOnlyTag in readOnlyProduct.tags {
-            if let existingStorageTag = storage.loadProductTag(tagID: readOnlyTag.tagID) {
+            if let existingStorageTag = storage.loadProductTag(siteID: siteID, tagID: readOnlyTag.tagID) {
                 existingStorageTag.update(with: readOnlyTag)
             } else {
                 let newStorageTag = storage.insertNewObject(ofType: Storage.ProductTag.self)


### PR DESCRIPTION
This is a quick fix for a situation I overlooked in my last Product Details PR — we need to take into account the `siteID` when upserting/pruning `ProductAttribute`, `ProductDefaultAttribute`, `ProductImage`, `ProductCategory`, and `ProductTag` entities. To do that, this PR updates the `StorageType+Extensions.swift` loaders and `ProductStore`'s `handleProduct*()` funcs accordingly.

Ref: #279 

## Testing
* Review the updated code
* Verify the unit tests are ✅ 

@mindgraffiti or @ctarda 1st :shipit: wins! 😄 
