### PR TITLE
Patch 1.7.1: Bugfix #916, some users can't load orders

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -164,9 +164,7 @@ public extension OrdersRemote {
 
     enum ParameterValues {
         static let fieldValues: String = """
-            id,parent_id,customer_id,number,status,currency,customer_note,date_created_gmt,
-            date_modified_gmt,date_paid_gmt,discount_total,discount_tax,shipping_total,
-            shipping_tax,total,total_tax,payment_method_title,line_items,shipping,billing,coupon_lines
+            id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method_title,line_items,shipping,billing,coupon_lines
             """
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 1.8
 -----
+
+1.7.1
+-----
+- Fixed a bug where Order List did not load for some users.
  
 1.7
 -----


### PR DESCRIPTION
Fixes #916. Original PR: #940.

This PR fixes the issue where some users cannot load orders.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
