### PR TITLE
Fixes ProductMapper errors for variation type products

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		748D424C210FA34400CF7D1B /* OrderStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748D424B210FA34400CF7D1B /* OrderStatsMapper.swift */; };
 		748D424E210FB1F500CF7D1B /* order-stats-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 748D424D210FB1F500CF7D1B /* order-stats-day.json */; };
 		7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */; };
+		7495AACF225D366D00801A89 /* variation-as-product.json in Resources */ = {isa = PBXBuildFile; fileRef = 7495AACE225D366D00801A89 /* variation-as-product.json */; };
 		7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 749737692141F2BE0008C490 /* top-performers-week-alt.json */; };
 		74A1196C2110F4BB00E1E5F0 /* OrderStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A1196B2110F4BB00E1E5F0 /* OrderStats.swift */; };
 		74A1D263211898F000931DFA /* site-visits-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 74A1D25F211898F000931DFA /* site-visits-day.json */; };
@@ -288,6 +289,7 @@
 		748D424B210FA34400CF7D1B /* OrderStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsMapper.swift; sourceTree = "<group>"; };
 		748D424D210FB1F500CF7D1B /* order-stats-day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-day.json"; sourceTree = "<group>"; };
 		7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "settings-general-alt.json"; sourceTree = "<group>"; };
+		7495AACE225D366D00801A89 /* variation-as-product.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "variation-as-product.json"; sourceTree = "<group>"; };
 		749737692141F2BE0008C490 /* top-performers-week-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "top-performers-week-alt.json"; sourceTree = "<group>"; };
 		74A1196B2110F4BB00E1E5F0 /* OrderStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStats.swift; sourceTree = "<group>"; };
 		74A1D25F211898F000931DFA /* site-visits-day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-visits-day.json"; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 				749737692141F2BE0008C490 /* top-performers-week-alt.json */,
 				74ABA1C6213F19FD00FFAD30 /* top-performers-month.json */,
 				74ABA1C7213F19FE00FFAD30 /* top-performers-year.json */,
+				7495AACE225D366D00801A89 /* variation-as-product.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -1052,6 +1055,7 @@
 				B53EF53621813681003E146F /* generic_success.json in Resources */,
 				74A1D265211898F000931DFA /* site-visits-month.json in Resources */,
 				74159623224D2C86003C21CF /* settings-product.json in Resources */,
