### PR TITLE
Product Details UI Mark1: Adds ProductLoaderVC + ProductDetailsVC

### DIFF
--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -1,15 +1,26 @@
-/// FeatureFlag exposes a series of features to be conditionally enabled on
-/// different builds.
+/// FeatureFlag exposes a series of features to be conditionally enabled on different builds.
+///
 enum FeatureFlag: Int {
+
     /// Throwaway case, to prevent a compiler error:
     /// `An enum with no cases cannot declare a raw type`
     case null
+
+    /// Enable the shipment tracking input section/screens
+    ///
     case manualShipmentTracking
 
+    /// Enable the new product details screen (via `FulfillViewController` or `ProductListViewController`)
+    ///
+    case productDetails
+
     /// Returns a boolean indicating if the feature is enabled
+    ///
     var enabled: Bool {
         switch self {
         case .manualShipmentTracking:
+            return BuildConfiguration.current == .localDeveloper
+        case .productDetails:
             return BuildConfiguration.current == .localDeveloper
         default:
             return true

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -1,9 +1,7 @@
 import Foundation
 import UIKit
-
 import Yosemite
 import Gridicons
-
 
 
 /// Renders the Order Fulfillment Interface
@@ -147,7 +145,7 @@ private extension FulfillViewController {
 
 // MARK: - Action Handlers
 //
-extension FulfillViewController {
+private extension FulfillViewController {
 
     /// Whenever the Fulfillment Action is pressed, we'll mark the order as Completed, and pull back to the previous screen.
     ///
@@ -181,7 +179,7 @@ extension FulfillViewController {
 
     /// Returns an Order Update Action that will result in the specified Order Status updated accordingly.
     ///
-    private func updateOrderAction(siteID: Int, orderID: Int, statusKey: String) -> Action {
+    func updateOrderAction(siteID: Int, orderID: Int, statusKey: String) -> Action {
         return OrderAction.updateOrder(siteID: siteID, orderID: orderID, statusKey: statusKey, onCompletion: { error in
             guard let error = error else {
                 WooAnalytics.shared.track(.orderStatusChangeSuccess)
@@ -197,7 +195,7 @@ extension FulfillViewController {
 
     /// Displays the `Order Fulfilled` Notice. Whenever the `Undo` button gets pressed, we'll execute the `onUndoAction` closure.
     ///
-    private func displayOrderCompleteNotice(onUndoAction: @escaping () -> Void) {
+    func displayOrderCompleteNotice(onUndoAction: @escaping () -> Void) {
         let message = NSLocalizedString("Order marked as fulfilled", comment: "Order fulfillment success notice")
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
         let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle, actionHandler: onUndoAction)
@@ -218,6 +216,14 @@ extension FulfillViewController {
         }
 
         AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Displays the product detail screen for the provided ProductID
+    ///
+    func productWasPressed(for productID: Int) {
+        let loaderViewController = ProductLoaderViewController(productID: productID, siteID: order.siteID)
+        let navController = WooNavigationController(rootViewController: loaderViewController)
+        present(navController, animated: true, completion: nil)
     }
 }
 
@@ -292,7 +298,7 @@ private extension FulfillViewController {
         }
 
         let viewModel = OrderItemViewModel(item: item, currency: order.currency)
-
+        cell.selectionStyle = .default
         cell.name = viewModel.name
         cell.quantity = viewModel.quantity
         cell.price = viewModel.price
@@ -401,6 +407,9 @@ extension FulfillViewController: UITableViewDelegate {
             let addTracking = ManualTrackingViewController(viewModel: viewModel)
             let navController = WooNavigationController(rootViewController: addTracking)
             present(navController, animated: true, completion: nil)
+
+        case .product(let item):
+            productWasPressed(for: item.productID)
 
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -269,7 +269,7 @@ extension FulfillViewController: UITableViewDataSource {
 }
 
 
-// MARK: - UITableViewDataSource Conformance
+// MARK: - Cell Configuration
 //
 private extension FulfillViewController {
 
@@ -298,7 +298,7 @@ private extension FulfillViewController {
         }
 
         let viewModel = OrderItemViewModel(item: item, currency: order.currency)
-        cell.selectionStyle = .default
+        cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
         cell.name = viewModel.name
         cell.quantity = viewModel.quantity
         cell.price = viewModel.price
@@ -411,7 +411,9 @@ extension FulfillViewController: UITableViewDelegate {
             present(navController, animated: true, completion: nil)
 
         case .product(let item):
-            productWasPressed(for: item.productID)
+            if FeatureFlag.productDetails.enabled {
+                productWasPressed(for: item.productID)
+            }
 
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -1,22 +1,43 @@
 import UIKit
 import Yosemite
 
+
 class ProductListViewController: UIViewController {
     @IBOutlet private var tableView: UITableView!
+    private var items = [OrderItem]()
 
     var viewModel: OrderDetailsViewModel!
-    private var items = [OrderItem]()
+
+    // MARK: - View Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         self.items = viewModel.order.items
-        title = NSLocalizedString("Details Order #\(viewModel.order.number)", comment: "Screen title: Details Order number (number)")
-        view.backgroundColor = StyleManager.tableViewBackgroundColor
-        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+        configureMainView()
         configureTableView()
     }
+}
 
+
+// MARK: - Configuration
+//
+private extension ProductListViewController {
+
+    /// Setup: Main View
+    ///
+    func configureMainView() {
+        title = NSLocalizedString("Details Order #\(viewModel.order.number)", comment: "Screen title: Details Order number (number)")
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+
+        // Don't show the Order details title in the next-view's back button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+    }
+
+    /// Setup: TableView
+    ///
     func configureTableView() {
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.sectionHeaderHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = Constants.rowHeight
@@ -28,15 +49,13 @@ class ProductListViewController: UIViewController {
         let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
     }
-
-    func itemAtIndexPath(_ indexPath: IndexPath) -> OrderItem {
-        return items[indexPath.row]
-    }
 }
+
 
 // MARK: - UITableViewDataSource Conformance
 //
 extension ProductListViewController: UITableViewDataSource {
+
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
@@ -68,17 +87,39 @@ extension ProductListViewController: UITableViewDataSource {
     }
 }
 
+
 // MARK: - UITableViewDelegate Conformance
 //
 extension ProductListViewController: UITableViewDelegate {
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+
+        let orderItem = itemAtIndexPath(indexPath)
+        productWasPressed(for: orderItem.productID)
     }
 }
 
-// MARK: - Private methods and more
+
+// MARK: - Private Helpers
 //
 private extension ProductListViewController {
+
+    func itemAtIndexPath(_ indexPath: IndexPath) -> OrderItem {
+        return items[indexPath.row]
+    }
+
+    func productWasPressed(for productID: Int) {
+        let loaderViewController = ProductLoaderViewController(productID: productID, siteID: viewModel.order.siteID)
+        navigationController?.pushViewController(loaderViewController, animated: true)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension ProductListViewController {
+
     struct Constants {
         static let sectionHeight = CGFloat(44)
         static let rowHeight = CGFloat(80)

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -71,7 +71,7 @@ extension ProductListViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? ProductDetailsTableViewCell else {
             fatalError()
         }
-        cell.selectionStyle = .default
+        cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
         cell.configure(item: itemViewModel, with: viewModel)
         return cell
     }
@@ -96,8 +96,10 @@ extension ProductListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        let orderItem = itemAtIndexPath(indexPath)
-        productWasPressed(for: orderItem.productID)
+        if FeatureFlag.productDetails.enabled {
+            let orderItem = itemAtIndexPath(indexPath)
+            productWasPressed(for: orderItem.productID)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -71,6 +71,7 @@ extension ProductListViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? ProductDetailsTableViewCell else {
             fatalError()
         }
+        cell.selectionStyle = .default
         cell.configure(item: itemViewModel, with: viewModel)
         return cell
     }
@@ -109,9 +110,12 @@ private extension ProductListViewController {
         return items[indexPath.row]
     }
 
+    /// Displays the product detail screen for the provided ProductID
+    ///
     func productWasPressed(for productID: Int) {
         let loaderViewController = ProductLoaderViewController(productID: productID, siteID: viewModel.order.siteID)
-        navigationController?.pushViewController(loaderViewController, animated: true)
+        let navController = WooNavigationController(rootViewController: loaderViewController)
+        present(navController, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -385,4 +385,3 @@ private extension ProductDetailsViewController {
         }
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -140,6 +140,7 @@ private extension ProductDetailsViewController {
 extension ProductDetailsViewController {
 
     @objc func pullToRefresh() {
+        DDLogInfo("♻️ Requesting product detail data be reloaded...")
         syncProduct() { [weak self] (error) in
             if let error = error {
                  DDLogError("⛔️ Error loading product details: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -46,7 +46,7 @@ class ProductDetailsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureNavigation()
+        configureNavigationTitle()
         configureTableView()
         registerTableViewCells()
         registerTableViewHeaderFooters()
@@ -71,15 +71,11 @@ private extension ProductDetailsViewController {
         tableView.separatorInset = .zero
     }
 
-    /// Setup: Navigation
+    /// Setup: Navigation Title
     ///
-    func configureNavigation() {
+    func configureNavigationTitle() {
         title = NSLocalizedString("Product", comment: "Title of product detail screen.")
-
-        // Don't show the Order details title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
     }
-
 
     /// Reloads the tableView's data, assuming the view has been loaded.
     ///
@@ -150,7 +146,7 @@ private extension ProductDetailsViewController {
 extension ProductDetailsViewController {
 
     @objc func pullToRefresh() {
-        // TODO: refresh the product screen
+        refreshControl.endRefreshing()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -1,0 +1,296 @@
+import UIKit
+import Yosemite
+
+
+/// ProductDetailsViewController: Displays the details for a given Product.
+///
+class ProductDetailsViewController: UIViewController {
+
+    /// Order to be Fulfilled
+    ///
+    private let product: Product?
+
+    /// Main TableView.
+    ///
+    @IBOutlet private weak var tableView: UITableView!
+
+    /// Sections to be rendered
+    ///
+    private var sections = [Section]()
+
+    /// Pull To Refresh Support.
+    ///
+    private lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
+        return refreshControl
+    }()
+
+    // MARK: - Initializers
+
+    /// Designated Initializer
+    ///
+    init(product: Product?) {
+        // TODO: this should not be nil
+        self.product = product
+        super.init(nibName: type(of: self).nibName, bundle: nil)
+    }
+
+    /// NSCoder Conformance
+    ///
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigation()
+        configureTableView()
+        registerTableViewCells()
+        registerTableViewHeaderFooters()
+    }
+}
+
+
+// MARK: - Configuration
+//
+private extension ProductDetailsViewController {
+
+    /// Setup: TableView
+    ///
+    func configureTableView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+        tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
+        tableView.estimatedSectionFooterHeight = Constants.rowHeight
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.refreshControl = refreshControl
+        tableView.separatorInset = .zero
+    }
+
+    /// Setup: Navigation
+    ///
+    func configureNavigation() {
+        title = NSLocalizedString("Product", comment: "Title of product detail screen.")
+
+        // Don't show the Order details title in the next-view's back button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+    }
+
+
+    /// Reloads the tableView's data, assuming the view has been loaded.
+    ///
+    func reloadTableViewDataIfPossible() {
+        guard isViewLoaded else {
+            return
+        }
+
+        tableView.reloadData()
+    }
+
+    /// Reloads the tableView's sections and data.
+    ///
+    func reloadTableViewSectionsAndData() {
+        reloadSections()
+        reloadTableViewDataIfPossible()
+    }
+
+    /// Registers all of the available TableViewCells
+    ///
+    func registerTableViewCells() {
+        let cells = [
+            BasicTableViewCell.self,
+        ]
+
+        for cell in cells {
+            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        }
+    }
+
+    /// Registers all of the available TableViewHeaderFooters
+    ///
+    func registerTableViewHeaderFooters() {
+        let headersAndFooters = [
+            TwoColumnSectionHeaderView.self,
+            ShowHideSectionFooter.self
+        ]
+
+        for kind in headersAndFooters {
+            tableView.register(kind.loadNib(), forHeaderFooterViewReuseIdentifier: kind.reuseIdentifier)
+        }
+    }
+}
+
+
+// MARK: - Cell Configuration
+//
+private extension ProductDetailsViewController {
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as BasicTableViewCell:
+            configureProductDetails(cell: cell)
+        default:
+            fatalError("Unidentified row type")
+        }
+    }
+
+    func configureProductDetails(cell: BasicTableViewCell) {
+        cell.textLabel?.text = "Hi there! 😃"
+        cell.accessoryType = .none
+        cell.selectionStyle = .default
+    }
+}
+
+
+// MARK: - Action Handlers
+//
+extension ProductDetailsViewController {
+
+    @objc func pullToRefresh() {
+        // TODO: refresh the product screen
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductDetailsViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if sections[section].title == nil {
+            // iOS 11 table bug. Must return a tiny value to collapse `nil` or `empty` section headers.
+            return .leastNonzeroMagnitude
+        }
+
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let leftText = sections[section].title else {
+            return nil
+        }
+
+        let headerID = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? TwoColumnSectionHeaderView else {
+            fatalError()
+        }
+
+        headerView.leftText = leftText
+        headerView.rightText = sections[section].rightTitle
+
+        return headerView
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        let lastSectionIndex = sections.count - 1
+
+        if sections[section].footer != nil || section == lastSectionIndex {
+            return UITableView.automaticDimension
+        }
+
+        return .leastNonzeroMagnitude
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return nil
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductDetailsViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch rowAtIndexPath(indexPath) {
+        default:
+            break
+        }
+    }
+}
+
+
+// MARK: - Private helpers
+//
+private extension ProductDetailsViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+
+// MARK: - Sections
+//
+private extension ProductDetailsViewController {
+
+    /// Setup: Sections
+    ///
+    func reloadSections() {
+        let summary = Section(row: .productSummary)
+        // TODO: More sections go here
+        sections = [summary].compactMap { $0 }
+    }
+}
+
+
+// MARK: - Constants
+//
+private extension ProductDetailsViewController {
+
+    enum Constants {
+        static let rowHeight = CGFloat(38)
+        static let sectionHeight = CGFloat(44)
+    }
+
+    struct Section {
+        let title: String?
+        let rightTitle: String?
+        let footer: String?
+        let rows: [Row]
+
+        init(title: String? = nil, rightTitle: String? = nil, footer: String? = nil, rows: [Row]) {
+            self.title = title
+            self.rightTitle = rightTitle
+            self.footer = footer
+            self.rows = rows
+        }
+
+        init(title: String? = nil, rightTitle: String? = nil, footer: String? = nil, row: Row) {
+            self.init(title: title, rightTitle: rightTitle, footer: footer, rows: [row])
+        }
+    }
+
+    enum Row {
+        case productSummary
+        // TODO: More rows go here
+
+        var reuseIdentifier: String {
+            switch self {
+            case .productSummary:
+                return SummaryTableViewCell.reuseIdentifier
+            }
+        }
+    }
+}
+

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductDetailsViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="sWt-Ef-Hwo" id="M8i-Ao-aa0"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sWt-Ef-Hwo">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="sWt-Ef-Hwo" secondAttribute="bottom" id="25y-U1-tbo"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sWt-Ef-Hwo" secondAttribute="trailing" id="8Sd-ON-WDx"/>
+                <constraint firstItem="sWt-Ef-Hwo" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="8nn-Dz-R2D"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="top" secondItem="sWt-Ef-Hwo" secondAttribute="top" constant="20" id="e1T-g5-2zR"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
@@ -22,7 +22,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sWt-Ef-Hwo">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="dtH-l3-88d"/>
@@ -35,7 +35,7 @@
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="sWt-Ef-Hwo" secondAttribute="bottom" id="25y-U1-tbo"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sWt-Ef-Hwo" secondAttribute="trailing" id="8Sd-ON-WDx"/>
                 <constraint firstItem="sWt-Ef-Hwo" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="8nn-Dz-R2D"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="top" secondItem="sWt-Ef-Hwo" secondAttribute="top" constant="20" id="e1T-g5-2zR"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="top" secondItem="sWt-Ef-Hwo" secondAttribute="top" id="e1T-g5-2zR"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
@@ -24,6 +24,10 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sWt-Ef-Hwo">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="dtH-l3-88d"/>
+                        <outlet property="delegate" destination="-1" id="5hl-Ok-FQ4"/>
+                    </connections>
                 </tableView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -1,0 +1,233 @@
+import Foundation
+import UIKit
+import Yosemite
+
+
+/// ProductLoaderViewController: Loads asynchronously a Product (given it's ProductID + SiteID).
+/// On Success the ProductDetailsViewController will be rendered "in place".
+///
+class ProductLoaderViewController: UIViewController {
+
+    /// UI Spinner
+    ///
+    private let activityIndicator = UIActivityIndicatorView(style: .gray)
+
+    /// Target ProductID
+    ///
+    private let productID: Int
+
+    /// Target Product's SiteID
+    ///
+    private let siteID: Int
+
+    /// UI Active State
+    ///
+    private var state: State = .loading {
+        didSet {
+            didLeave(state: oldValue)
+            didEnter(state: state)
+        }
+    }
+
+    // MARK: - Initializers
+
+    init(productID: Int, siteID: Int) {
+        self.productID = productID
+        self.siteID = siteID
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("Please specify the ProductID and SiteID!")
+    }
+
+
+    // MARK: - Overridden Methods
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationItem()
+        configureSpinner()
+        configureMainView()
+
+        reloadProduct()
+    }
+}
+
+
+// MARK: - Actions
+//
+private extension ProductLoaderViewController {
+
+    /// Loads (and displays) the specified Product.
+    ///
+    func reloadProduct() {
+        let action = ProductAction.retrieveProduct(siteID: siteID, productID: productID) { [weak self] (product, error) in
+            guard let `self` = self else {
+                return
+            }
+
+            guard let product = product else {
+                DDLogError("⛔️ Error loading Product for siteID: \(self.siteID) productID:\(self.productID) error:\(error.debugDescription)")
+                self.state = .failure
+                return
+            }
+
+            self.state = .success(product: product)
+        }
+
+        state = .loading
+        StoresManager.shared.dispatch(action)
+    }
+}
+
+
+// MARK: - Configuration
+//
+private extension ProductLoaderViewController {
+
+    /// Setup: Navigation
+    ///
+    func configureNavigationItem() {
+        title = NSLocalizedString("Loading Product", comment: "Displayed when an Product is being retrieved")
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+    }
+
+    /// Setup: Main View
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+        view.addSubview(activityIndicator)
+        view.pinSubviewAtCenter(activityIndicator)
+    }
+
+    /// Setup: Spinner
+    ///
+    func configureSpinner() {
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+    }
+}
+
+
+// MARK: - Overlays
+//
+private extension ProductLoaderViewController {
+
+    /// Starts the Spinner
+    ///
+    func startSpinner() {
+        activityIndicator.startAnimating()
+    }
+
+    /// Stops the Spinner
+    ///
+    func stopSpinner() {
+        activityIndicator.stopAnimating()
+    }
+
+    /// Displays the Loading Overlay.
+    ///
+    func displayFailureOverlay() {
+        let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
+        overlayView.messageImage = .waitingForCustomersImage
+        overlayView.messageText = NSLocalizedString("The Product couldn't be loaded.", comment: "Fetching a product failed")
+        overlayView.actionText = NSLocalizedString("Retry", comment: "Retry the last action")
+        overlayView.onAction = { [weak self] in
+            self?.reloadProduct()
+        }
+
+        overlayView.attach(to: view)
+    }
+
+    /// Removes all of the the OverlayMessageView instances in the view hierarchy.
+    ///
+    func removeAllOverlays() {
+        for subview in view.subviews where subview is OverlayMessageView {
+            subview.removeFromSuperview()
+        }
+    }
+
+    /// Presents the ProductDetailsViewController, as a childViewController, for a given Product.
+    ///
+    func presentProductDetails(for product: Product) {
+
+        // TODO: Setup the ProductDetailsViewController with a real product we load in this VC
+        let detailsViewController = ProductDetailsViewController(product: nil)
+
+        // Attach
+        addChild(detailsViewController)
+        attachSubview(detailsViewController.view)
+        detailsViewController.didMove(toParent: self)
+
+        // And, of course, borrow the Child's Title
+        title = detailsViewController.title
+    }
+
+    /// Removes all of the children UIViewControllers
+    ///
+    func detachChildrenViewControllers() {
+        for child in children {
+            child.view.removeFromSuperview()
+            child.removeFromParent()
+            child.didMove(toParent: nil)
+        }
+    }
+}
+
+
+// MARK: - UI Methods
+//
+private extension ProductLoaderViewController {
+
+    /// Attaches a given Subview, and ensures it's pinned to all the edges
+    ///
+    func attachSubview(_ subview: UIView) {
+        subview.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(subview)
+        view.pinSubviewToAllEdges(subview)
+    }
+}
+
+
+// MARK: - Finite State Machine Management
+//
+private extension ProductLoaderViewController {
+
+    /// Runs whenever the FSM enters a State.
+    ///
+    func didEnter(state: State) {
+        switch state {
+        case .loading:
+            startSpinner()
+        case .success(let product):
+            presentProductDetails(for: product)
+        case .failure:
+            displayFailureOverlay()
+        }
+    }
+
+    /// Runs whenever the FSM leaves a State.
+    ///
+    func didLeave(state: State) {
+        switch state {
+        case .loading:
+            stopSpinner()
+        case .success:
+            detachChildrenViewControllers()
+        case .failure:
+            removeAllOverlays()
+        }
+    }
+}
+
+
+// MARK: - ProductLoader Possible States
+//
+private enum State {
+    case loading
+    case success(product: Product)
+    case failure
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -48,11 +48,50 @@ class ProductLoaderViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureNavigationItem()
+        configureNavigationTitle()
         configureSpinner()
         configureMainView()
-
+        configureDismissButton()
         reloadProduct()
+    }
+}
+
+
+// MARK: - Configuration
+//
+private extension ProductLoaderViewController {
+
+    /// Setup: Navigation Title
+    ///
+    func configureNavigationTitle() {
+        title = NSLocalizedString("Loading Product", comment: "Displayed when an Product is being retrieved")
+    }
+
+    /// Setup: Main View
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+        view.addSubview(activityIndicator)
+        view.pinSubviewAtCenter(activityIndicator)
+    }
+
+    /// Setup: Spinner
+    ///
+    func configureSpinner() {
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    /// Setup: Dismiss Button
+    ///
+    func configureDismissButton() {
+        let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Product details screen - button title for closing the view")
+        let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(dismissButtonTapped))
+        leftBarButton.tintColor = .white
+        navigationItem.setLeftBarButton(leftBarButton, animated: false)
     }
 }
 
@@ -81,33 +120,9 @@ private extension ProductLoaderViewController {
         state = .loading
         StoresManager.shared.dispatch(action)
     }
-}
 
-
-// MARK: - Configuration
-//
-private extension ProductLoaderViewController {
-
-    /// Setup: Navigation
-    ///
-    func configureNavigationItem() {
-        title = NSLocalizedString("Loading Product", comment: "Displayed when an Product is being retrieved")
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
-    }
-
-    /// Setup: Main View
-    ///
-    func configureMainView() {
-        view.backgroundColor = StyleManager.tableViewBackgroundColor
-        view.addSubview(activityIndicator)
-        view.pinSubviewAtCenter(activityIndicator)
-    }
-
-    /// Setup: Spinner
-    ///
-    func configureSpinner() {
-        activityIndicator.hidesWhenStopped = true
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+    @objc func dismissButtonTapped() {
+        dismiss(animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -104,7 +104,7 @@ private extension ProductLoaderViewController {
     ///
     func loadProduct() {
         let action = ProductAction.retrieveProduct(siteID: siteID, productID: productID) { [weak self] (product, error) in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -52,7 +52,7 @@ class ProductLoaderViewController: UIViewController {
         configureSpinner()
         configureMainView()
         configureDismissButton()
-        reloadProduct()
+        loadProduct()
     }
 }
 
@@ -102,7 +102,7 @@ private extension ProductLoaderViewController {
 
     /// Loads (and displays) the specified Product.
     ///
-    func reloadProduct() {
+    func loadProduct() {
         let action = ProductAction.retrieveProduct(siteID: siteID, productID: productID) { [weak self] (product, error) in
             guard let `self` = self else {
                 return
@@ -151,7 +151,7 @@ private extension ProductLoaderViewController {
         overlayView.messageText = NSLocalizedString("The Product couldn't be loaded.", comment: "Fetching a product failed")
         overlayView.actionText = NSLocalizedString("Retry", comment: "Retry the last action")
         overlayView.onAction = { [weak self] in
-            self?.reloadProduct()
+            self?.loadProduct()
         }
 
         overlayView.attach(to: view)
@@ -168,9 +168,7 @@ private extension ProductLoaderViewController {
     /// Presents the ProductDetailsViewController, as a childViewController, for a given Product.
     ///
     func presentProductDetails(for product: Product) {
-
-        // TODO: Setup the ProductDetailsViewController with a real product we load in this VC
-        let detailsViewController = ProductDetailsViewController(product: nil)
+        let detailsViewController = ProductDetailsViewController(product: product)
 
         // Attach
         addChild(detailsViewController)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		74C6FEA521C2F1FA009286B6 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C6FEA421C2F1FA009286B6 /* AboutViewController.swift */; };
 		74D0A5302139CF1300E2919F /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D0A52F2139CF1300E2919F /* String+Helpers.swift */; };
 		74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74E0F440211C9AE600A79CCE /* PeriodDataViewController.xib */; };
+		74EC34A5225FE21F004BBC2E /* ProductLoaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EC34A4225FE21F004BBC2E /* ProductLoaderViewController.swift */; };
+		74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */; };
+		74EC34A9225FE69C004BBC2E /* ProductDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */; };
 		74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F301592200EC0800931B9E /* NSDecimalNumberWooTests.swift */; };
 		74F9E9CD214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */; };
 		74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */; };
@@ -397,6 +400,9 @@
 		74C6FEA421C2F1FA009286B6 /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		74D0A52F2139CF1300E2919F /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		74E0F440211C9AE600A79CCE /* PeriodDataViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PeriodDataViewController.xib; sourceTree = "<group>"; };
+		74EC34A4225FE21F004BBC2E /* ProductLoaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductLoaderViewController.swift; sourceTree = "<group>"; };
+		74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsViewController.swift; sourceTree = "<group>"; };
+		74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductDetailsViewController.xib; sourceTree = "<group>"; };
 		74F301592200EC0800931B9E /* NSDecimalNumberWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDecimalNumberWooTests.swift; sourceTree = "<group>"; };
 		74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoPeriodDataTableViewCell.xib; sourceTree = "<group>"; };
 		74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoPeriodDataTableViewCell.swift; sourceTree = "<group>"; };
@@ -783,6 +789,16 @@
 			path = About;
 			sourceTree = "<group>";
 		};
+		74EC34A3225FE1F3004BBC2E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				74EC34A4225FE21F004BBC2E /* ProductLoaderViewController.swift */,
+				74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */,
+				74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */,
+			);
+			path = Products;
+			sourceTree = "<group>";
+		};
 		74F9E9CA214C034A00A3F2D2 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -969,6 +985,7 @@
 				CE85FD5120F677460080B73E /* Dashboard */,
 				CE1CCB4920570B05000EE3AC /* Orders */,
 				B59C09DA2188D6E800AB41D6 /* Notifications */,
+				74EC34A3225FE1F3004BBC2E /* Products */,
 				B56DB3CD2049BFAA00D4AA8E /* Main.storyboard */,
 				CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */,
 			);
@@ -1263,6 +1280,7 @@
 				B5FD111121D3CE7700560344 /* NewNoteViewController.xib */,
 				D81D9226222E7F0800FFA585 /* OrderStatusListViewController.swift */,
 				D81D9227222E7F0800FFA585 /* OrderStatusListViewController.xib */,
+				CE21B3DC20FF9BC200A259D5 /* ProductListViewController.swift */,
 				D83F5932225B2EB800626E75 /* ManualTrackingViewController.swift */,
 				D843D5C622434A08001BFA55 /* ManualTrackingViewController.xib */,
 				D843D5D122485009001BFA55 /* ShippingProvidersViewController.swift */,
@@ -1447,7 +1465,6 @@
 				CE21B3DF20FFC59700A259D5 /* ProductDetailsTableViewCell.xib */,
 				CE32B11320BF8779006FBCF4 /* ProductListTableViewCell.swift */,
 				CE32B11420BF8779006FBCF4 /* ProductListTableViewCell.xib */,
-				CE21B3DC20FF9BC200A259D5 /* ProductListViewController.swift */,
 				CEE006032077D1280079161F /* SummaryTableViewCell.swift */,
 				CEE006042077D1280079161F /* SummaryTableViewCell.xib */,
 			);
@@ -1652,6 +1669,7 @@
 				CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */,
 				CE24BCD0212DE8A6001CD12E /* HeadlineLabelTableViewCell.xib in Resources */,
 				B559EBB020A0BF8F00836CD4 /* LICENSE in Resources */,
+				74EC34A9225FE69C004BBC2E /* ProductDetailsViewController.xib in Resources */,
 				CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */,
 				B5FD110E21D3CB8500560344 /* OrderTableViewCell.xib in Resources */,
 				D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */,
@@ -2009,6 +2027,7 @@
 				CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */,
 				B5C3876421C41B9F006CE970 /* UIApplication+Woo.swift in Sources */,
 				74A93A40212DC60B00C13E04 /* NewOrdersViewController.swift in Sources */,
+				74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
@@ -2045,6 +2064,7 @@
 				B53B898D20D462A000EDB467 /* StoresManager.swift in Sources */,
 				B5D1AFC020BC67C200DB0E8C /* WooConstants.swift in Sources */,
 				93FA787421CD7E9E00B663E5 /* CurrencySettings.swift in Sources */,
+				74EC34A5225FE21F004BBC2E /* ProductLoaderViewController.swift in Sources */,
 				B560D68C2195BD1E0027BB7E /* NoteDetailsCommentTableViewCell.swift in Sources */,
 				743E272021AEF20100D6DC82 /* FancyAlertViewController+Upgrade.swift in Sources */,
 				CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */,


### PR DESCRIPTION
This PR adds the ability to launch the product details modal from either the `FulfillViewController` or `ProductListViewController`:

![product_loading](https://user-images.githubusercontent.com/154014/56066391-39770380-5d3d-11e9-9b94-d248e631c031.gif)

**Note:** everything in this PR has been feature flagged as `.localDeveloper`!

Fixes: #855 

### ProductLoaderViewController

The new `ProductLoaderViewController` (which is similar to our much-beloved `OrderLoaderViewController`) decouples the Product Detail VC from any specific navigation flow. ProductLoader does the following when launched:

**1.** Displays a fullscreen spinner and temp `Loading Product` nav bar title:
![product_load copy 2](https://user-images.githubusercontent.com/154014/56066942-ec942c80-5d3e-11e9-9392-f0ee1312ac85.png)

**2.** Asynchronously fetches a `Product` given the passed-in `productID` + `siteID`

**3.** When the product is retrieved, the (new) `ProductDetailsViewController` is instantiated and rendered in place

**4.** If an error occurs while loading the product, an error overlay is displayed:
![product_error copy 2](https://user-images.githubusercontent.com/154014/56066979-18171700-5d3f-11e9-81f8-3160d625bdf6.png)

### ProductDetailsViewController

The shell of `ProductDetailsViewController` was also implemented in this PR and it will be updated in subsequent PRs. For now this VC contains:
* Core Initialization logic (using real product data)
* Basic `UITableView` setup & config
* `EntityListener` setup & config
* Pull to refresh logic (including fetching real product data)

### Other stuff

* `ProductListViewController.swift` was located in the wrong project folder so it was moved
* Added a new `FeatureFlag` → `productDetails`

## Testing!
1. Take a look at the code focusing primarily on `ProductLoaderViewController` — `ProductDetailsViewController` will be updated in upcoming PRs
2. Run the unit tests, verify they are ✅ 
3. Build and run the app:
    * Verify you can see the shell product details screen when tapping on a order item in `FulfillViewController` or `ProductListViewController` 
    * Turn off your network connection and tap on an order line item in `FulfillViewController` or `ProductListViewController` — Verify the error overlay displays (eventually)
    * Test out pull-to-refresh on `ProductDetailsViewController`

@ctarda and @mindgraffiti → would you mind giving this PR a 👀 ?

