### PR TITLE
Bugfix: Some users can't load orders

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -164,9 +164,7 @@ public extension OrdersRemote {
 
     enum ParameterValues {
         static let fieldValues: String = """
-            id,parent_id,customer_id,number,status,currency,customer_note,date_created_gmt,
-            date_modified_gmt,date_paid_gmt,discount_total,discount_tax,shipping_total,
-            shipping_tax,total,total_tax,payment_method_title,line_items,shipping,billing,coupon_lines
+            id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method_title,line_items,shipping,billing,coupon_lines
             """
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - update: this app supports iOS 12.0 and up.
 - improvement: improved support for large text sizes.
+- bugfix: fixes Order List not loading for some users.
  
 1.7
 -----


### PR DESCRIPTION
Fixes #916.

_fields must be ordered in the exact manner they appear in a response or the entire API request will fail. 

## To test
Follow the Site URL login flow. See 1987084-zen for login details.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
