### PR TITLE
 Order fulfillment: remove feature flag for manual shipment tracking

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 1.9
 -----
 - bugfix: fixes "Unable to load content" error message when attempting to get Top Performers content.
+- new feature: You can now manually add shipment tracking to an Order
  
 1.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 1.9
 -----
 - bugfix: fixes "Unable to load content" error message when attempting to get Top Performers content.
-- new feature: You can now manually add shipment tracking to an Order
+- new feature: You can now manually add shipment tracking to an Order. This feature is for users who have the [Shipment Tracking plugin](https://woocommerce.com/products/shipment-tracking) installed.
 - bugfix: fixes Store Picker: some users are unable to continue after logging in.
  
 1.8

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -6,10 +6,6 @@ enum FeatureFlag: Int {
     /// `An enum with no cases cannot declare a raw type`
     case null
 
-    /// Enable the shipment tracking input section/screens
-    ///
-    case manualShipmentTracking
-
     /// Enable the new product details screen (via `FulfillViewController` or `ProductListViewController`)
     ///
     case productDetails
@@ -18,8 +14,6 @@ enum FeatureFlag: Int {
     ///
     var enabled: Bool {
         switch self {
-        case .manualShipmentTracking:
-            return BuildConfiguration.current == .localDeveloper
         case .productDetails:
             return BuildConfiguration.current == .localDeveloper
         default:

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -616,11 +616,7 @@ private extension FulfillViewController {
             return Section(title: title, secondaryTitle: nil, rows: [row])
         }()
 
-        if FeatureFlag.manualShipmentTracking.enabled {
-            sections =  [products, note, address, tracking, addTracking].compactMap { $0 }
-        } else {
-            sections = [products, note, address].compactMap { $0 }
-        }
+        sections =  [products, note, address, tracking, addTracking].compactMap { $0 }
     }
 }
 


### PR DESCRIPTION
Fixes #862 

This PR might be a bit premature, but as far as I know there is no new work left for manual shipment tracking, and this PR could be merged at any time whenever we decide this feature is ready for release, so here it is! 

I am opening this PR as a draft, will upgrade it to a full PR when PRs #959 and #960 are merged.

## Changes
- Removed the feature flag
- Updated the release notes

## Testing
- Checkout the branch, make sure it builds, tests pass and the feature is available on the simulator
- Build on a device, and check that the feature is available

To check that the feature is available, log in to a store that has the [Shipment Tracking Extension](http://woocommerce.com/products/shipment-tracking/?_ga=2.213023133.823373140.1557804345-403441387.1556787590) installed, navigate to an order in Processing status, Fulfill order and check that the "Add Tracking" button is available

- [x ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.