### PR TITLE
Order details: Tracking numbers can now be copied to the pasteboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.6
 -----
- 
+- improvement: Tracking numbers can now be copied to the pasteboard from the order details screen.
+
 1.5
 -----
 - bugfix: Sometimes Settings would style all the options like "Log Out". No longer happens now.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -139,7 +139,7 @@ public enum WooAnalyticsStat: String {
     case orderDetailCustomerSMSOptionTapped     = "order_detail_customer_info_phone_menu_sms_tapped"
     case orderDetailOrderStatusEditButtonTapped = "order_detail_order_status_edit_button_tapped"
     case orderDetailProductDetailTapped         = "order_detail_product_detail_button_tapped"
-    case orderDetailTrackPackageButtonTapped = "order_detail_track_package_button_tapped"
+    case orderDetailTrackPackageButtonTapped    = "order_detail_track_package_button_tapped"
     case orderFulfillmentCompleteButtonTapped   = "order_fulfillment_mark_order_complete_button_tapped"
     case orderMarkedCompleteUndoButtonTapped    = "snack_order_marked_complete_undo_button_tapped"
     case orderShareStoreButtonTapped            = "orders_list_share_your_store_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -815,10 +815,9 @@ extension OrderDetailsViewController: UITableViewDelegate {
             return UISwipeActionsConfiguration(actions: [])
         }
 
-        let row = rowAtIndexPath(indexPath)
         let copyActionTitle = NSLocalizedString("Copy", comment: "Copy address text button title — should be one word and as short as possible.")
         let copyAction = UIContextualAction(style: .normal, title: copyActionTitle) { [weak self] (action, view, success) in
-            self?.copyText(at: row)
+            self?.copyText(at: indexPath)
             success(true)
         }
         copyAction.backgroundColor = StyleManager.wooCommerceBrandColor
@@ -844,8 +843,7 @@ extension OrderDetailsViewController: UITableViewDelegate {
             return
         }
 
-        let row = rowAtIndexPath(indexPath)
-        copyText(at: row)
+        copyText(at: indexPath)
     }
 }
 
@@ -905,6 +903,10 @@ private extension OrderDetailsViewController {
             if let _ = viewModel.order.shippingAddress {
                 return true
             }
+        case .tracking:
+            if orderTracking(at: indexPath)?.trackingNumber.isEmpty == false {
+                return true
+            }
         default:
             break
         }
@@ -914,14 +916,18 @@ private extension OrderDetailsViewController {
 
     /// Sends the provided Row's text data to the pasteboard
     ///
-    /// - Parameter row: Row to copy text data from
+    /// - Parameter indexPath: IndexPath to copy text data from
     ///
-    func copyText(at row: Row) {
+    func copyText(at indexPath: IndexPath) {
+        let row = rowAtIndexPath(indexPath)
+
         switch row {
         case .billingAddress:
             sendToPasteboard(viewModel.order.billingAddress?.fullNameWithCompanyAndAddress)
         case .shippingAddress:
             sendToPasteboard(viewModel.order.shippingAddress?.fullNameWithCompanyAndAddress)
+        case .tracking:
+            sendToPasteboard(orderTracking(at: indexPath)?.trackingNumber, includeTrailingNewline: false)
         default:
             break // We only send text to the pasteboard from the address rows right meow
         }
@@ -930,15 +936,20 @@ private extension OrderDetailsViewController {
     /// Sends the provided text to the general pasteboard and triggers a success haptic. If the text param
     /// is nil, nothing is sent to the pasteboard.
     ///
-    /// - Parameter text: string value to send to the pasteboard
+    /// - Parameter
+    ///   - text: string value to send to the pasteboard
+    ///   - includeTrailingNewline: It true, insert a trailing newline; defaults to true
     ///
-    func sendToPasteboard(_ text: String?) {
-        guard let text = text, text.isEmpty == false else {
+    func sendToPasteboard(_ text: String?, includeTrailingNewline: Bool = true) {
+        guard var text = text, text.isEmpty == false else {
             return
         }
 
-        // Insert an extra newline to make life easier when pasting
-        UIPasteboard.general.string = text + "\n"
+        if includeTrailingNewline {
+            text += "\n"
+        }
+
+        UIPasteboard.general.string = text
         hapticGenerator.notificationOccurred(.success)
     }
 }


### PR DESCRIPTION
Just a quick PR to allow tracking numbers to be copied to the pasteboard via long press or right swipe:

![track_copy](https://user-images.githubusercontent.com/154014/55491527-3d977880-55fb-11e9-96fe-3030cb44163b.gif)

## Testing

1. Build and run the app
2. Tap the Orders tab and open the details for an order that already has shipment tracking data
- [ ] Verify no cell except the address & package tracking cells are able to do a leading swipe
- [ ] Verify no cell (including address & package tracking) can do a trailing swipe (swiping to the left)
- [ ] Verify no cell except the address & package tracking cells display a edit (`Copy`) menu if long press

**Note:** You will not be able to copy the cells ☝️ if the address or tracking number is empty. 😄 

**Extra credit:** Change the current scheme's app language to RTL and test all of that ☝️ again (the swiping directions will be reversed)

/cc @AmandaRiu @kyleaparker 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
