### PR TITLE
Bug Fix: malformed Jetpack API request URLs.

### DIFF
--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -91,7 +91,7 @@ private extension JetpackRequest {
     var dotcomParams: [String: String] {
         var output = [
             "json": "true",
-            "path": jetpackPath + jetpackQueryParams + "&_method=" + method.rawValue.lowercased()
+            "path": jetpackPath + "&_method=" + method.rawValue.lowercased() + jetpackQueryParams
         ]
 
         if let jetpackBodyParams = jetpackBodyParams {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.9
 -----
 - bugfix: fixes "Unable to load content" error message when attempting to get Top Performers content.
+- bugfix: fixes Store Picker: some users are unable to continue after logging in.
  
 1.8
 -----


### PR DESCRIPTION
Fixes #951.

Store Picker: some users are unable to continue after logging in. (They log in successfully, they have a Store, but the continue button is disabled and an error displays to the user.) Some users are able to get logged in and continue, but are unable to load orders.

Occasionally we come across users who have WC 3.5+, Jetpack properly connected, and know their WordPress.com logins. I would look into the issue, find nothing, and mark it as an edge case. Until I encountered the third user this was happening to, and realized their Jetpack version was old.

Some sites were unable to log in because the `SiteAPIRemote` request was malformed and returning a cryptic error response. 

Example of the malformed API request: 
```
https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{{site_id}}/rest-api/?json=true&path=/&_fields=authentication,namespaces&_method=get
```

The corrected API request:
```
https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/{{site_id}}/rest-api/?_method=get&json=true&path=/&_fields=authentication,namespaces
```

There are no exact steps to reproduce. The error is produced on Jetpack plugin version 4 thru 6 (debugged and tested the fix while SSPing into ), but I don't have specific version numbers when it was fixed. I plan to ask support to request users update their Jetpack plugin to 7. The closest working theory I have is that the URL parser for the received Jetpack-proxy requests was less flexible or less forgiving in how it decomposed URLs. To be fair, the URL requests **were** malformed.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
