### PR TITLE
Use and recognize WordPress.com opt out of analytics setting

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D5BECD217E0F98007B0348 /* SiteSettingsRemoteTests.swift */; };
 		74E30951216E8DCE00ABCE4C /* site-visits-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 74E30950216E8DCE00ABCE4C /* site-visits-alt.json */; };
 		933A2732222234F800C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
+		9387A6F0226E3F15001B53D7 /* AccountSettingsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */; };
 		93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */; };
 		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
 		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
@@ -341,6 +342,7 @@
 		74E30950216E8DCE00ABCE4C /* site-visits-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-visits-alt.json"; sourceTree = "<group>"; };
 		753D6504FF01F09F6A33B73E /* Pods-Networking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.debug.xcconfig"; sourceTree = "<group>"; };
 		933A2731222234F800C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsMapperTests.swift; sourceTree = "<group>"; };
 		93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettings.swift; sourceTree = "<group>"; };
 		93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsMapper.swift; sourceTree = "<group>"; };
 		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
@@ -870,6 +872,7 @@
 			isa = PBXGroup;
 			children = (
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
+				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
@@ -1305,6 +1308,7 @@
 				B567AF2F20A0FB8F00AB6C62 /* AuthenticatedRequestTests.swift in Sources */,
 				B5C6FCCD20A34B8300A4F8E4 /* OrderListMapperTests.swift in Sources */,
 				B518663520A0A2E800037A38 /* Constants.swift in Sources */,
+				9387A6F0226E3F15001B53D7 /* AccountSettingsMapperTests.swift in Sources */,
 				7470B1852257CED10000117E /* ProductVariationMapperTests.swift in Sources */,
 				B57B1E6721C916850046E764 /* NetworkErrorTests.swift in Sources */,
 				74002D6C2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -112,6 +112,10 @@
 		74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D5BECD217E0F98007B0348 /* SiteSettingsRemoteTests.swift */; };
 		74E30951216E8DCE00ABCE4C /* site-visits-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = 74E30950216E8DCE00ABCE4C /* site-visits-alt.json */; };
 		933A2732222234F800C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
+		93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */; };
+		93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */; };
+		93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = 93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */; };
+		93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */; };
 		B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */; };
 		B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CE20BEE38B00BB1B69 /* Account.swift */; };
 		B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6D020BEE39600BB1B69 /* AccountRemote.swift */; };
@@ -337,6 +341,10 @@
 		74E30950216E8DCE00ABCE4C /* site-visits-alt.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-visits-alt.json"; sourceTree = "<group>"; };
 		753D6504FF01F09F6A33B73E /* Pods-Networking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Networking.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Networking/Pods-Networking.debug.xcconfig"; sourceTree = "<group>"; };
 		933A2731222234F800C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettings.swift; sourceTree = "<group>"; };
+		93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsMapper.swift; sourceTree = "<group>"; };
+		93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings.json"; sourceTree = "<group>"; };
+		93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountMapper.swift; sourceTree = "<group>"; };
 		B505F6CE20BEE38B00BB1B69 /* Account.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		B505F6D020BEE39600BB1B69 /* AccountRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountRemote.swift; sourceTree = "<group>"; };
@@ -536,6 +544,7 @@
 			children = (
 				B5969E1420A47F99005E9DF1 /* RemoteTests.swift */,
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
+				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				B554FA8A2180B1D500C54DFF /* NotificationsRemoteTests.swift */,
@@ -682,6 +691,7 @@
 				CE6BFEE62236CF0D005C79FB /* Product */,
 				74A1D26921189AC100931DFA /* Stats */,
 				B505F6CE20BEE38B00BB1B69 /* Account.swift */,
+				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -727,6 +737,7 @@
 				740211DE2193985A002248DA /* comment-moderate-spam.json */,
 				B524194621AC643900D6FC0A /* device-settings.json */,
 				B505F6D420BEE4E600BB1B69 /* me.json */,
+				93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */,
 				B58D10C92114D22E00107ED4 /* new-order-note.json */,
 				B5A24178217F98F600595DEF /* notifications-load-all.json */,
 				B554FA8C2180B59700C54DFF /* notifications-load-hashes.json */,
