### PR TITLE
Top Performers: mapping error causes "Unable to load content" error message

### DIFF
--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -36,9 +36,9 @@ public struct TopEarnerStatsItem: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(productID: Int, productName: String, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
+    public init(productID: Int, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
         self.productID = productID
-        self.productName = productName
+        self.productName = productName ?? String()
         self.quantity = quantity
         self.price = price
         self.total = total

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -38,7 +38,7 @@ public struct TopEarnerStatsItem: Decodable {
     ///
     public init(productID: Int, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
         self.productID = productID
-        self.productName = productName ?? String()
+        self.productName = productName ?? ""
         self.quantity = quantity
         self.price = price
         self.total = total

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -11,7 +11,7 @@ public struct TopEarnerStatsItem: Decodable {
 
     /// Product name
     ///
-    public let productName: String
+    public let productName: String?
 
     /// Quantity sold
     ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 1.9
 -----
+- bugfix: fixes "Unable to load content" error message when attempting to get Top Performers content.
  
 1.8
 -----


### PR DESCRIPTION
Fixes #949.

This PR contains a bug fix where the "Unable to load content" error message would appear for some users, due to Top Performers being unable to load content.

Some users do not name their products, which causes a `null` to appear in the `name` field in an API response. 

**Example:**

```
{
    "date": "2019",
    "unit": "year",
    "limit": "3",
    "data": [
        {
            "ID": 11111,
            "name": null,
            "total": 220,
            "quantity": 1,
            "price": 0,
            "image": "",
            "currency": "USD"
        },
        {
            "ID": 22222,
            "name": null,
            "total": 150,
            "quantity": 1,
            "price": 0,
            "image": "",
            "currency": "USD"
        }
    ]
}
```

On iOS, we have created the product mapper to enforce all fields as non-null, so an error is getting thrown and the error bubbles up to the user as an "Unable to load content" snackbar message. 

**Console error message:**

```
2019/05/05 08:18:15:631  ⛔️ Error loading dashboard: valueNotFound(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "data", intValue: nil), _JSONKey(stringValue: "Index 1", intValue: 1), CodingKeys(stringValue: "name", intValue: nil)], debugDescription: "Expected String value but found null instead.", underlyingError: nil))
```

**To Reproduce**
Steps to reproduce the behavior:
1. Go to My Store > Top Performers > This Year
2. Find a product listed there, that has a name.
3. Go to your Store's website > WooCommerce. Find that specific product.
4. Erase the product name and Save.
5. Return to the app, pull-to-refresh. 
6. See snackbar-style error message "Unable to load content" appear under the "This Year" tab. (It also makes the tab show an empty content view.)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
