### PR TITLE
Order details screen: add option to delete shipment tracking

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -52,6 +52,15 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// More icon
+    ///
+    static var moreImage: UIImage {
+        let tintColor = StyleManager.wooCommerceBrandColor
+        return Gridicon.iconOfType(.ellipsis)
+            .imageWithTintColor(tintColor)!
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// Jetpack Logo Image
     ///
     static var jetpackLogoImage: UIImage {

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
@@ -42,8 +42,6 @@ class OrderDetailsViewModel {
 
     let fulfillTitle = NSLocalizedString("Fulfill order", comment: "Fulfill order button title")
 
-    let trackTitle = NSLocalizedString("Track package", comment: "Track package button title")
-
     var isProcessingPayment: Bool {
         return order.statusKey == OrderStatusEnum.processing.rawValue
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
@@ -7,6 +7,9 @@ final class OrderTrackingTableViewCell: UITableViewCell {
     @IBOutlet private var middleLine: UILabel!
     @IBOutlet private var bottomLine: UILabel!
     @IBOutlet private var topBorder: UIView!
+    private var ellipsisButton = UIButton(type: .detailDisclosure)
+
+    var onEllipsisTouchUp: (() -> Void)?
 
     var topText: String? {
         get {
@@ -43,6 +46,7 @@ final class OrderTrackingTableViewCell: UITableViewCell {
         configureTopLine()
         configureMiddleLine()
         configureBottomLine()
+        configureActionButton()
     }
 
     private func configureTopLine() {
@@ -56,7 +60,29 @@ final class OrderTrackingTableViewCell: UITableViewCell {
     private func configureBottomLine() {
         bottomLine.applySubheadlineStyle()
     }
+
+    private func configureActionButton() {
+        let deleteIcon = UIImage.moreImage
+            .imageFlippedForRightToLeftLayoutDirection()
+            .imageWithTintColor(StyleManager.wooCommerceBrandColor)
+
+        ellipsisButton.setImage(deleteIcon!, for: .normal)
+        ellipsisButton.addTarget(self, action: #selector(iconTapped), for: .touchUpInside)
+
+        self.accessoryView = ellipsisButton
+
+        configureActionButtonForVoiceOver()
+    }
 }
+
+
+/// MARK: - Actions
+private extension OrderTrackingTableViewCell {
+    @objc func iconTapped() {
+        onEllipsisTouchUp?()
+    }
+}
+
 
 /// MARK: - Accessibility
 ///
@@ -82,6 +108,15 @@ private extension OrderTrackingTableViewCell {
                               comment: "Accessibility label for Shipment date in Order details screen. Shipped: February 27, 2018."),
             bottomText ?? "")
     }
+
+    func configureActionButtonForVoiceOver() {
+        ellipsisButton.accessibilityLabel = NSLocalizedString("More",
+                                                            comment:
+            "Accessibility hint for more button in an individual Shipment Tracking in the order details screen")
+        ellipsisButton.accessibilityHint = NSLocalizedString("Shows more options.",
+                                                           comment:
+            "Accessibility hint for Delete Shipment button in Order details screen")
+    }
 }
 
 /// MARK: - Expose private outlets for tests
@@ -97,5 +132,9 @@ extension OrderTrackingTableViewCell {
 
     func getBottomLabel() -> UILabel {
         return bottomLine
+    }
+
+    func getActionButton() -> UIButton {
+        return ellipsisButton
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
@@ -7,10 +7,6 @@ final class OrderTrackingTableViewCell: UITableViewCell {
     @IBOutlet private var middleLine: UILabel!
     @IBOutlet private var bottomLine: UILabel!
     @IBOutlet private var topBorder: UIView!
-    @IBOutlet private var actionButton: UIButton!
-    @IBOutlet private var internalSeparator: UIView!
-
-    var onActionTouchUp: (() -> Void)?
 
     var topText: String? {
         get {
@@ -42,37 +38,11 @@ final class OrderTrackingTableViewCell: UITableViewCell {
         }
     }
 
-    var actionButtonNormalText: String? {
-        get {
-            return actionButton.title(for: .normal)
-        }
-        set {
-            actionButton.setTitle(newValue, for: .normal)
-            configureActionButtonForVoiceOver()
-        }
-    }
-
-    func showActionButton() {
-        actionButton.isHidden = false
-        internalSeparator.isHidden = false
-    }
-
-    func hideActionButton() {
-        actionButton.isHidden = true
-        internalSeparator.isHidden = true
-    }
-
     override func awakeFromNib() {
         super.awakeFromNib()
-        configureButtonSeparator()
         configureTopLine()
         configureMiddleLine()
         configureBottomLine()
-        configureActionButton()
-    }
-
-    private func configureButtonSeparator() {
-        topBorder.backgroundColor = StyleManager.wooGreyBorder
     }
 
     private func configureTopLine() {
@@ -85,17 +55,6 @@ final class OrderTrackingTableViewCell: UITableViewCell {
 
     private func configureBottomLine() {
         bottomLine.applySubheadlineStyle()
-    }
-
-    private func configureActionButton() {
-        actionButton.applyTertiaryButtonStyle()
-        configureActionButtonForVoiceOver()
-    }
-}
-
-extension OrderTrackingTableViewCell {
-    @IBAction func actionButtonPressed(_ sender: Any) {
-        onActionTouchUp?()
     }
 }
 
@@ -123,14 +82,6 @@ private extension OrderTrackingTableViewCell {
                               comment: "Accessibility label for Shipment date in Order details screen. Shipped: February 27, 2018."),
             bottomText ?? "")
     }
-
-    func configureActionButtonForVoiceOver() {
-        actionButton.accessibilityLabel = actionButtonNormalText
-        actionButton.accessibilityTraits = .button
-        actionButton.accessibilityHint = NSLocalizedString("Tracks a shipment.",
-                                                           comment:
-            "Accessibility hint for Track Package button in Order details screen")
-    }
 }
 
 /// MARK: - Expose private outlets for tests
@@ -146,9 +97,5 @@ extension OrderTrackingTableViewCell {
 
     func getBottomLabel() -> UILabel {
         return bottomLine
-    }
-
-    func getActionButton() -> UIButton {
-        return actionButton
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.xib
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="OrderTrackingTableViewCell" rowHeight="188" id="KGk-i7-Jjw" customClass="OrderTrackingTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="OrderTrackingTableViewCell" rowHeight="188" id="KGk-i7-Jjw" customClass="OrderTrackingTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="331" height="154"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
@@ -47,22 +47,6 @@
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="SIM-Wl-ZSt">
                                 <rect key="frame" x="0.0" y="85.5" width="299" height="48"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mav-Sc-Nqa">
-                                        <rect key="frame" x="0.0" y="0.0" width="299" height="1"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="Pfr-XS-Lqh"/>
-                                        </constraints>
-                                    </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q04-tu-Hwj">
-                                        <rect key="frame" x="0.0" y="1" width="299" height="47"/>
-                                        <state key="normal" title="Button"/>
-                                        <connections>
-                                            <action selector="actionButtonPressed:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="vJf-Pe-OWy"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
                             </stackView>
                         </subviews>
                     </stackView>
@@ -76,11 +60,8 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="actionButton" destination="q04-tu-Hwj" id="yfI-P3-JyX"/>
                 <outlet property="bottomLine" destination="QPn-Oj-khc" id="TQ5-DT-vlI"/>
-                <outlet property="internalSeparator" destination="Mav-Sc-Nqa" id="Tu8-Dw-dRl"/>
                 <outlet property="middleLine" destination="5Tp-fv-Tte" id="0Kp-r9-HEk"/>
-                <outlet property="topBorder" destination="Mav-Sc-Nqa" id="fen-Nr-OeV"/>
                 <outlet property="topLine" destination="kb4-pd-pEb" id="eC2-Xc-JAH"/>
             </connections>
             <point key="canvasLocation" x="39.200000000000003" y="125.93703148425789"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.xib
@@ -12,7 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="OrderTrackingTableViewCell" rowHeight="188" id="KGk-i7-Jjw" customClass="OrderTrackingTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="OrderTrackingTableViewCell" rowHeight="188" id="KGk-i7-Jjw" customClass="OrderTrackingTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="331" height="154"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -656,7 +656,6 @@ private extension OrderDetailsViewController {
     }
 
     func deleteTracking(_ tracking: ShipmentTracking) {
-
         let siteID = viewModel.order.siteID
         let orderID = viewModel.order.orderID
         let trackingID = tracking.trackingID
@@ -667,11 +666,9 @@ private extension OrderDetailsViewController {
                                                                     if let error = error {
                                                                         DDLogError("⛔️ Delete Tracking Failure: orderID \(orderID). Error: \(error)")
 
-                                                                        //self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
+                                                                        self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
                                                                         return
                                                                     }
-
-                                                                    //self?.syncTrackingsHiddingAddButtonIfNecessary()
                                                                     self?.reloadSections()
 
         }
@@ -1133,6 +1130,28 @@ extension OrderDetailsViewController: MFMailComposeViewControllerDelegate {
 
         // Workaround: Restore WC's navBar appearance
         UINavigationBar.applyWooAppearance()
+    }
+}
+
+
+// MARK: - Error notice
+private extension OrderDetailsViewController {
+    /// Displays the `Unable to delete tracking` Notice.
+    ///
+    func displayDeleteErrorNotice(orderID: Int, tracking: ShipmentTracking) {
+        let title = NSLocalizedString(
+            "Unable to delete tracking for order #\(orderID)",
+            comment: "Content of error presented when Delete Shipment Tracking Action Failed. It reads: Unable to delete tracking for order #{order number}"
+        )
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: title,
+                            message: nil,
+                            feedbackType: .error,
+                            actionTitle: actionTitle) { [weak self] in
+                                self?.deleteTracking(tracking)
+        }
+
+        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -988,7 +988,7 @@ private extension OrderDetailsViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = StyleManager.wooCommerceBrandColor
 
-        actionSheet.addCancelActionWithTitle(TrackingAction.cancel)
+        actionSheet.addCancelActionWithTitle(TrackingAction.dismiss)
 
         if tracking.trackingURL?.isEmpty == false {
             actionSheet.addDefaultActionWithTitle(TrackingAction.trackShipment) { [weak self] _ in
@@ -1148,7 +1148,7 @@ private extension OrderDetailsViewController {
     }
 
     enum TrackingAction {
-        static let cancel = NSLocalizedString("Cancel", comment: "Dismiss the shipment tracking action sheet")
+        static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the shipment tracking action sheet")
         static let trackShipment = NSLocalizedString("Track Shipment", comment: "Track shiopment button title")
         static let deleteTracking = NSLocalizedString("Delete Tracking", comment: "Delete tracking button title")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -567,14 +567,6 @@ private extension OrderDetailsViewController {
                                                 comment: "Order details > tracking. " +
                 " This is where the shipping date would normally display.")
         }
-
-        guard let url = tracking.trackingURL, url.isEmpty == false else {
-            cell.hideActionButton()
-            return
-        }
-
-        cell.showActionButton()
-        cell.actionButtonNormalText = viewModel.trackTitle
     }
 
     func configureShippingAddress(cell: CustomerInfoTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -557,6 +557,10 @@ private extension OrderDetailsViewController {
         cell.topText = tracking.trackingProvider
         cell.middleText = tracking.trackingNumber
 
+        cell.onEllipsisTouchUp = { [weak self] in
+            self?.trackingWasPressed(at: indexPath)
+        }
+
         if let dateShipped = tracking.dateShipped?.toString(dateStyle: .medium, timeStyle: .none) {
             cell.bottomText = String.localizedStringWithFormat(
                 NSLocalizedString("Shipped %@",
@@ -817,8 +821,6 @@ extension OrderDetailsViewController: UITableViewDelegate {
         case .productDetails:
             WooAnalytics.shared.track(.orderDetailProductDetailTapped)
             performSegue(withIdentifier: Constants.productDetailsSegue, sender: nil)
-        case .tracking:
-            trackingWasPressed(at: indexPath)
         default:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -668,7 +668,7 @@ private extension OrderDetailsViewController {
                                                                  orderID: orderID,
                                                                  trackingID: trackingID) { [weak self] error in
                                                                     if let error = error {
-                                                                        DDLogError("⛔️ Order Details - Delete Tracking Failure: orderID \(orderID). Error: \(error)")
+                                                                        DDLogError("⛔️ Order Details - Delete Tracking: orderID \(orderID). Error: \(error)")
 
                                                                         self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
                                                                         return

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -664,7 +664,7 @@ private extension OrderDetailsViewController {
                                                                  orderID: orderID,
                                                                  trackingID: trackingID) { [weak self] error in
                                                                     if let error = error {
-                                                                        DDLogError("⛔️ Delete Tracking Failure: orderID \(orderID). Error: \(error)")
+                                                                        DDLogError("⛔️ Order Details - Delete Tracking Failure: orderID \(orderID). Error: \(error)")
 
                                                                         self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
                                                                         return
@@ -1168,7 +1168,7 @@ private extension OrderDetailsViewController {
 
     enum TrackingAction {
         static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the shipment tracking action sheet")
-        static let trackShipment = NSLocalizedString("Track Shipment", comment: "Track shiopment button title")
+        static let trackShipment = NSLocalizedString("Track Shipment", comment: "Track shipment button title")
         static let deleteTracking = NSLocalizedString("Delete Tracking", comment: "Delete tracking button title")
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderTrackingTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderTrackingTableViewCellTests.swift
@@ -15,7 +15,6 @@ final class OrderTrackingTableViewCellTests: XCTestCase {
                                                trackingURL: "http://automattic.com",
                                                dateShipped: Date(timeIntervalSince1970: 0))
 
-        static let buttonTitle = "Track shipment"
     }
 
     override func setUp() {
@@ -45,18 +44,6 @@ final class OrderTrackingTableViewCellTests: XCTestCase {
         populateCell()
 
         XCTAssertEqual(cell?.getBottomLabel().text, MockData.localizedShipmentDate)
-    }
-
-    func testActionButtonExecutesCallback() {
-        let expect = expectation(description: "The action assigned gets called")
-
-        cell?.onActionTouchUp = {
-            expect.fulfill()
-        }
-
-        cell?.getActionButton().sendActions(for: .touchUpInside)
-
-        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testTopLabelHasSubheadlineStyle() {
@@ -89,21 +76,6 @@ final class OrderTrackingTableViewCellTests: XCTestCase {
         XCTAssertEqual(cellLabel?.textColor, mockLabel.textColor)
     }
 
-    func testActionButtonHasSecondaryButtonStyle() {
-        let mockButton = UIButton()
-        mockButton.applyTertiaryButtonStyle()
-
-        let cellButton = cell?.getActionButton()
-
-        XCTAssertEqual(cellButton?.backgroundColor, mockButton.backgroundColor)
-        XCTAssertEqual(cellButton?.contentEdgeInsets, mockButton.contentEdgeInsets)
-        XCTAssertEqual(cellButton?.tintColor, mockButton.tintColor)
-        XCTAssertEqual(cellButton?.layer.borderWidth, mockButton.layer.borderWidth)
-        XCTAssertEqual(cellButton?.layer.cornerRadius, mockButton.layer.cornerRadius)
-
-        XCTAssertEqual(cellButton?.titleLabel?.font, mockButton.titleLabel?.font)
-    }
-
     func testTopLabelAccessibilityLabelMatchesExpectation() {
         populateCell()
 
@@ -122,24 +94,9 @@ final class OrderTrackingTableViewCellTests: XCTestCase {
         XCTAssertEqual(cell?.getMiddleLabel().accessibilityLabel, expectedLabel)
     }
 
-    func testButtonAccessibilityLabelMatchesExpectation() {
-        populateCell()
-
-        XCTAssertEqual(cell?.getActionButton().accessibilityLabel, MockData.buttonTitle)
-    }
-
-    func testButtonAccessibilityhintMatchesExpectation() {
-        populateCell()
-
-        let expectedHint = "Tracks a shipment."
-
-        XCTAssertEqual(cell?.getActionButton().accessibilityHint, expectedHint)
-    }
-
     private func populateCell() {
         cell?.topText = MockData.tracking.trackingProvider
         cell?.middleText = MockData.tracking.trackingNumber
         cell?.bottomText = MockData.localizedShipmentDate
-        cell?.actionButtonNormalText = MockData.buttonTitle
     }
 }


### PR DESCRIPTION
Fixes #876 

<img src="https://user-images.githubusercontent.com/2722505/57663796-0f5c7e00-7628-11e9-84f3-e31b62037d6c.gif" width="350" />

## Changes
- Updated `OrderTrackingTableViewCell` to remove the "track" button and a separator
- Updated `OrderDetailsViewController` to present an alert sheet and to add the delete action

## Testing
- Checkout the branch, run the tests
- Navigate to an order with shipment trackings (`OrderDetailsViewController`)
- Tap one of the trackings. Tap the Delete Tracking and Track Shipment buttons and check that they work as expected

**Note**: When presenting the sheet in the simulator, on iPhone, there will be an Autolayout error:

```
2019-05-14 09:14:16.959312+0800 WooCommerce[12158:259530] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60000164e170 UIView:0x7fab0565b430.width == - 16   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000164e170 UIView:0x7fab0565b430.width == - 16   (active)>
```

We have discussed that error in the past, and found it to be out of our control (p1556162547026400-slack-woo-mobile)

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.