@@ -782,6 +793,7 @@
 			children = (
 				B567AF2820A0FA1E00AB6C62 /* Mapper.swift */,
 				B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */,
+				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				B554FA8E2180BC7000C54DFF /* NoteHashListMapper.swift */,
@@ -1050,6 +1062,7 @@
 				7412A51121702E9700994370 /* order-stats-alt.json in Resources */,
 				74046E21217A73D0007DD7BF /* settings-general.json in Resources */,
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
+				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
 				741D336D2256B4E300109FAE /* product-variations-load-all.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
@@ -1183,6 +1196,7 @@
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
+				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
 				D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */,
 				B5C151BB217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift in Sources */,
@@ -1215,6 +1229,7 @@
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,
 				B53EF5322180F21C003E146F /* Dictionary+Woo.swift in Sources */,
 				74A1D26D21189DFF00931DFA /* SiteVisitStatsMapper.swift in Sources */,
+				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
 				B518662220A097C200037A38 /* Network.swift in Sources */,
 				B572F69A21AC475C003EEFF0 /* DevicesRemote.swift in Sources */,
@@ -1273,6 +1288,7 @@
 				7470B1872257D5C10000117E /* ProductVariationListMapperTests.swift in Sources */,
 				74C8F06A20EEBC8C00B6EDC9 /* OrderMapperTests.swift in Sources */,
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
+				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,

--- a/Networking/Networking/Extensions/CodingUserInfoKey+Woo.swift
+++ b/Networking/Networking/Extensions/CodingUserInfoKey+Woo.swift
@@ -20,7 +20,7 @@ extension CodingUserInfoKey {
     /// Used to store the ProductID within a Coder/Decoder's userInfo dictionary.
     ///
     public static let productID = CodingUserInfoKey(rawValue: "productID")!
-    
+
     /// Used to store the UserID within a Coder/Decoder's userInfo dictionary.
     ///
     public static let userID = CodingUserInfoKey(rawValue: "userID")!

--- a/Networking/Networking/Extensions/CodingUserInfoKey+Woo.swift
+++ b/Networking/Networking/Extensions/CodingUserInfoKey+Woo.swift
@@ -20,4 +20,8 @@ extension CodingUserInfoKey {
     /// Used to store the ProductID within a Coder/Decoder's userInfo dictionary.
     ///
     public static let productID = CodingUserInfoKey(rawValue: "productID")!
+    
+    /// Used to store the UserID within a Coder/Decoder's userInfo dictionary.
+    ///
+    public static let userID = CodingUserInfoKey(rawValue: "userID")!
 }

--- a/Networking/Networking/Mapper/AccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/AccountSettingsMapper.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+
+/// Mapper: AccountSettings
+///
+class AccountSettingsMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into an AccountSettings entity.
+    ///
+    func map(response: Data) throws -> AccountSettings {
+        let decoder = JSONDecoder()
+        return try decoder.decode(AccountSettings.self, from: response)
+    }
+}

--- a/Networking/Networking/Mapper/AccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/AccountSettingsMapper.swift
@@ -3,12 +3,22 @@ import Foundation
 
 /// Mapper: AccountSettings
 ///
-class AccountSettingsMapper: Mapper {
+struct AccountSettingsMapper: Mapper {
+
+    /// User Identifier associated to the account settings that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because UserID is not returned in the /me/settings endpoint.
+    ///
+    let userID: Int
 
     /// (Attempts) to convert a dictionary into an AccountSettings entity.
     ///
     func map(response: Data) throws -> AccountSettings {
         let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .userID: userID
+        ]
+
         return try decoder.decode(AccountSettings.self, from: response)
     }
 }

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -27,10 +27,10 @@ public struct AccountSettings: Decodable {
         guard let userID = decoder.userInfo[.userID] as? Int else {
             throw AccountSettingsDecodingError.missingUserID
         }
-        
+
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let tracksOptOut = try container.decode(Bool.self, forKey: .tracksOptOut)
-        
+
         self.init(userID: userID, tracksOptOut: tracksOptOut)
     }
 }

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -52,7 +52,8 @@ private extension AccountSettings {
 extension AccountSettings: Equatable {
 
     public static func == (lhs: AccountSettings, rhs: AccountSettings) -> Bool {
-        return lhs.tracksOptOut == rhs.tracksOptOut
+        return lhs.userID == rhs.userID &&
+            lhs.tracksOptOut == rhs.tracksOptOut
     }
 }
 

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -4,9 +4,35 @@ import Foundation
 ///
 public struct AccountSettings: Decodable {
 
+    /// Dotcom UserID
+    ///
+    public let userID: Int
+
     /// Tracks analytics opt out dotcom setting
     ///
     public let tracksOptOut: Bool
+    
+    
+    /// Default initializer for AccountSettings.
+    ///
+    public init(userID: Int, tracksOptOut: Bool) {
+        self.userID = userID
+        self.tracksOptOut = tracksOptOut
+    }
+    
+
+    /// The public initializer for AccountSettings.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let userID = decoder.userInfo[.userID] as? Int else {
+            throw AccountSettingsDecodingError.missingUserID
+        }
+        
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let tracksOptOut = try container.decode(Bool.self, forKey: .tracksOptOut)
+        
+        self.init(userID: userID, tracksOptOut: tracksOptOut)
+    }
 }
 
 
