### PR TITLE
Order fulfillment: Pre-populate custom provider name with search term

### DIFF
--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -241,7 +241,8 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
 
     let isCustom: Bool = true
 
-    init(order: Order) {
+    init(order: Order, initialName: String? = nil) {
         self.order = order
+        self.providerName = initialName
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -324,7 +324,9 @@ private extension ShipmentProvidersViewController {
     }
 
     func addCustomProvider() {
-        let addCustomTrackingViewModel = AddCustomTrackingViewModel(order: viewModel.order)
+        let initialCustomProviderName = searchController.searchBar.text
+        let addCustomTrackingViewModel = AddCustomTrackingViewModel(order: viewModel.order,
+                                                                    initialName: initialCustomProviderName)
         let addCustomTrackingViewController = ManualTrackingViewController(viewModel: addCustomTrackingViewModel)
         navigationController?.pushViewController(addCustomTrackingViewController, animated: true)
     }

--- a/WooCommerce/WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift
@@ -17,6 +17,7 @@ final class AddManualCustomTrackingViewModelTests: XCTestCase {
                                                          .datePicker]
 
         static let accessoryType = UITableViewCell.AccessoryType.none
+        static let initialName = "Hogsmeade"
     }
 
     override func setUp() {
@@ -110,5 +111,11 @@ final class AddManualCustomTrackingViewModelTests: XCTestCase {
 
     func testCanCommitReturnsFalseWithoutNameAndWithoutTrackingNumber() {
         XCTAssertFalse(subject!.canCommit)
+    }
+
+    func testInitialisingWithProviderNameReturnsName() {
+        let viewModel = AddCustomTrackingViewModel(order: MockData.order, initialName: MockData.initialName)
+
+        XCTAssertEqual(viewModel.providerName, MockData.initialName)
     }
 }


### PR DESCRIPTION
Implements #890 

When users select a custom shipment provider in the list of providers, we'd pre-populate the provider name with the search term introduced by users when filtering the list (if the list was filtered)

![ezgif-5-1a838f5cd5cc](https://user-images.githubusercontent.com/2722505/57664856-4df43780-762c-11e9-8e90-5a8935dc20e9.gif)

## Changes
- Added an optional parameter to the view model backing the "add tracking" screen (`AddCustomTrackingViewModel`) to provide an initial value to the provider name

## Testing
- Run the tests
- Navigate to the fulfill order screen
- Tap Add tracking
- Tap the provider name, select Custom Provider in the list of providers
- Tap the provider name, filter the list of providers. Tap Custom Provider, notice the name is pre-populated with the search term.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.