### PR TITLE
Update the WordPress Shared pod

### DIFF
--- a/Networking/Networking.xcodeproj/xcshareddata/xcschemes/Networking.xcscheme
+++ b/Networking/Networking.xcodeproj/xcshareddata/xcschemes/Networking.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Podfile
+++ b/Podfile
@@ -27,8 +27,9 @@ target 'WooCommerce' do
   #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
   pod 'WordPressAuthenticator', '~> 1.3.0'
 
-  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'
-  # pod 'WordPressShared', '~> 1.1'
+  # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
+  pod 'WordPressShared', '~> 1.7-beta'
+  
   pod 'WordPressUI', '~> 1.2'
 
 

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 inhibit_all_warnings!
 use_frameworks!
 
-platform :ios, '11.0'
+platform :ios, '12.0'
 workspace 'WooCommerce.xcworkspace'
 
 plugin 'cocoapods-repo-update'
@@ -27,7 +27,8 @@ target 'WooCommerce' do
   #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
   pod 'WordPressAuthenticator', '~> 1.3.0'
 
-  pod 'WordPressShared', '~> 1.1'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'
+  # pod 'WordPressShared', '~> 1.1'
   pod 'WordPressUI', '~> 1.2'
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -69,7 +69,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.8.0-beta.1):
+  - WordPressShared (1.7.5-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
@@ -95,7 +95,7 @@ DEPENDENCIES:
   - Gridicons (~> 0.18)
   - KeychainAccess (~> 3.1)
   - WordPressAuthenticator (~> 1.3.0)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `task/support-swift-5`)
+  - WordPressShared (~> 1.7-beta)
   - WordPressUI (~> 1.2)
   - XLPagerTabStrip (~> 8.1)
   - ZendeskSDK (~> 2.3.1)
@@ -124,20 +124,11 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - wpxmlrpc
     - XLPagerTabStrip
     - ZendeskSDK
-
-EXTERNAL SOURCES:
-  WordPressShared:
-    :branch: task/support-swift-5
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
-
-CHECKOUT OPTIONS:
-  WordPressShared:
-    :commit: be5bf836156d2fc881363d581736f6223bcb0248
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -162,12 +153,12 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPressAuthenticator: b14ec6a2ddfe65bc2abd1c517ef7ec86aaa9d0f5
   WordPressKit: 61a83ade68516f1398176b80c199489af0e83303
-  WordPressShared: 1ffbeabf6fe79d9e24f78220d19de1da658df042
+  WordPressShared: 6949d39fefa19e5bed98fa482d1be29fea77849a
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 63166e21c9844fa30f2d95d30f335e73be5caf22
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
 
-PODFILE CHECKSUM: 68931a229294f7db8e4740cd2300b86f83402642
+PODFILE CHECKSUM: e9c534e7919b7efec99ba3a86200f561f44416dd
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -69,7 +69,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.7.2):
+  - WordPressShared (1.8.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
@@ -95,7 +95,7 @@ DEPENDENCIES:
   - Gridicons (~> 0.18)
   - KeychainAccess (~> 3.1)
   - WordPressAuthenticator (~> 1.3.0)
-  - WordPressShared (~> 1.1)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `task/support-swift-5`)
   - WordPressUI (~> 1.2)
   - XLPagerTabStrip (~> 8.1)
   - ZendeskSDK (~> 2.3.1)
@@ -124,11 +124,20 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - wpxmlrpc
     - XLPagerTabStrip
     - ZendeskSDK
+
+EXTERNAL SOURCES:
+  WordPressShared:
+    :branch: task/support-swift-5
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
+
+CHECKOUT OPTIONS:
+  WordPressShared:
+    :commit: be5bf836156d2fc881363d581736f6223bcb0248
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -153,12 +162,12 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPressAuthenticator: b14ec6a2ddfe65bc2abd1c517ef7ec86aaa9d0f5
   WordPressKit: 61a83ade68516f1398176b80c199489af0e83303
-  WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
+  WordPressShared: 1ffbeabf6fe79d9e24f78220d19de1da658df042
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 63166e21c9844fa30f2d95d30f335e73be5caf22
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
 
-PODFILE CHECKSUM: 8482e446d484a2387701a07c9133b984eeccf393
+PODFILE CHECKSUM: 68931a229294f7db8e4740cd2300b86f83402642
 
 COCOAPODS: 1.6.1

--- a/Storage/Storage.xcodeproj/xcshareddata/xcschemes/Storage.xcscheme
+++ b/Storage/Storage.xcodeproj/xcshareddata/xcschemes/Storage.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/GenerateCredentials.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/GenerateCredentials.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Yosemite/Yosemite.xcodeproj/xcshareddata/xcschemes/Yosemite.xcscheme
+++ b/Yosemite/Yosemite.xcodeproj/xcshareddata/xcschemes/Yosemite.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR temporarily points to the new WordPressShared pod changes. It will point to the new pod version after it is released. This is Step 1 in updating the main WCiOS project to support Swift 5.

Ref. #819 and Ref. https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/201

## To test
- run `bundle exec pod install`
- check project for warnings (Swift 5 notice is expected to be there, no others)
- run unit tests and ensure they pass
- run the app

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