@@ -15,10 +41,10 @@ public struct AccountSettings: Decodable {
 private extension AccountSettings {
 
     enum CodingKeys: String, CodingKey {
+        case userID         = "UserID"
         case tracksOptOut   = "tracks_opt_out"
     }
 }
-
 
 
 // MARK: - Equatable Conformance
@@ -28,4 +54,11 @@ extension AccountSettings: Equatable {
     public static func == (lhs: AccountSettings, rhs: AccountSettings) -> Bool {
         return lhs.tracksOptOut == rhs.tracksOptOut
     }
+}
+
+
+// MARK: - Decoding Errors
+//
+enum AccountSettingsDecodingError: Error {
+    case missingUserID
 }

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -11,15 +11,15 @@ public struct AccountSettings: Decodable {
     /// Tracks analytics opt out dotcom setting
     ///
     public let tracksOptOut: Bool
-    
-    
+
+
     /// Default initializer for AccountSettings.
     ///
     public init(userID: Int, tracksOptOut: Bool) {
         self.userID = userID
         self.tracksOptOut = tracksOptOut
     }
-    
+
 
     /// The public initializer for AccountSettings.
     ///

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// WordPress.com Account Settings
+///
+public struct AccountSettings: Decodable {
+
+    /// Tracks analytics opt out dotcom setting
+    ///
+    public let tracksOptOut: Bool
+}
+
+
+/// Defines all of the AccountSettings CodingKeys
+///
+private extension AccountSettings {
+
+    enum CodingKeys: String, CodingKey {
+        case tracksOptOut   = "tracks_opt_out"
+    }
+}
+
+
+
+// MARK: - Equatable Conformance
+//
+extension AccountSettings: Equatable {
+
+    public static func == (lhs: AccountSettings, rhs: AccountSettings) -> Bool {
+        return lhs.tracksOptOut == rhs.tracksOptOut
+    }
+}

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -16,6 +16,17 @@ public class AccountRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    public func loadAccountSettings(completion: @escaping (AccountSettings?, Error?) -> Void) {
+        let path = "me/settings"
+        let parameters = [
+            "fields": "tracks_opt_out"
+        ]
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
+        let mapper = AccountSettingsMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
 
     /// Loads the Sites collection associated with the WordPress.com User.
     ///

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -16,13 +16,18 @@ public class AccountRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    public func loadAccountSettings(completion: @escaping (AccountSettings?, Error?) -> Void) {
+
+    /// Loads the AccountSettings associated with the Credential's authToken.
+    /// - Parameters:
+    ///   - for: The dotcom user ID - used primarily for persistence not on the actual network call
+    ///
+    public func loadAccountSettings(for userID: Int, completion: @escaping (AccountSettings?, Error?) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out"
         ]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)
-        let mapper = AccountSettingsMapper()
+        let mapper = AccountSettingsMapper(userID: userID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/NetworkingTests/Mapper/AccountSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/AccountSettingsMapperTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Networking
+
+
+/// AccountSettingsMapper Unit Tests
+///
+class AccountSettingsMapperTests: XCTestCase {
+
+    /// Verifies that all of the AccountSettings fields are properly parsed.
+    ///
+    func testAccountFieldsArePropertlyParsed() {
+        guard let account = mapLoadAccountSettingsResponse() else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(account.userID, 10)
+        XCTAssertTrue(account.tracksOptOut)
+    }
+}
+
+
+
+// MARK: - Private Methods.
+//
+private extension AccountSettingsMapperTests {
+
+    /// Returns the AccountSettingsMapper output upon receiving `me-settings` mockup response (Data Encoded).
+    ///
+    func mapLoadAccountSettingsResponse() -> AccountSettings? {
+        guard let response = Loader.contentsOf("me-settings") else {
+            return nil
+        }
+
+        return try? AccountSettingsMapper(userID: 10).map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Networking
+
+
+/// AccountSettingsRemote Unit Tests
+///
+class AccountSettingsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockupNetwork()
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+
+    /// Verifies that loadAccountDetails properly parses the `me` sample response.
+    ///
+    func testLoadAccountDetailsProperlyReturnsParsedAccount() {
+        let remote = AccountRemote(network: network)
+        let expectation = self.expectation(description: "Load Account Settings Details")
+
+        network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
+
+        remote.loadAccount { (account, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(account)
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}

--- a/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
@@ -25,9 +25,10 @@ class AccountSettingsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
 
-        remote.loadAccount { (account, error) in
+        remote.loadAccountSettings { (accountSettings, error) in
             XCTAssertNil(error)
-            XCTAssertNotNil(account)
+            XCTAssertNotNil(accountSettings)
+            XCTAssertTrue(accountSettings!.tracksOptOut)
 
             expectation.fulfill()
         }

--- a/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountSettingsRemoteTests.swift
@@ -25,9 +25,10 @@ class AccountSettingsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
 
-        remote.loadAccountSettings { (accountSettings, error) in
+        remote.loadAccountSettings(for: 1) { (accountSettings, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(accountSettings)
+            XCTAssertEqual(1, accountSettings!.userID)
             XCTAssertTrue(accountSettings!.tracksOptOut)
 
             expectation.fulfill()

--- a/Networking/NetworkingTests/Responses/me-settings.json
+++ b/Networking/NetworkingTests/Responses/me-settings.json
@@ -12,7 +12,7 @@
 	"user_email": "moocow@example.com",
 	"user_email_change_pending": false,
 	"new_user_email": "",
-	"user_URL": "http://www.xcode.wtf",
+	"user_URL": "http://www.xcode.moo",
 	"language": "en",
 	"avatar_URL": "https://2.gravatar.com/avatar/x?s=200&amp;d=mm",
 	"primary_site_ID": 57773116,

--- a/Networking/NetworkingTests/Responses/me-settings.json
+++ b/Networking/NetworkingTests/Responses/me-settings.json
@@ -1,0 +1,61 @@
+{
+	"enable_translator": false,
+	"surprise_me": false,
+	"post_post_flag": false,
+	"holidaysnow": false,
+	"user_login": "test123123",
+	"password": "",
+	"display_name": "test123123",
+	"first_name": "Dem 123",
+	"last_name": "Nines",
+	"description": "🙃\n\nThis is a bit more about me.\n\nAnd multi line text.",
+	"user_email": "moocow@example.com",
+	"user_email_change_pending": false,
+	"new_user_email": "",
+	"user_URL": "http://www.xcode.wtf",
+	"language": "en",
+	"avatar_URL": "https://2.gravatar.com/avatar/x?s=200&amp;d=mm",
+	"primary_site_ID": 57773116,
+	"comment_like_notification": true,
+	"mentions_notification": true,
+	"subscription_delivery_email_default": "instantly",
+	"subscription_delivery_jabber_default": false,
+	"subscription_delivery_mail_option": "html",
+	"subscription_delivery_day": 1,
+	"subscription_delivery_hour": 6,
+	"subscription_delivery_email_blocked": false,
+	"two_step_enabled": true,
+	"two_step_sms_enabled": false,
+	"two_step_backup_codes_printed": true,
+	"two_step_sms_country": "US",
+	"two_step_sms_phone_number": "4145551212",
+	"user_login_can_be_changed": true,
+	"calypso_preferences": {
+		"recentSites": [
+			57773116,
+			131820877,
+			157622730,
+			138332102
+		],
+		"editor-mode": "tinymce",
+		"firstViewHistory": [
+			{
+				"view": "stats",
+				"timestamp": 1470247961321,
+				"disabled": true
+			}
+		],
+		"guided-tours-history": [
+			{
+				"timestamp": 1510925179923,
+				"tourName": "simplePaymentsTour",
+				"finished": true
+			}
+		],
+		"editor-sidebar": "open"
+	},
+	"jetpack_connect": [],
+	"is_desktop_app_user": true,
+	"locale_variant": false,
+	"tracks_opt_out": true
+}

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9302E3A5220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift */; };
 		9302E3AC220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9302E3AB220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift */; };
 		933A27302222344D00C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A272F2222344D00C2143A /* Logging.swift */; };
+		937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937D6C45226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift */; };
+		937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937D6C46226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift */; };
 		B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505255320EE6914008090F5 /* StorageType+Extensions.swift */; };
 		B505F6DA20BEEA3200BB1B69 /* Account+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6D820BEEA3100BB1B69 /* Account+CoreDataProperties.swift */; };
 		B505F6DB20BEEA3200BB1B69 /* Account+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6D920BEEA3200BB1B69 /* Account+CoreDataClass.swift */; };
@@ -169,6 +171,8 @@
 		9302E3A7220DC69400DA5018 /* Model 10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 10.xcdatamodel"; sourceTree = "<group>"; };
 		9302E3AB220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataIterativeMigratorTests.swift; sourceTree = "<group>"; };
 		933A272F2222344D00C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		937D6C45226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountSettings+CoreDataClass.swift"; sourceTree = "<group>"; };
+		937D6C46226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountSettings+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		93D8BBF9226A6B3200AD2EB3 /* Model 14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 14.xcdatamodel"; sourceTree = "<group>"; };
 		A3821B262583F14863740A37 /* Pods-Storage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.debug.xcconfig"; sourceTree = "<group>"; };
 		B505255320EE6914008090F5 /* StorageType+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StorageType+Extensions.swift"; sourceTree = "<group>"; };
@@ -401,6 +405,8 @@
 				B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */,
 				B505F6D920BEEA3200BB1B69 /* Account+CoreDataClass.swift */,
 				B505F6D820BEEA3100BB1B69 /* Account+CoreDataProperties.swift */,
+				937D6C45226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift */,
+				937D6C46226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift */,
 				74F009BE2183B99B002B4566 /* Note+CoreDataClass.swift */,
 				74F009BF2183B99B002B4566 /* Note+CoreDataProperties.swift */,
 				CE12FBCC221F0E1A00C59248 /* Order+CoreDataClass.swift */,
@@ -700,6 +706,7 @@
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
 				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
+				937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */,
 				74E218F32252BA8400E4B0D7 /* ProductVariationAttribute+CoreDataProperties.swift in Sources */,
 				74E218F72252BB7800E4B0D7 /* ProductVariation+CoreDataProperties.swift in Sources */,
 				74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */,
@@ -716,6 +723,7 @@
 				CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */,
 				7474539B2242C85E00E0B5EE /* ProductDimensions+CoreDataClass.swift in Sources */,
 				B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */,
+				937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */,
 				B52B0F7B20AA28A800477698 /* Object.swift in Sources */,
 				7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */,
 				746A9D23214078080013F6FF /* TopEarnerStatsItem+CoreDataClass.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		9302E3A7220DC69400DA5018 /* Model 10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 10.xcdatamodel"; sourceTree = "<group>"; };
 		9302E3AB220E1CE900DA5018 /* CoreDataIterativeMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataIterativeMigratorTests.swift; sourceTree = "<group>"; };
 		933A272F2222344D00C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		93D8BBF9226A6B3200AD2EB3 /* Model 14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 14.xcdatamodel"; sourceTree = "<group>"; };
 		A3821B262583F14863740A37 /* Pods-Storage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Storage/Pods-Storage.debug.xcconfig"; sourceTree = "<group>"; };
 		B505255320EE6914008090F5 /* StorageType+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StorageType+Extensions.swift"; sourceTree = "<group>"; };
 		B505F6D820BEEA3100BB1B69 /* Account+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Account+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -1023,6 +1024,7 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				93D8BBF9226A6B3200AD2EB3 /* Model 14.xcdatamodel */,
 				74159626224D5644003C21CF /* Model 13.xcdatamodel */,
 				D82A61EF2239EB9900335D40 /* Model 12.xcdatamodel */,
 				CE3B7ACF2225E5CE0050FE4B /* Model 11.xcdatamodel */,
@@ -1037,7 +1039,7 @@
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = 74159626224D5644003C21CF /* Model 13.xcdatamodel */;
+			currentVersion = 93D8BBF9226A6B3200AD2EB3 /* Model 14.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage/Model/Account+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Account+CoreDataProperties.swift
@@ -13,6 +13,5 @@ extension Account {
     @NSManaged public var gravatarUrl: String?
     @NSManaged public var userID: Int64
     @NSManaged public var username: String?
-    @NSManaged public var tracksOptOut: Bool
 
 }

--- a/Storage/Storage/Model/Account+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Account+CoreDataProperties.swift
@@ -11,6 +11,8 @@ extension Account {
     @NSManaged public var displayName: String?
     @NSManaged public var email: String?
     @NSManaged public var gravatarUrl: String?
-    @NSManaged public var username: String?
     @NSManaged public var userID: Int64
+    @NSManaged public var username: String?
+    @NSManaged public var tracksOptOut: Bool
+
 }

--- a/Storage/Storage/Model/AccountSettings+CoreDataClass.swift
+++ b/Storage/Storage/Model/AccountSettings+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(AccountSettings)
+public class AccountSettings: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/AccountSettings+CoreDataProperties.swift
+++ b/Storage/Storage/Model/AccountSettings+CoreDataProperties.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CoreData
+
+
+extension AccountSettings {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<AccountSettings> {
+        return NSFetchRequest<AccountSettings>(entityName: "AccountSettings")
+    }
+
+    @NSManaged public var tracksOptOut: Bool
+    @NSManaged public var userID: Int64
+
+}

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 13.xcdatamodel</string>
+	<string>Model 14.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 14.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 14.xcdatamodel/contents
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18E226" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.98" systemVersion="18E226" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="gravatarUrl" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES">
         <attribute name="body" optional="YES" attributeType="Binary" syncable="YES"/>
@@ -370,7 +373,8 @@
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="135"/>
+        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
+        <element name="AccountSettings" positionX="-846" positionY="270" width="128" height="75"/>
         <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
         <element name="Order" positionX="-20" positionY="27" width="128" height="720"/>
         <element name="OrderCoupon" positionX="-206.01953125" positionY="379.74609375" width="128" height="120"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 14.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 14.xcdatamodel/contents
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18E226" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="subtype" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timestamp" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="number" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem" syncable="YES"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote" syncable="YES"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults" syncable="YES"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="note" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String" syncable="YES"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderStats" representedClassName="OrderStats" syncable="YES">
+        <attribute name="averageGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageNetSales" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageOrders" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageProducts" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalNetSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderStatsItem" inverseName="stats" inverseEntity="OrderStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsItem" representedClassName="OrderStatsItem" syncable="YES">
+        <attribute name="avgOrderValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="avgProductsPerOrder" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="grossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="netSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShipping" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStats" inverseName="items" inverseEntity="OrderStats" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String" syncable="YES"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersKey" attributeType="String" syncable="YES"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="catalogVisibilityKey" attributeType="String" syncable="YES"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="permalink" attributeType="String" syncable="YES"/>
+        <attribute name="price" attributeType="String" syncable="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productTypeKey" attributeType="String" syncable="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="stockStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductCategory" inverseName="product" inverseEntity="ProductCategory" syncable="YES"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute" syncable="YES"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions" syncable="YES"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage" syncable="YES"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag" syncable="YES"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="categories" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String" syncable="YES"/>
+        <attribute name="length" attributeType="String" syncable="YES"/>
+        <attribute name="width" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="src" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersKey" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateOnSaleFrom" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateOnSaleTo" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="permalink" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" attributeType="String" syncable="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClass" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClassID" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="stockQuantity" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="stockStatusKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxStatusKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariationAttribute" inverseName="productVariation" inverseEntity="ProductVariationAttribute" syncable="YES"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductVariationDimensions" inverseName="productVariation" inverseEntity="ProductVariationDimensions" syncable="YES"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductVariationImage" inverseName="productVariation" inverseEntity="ProductVariationImage" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariationAttribute" representedClassName="ProductVariationAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariationDimensions" representedClassName="ProductVariationDimensions" syncable="YES">
+        <attribute name="height" attributeType="String" syncable="YES"/>
+        <attribute name="length" attributeType="String" syncable="YES"/>
+        <attribute name="width" attributeType="String" syncable="YES"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation" syncable="YES"/>
+    </entity>
+    <entity name="ProductVariationImage" representedClassName="ProductVariationImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="src" attributeType="String" syncable="YES"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="trackingID" attributeType="String" syncable="YES"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider" syncable="YES"/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="plan" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="limit" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="135"/>
+        <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
+        <element name="Order" positionX="-20" positionY="27" width="128" height="720"/>
+        <element name="OrderCoupon" positionX="-206.01953125" positionY="379.74609375" width="128" height="120"/>
+        <element name="OrderItem" positionX="-364.890625" positionY="379.453125" width="128" height="240"/>
+        <element name="OrderNote" positionX="-365.16796875" positionY="630.2109375" width="128" height="135"/>
+        <element name="OrderSearchResults" positionX="144.44140625" positionY="743.43359375" width="128" height="75"/>
+        <element name="OrderStats" positionX="137.859375" positionY="388.33203125" width="128" height="225"/>
+        <element name="OrderStatsItem" positionX="321.74609375" positionY="425.51171875" width="128" height="330"/>
+        <element name="OrderStatus" positionX="-29.671875" positionY="781.29296875" width="128" height="105"/>
+        <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="883"/>
+        <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
+        <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
+        <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
+        <element name="ProductVariation" positionX="-1007.2265625" positionY="-77.41796875" width="128" height="568"/>
+        <element name="ProductVariationAttribute" positionX="-1223.453125" positionY="67.7109375" width="151.01953125" height="103"/>
+        <element name="ProductVariationDimensions" positionX="-1274.84765625" positionY="196.52734375" width="163.98046875" height="105"/>
+        <element name="ProductVariationImage" positionX="-1308.1953125" positionY="324.6328125" width="156.37890625" height="148"/>
+        <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
+        <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
+        <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
+        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="150"/>
+        <element name="SiteSetting" positionX="-362.54296875" positionY="217.9921875" width="128" height="135"/>
+        <element name="SiteVisitStats" positionX="134.515625" positionY="224.62109375" width="128" height="90"/>
+        <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
+        <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
+        <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+    </elements>
+</model>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -11,6 +11,13 @@ public extension StorageType {
         let predicate = NSPredicate(format: "userID = %ld", userId)
         return firstObject(ofType: Account.self, matching: predicate)
     }
+    
+    /// Retrieves the Stores AccountSettings.
+    ///
+    func loadAccountSettings(userId: Int) -> AccountSettings? {
+        let predicate = NSPredicate(format: "userID = %ld", userId)
+        return firstObject(ofType: AccountSettings.self, matching: predicate)
+    }
 
     /// Retrieves the Stored Site.
     ///

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -11,7 +11,7 @@ public extension StorageType {
         let predicate = NSPredicate(format: "userID = %ld", userId)
         return firstObject(ofType: Account.self, matching: predicate)
     }
-    
+
     /// Retrieves the Stores AccountSettings.
     ///
     func loadAccountSettings(userId: Int) -> AccountSettings? {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		74FD596E216FB6ED00A5AE83 /* OrderStats+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FD596C216FB6ED00A5AE83 /* OrderStats+ReadOnlyConvertible.swift */; };
 		74FD596F216FB6ED00A5AE83 /* OrderStatsItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FD596D216FB6ED00A5AE83 /* OrderStatsItem+ReadOnlyConvertible.swift */; };
 		933A27352222352500C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27342222352500C2143A /* Logging.swift */; };
+		93E7507A226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E75079226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift */; };
 		B505254C20EE6491008090F5 /* Site+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505254B20EE6491008090F5 /* Site+ReadOnlyConvertible.swift */; };
 		B52E002B2119E64800700FDE /* ManagedObjectsDidChangeNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52E002A2119E64800700FDE /* ManagedObjectsDidChangeNotification.swift */; };
 		B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52E002D211A3F5500700FDE /* ReadOnlyType.swift */; };
