### PR TITLE
Change the type of event firing and the data reported in the OrderStatusListViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
@@ -164,9 +164,6 @@ private extension OrderStatusListViewController {
             return
         }
 
-        WooAnalytics.shared.track(.orderDetailOrderStatusEditButtonTapped,
-                                  withProperties: ["status": newStatus])
-
         let orderID = order.orderID
         let undoStatus = order.statusKey
 
@@ -174,9 +171,17 @@ private extension OrderStatusListViewController {
         let undo = updateOrderAction(siteID: order.siteID, orderID: orderID, statusKey: undoStatus)
 
         StoresManager.shared.dispatch(done)
+        WooAnalytics.shared.track(.orderStatusChange,
+                                  withProperties: ["id": orderID,
+                                                   "from": undoStatus,
+                                                   "to": newStatus])
 
         displayOrderUpdatedNotice {
             StoresManager.shared.dispatch(undo)
+            WooAnalytics.shared.track(.orderStatusChange,
+                                      withProperties: ["id": orderID,
+                                                       "from": newStatus,
+                                                       "to": undoStatus])
         }
     }
 


### PR DESCRIPTION
Fixes #881. Sorry I didn't catch this during the initial review. After taking the data workshop, I'm a bit better at understanding what should be reported and where.

The problem with using the event `.orderDetailOrderStatusEditButtonTapped` is that it should be reserved for that button's action only. What should be reported here is an order status change. Notice that we also needed to report the order status change back to the original settings if the user taps the "Undo" button in the snack bar.

## To Test
1. Navigate to an Order > Order detail screen. 
2. Tap on the pencil icon in the order status card, so that the order status list will appear.
3. Choose a new order status and save it.
4. In Tracks > Live view, the expected behavior is to report 1 event for `orderDetailOrderStatusEditButtonTapped` and 1 event `orderStatusChange`.
(The old version would report 2 events for `orderDetailOrderStatusEditButtonTapped`.)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
