### PR TITLE
Order fulfillment: Hide the `Add Tracking` button until the request to sync tracking succeeds

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -521,7 +521,7 @@ private extension FulfillViewController {
         }()
 
         let addTracking: Section? = {
-            // Hide the section if we consider the shipment
+            // Hide the section if the shipment
             // tracking plugin is not installed
             guard trackingIsReachable else {
                 return nil


### PR DESCRIPTION
Fixes #852 

As discussed in [this comment](https://github.com/woocommerce/woocommerce-ios/issues/852#issuecomment-482308373), the `Add Tracking` button is hidden until we have confirmation that the remote service exists and returns data.

## Changes
- Added a property to the `FulFillViewController`, initialised to false, that will be reset to true when data sync succeeds.
- Present button only when said property is true

## Testing
### Assuming the current store has the plugin installed:
- Navigate to Orders > Select one Order > Order Details
- Kill the network connection
- Tap "Fulfill order"

This should be the result:
![Simulator Screen Shot - iPhone 8 - 2019-04-15 at 14 32 21](https://user-images.githubusercontent.com/2722505/56111965-39207780-5f8c-11e9-8444-60e98b10f441.png)

As soon as the network returns, the button should be active again:
![Simulator Screen Shot - iPhone 8 - 2019-04-15 at 14 38 54](https://user-images.githubusercontent.com/2722505/56111985-45a4d000-5f8c-11e9-8e5f-ec9aebd7cf1c.png)

### In the case of a store without the plugin installed:
- Navigate to orders > Select an order > Order details

The button should not be visible:

![Simulator Screen Shot - iPhone 8 - 2019-04-15 at 14 43 09](https://user-images.githubusercontent.com/2722505/56112167-cfed3400-5f8c-11e9-8d58-b94812d41226.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.