@@ -189,6 +190,7 @@
 		7F47E19203B04CF6BB5EA659 /* Pods-Yosemite.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.debug.xcconfig"; sourceTree = "<group>"; };
 		933A27342222352500C2143A /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		93D120F57D5D14A10B3AFFFD /* Pods-Yosemite.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release.xcconfig"; sourceTree = "<group>"; };
+		93E75079226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AccountSettings+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_YosemiteTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABE0D84C5393D9EE2CCF2B7E /* Pods-YosemiteTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release.xcconfig"; sourceTree = "<group>"; };
 		B505254B20EE6491008090F5 /* Site+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Site+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 			isa = PBXGroup;
 			children = (
 				B5EED1A720F4F3CF00652449 /* Account+ReadOnlyConvertible.swift */,
+				93E75079226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift */,
 				74B2601E2188A92A0041793A /* Note+ReadOnlyConvertible.swift */,
 				74D7F29A20F6A7FB0058B2F0 /* Order+ReadOnlyConvertible.swift */,
 				74685D4F20F7F3CE008958C1 /* OrderCoupon+ReadOnlyConvertible.swift */,
@@ -752,6 +755,7 @@
 				74B260212188B5F30041793A /* Note+ReadOnlyType.swift in Sources */,
 				B505254C20EE6491008090F5 /* Site+ReadOnlyConvertible.swift in Sources */,
 				B52E002B2119E64800700FDE /* ManagedObjectsDidChangeNotification.swift in Sources */,