+				7495AACF225D366D00801A89 /* variation-as-product.json in Resources */,
 				74A1D266211898F000931DFA /* site-visits-year.json in Resources */,
 				743BF8BE21191B63008A9D87 /* site-visits.json in Resources */,
 				CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -231,7 +231,7 @@ public struct Product: Decodable {
         let onSale = try container.decode(Bool.self, forKey: .onSale)
 
         let purchasable = try container.decode(Bool.self, forKey: .purchasable)
-        let totalSales = try container.decode(Int.self, forKey: .totalSales)
+        let totalSales = container.failsafeDecodeIfPresent(Int.self, forKey: .totalSales) ?? 0
         let virtual = try container.decode(Bool.self, forKey: .virtual)
 
         let downloadable = try container.decode(Bool.self, forKey: .downloadable)

--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -32,12 +32,12 @@ public struct ProductAttribute: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let attributeID = try container.decode(Int.self, forKey: .attributeID)
-        let name = try container.decode(String.self, forKey: .name)
-        let position = try container.decode(Int.self, forKey: .position)
-        let visible = try container.decode(Bool.self, forKey: .visible)
-        let variation = try container.decode(Bool.self, forKey: .variation)
-        let options = try container.decode([String].self, forKey: .options)
+        let attributeID = container.failsafeDecodeIfPresent(Int.self, forKey: .attributeID) ?? 0
+        let name = container.failsafeDecodeIfPresent(String.self, forKey: .name) ?? String()
+        let position = container.failsafeDecodeIfPresent(Int.self, forKey: .position) ?? 0
+        let visible = container.failsafeDecodeIfPresent(Bool.self, forKey: .visible) ?? true
+        let variation = container.failsafeDecodeIfPresent(Bool.self, forKey: .variation) ?? true
+        let options = container.failsafeDecodeIfPresent([String].self, forKey: .options) ?? [String]()
 
         self.init(attributeID: attributeID,
                   name: name,

--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -11,6 +11,12 @@ public struct ProductAttribute: Decodable {
     public let variation: Bool
     public let options: [String]
 
+    // Variation type products alter the structure of this ProductAttribute type.
+    // Because of that, we need to also include this option String as well. 🤯
+    // For more details see: https://github.com/woocommerce/woocommerce-ios/issues/859
+    private let option: String
+
+
     /// ProductAttribute initializer.
     ///
     public init(attributeID: Int,
@@ -25,6 +31,7 @@ public struct ProductAttribute: Decodable {
         self.visible = visible
         self.variation = variation
         self.options = options
+        self.option = ""
     }
 
     /// Public initializer for ProductAttribute.
@@ -37,7 +44,14 @@ public struct ProductAttribute: Decodable {
         let position = container.failsafeDecodeIfPresent(Int.self, forKey: .position) ?? 0
         let visible = container.failsafeDecodeIfPresent(Bool.self, forKey: .visible) ?? true
         let variation = container.failsafeDecodeIfPresent(Bool.self, forKey: .variation) ?? true
-        let options = container.failsafeDecodeIfPresent([String].self, forKey: .options) ?? [String]()
+
+        var options = container.failsafeDecodeIfPresent([String].self, forKey: .options) ?? [String]()
+        if options.isEmpty {
+            // This `ProductAttribute` may be linked to a variation type product → check if the `option` field contains anything.
+            if let variationTypeOption = container.failsafeDecodeIfPresent(String.self, forKey: .option) {
+                options.append(variationTypeOption)
+            }
+        }
 
         self.init(attributeID: attributeID,
                   name: name,
@@ -59,6 +73,7 @@ private extension ProductAttribute {
         case visible        = "visible"
         case variation      = "variation"
         case options        = "options"
+        case option         = "option"
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -11,8 +11,8 @@ public struct ProductAttribute: Decodable {
     public let variation: Bool
     public let options: [String]
 
-    // Variation type products alter the structure of this ProductAttribute type.
-    // Because of that, we need to also include this option String as well. 🤯
+    // Variation type products alter the structure of ProductAttribute.
+    // Because of that, we need to also include this private `option` String as well. 🤯
     // For more details see: https://github.com/woocommerce/woocommerce-ios/issues/859
     private let option: String
 
@@ -73,7 +73,7 @@ private extension ProductAttribute {
         case visible        = "visible"
         case variation      = "variation"
         case options        = "options"
-        case option         = "option"
+        case option         = "option"  // Exists because of variation type products only
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductType.swift
+++ b/Networking/Networking/Model/Product/ProductType.swift
@@ -8,6 +8,7 @@ public enum ProductType: Decodable, Hashable {
     case grouped
     case external
     case variable
+    case variation
     case custom(String) // in case there are extensions modifying product types
 }
 
@@ -28,6 +29,8 @@ extension ProductType: RawRepresentable {
             self = .external
         case Keys.variable:
             self = .variable
+        case Keys.variation:
+            self = .variation
         default:
             self = .custom(rawValue)
         }
@@ -41,6 +44,7 @@ extension ProductType: RawRepresentable {
         case .grouped:              return Keys.grouped
         case .external:             return Keys.external
         case .variable:             return Keys.variable
+        case .variation:            return Keys.variation
         case .custom(let payload):  return payload
         }
     }
@@ -54,4 +58,5 @@ private enum Keys {
     static let grouped  = "grouped"
     static let external = "external"
     static let variable = "variable"
+    static let variation = "variation"
 }

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -14,6 +14,10 @@ class ProductMapperTests: XCTestCase {
     ///
     private let dummyProductID = 282
 
+    /// Dummy Product Variation ID.
+    ///
+    private let dummyProductVariationID = 295
+
     /// Verifies that all of the Product Fields are parsed correctly.
     ///
     func testProductFieldsAreProperlyParsed() {
@@ -98,6 +102,88 @@ class ProductMapperTests: XCTestCase {
 
         XCTAssertEqual(product.menuOrder, 0)
         XCTAssertEqual(product.productType, ProductType(rawValue: "booking"))
+    }
+
+    /// Verifies that all of the Product Fields are parsed correctly when using a variation fetched via the Products endpoint.
+    ///
+    func testVariationProductFieldsAreProperlyParsed() {
+        guard let product = mapLoadVariationProductResponse() else {
+            XCTFail("Failed to parse product variation")
+            return
+        }
+
+        XCTAssertEqual(product.siteID, dummySiteID)
+        XCTAssertEqual(product.productID, dummyProductVariationID)
+        XCTAssertEqual(product.name, "Paper Airplane - Black, Long")
+        XCTAssertEqual(product.slug, "paper-airplane-3")
+        XCTAssertEqual(product.permalink, "https://paperairplane.store/product/paper-airplane/?attribute_color=Black&attribute_length=Long")
+
+        let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-04-04T22:06:45")
+        let dateModified = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-04-09T20:24:03")
+        XCTAssertEqual(product.dateCreated, dateCreated)
+        XCTAssertEqual(product.dateModified, dateModified)
+
+        XCTAssertEqual(product.productTypeKey, "variation")
+        XCTAssertEqual(product.statusKey, "publish")
+        XCTAssertFalse(product.featured)
+        XCTAssertEqual(product.catalogVisibilityKey, "visible")
+
+        XCTAssertEqual(product.fullDescription, "<p>Long paper airplane. Color is black. </p>\n")
+        XCTAssertEqual(product.briefDescription, "")
+        XCTAssertEqual(product.sku, "345345-2")
+
+        XCTAssertEqual(product.price, "22.72")
+        XCTAssertEqual(product.regularPrice, "22.72")
+        XCTAssertEqual(product.salePrice, "")
+        XCTAssertFalse(product.onSale)
+
+        XCTAssertTrue(product.purchasable)
+        XCTAssertEqual(product.totalSales, 0)
+        XCTAssertFalse(product.virtual)
+
+        XCTAssertFalse(product.downloadable)
+        XCTAssertEqual(product.downloadLimit, -1)
+        XCTAssertEqual(product.downloadExpiry, -1)
+
+        XCTAssertEqual(product.externalURL, "")
+        XCTAssertEqual(product.taxStatusKey, "taxable")
+        XCTAssertEqual(product.taxClass, "")
+
+        XCTAssertFalse(product.manageStock)
+        XCTAssertNil(product.stockQuantity)
+        XCTAssertEqual(product.stockStatusKey, "instock")
+
+        XCTAssertEqual(product.backordersKey, "no")
+        XCTAssertFalse(product.backordersAllowed)
+        XCTAssertFalse(product.backordered)
+
+        XCTAssertTrue(product.soldIndividually)
+        XCTAssertEqual(product.weight, "888")
+
+        XCTAssertTrue(product.shippingRequired)
+        XCTAssertTrue(product.shippingTaxable)
+        XCTAssertEqual(product.shippingClass, "")
+        XCTAssertEqual(product.shippingClassID, 0)
+
+        XCTAssertTrue(product.reviewsAllowed)
+        XCTAssertEqual(product.averageRating, "0.00")
+        XCTAssertEqual(product.ratingCount, 0)
+
+        XCTAssertEqual(product.relatedIDs, [])
+        XCTAssertEqual(product.upsellIDs, [])
+        XCTAssertEqual(product.crossSellIDs, [])
+        XCTAssertEqual(product.parentID, 205)
+
+        XCTAssertEqual(product.purchaseNote, "")
+        XCTAssertEqual(product.images.count, 1)
+
+        XCTAssertEqual(product.attributes.count, 2)
+        XCTAssertEqual(product.defaultAttributes.count, 0)
+        XCTAssertEqual(product.variations.count, 0)
+        XCTAssertEqual(product.groupedProducts, [])
+
+        XCTAssertEqual(product.menuOrder, 2)
+        XCTAssertEqual(product.productType, ProductType.variation)
     }
 
     /// Test that ProductTypeKey converts to a ProductType enum properly.
@@ -230,5 +316,11 @@ private extension ProductMapperTests {
     ///
     func mapLoadProductResponse() -> Product? {
         return mapProduct(from: "product")
+    }
+
+    /// Returns the ProductMapper output upon receiving `variation-as-product`
+    ///
+    func mapLoadVariationProductResponse() -> Product? {
+        return mapProduct(from: "variation-as-product")
     }
 }

--- a/Networking/NetworkingTests/Responses/variation-as-product.json
+++ b/Networking/NetworkingTests/Responses/variation-as-product.json
@@ -1,0 +1,121 @@
+{
+    "data": {
+        "id": 295,
+        "name": "Paper Airplane - Black, Long",
+        "slug": "paper-airplane-3",
+        "permalink": "https:\/\/paperairplane.store\/product\/paper-airplane\/?attribute_color=Black&attribute_length=Long",
+        "date_created": "2019-04-04T17:06:45",
+        "date_created_gmt": "2019-04-04T22:06:45",
+        "date_modified": "2019-04-09T15:24:03",
+        "date_modified_gmt": "2019-04-09T20:24:03",
+        "type": "variation",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "<p>Long paper airplane. Color is black. <\/p>\n",
+        "short_description": "",
+        "sku": "345345-2",
+        "price": "22.72",
+        "regular_price": "22.72",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;<\/span>22.72<\/span>",
+        "on_sale": false,
+        "purchasable": true,
+        "total_sales": "0",
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "stock_status": "instock",
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "sold_individually": true,
+        "weight": "888",
+        "dimensions": {
+            "length": "11",
+            "width": "22",
+            "height": "33"
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": true,
+        "average_rating": "0.00",
+        "rating_count": 0,
+        "related_ids": [],
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 205,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [],
+        "images": [
+            {
+                "id": 301,
+                "date_created": "2019-04-09T10:23:58",
+                "date_created_gmt": "2019-04-09T20:23:58",
+                "date_modified": "2019-04-09T10:23:58",
+                "date_modified_gmt": "2019-04-09T20:23:58",
+                "src": "https:\/\/i0.wp.com\/paperairplane.store\/wp-content\/uploads\/2019\/04\/paper_plane_black.png?fit=600%2C473&ssl=1",
+                "name": "paper_plane_black",
+                "alt": ""
+            }
+        ],
+        "attributes": [
+            {
+                "id": 0,
+                "name": "Color",
+                "option": "Black"
+            },
+            {
+                "id": 0,
+                "name": "Length",
+                "option": "Long"
+            }
+        ],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 2,
+        "meta_data": [
+            {
+                "id": 6034,
+                "key": "_created_via",
+                "value": "ajax-unknown"
+            }
+        ],
+        "jetpack_publicize_connections": [],
+        "jetpack_sharing_enabled": true,
+        "jetpack_likes_enabled": true,
+        "_links": {
+            "self": [
+                {
+                    "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/products\/295"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/products"
+                }
+            ],
+            "up": [
+                {
+                    "href": "https:\/\/paperairplane.store\/wp-json\/wc\/v3\/products\/205"
+                }
+            ]
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -38,6 +38,10 @@ class ProductStoreTests: XCTestCase {
     ///
     private let sampleProductID = 282
 
+    /// Testing Variation Type ProductID
+    ///
+    private let sampleVariationTypeProductID = 295
+
     /// Testing VariationID #1
     ///
     private let sampleVariation1ID = 215
@@ -157,6 +161,26 @@ class ProductStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/282", filename: "product")
         let action = ProductAction.retrieveProduct(siteID: sampleSiteID, productID: sampleProductID) { (product, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(product)
+            XCTAssertEqual(product, remoteProduct)
+
+            expectation.fulfill()
+        }
+
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.retrieveProduct` returns the expected `Product` for `variation` product types.
+    ///
+    func testRetrieveSingleVariationTypeProductReturnsExpectedFields() {
+        let expectation = self.expectation(description: "Retrieve single variation type product")
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let remoteProduct = sampleVariationTypeProduct()
+
+        network.simulateResponse(requestUrlSuffix: "products/295", filename: "variation-as-product")
+        let action = ProductAction.retrieveProduct(siteID: sampleSiteID, productID: sampleVariationTypeProductID) { (product, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(product)
             XCTAssertEqual(product, remoteProduct)
@@ -1056,6 +1080,98 @@ private extension ProductStoreTests {
         let defaultAttribute1 = ProductDefaultAttribute(attributeID: 0, name: "Color", option: "Purple")
 
         return [defaultAttribute1]
+    }
+
+    func sampleVariationTypeProduct(_ siteID: Int? = nil) -> Networking.Product {
+        let testSiteID = siteID ?? sampleSiteID
+        return Product(siteID: testSiteID,
+                       productID: sampleVariationTypeProductID,
+                       name: "Paper Airplane - Black, Long",
+                       slug: "paper-airplane-3",
+                       permalink: "https://paperairplane.store/product/paper-airplane/?attribute_color=Black&attribute_length=Long",
+                       dateCreated: date(with: "2019-04-04T22:06:45"),
+                       dateModified: date(with: "2019-04-09T20:24:03"),
+                       productTypeKey: "variation",
+                       statusKey: "publish",
+                       featured: false,
+                       catalogVisibilityKey: "visible",
+                       fullDescription: "<p>Long paper airplane. Color is black. </p>\n",
+                       briefDescription: "",
+                       sku: "345345-2",
+                       price: "22.72",
+                       regularPrice: "22.72",
+                       salePrice: "",
+                       onSale: false,
+                       purchasable: true,
+                       totalSales: 0,
+                       virtual: false,
+                       downloadable: false,
+                       downloadLimit: -1,
+                       downloadExpiry: -1,
+                       externalURL: "",
+                       taxStatusKey: "taxable",
+                       taxClass: "",
+                       manageStock: false,
+                       stockQuantity: nil,
+                       stockStatusKey: "instock",
+                       backordersKey: "no",
+                       backordersAllowed: false,
+                       backordered: false,
+                       soldIndividually: true,
+                       weight: "888",
+                       dimensions: sampleVariationTypeDimensions(),
+                       shippingRequired: true,
+                       shippingTaxable: true,
+                       shippingClass: "",
+                       shippingClassID: 0,
+                       reviewsAllowed: true,
+                       averageRating: "0.00",
+                       ratingCount: 0,
+                       relatedIDs: [],
+                       upsellIDs: [],
+                       crossSellIDs: [],
+                       parentID: 205,
+                       purchaseNote: "",
+                       categories: [],
+                       tags: [],
+                       images: sampleVariationTypeImages(),
+                       attributes: sampleVariationTypeAttributes(),
+                       defaultAttributes: [],
+                       variations: [],
+                       groupedProducts: [],
+                       menuOrder: 2)
+    }
+
+    func sampleVariationTypeDimensions() -> Networking.ProductDimensions {
+        return ProductDimensions(length: "11", width: "22", height: "33")
+    }
+
+    func sampleVariationTypeImages() -> [Networking.ProductImage] {
+        let image1 = ProductImage(imageID: 301,
+                                  dateCreated: date(with: "2019-04-09T20:23:58"),
+                                  dateModified: date(with: "2019-04-09T20:23:58"),
+                                  src: "https://i0.wp.com/paperairplane.store/wp-content/uploads/2019/04/paper_plane_black.png?fit=600%2C473&ssl=1",
+                                  name: "paper_plane_black",
+                                  alt: "")
+        return [image1]
+    }
+
+    func sampleVariationTypeAttributes() -> [Networking.ProductAttribute] {
+        let attribute1 = ProductAttribute(attributeID: 0,
+                                          name: "Color",
+                                          position: 0,
+                                          visible: true,
+                                          variation: true,
+                                          options: ["Black"])
+
+        let attribute2 = ProductAttribute(attributeID: 0,
+                                          name: "Length",
+                                          position: 0,
+                                          visible: true,
+                                          variation: true,
+                                          options: ["Long"])
+
+        return [attribute1, attribute2]
     }
 }
 


### PR DESCRIPTION
This PR allows us to use the product endpoint (aka `ProductRemote.loadProduct()`) to fetch product variations. Without the updates contained in this PR, `ProductMapper` would blow chunks parsing the response JSON due to changes with the `total_sales` type as well as the structure of `ProductAttribute`. 

Please see [the original issue](https://github.com/woocommerce/woocommerce-ios/issues/859) for more details on all this.

Fixes: #859 

## Testing

For now, just review the code and make sure the unit tests pass. 

😄 

/cc @nbradbury just in case you are interested...