### PR TITLE
Remove orderID from the API to fetch all the shipment providers

### DIFF
--- a/Networking/Networking/Remote/ShipmentsRemote.swift
+++ b/Networking/Networking/Remote/ShipmentsRemote.swift
@@ -95,8 +95,14 @@ public final class ShipmentsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    public func loadShipmentTrackingProviderGroups(for siteID: Int, orderID: Int, completion: @escaping ([ShipmentTrackingProviderGroup]?, Error?) -> Void) {
-        let path = "\(Constants.ordersPath)/" + String(orderID) + "/" + "\(Constants.shipmentPath)/\(Constants.providersPath)"
+    public func loadShipmentTrackingProviderGroups(for siteID: Int, completion: @escaping ([ShipmentTrackingProviderGroup]?, Error?) -> Void) {
+        // Any orderID would do, as long as there is an orderID in the path
+        // and it is a number.
+        // https://github.com/woocommerce/woocommerce-ios/issues/875
+        //
+        let orderID = "8"
+        
+        let path = "\(Constants.ordersPath)/" + orderID + "/" + "\(Constants.shipmentPath)/\(Constants.providersPath)"
 
         let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ShipmentTrackingProviderListMapper(siteID: siteID)

--- a/Networking/Networking/Remote/ShipmentsRemote.swift
+++ b/Networking/Networking/Remote/ShipmentsRemote.swift
@@ -101,7 +101,7 @@ public final class ShipmentsRemote: Remote {
         // https://github.com/woocommerce/woocommerce-ios/issues/875
         //
         let orderID = "8"
-        
+
         let path = "\(Constants.ordersPath)/" + orderID + "/" + "\(Constants.shipmentPath)/\(Constants.providersPath)"
 
         let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)

--- a/Networking/NetworkingTests/Remote/ShipmentsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShipmentsRemoteTests.swift
@@ -16,7 +16,7 @@ final class ShipmentsRemoteTests: XCTestCase {
 
     /// Dummy Order ID
     ///
-    let sampleOrderID = 567
+    let sampleOrderID = 8
 
     /// Repeat always!
     ///
@@ -378,7 +378,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking providers information")
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/providers", filename: "shipment_tracking_providers")
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (groups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID) { (groups, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(groups)
             XCTAssertEqual(groups?.count, 19)
@@ -394,7 +394,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let remote = ShipmentsRemote(network: network)
         let expectation = self.expectation(description: "Load shipment tracking providers information contains errors")
 
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (shipmentTrackingGroups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID) { (shipmentTrackingGroups, error) in
             XCTAssertNil(shipmentTrackingGroups)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -411,7 +411,7 @@ final class ShipmentsRemoteTests: XCTestCase {
 
         network.simulateError(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/providers", error: NetworkError.notFound)
 
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (shipmentTrackingGroups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID) { (shipmentTrackingGroups, error) in
             XCTAssertNil(shipmentTrackingGroups)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -428,7 +428,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking information")
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/providers", filename: "shipment_tracking_plugin_not_active")
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (shipmentTrackingGroups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID) { (shipmentTrackingGroups, error) in
             XCTAssertNil(shipmentTrackingGroups)
             XCTAssertNotNil(error)
 

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -55,8 +55,7 @@ final class ShippingProvidersViewModel {
             return
         }
 
-        let loadGroupsAction = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: siteID,
-                                                                                   orderID: orderID) { [weak self] error in
+        let loadGroupsAction = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: siteID) { [weak self] error in
             if let error = error {
                 self?.handleError(error)
             }

--- a/Yosemite/Yosemite/Actions/ShipmentAction.swift
+++ b/Yosemite/Yosemite/Actions/ShipmentAction.swift
@@ -12,7 +12,7 @@ public enum ShipmentAction: Action {
 
     /// Synchronizes all the shipment tracking providers associated with the provided `siteID` and `orderID`
     ///
-    case synchronizeShipmentTrackingProviders(siteID: Int, orderID: Int, onCompletion: (Error?) -> Void)
+    case synchronizeShipmentTrackingProviders(siteID: Int, onCompletion: (Error?) -> Void)
 
     /// Adds a shipment tracking with `trackingID` associated with the provided `siteID` and `orderID`
     ///

--- a/Yosemite/Yosemite/Stores/ShipmentStore.swift
+++ b/Yosemite/Yosemite/Stores/ShipmentStore.swift
@@ -34,8 +34,8 @@ public class ShipmentStore: Store {
         switch action {
         case .synchronizeShipmentTrackingData(let siteID, let orderID, let onCompletion):
             synchronizeShipmentTrackingData(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
-        case .synchronizeShipmentTrackingProviders(let siteID, let orderID, let onCompletion):
-            syncronizeShipmentTrackingProviderGroupsData(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
+        case .synchronizeShipmentTrackingProviders(let siteID, let onCompletion):
+            syncronizeShipmentTrackingProviderGroupsData(siteID: siteID, onCompletion: onCompletion)
         case .addTracking(let siteID,
                           let orderID,
                           let providerGroupName,
@@ -87,19 +87,17 @@ private extension ShipmentStore {
         }
     }
 
-    func syncronizeShipmentTrackingProviderGroupsData(siteID: Int, orderID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func syncronizeShipmentTrackingProviderGroupsData(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = ShipmentsRemote(network: network)
-        remote.loadShipmentTrackingProviderGroups(for: siteID, orderID: orderID) { [weak self] (groups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: siteID) { [weak self] (groups, error) in
             guard let readOnlyShipmentTrackingProviderGroups = groups else {
                 onCompletion(error)
                 return
             }
 
-            self?.upsertTrackingProviderDataInBackground(siteID: siteID,
-                                                                 orderID: orderID,
-                                                                 readOnlyShipmentTrackingProviderGroups: readOnlyShipmentTrackingProviderGroups,
-                                                                 onCompletion: {
-                onCompletion(nil)
+            self?.upsertTrackingProviderDataInBackground(siteID: siteID,                                                                 readOnlyShipmentTrackingProviderGroups: readOnlyShipmentTrackingProviderGroups,
+                                                         onCompletion: {
+                                                            onCompletion(nil)
             })
         }
     }
@@ -148,7 +146,6 @@ extension ShipmentStore {
     }
 
     func upsertTrackingProviderDataInBackground(siteID: Int,
-                                                orderID: Int,
                                                 readOnlyShipmentTrackingProviderGroups: [Networking.ShipmentTrackingProviderGroup],
                                                         onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage

--- a/Yosemite/Yosemite/Stores/ShipmentStore.swift
+++ b/Yosemite/Yosemite/Stores/ShipmentStore.swift
@@ -95,7 +95,8 @@ private extension ShipmentStore {
                 return
             }
 
-            self?.upsertTrackingProviderDataInBackground(siteID: siteID,                                                                 readOnlyShipmentTrackingProviderGroups: readOnlyShipmentTrackingProviderGroups,
+            self?.upsertTrackingProviderDataInBackground(siteID: siteID,
+                                                         readOnlyShipmentTrackingProviderGroups: readOnlyShipmentTrackingProviderGroups,
                                                          onCompletion: {
                                                             onCompletion(nil)
             })

--- a/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
@@ -32,7 +32,7 @@ final class ShipmentStoreTests: XCTestCase {
 
     /// Dummy Order ID
     ///
-    private let sampleOrderID = 963
+    private let sampleOrderID = 8
 
     /// Mock Country name
     ///
@@ -227,7 +227,7 @@ final class ShipmentStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "orders/" + String(sampleOrderID) + "/" + "shipment-trackings/providers",
                                  filename: "shipment_tracking_providers")
-        let action = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: sampleSiteID, orderID: sampleOrderID) { error in
+        let action = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: sampleSiteID) { error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ShipmentTrackingProviderGroup.self), 19)
 
@@ -255,7 +255,7 @@ final class ShipmentStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "orders/" + String(sampleOrderID) + "/" + "shipment-trackings/providers",
                                  filename: "shipment_tracking_plugin_not_active")
-        let action = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: sampleSiteID, orderID: sampleOrderID) { error in
+        let action = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: sampleSiteID) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -270,7 +270,7 @@ final class ShipmentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve shipment tracking provider grup list empty response")
         let shipmentStore = ShipmentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: sampleSiteID, orderID: sampleOrderID) { error in
+        let action = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: sampleSiteID) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -290,7 +290,6 @@ final class ShipmentStoreTests: XCTestCase {
         let group = DispatchGroup()
         group.enter()
         shipmentStore.upsertTrackingProviderDataInBackground(siteID: sampleSiteID,
-                                                             orderID: sampleOrderID,
                                                              readOnlyShipmentTrackingProviderGroups: australiaMutatedAndSwedenMutated()) {
                                                                 XCTAssertTrue(Thread.isMainThread)
                                                                 group.leave()
@@ -326,7 +325,6 @@ final class ShipmentStoreTests: XCTestCase {
         let group = DispatchGroup()
         group.enter()
         shipmentStore.upsertTrackingProviderDataInBackground(siteID: sampleSiteID,
-                                                             orderID: sampleOrderID,
                                                              readOnlyShipmentTrackingProviderGroups: sampleShipmentTrackingProviderGroupListMutatedOneGroup()) {
                                                                 XCTAssertTrue(Thread.isMainThread)
                                                                 group.leave()


### PR DESCRIPTION
Implements #875 

To be honest, I am not sure we would be better off after removing the orderID. I understand it is not necessary, but removing it introduces some asymmetry in the API (i.e. all cases in `ShipmentAction` require an `orderID` except `synchronizeShipmentTrackingProviders`).

@mindgraffiti @bummytime would you mind taking a 👀  if you have some time and sharing your thoughts? Should we really remove the `orderID` parameter?

## Changes
- Removed the `orderID` parameter from the APIs to fetch the list of shipment providers
- Hardcoded an `orderID` in the remote request (as it is still required in the request path)

## Testing
- Checkout the branch, run the tests.
- Navigate to an order > add tracking > list of shipment providers. Check that the list loads.

*Warning* This PR depends on #873. That's why I open it as a draft PR
 
Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.