+				93E7507A226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift in Sources */,
 				749374FE2249601F007D85D1 /* ProductStore.swift in Sources */,
 				B5B5C797208E49B600642956 /* Action+Internal.swift in Sources */,
 				74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -7,8 +7,10 @@ import Networking
 //
 public enum AccountAction: Action {
     case loadAccount(userID: Int, onCompletion: (Account?) -> Void)
+    case loadAccountSettings(userID: Int, onCompletion: (AccountSettings?) -> Void)
     case loadSite(siteID: Int, onCompletion: (Site?) -> Void)
     case synchronizeAccount(onCompletion: (Account?, Error?) -> Void)
+    case synchronizeAccountSettings(userID: Int, onCompletion: (AccountSettings?, Error?) -> Void)
     case synchronizeSites(onCompletion: (Error?) -> Void)
     case synchronizeSitePlan(siteID: Int, onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -7,6 +7,7 @@ import Storage
 // MARK: - Exported ReadOnly Symbols
 
 public typealias Account = Networking.Account
+public typealias AccountSettings = Networking.AccountSettings
 public typealias Address = Networking.Address
 public typealias APNSDevice = Networking.APNSDevice
 public typealias CommentStatus = Networking.CommentStatus

--- a/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Storage
+
+
+// MARK: - Storage.AccountSettings: ReadOnlyConvertible
+//
+extension Storage.AccountSettings: ReadOnlyConvertible {
+
+    /// Updates the Storage.AccountSettings with the a ReadOnly.
+    ///
+    public func update(with accountSettings: Yosemite.AccountSettings) {
+        userID = Int64(accountSettings.userID)
+        tracksOptOut = accountSettings.tracksOptOut
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.AccountSettings {
+        return AccountSettings(userID: Int(userID),
+                               tracksOptOut: tracksOptOut)
+    }
+}

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -30,10 +30,14 @@ public class AccountStore: Store {
         switch action {
         case .loadAccount(let userID, let onCompletion):
             loadAccount(userID: userID, onCompletion: onCompletion)
+        case .loadAccountSettings(let userID, let onCompletion):
+            loadAccountSettings(userID: userID, onCompletion: onCompletion)
         case .loadSite(let siteID, let onCompletion):
             loadSite(siteID: siteID, onCompletion: onCompletion)
         case .synchronizeAccount(let onCompletion):
             synchronizeAccount(onCompletion: onCompletion)
+        case .synchronizeAccountSettings(let userID, let onCompletion):
+            synchronizeAccountSettings(userID: userID, onCompletion: onCompletion)
         case .synchronizeSites(let onCompletion):
             synchronizeSites(onCompletion: onCompletion)
         case .synchronizeSitePlan(let siteID, let onCompletion):

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -69,13 +69,13 @@ private extension AccountStore {
     ///
     func synchronizeAccountSettings(userID: Int, onCompletion: @escaping (AccountSettings?, Error?) -> Void) {
         let remote = AccountRemote(network: network)
-        
+
         remote.loadAccountSettings(for: userID) { [weak self] (accountSettings, error) in
             guard let accountSettings = accountSettings else {
                 onCompletion(nil, error)
                 return
             }
-            
+
             self?.upsertStoredAccountSettings(readOnlyAccountSettings: accountSettings)
             onCompletion(accountSettings, nil)
         }
@@ -158,7 +158,8 @@ extension AccountStore {
         assert(Thread.isMainThread)
 
         let storage = storageManager.viewStorage
-        let storageAccount = storage.loadAccountSettings(userId: readOnlyAccountSettings.userID) ?? storage.insertNewObject(ofType: Storage.AccountSettings.self)
+        let storageAccount = storage.loadAccountSettings(userId: readOnlyAccountSettings.userID) ??
+            storage.insertNewObject(ofType: Storage.AccountSettings.self)
 
         storageAccount.update(with: readOnlyAccountSettings)
         storage.saveIfNeeded()

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -144,22 +144,22 @@ extension AccountStore {
     ///
     func upsertStoredAccount(readOnlyAccount: Networking.Account) {
         assert(Thread.isMainThread)
-        
+
         let storage = storageManager.viewStorage
         let storageAccount = storage.loadAccount(userId: readOnlyAccount.userID) ?? storage.insertNewObject(ofType: Storage.Account.self)
-        
+
         storageAccount.update(with: readOnlyAccount)
         storage.saveIfNeeded()
     }
-    
+
     /// Updates (OR Inserts) the specified ReadOnly AccountSettings Entity into the Storage Layer.
     ///
     func upsertStoredAccountSettings(readOnlyAccountSettings: Networking.AccountSettings) {
         assert(Thread.isMainThread)
-        
+
         let storage = storageManager.viewStorage
         let storageAccount = storage.loadAccountSettings(userId: readOnlyAccountSettings.userID) ?? storage.insertNewObject(ofType: Storage.AccountSettings.self)
-        
+
         storageAccount.update(with: readOnlyAccountSettings)
         storage.saveIfNeeded()
     }

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -62,8 +62,8 @@ private extension AccountStore {
             onCompletion(account, nil)
         }
     }
-    
-    
+
+
     /// Synchronizes the WordPress.com account settings associated with the Network's Auth Token.
     /// User ID is passed along because the API doesn't include it in the response.
     ///
@@ -120,7 +120,7 @@ private extension AccountStore {
         let account = storageManager.viewStorage.loadAccount(userId: userID)?.toReadOnly()
         onCompletion(account)
     }
-    
+
     /// Loads the AccountSettings associated with the specified userID.
     func loadAccountSettings(userID: Int, onCompletion: @escaping (AccountSettings?) -> Void) {
         let accountSettings = storageManager.viewStorage.loadAccountSettings(userId: userID)?.toReadOnly()
@@ -163,7 +163,7 @@ extension AccountStore {
         storageAccount.update(with: readOnlyAccountSettings)
         storage.saveIfNeeded()
     }
-    
+
     /// Updates the specified ReadOnly Site Plan attribute in the Site entity, in the Storage Layer.
     ///
     func updateStoredSitePlanInBackground(plan: SitePlan, onCompletion: @escaping () -> Void) {


### PR DESCRIPTION
Closes #574 

Adds Storage, Networking, and basic Yosemite components to support the Tracks opt-out setting to be synced to the app. 

## Things to note

* The `/me/settings` endpoint does contain a few things that `/me` has but the field names aren't identical. I opted for a new data model for the endpoint in case we need to add additional items down the road.
* I've created a new data model to accommodate the new `AccountSettings` entity and decided to not use a relationship to `Account` for now. 
* User ID isn't returned by the `/me/settings` endpoint so I'm stuffing it into the mapper as a parameter like we've done elsewhere.

## To Test

1. Make sure unit tests run.
2. Make sure upgrading from a previous version succeeds.