### PR TITLE
Patch 1.8.1: Bugfix #949. Top Performers: mapping error causes "Unable to load content" error message 

### DIFF
--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -36,9 +36,9 @@ public struct TopEarnerStatsItem: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(productID: Int, productName: String, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
+    public init(productID: Int, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
         self.productID = productID
-        self.productName = productName
+        self.productName = productName ?? String()
         self.quantity = quantity
         self.price = price
         self.total = total

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -38,7 +38,7 @@ public struct TopEarnerStatsItem: Decodable {
     ///
     public init(productID: Int, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
         self.productID = productID
-        self.productName = productName ?? String()
+        self.productName = productName ?? ""
         self.quantity = quantity
         self.price = price
         self.total = total

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -11,7 +11,7 @@ public struct TopEarnerStatsItem: Decodable {
 
     /// Product name
     ///
-    public let productName: String
+    public let productName: String?
 
     /// Quantity sold
     ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 1.9
 -----
+
+1.8.1
+-----
+- bugfix: fixes "Unable to load content" error message when attempting to get Top Performers content.
  
 1.8
 -----


### PR DESCRIPTION
Fixes #949. Original PR #954.

This PR fixes the bug in Top Performers, where the mapping error causes "Unable to load content" error message.

cc: @astralbodies 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
