### PR TITLE
Xcode 10.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,15 @@ version: 2.1
 
 orbs:
   # This uses the Orbs located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.18
+  ios: wordpress-mobile/ios@0.0.25
 
 workflows:
   woocommerce_ios:
     jobs:
       - ios/test:
           name: Test
+          xcode-version: "10.2.0"
           workspace: WooCommerce.xcworkspace
           scheme: WooCommerce
           device: iPhone XS
-          ios-version: "12.1"
+          ios-version: "12.2"

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -984,6 +984,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = B557D9D9209753AA005962F4;
 			productRefGroup = B557D9E4209753AA005962F4 /* Products */;

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -140,7 +140,7 @@ public class OrdersRemote: Remote {
 // MARK: - Constants!
 //
 public extension OrdersRemote {
-    public enum Defaults {
+    enum Defaults {
         public static let pageSize: Int     = 25
         public static let pageNumber: Int   = 1
         public static let statusAny: String = "any"

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -104,7 +104,7 @@ public class ProductsRemote: Remote {
 // MARK: - Constants
 //
 public extension ProductsRemote {
-    public enum Defaults {
+    enum Defaults {
         public static let pageSize: Int   = 25
         public static let pageNumber: Int = 1
         public static let context: String = "view"

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -128,9 +128,9 @@ public extension NSNotification.Name {
 
     /// Posted whenever an Invalid Token Error is received.
     ///
-    public static let RemoteDidReceiveInvalidTokenError = NSNotification.Name(rawValue: "RemoteDidReceiveInvalidTokenError")
+    static let RemoteDidReceiveInvalidTokenError = NSNotification.Name(rawValue: "RemoteDidReceiveInvalidTokenError")
 
     /// Posted whenever a Jetpack Timeout is received.
     ///
-    public static let RemoteDidReceiveJetpackTimeoutError = NSNotification.Name(rawValue: "RemoteDidReceiveJetpackTimeoutError")
+    static let RemoteDidReceiveJetpackTimeoutError = NSNotification.Name(rawValue: "RemoteDidReceiveJetpackTimeoutError")
 }

--- a/Podfile
+++ b/Podfile
@@ -41,7 +41,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack/Swift', '~> 3.4'
   pod 'XLPagerTabStrip', '~> 8.1'
   pod 'Charts', '~> 3.2'
-  pod 'ZendeskSDK', '~> 2.2'
+  pod 'ZendeskSDK', '~> 2.3.1'
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,13 +75,13 @@ PODS:
   - WordPressUI (1.2.0)
   - wpxmlrpc (0.8.4)
   - XLPagerTabStrip (8.1.1)
-  - ZendeskSDK (2.3.0):
-    - ZendeskSDK/Providers (= 2.3.0)
-    - ZendeskSDK/UI (= 2.3.0)
-  - ZendeskSDK/Core (2.3.0)
-  - ZendeskSDK/Providers (2.3.0):
+  - ZendeskSDK (2.3.1):
+    - ZendeskSDK/Providers (= 2.3.1)
+    - ZendeskSDK/UI (= 2.3.1)
+  - ZendeskSDK/Core (2.3.1)
+  - ZendeskSDK/Providers (2.3.1):
     - ZendeskSDK/Core
-  - ZendeskSDK/UI (2.3.0):
+  - ZendeskSDK/UI (2.3.1):
     - ZendeskSDK/Core
     - ZendeskSDK/Providers
 
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.1)
   - WordPressUI (~> 1.2)
   - XLPagerTabStrip (~> 8.1)
-  - ZendeskSDK (~> 2.2)
+  - ZendeskSDK (~> 2.3.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -157,8 +157,8 @@ SPEC CHECKSUMS:
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 63166e21c9844fa30f2d95d30f335e73be5caf22
-  ZendeskSDK: af6509ad7968d367f95b2645713802712152f879
+  ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
 
-PODFILE CHECKSUM: 3bb11e9f63fdd94c71819db0d3636f587b144968
+PODFILE CHECKSUM: 8482e446d484a2387701a07c9133b984eeccf393
 
 COCOAPODS: 1.6.1

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -534,6 +534,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = B54CA58F20A4BBA500F38CD1;
 			productRefGroup = B54CA59A20A4BBA500F38CD1 /* Products */;

--- a/Storage/Storage/Protocols/StorageManagerType.swift
+++ b/Storage/Storage/Protocols/StorageManagerType.swift
@@ -4,7 +4,7 @@ import Foundation
 // MARK: - StorageManagerType Notifications
 //
 public extension NSNotification.Name {
-    public static let StorageManagerDidResetStorage = NSNotification.Name(rawValue: "StorageManagerDidResetStorage")
+    static let StorageManagerDidResetStorage = NSNotification.Name(rawValue: "StorageManagerDidResetStorage")
 }
 
 

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -7,84 +7,84 @@ public extension StorageType {
 
     /// Retrieves the Stored Account.
     ///
-    public func loadAccount(userId: Int) -> Account? {
+    func loadAccount(userId: Int) -> Account? {
         let predicate = NSPredicate(format: "userID = %ld", userId)
         return firstObject(ofType: Account.self, matching: predicate)
     }
 
     /// Retrieves the Stored Site.
     ///
-    public func loadSite(siteID: Int) -> Site? {
+    func loadSite(siteID: Int) -> Site? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         return firstObject(ofType: Site.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order.
     ///
-    public func loadOrder(orderID: Int) -> Order? {
+    func loadOrder(orderID: Int) -> Order? {
         let predicate = NSPredicate(format: "orderID = %ld", orderID)
         return firstObject(ofType: Order.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Lookup.
     ///
-    public func loadOrderSearchResults(keyword: String) -> OrderSearchResults? {
+    func loadOrderSearchResults(keyword: String) -> OrderSearchResults? {
         let predicate = NSPredicate(format: "keyword = %@", keyword)
         return firstObject(ofType: OrderSearchResults.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Item.
     ///
-    public func loadOrderItem(itemID: Int) -> OrderItem? {
+    func loadOrderItem(itemID: Int) -> OrderItem? {
         let predicate = NSPredicate(format: "itemID = %ld", itemID)
         return firstObject(ofType: OrderItem.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Coupon.
     ///
-    public func loadOrderCoupon(couponID: Int) -> OrderCoupon? {
+    func loadOrderCoupon(couponID: Int) -> OrderCoupon? {
         let predicate = NSPredicate(format: "couponID = %ld", couponID)
         return firstObject(ofType: OrderCoupon.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Note.
     ///
-    public func loadOrderNote(noteID: Int) -> OrderNote? {
+    func loadOrderNote(noteID: Int) -> OrderNote? {
         let predicate = NSPredicate(format: "noteID = %ld", noteID)
         return firstObject(ofType: OrderNote.self, matching: predicate)
     }
 
     /// Retrieves the Stored TopEarnerStats.
     ///
-    public func loadTopEarnerStats(date: String, granularity: String) -> TopEarnerStats? {
+    func loadTopEarnerStats(date: String, granularity: String) -> TopEarnerStats? {
         let predicate = NSPredicate(format: "date ==[c] %@ AND granularity ==[c] %@", date, granularity)
         return firstObject(ofType: TopEarnerStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored SiteVisitStats.
     ///
-    public func loadSiteVisitStats(granularity: String) -> SiteVisitStats? {
+    func loadSiteVisitStats(granularity: String) -> SiteVisitStats? {
         let predicate = NSPredicate(format: "granularity ==[c] %@", granularity)
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderStats.
     ///
-    public func loadOrderStats(granularity: String) -> OrderStats? {
+    func loadOrderStats(granularity: String) -> OrderStats? {
         let predicate = NSPredicate(format: "granularity ==[c] %@", granularity)
         return firstObject(ofType: OrderStats.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderStatsItem.
     ///
-    public func loadOrderStatsItem(period: String) -> OrderStatsItem? {
+    func loadOrderStatsItem(period: String) -> OrderStatsItem? {
         let predicate = NSPredicate(format: "period ==[c] %@", period)
         return firstObject(ofType: OrderStatsItem.self, matching: predicate)
     }
 
     /// Retrieves all of the Stores OrderStatuses for the provided siteID.
     ///
-    public func loadOrderStatuses(siteID: Int) -> [OrderStatus]? {
+    func loadOrderStatuses(siteID: Int) -> [OrderStatus]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \OrderStatus.name, ascending: false)
         return allObjects(ofType: OrderStatus.self, matching: predicate, sortedBy: [descriptor])
@@ -92,14 +92,14 @@ public extension StorageType {
 
     /// Retrieves the Stored OrderStatus
     ///
-    public func loadOrderStatus(siteID: Int, slug: String) -> OrderStatus? {
+    func loadOrderStatus(siteID: Int, slug: String) -> OrderStatus? {
         let predicate = NSPredicate(format: "siteID = %ld AND slug ==[c] %@", siteID, slug)
         return firstObject(ofType: OrderStatus.self, matching: predicate)
     }
 
     /// Retrieves **all** of the stored SiteSettings for the provided siteID.
     ///
-    public func loadAllSiteSettings(siteID: Int) -> [SiteSetting]? {
+    func loadAllSiteSettings(siteID: Int) -> [SiteSetting]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
@@ -107,7 +107,7 @@ public extension StorageType {
 
     /// Retrieves stored SiteSettings for the provided siteID and settingGroupKey.
     ///
-    public func loadSiteSettings(siteID: Int, settingGroupKey: String) -> [SiteSetting]? {
+    func loadSiteSettings(siteID: Int, settingGroupKey: String) -> [SiteSetting]? {
         let predicate = NSPredicate(format: "siteID = %ld AND settingGroupKey ==[c] %@", siteID, settingGroupKey)
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
@@ -115,35 +115,35 @@ public extension StorageType {
 
     /// Retrieves the Stored SiteSetting.
     ///
-    public func loadSiteSetting(siteID: Int, settingID: String) -> SiteSetting? {
+    func loadSiteSetting(siteID: Int, settingID: String) -> SiteSetting? {
         let predicate = NSPredicate(format: "siteID = %ld AND settingID ==[c] %@", siteID, settingID)
         return firstObject(ofType: SiteSetting.self, matching: predicate)
     }
 
     /// Retrieves the Notification.
     ///
-    public func loadNotification(noteID: Int64) -> Note? {
+    func loadNotification(noteID: Int64) -> Note? {
         let predicate = NSPredicate(format: "noteID = %ld", noteID)
         return firstObject(ofType: Note.self, matching: predicate)
     }
 
     /// Retrieves the Notification.
     ///
-    public func loadNotification(noteID: Int64, noteHash: Int) -> Note? {
+    func loadNotification(noteID: Int64, noteHash: Int) -> Note? {
         let predicate = NSPredicate(format: "noteID = %ld AND noteHash = %ld", noteID, noteHash)
         return firstObject(ofType: Note.self, matching: predicate)
     }
 
     /// Retrieves a specific stored ShipmentTracking entity.
     ///
-    public func loadShipmentTracking(siteID: Int, orderID: Int, trackingID: String) -> ShipmentTracking? {
+    func loadShipmentTracking(siteID: Int, orderID: Int, trackingID: String) -> ShipmentTracking? {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld AND trackingID ==[c] %@", siteID, orderID, trackingID)
         return firstObject(ofType: ShipmentTracking.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ShipmentTracking entities for the provided siteID and orderID.
     ///
-    public func loadShipmentTrackingList(siteID: Int, orderID: Int) -> [ShipmentTracking]? {
+    func loadShipmentTrackingList(siteID: Int, orderID: Int) -> [ShipmentTracking]? {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTracking.orderID, ascending: false)
         return allObjects(ofType: ShipmentTracking.self, matching: predicate, sortedBy: [descriptor])
@@ -151,14 +151,14 @@ public extension StorageType {
 
     /// Retrieves a specific stored ShipmentTrackingProviderGroup
     ///
-    public func loadShipmentTrackingProviderGroup(siteID: Int, providerGroupName: String) -> ShipmentTrackingProviderGroup? {
+    func loadShipmentTrackingProviderGroup(siteID: Int, providerGroupName: String) -> ShipmentTrackingProviderGroup? {
         let predicate = NSPredicate(format: "siteID = %ld AND name ==[c] %@", siteID, providerGroupName)
         return firstObject(ofType: ShipmentTrackingProviderGroup.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ShipmentTrackingProviderGroup entities for the provided siteID.
     ///
-    public func loadShipmentTrackingProviderGroupList(siteID: Int) -> [ShipmentTrackingProviderGroup]? {
+    func loadShipmentTrackingProviderGroupList(siteID: Int) -> [ShipmentTrackingProviderGroup]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTrackingProviderGroup.name, ascending: true)
         return allObjects(ofType: ShipmentTrackingProviderGroup.self, matching: predicate, sortedBy: [descriptor])
@@ -166,7 +166,7 @@ public extension StorageType {
 
     /// Retrieves all of the stored ShipmentTrackingProvider entities for the provided siteID.
     ///
-    public func loadShipmentTrackingProviderList(siteID: Int) -> [ShipmentTrackingProvider]? {
+    func loadShipmentTrackingProviderList(siteID: Int) -> [ShipmentTrackingProvider]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTrackingProvider.name, ascending: true)
         return allObjects(ofType: ShipmentTrackingProvider.self, matching: predicate, sortedBy: [descriptor])
@@ -174,14 +174,14 @@ public extension StorageType {
 
     /// Retrieves a stored ShipmentTrackingProvider for the provided siteID.
     ///
-    public func loadShipmentTrackingProvider(siteID: Int, name: String) -> ShipmentTrackingProvider? {
+    func loadShipmentTrackingProvider(siteID: Int, name: String) -> ShipmentTrackingProvider? {
         let predicate = NSPredicate(format: "siteID = %ld AND name ==[c] %@", siteID, name)
         return firstObject(ofType: ShipmentTrackingProvider.self, matching: predicate)
     }
 
     /// Retrieves all of the stored Products for the provided siteID.
     ///
-    public func loadProducts(siteID: Int) -> [Product]? {
+    func loadProducts(siteID: Int) -> [Product]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \Product.productID, ascending: false)
         return allObjects(ofType: Product.self, matching: predicate, sortedBy: [descriptor])
@@ -189,7 +189,7 @@ public extension StorageType {
 
     /// Retrieves a stored Product for the provided siteID.
     ///
-    public func loadProduct(siteID: Int, productID: Int) -> Product? {
+    func loadProduct(siteID: Int, productID: Int) -> Product? {
         let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld", siteID, productID)
         return firstObject(ofType: Product.self, matching: predicate)
     }
@@ -198,7 +198,7 @@ public extension StorageType {
     ///
     /// Note: WC attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    public func loadProductAttribute(siteID: Int, productID: Int, attributeID: Int, name: String) -> ProductAttribute? {
+    func loadProductAttribute(siteID: Int, productID: Int, attributeID: Int, name: String) -> ProductAttribute? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND attributeID = %ld AND name ==[c] %@",
                                     siteID, productID, attributeID, name)
         return firstObject(ofType: ProductAttribute.self, matching: predicate)
@@ -208,7 +208,7 @@ public extension StorageType {
     ///
     /// Note: WC default attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    public func loadProductDefaultAttribute(siteID: Int, productID: Int, defaultAttributeID: Int, name: String) -> ProductDefaultAttribute? {
+    func loadProductDefaultAttribute(siteID: Int, productID: Int, defaultAttributeID: Int, name: String) -> ProductDefaultAttribute? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND attributeID = %ld AND name ==[c] %@",
                                     siteID, productID, defaultAttributeID, name)
         return firstObject(ofType: ProductDefaultAttribute.self, matching: predicate)
@@ -216,28 +216,28 @@ public extension StorageType {
 
     /// Retrieves the Stored Product Image.
     ///
-    public func loadProductImage(siteID: Int, productID: Int, imageID: Int) -> ProductImage? {
+    func loadProductImage(siteID: Int, productID: Int, imageID: Int) -> ProductImage? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND imageID = %ld", siteID, productID, imageID)
         return firstObject(ofType: ProductImage.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Category.
     ///
-    public func loadProductCategory(siteID: Int, productID: Int, categoryID: Int) -> ProductCategory? {
+    func loadProductCategory(siteID: Int, productID: Int, categoryID: Int) -> ProductCategory? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND categoryID = %ld", siteID, productID, categoryID)
         return firstObject(ofType: ProductCategory.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Tag.
     ///
-    public func loadProductTag(siteID: Int, productID: Int, tagID: Int) -> ProductTag? {
+    func loadProductTag(siteID: Int, productID: Int, tagID: Int) -> ProductTag? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND tagID = %ld", siteID, productID, tagID)
         return firstObject(ofType: ProductTag.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ProductVariations for the provided siteID and productID.
     ///
-    public func loadProductVariations(siteID: Int, productID: Int) -> [ProductVariation]? {
+    func loadProductVariations(siteID: Int, productID: Int) -> [ProductVariation]? {
         let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld", siteID, productID)
         let descriptor = NSSortDescriptor(keyPath: \ProductVariation.variationID, ascending: false)
         return allObjects(ofType: ProductVariation.self, matching: predicate, sortedBy: [descriptor])
@@ -245,7 +245,7 @@ public extension StorageType {
 
     /// Retrieves a stored ProductVariation for the provided siteID, productID, and variationID.
     ///
-    public func loadProductVariation(siteID: Int, productID: Int, variationID: Int) -> ProductVariation? {
+    func loadProductVariation(siteID: Int, productID: Int, variationID: Int) -> ProductVariation? {
         let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld AND variationID = %ld", siteID, productID, variationID)
         return firstObject(ofType: ProductVariation.self, matching: predicate)
     }
@@ -254,7 +254,7 @@ public extension StorageType {
     ///
     /// Note: WC variation attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    public func loadProductVariationAttribute(siteID: Int, variationID: Int, attributeID: Int, name: String) -> ProductVariationAttribute? {
+    func loadProductVariationAttribute(siteID: Int, variationID: Int, attributeID: Int, name: String) -> ProductVariationAttribute? {
         let predicate = NSPredicate(format: "productVariation.siteID = %ld AND productVariation.variationID = %ld AND attributeID = %ld AND name ==[c] %@",
                                     siteID, variationID, attributeID, name)
         return firstObject(ofType: ProductVariationAttribute.self, matching: predicate)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1701,7 +1701,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-resources.sh",
 				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressAuthenticator/WordPressAuthenticator.bundle",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2.1/ZendeskSDKStrings.bundle",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskSDKStrings.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -1794,9 +1794,9 @@
 				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressUI/WordPressUI.framework",
 				"${BUILT_PRODUCTS_DIR}/XLPagerTabStrip/XLPagerTabStrip.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2.1/ZendeskCoreSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2.1/ZendeskProviderSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2.1/ZendeskSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskCoreSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskProviderSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskSDK.framework",
 				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
 				"${BUILT_PRODUCTS_DIR}/wpxmlrpc/wpxmlrpc.framework",
 			);

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = B5C9DDEB2087FEC0006B910A;
 			productRefGroup = B5C9DDF62087FEC0006B910A /* Products */;

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -248,11 +248,11 @@ public extension ResultsController {
 
     // MARK: - ResultsController.ChangeType
     //
-    public typealias ChangeType = NSFetchedResultsChangeType
+    typealias ChangeType = NSFetchedResultsChangeType
 
     // MARK: - ResultsController.SectionInfo
     //
-    public class SectionInfo {
+    class SectionInfo {
 
         /// Name of the section
         ///


### PR DESCRIPTION
This fixes compatibility with Xcode 10.2 by updating Zendesk and fixing the new Xcode warnings/errors.

Related pull requests and issues:

- CocoaPods update: #867.
- WordPressAutenticator: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/67, https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/68, https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/70
- WordPressKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/140
- CircleCI Orb: https://github.com/wordpress-mobile/circleci-orbs/pull/21
- Zendesk SDK: https://github.com/zendesk/zendesk_sdk_ios/issues/480.
- WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/11381

**Note:** Due to the Zendesk SDK update this breaks compatibility with Xcode 10.1. We should merge this very carefully with plenty of notice.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
