### PR TITLE
Product Details: Basic information

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		CE132BBC223859710029DB6C /* ProductTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE132BBB223859710029DB6C /* ProductTag.swift */; };
 		CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = CE19CB10222486A500E8AF7A /* order-statuses.json */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
+		CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227092228DD44C00C0626C /* ProductStatus.swift */; };
 		CE50345E21B571A7007573C6 /* SitePlanMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE50345D21B571A7007573C6 /* SitePlanMapper.swift */; };
 		CE50346021B5799F007573C6 /* SitePlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE50345F21B5799F007573C6 /* SitePlan.swift */; };
 		CE50346721B5DCBE007573C6 /* site-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = CE50346621B5DCBE007573C6 /* site-plan.json */; };
@@ -427,6 +428,7 @@
 		CE132BBB223859710029DB6C /* ProductTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTag.swift; sourceTree = "<group>"; };
 		CE19CB10222486A500E8AF7A /* order-statuses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-statuses.json"; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
+		CE227092228DD44C00C0626C /* ProductStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatus.swift; sourceTree = "<group>"; };
 		CE50345D21B571A7007573C6 /* SitePlanMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePlanMapper.swift; sourceTree = "<group>"; };
 		CE50345F21B5799F007573C6 /* SitePlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePlan.swift; sourceTree = "<group>"; };
 		CE50346621B5DCBE007573C6 /* site-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-plan.json"; sourceTree = "<group>"; };
@@ -888,13 +890,14 @@
 			isa = PBXGroup;
 			children = (
 				CE6BFEE42236BF05005C79FB /* Product.swift */,
-				CE6BFEE92236E191005C79FB /* ProductType.swift */,
-				CE132BB9223851F80029DB6C /* ProductCategory.swift */,
-				CE132BBB223859710029DB6C /* ProductTag.swift */,
-				CE0A0F12223942D90075ED8D /* ProductImage.swift */,
 				CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */,
-				CE6BFEE72236D133005C79FB /* ProductDimensions.swift */,
+				CE132BB9223851F80029DB6C /* ProductCategory.swift */,
 				CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */,
+				CE6BFEE72236D133005C79FB /* ProductDimensions.swift */,
+				CE0A0F12223942D90075ED8D /* ProductImage.swift */,
+				CE227092228DD44C00C0626C /* ProductStatus.swift */,
+				CE6BFEE92236E191005C79FB /* ProductType.swift */,
+				CE132BBB223859710029DB6C /* ProductTag.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -1149,6 +1152,7 @@
 				74A1196C2110F4BB00E1E5F0 /* OrderStats.swift in Sources */,
 				B58E5BEA20FFB3D0003C986E /* CodingUserInfoKey+Woo.swift in Sources */,
 				B59325D3217E4206000B0E8E /* NoteMedia.swift in Sources */,
+				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,

--- a/Networking/Networking/Extensions/KeyedDecodingContainer+Woo.swift
+++ b/Networking/Networking/Extensions/KeyedDecodingContainer+Woo.swift
@@ -68,6 +68,18 @@ extension KeyedDecodingContainer {
 
         return nil
     }
+
+    func failsafeDecodeIfPresent(decimalForKey key: KeyedDecodingContainer<K>.Key) -> Decimal? {
+        if let decimal = failsafeDecodeIfPresent(Decimal.self, forKey: key) {
+            return decimal
+        }
+
+        if let integerAsDecimal = failsafeDecodeIfPresent(Int.self, forKey: key) {
+            return Decimal(integerLiteral: integerAsDecimal)
+        }
+
+        return nil
+    }
 }
 
 

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -225,9 +225,26 @@ public struct Product: Decodable {
         let briefDescription = try container.decodeIfPresent(String.self, forKey: .briefDescription)
         let sku = try container.decodeIfPresent(String.self, forKey: .sku)
 
-        let price = try container.decode(String.self, forKey: .price)
+        // Even though a plain install of WooCommerce Core provides string values,
+        // some plugins alter the field value from String to Int or Decimal.
+        var price = ""
+        if let parsedStringValue = container.failsafeDecodeIfPresent(stringForKey: .price) {
+            price = parsedStringValue
+        } else if let parsedDecimalValue = container.failsafeDecodeIfPresent(decimalForKey: .price) {
+            price = NSDecimalNumber(decimal: parsedDecimalValue).stringValue
+        }
+
         let regularPrice = try container.decodeIfPresent(String.self, forKey: .regularPrice)
-        let salePrice = try container.decodeIfPresent(String.self, forKey: .salePrice)
+
+        // Even though a plain install of WooCommerce Core provides string values,
+        // some plugins alter the field value from String to Int or Decimal.
+        var salePrice = ""
+        if let parsedSalePriceString = container.failsafeDecodeIfPresent(stringForKey: .salePrice) {
+            salePrice = parsedSalePriceString
+        } else if let parsedSalePriceDecimal = container.failsafeDecodeIfPresent(decimalForKey: .salePrice) {
+            salePrice = NSDecimalNumber(decimal: parsedSalePriceDecimal).stringValue
+        }
+
         let onSale = try container.decode(Bool.self, forKey: .onSale)
 
         let purchasable = try container.decode(Bool.self, forKey: .purchasable)
@@ -449,9 +466,9 @@ extension Product: Comparable {
             lhs.fullDescription == rhs.fullDescription &&
             lhs.briefDescription == rhs.briefDescription &&
             lhs.sku == rhs.sku &&
-            lhs.price == rhs.price &&
+            // lhs.price == rhs.price &&    // can't compare because object type unknown
             lhs.regularPrice == rhs.regularPrice &&
-            lhs.salePrice == rhs.salePrice &&
+            // lhs.salePrice == rhs.salePrice && // can't compare because object type unknown
             lhs.onSale == rhs.onSale &&
             lhs.purchasable == rhs.purchasable &&
             lhs.totalSales == rhs.totalSales &&

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -79,6 +79,10 @@ public struct Product: Decodable {
 
     /// Computed Properties
     ///
+    public var productStatus: ProductStatus {
+        return ProductStatus(rawValue: statusKey)
+    }
+
     public var productType: ProductType {
         return ProductType(rawValue: productTypeKey)
     }

--- a/Networking/Networking/Model/Product/ProductStatus.swift
+++ b/Networking/Networking/Model/Product/ProductStatus.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+
+/// Represents a ProductStatus Entity.
+///
+public enum ProductStatus: Decodable, Hashable {
+    case publish
+    case draft
+    case pending
+    case privateStatus  // `private` is a reserved keyword
+    case custom(String) // in case there are extensions modifying product statuses
+}
+
+
+/// RawRepresentable Conformance
+///
+extension ProductStatus: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.publish:
+            self = .publish
+        case Keys.draft:
+            self = .draft
+        case Keys.pending:
+            self = .pending
+        case Keys.privateStatus:
+            self = .privateStatus
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .publish:              return Keys.publish
+        case .draft:                return Keys.draft
+        case .pending:              return Keys.pending
+        case .privateStatus:        return Keys.privateStatus
+        case .custom(let payload):  return payload
+        }
+    }
+
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .publish:
+            return NSLocalizedString("Publish", comment: "Display label for the product's published status")
+        case .draft:
+            return NSLocalizedString("Draft", comment: "Display label for the product's draft status")
+        case .pending:
+            return NSLocalizedString("Pending", comment: "Display label for the product's pending status")
+        case .privateStatus:
+            return NSLocalizedString("Private", comment: "Display label for the product's private status")
+        case .custom(let payload):
+            return payload // unable to localize at runtime.
+        }
+    }
+}
+
+
+/// Enum containing the 'Known' ProductType Keys
+///
+private enum Keys {
+    static let publish       = "publish"
+    static let draft         = "draft"
+    static let pending       = "pending"
+    static let privateStatus = "private"
+}

--- a/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
@@ -21,6 +21,12 @@ extension UILabel {
         textColor = StyleManager.defaultTextColor
     }
 
+    func applySecondaryBodyStyle() {
+        adjustsFontForContentSizeCategory = true
+        font = .body
+        textColor = StyleManager.wooGreyTextMin
+    }
+
     func applyFootnoteStyle() {
         adjustsFontForContentSizeCategory = true
         font = .footnote

--- a/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
@@ -46,6 +46,13 @@ extension UILabel {
         font = .footnote
     }
 
+    func applyPaddedLabelSubheadStyles() {
+        adjustsFontForContentSizeCategory = true
+        layer.borderWidth = 1.0
+        layer.cornerRadius = 4.0
+        font = .subheadline
+    }
+
     func applyEmptyStateTitleStyle() {
         adjustsFontForContentSizeCategory = true
         font = .body

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -23,9 +23,15 @@ protocol Style {
     var buttonDisabledColor: UIColor { get }
     var buttonDisabledHighlightedColor: UIColor { get }
     var buttonDisabledTitleColor: UIColor { get }
+
     var cellSeparatorColor: UIColor { get }
+
     var defaultTextColor: UIColor { get }
     var destructiveActionColor: UIColor { get }
+
+    var goldStarColor: UIColor { get }
+    var grayStarColor: UIColor { get }
+
     var sectionBackgroundColor: UIColor { get }
     var sectionTitleColor: UIColor { get }
     var statusDangerColor: UIColor { get }
@@ -37,7 +43,7 @@ protocol Style {
     var statusSuccessColor: UIColor { get }
     var statusSuccessBoldColor: UIColor { get }
     var tableViewBackgroundColor: UIColor { get }
-    var goldStarColor: UIColor { get }
+
     var wooCommerceBrandColor: UIColor { get }
     var wooAccent: UIColor { get }
     var wooGreyLight: UIColor { get }
@@ -86,7 +92,6 @@ class DefaultStyle: Style {
     let sectionBackgroundColor          = HandbookColors.wooGreyLight
     let sectionTitleColor               = HandbookColors.wooSecondary
     let tableViewBackgroundColor        = HandbookColors.wooGreyLight
-    let goldStarColor                   = UIColor(red: 238.0/255.0, green: 180.0/255.0, blue: 34.0/255.0, alpha: 1.0)
 
     let statusDangerColor               = HandbookColors.statusRedDimmed
     let statusDangerBoldColor           = HandbookColors.statusRed
@@ -105,6 +110,11 @@ class DefaultStyle: Style {
     let wooGreyMid                      = HandbookColors.wooGreyMid
     let wooGreyTextMin                  = HandbookColors.wooGreyTextMin
     let wooWhite                        = HandbookColors.wooWhite
+
+    /// Stars
+    ///
+    let goldStarColor                   = HandbookColors.goldStarColor
+    let grayStarColor                   = HandbookColors.grayStarColor
 
     /// NavBar
     ///
@@ -131,14 +141,19 @@ private extension DefaultStyle {
         static let statusGreenDimmed     = UIColor(red: 239.00/255.0, green: 249.0/255.0, blue: 230.0/255.0, alpha: 1.0)
         static let statusGreen           = UIColor(red: 201.0/255.0, green: 233.0/255.0, blue: 169.0/255.0, alpha: 1.0)
 
-        static let wooPrimary            = UIColor(red: 0x96/255.0, green: 0x58/255.0, blue: 0x8A/255.0, alpha: 0xFF/255.0)
+        static let wooPrimary            = UIColor(red: 0x96/255.0, green: 0x58/255.0, blue: 0x8A/255.0, alpha: 0xFF/255.0) // woo purple
         static let wooSecondary          = UIColor(red: 60.0/255.0, green: 60.0/255.0, blue: 60.0/255.0, alpha: 1.0)
         static let wooAccent             = UIColor(red: 113.0/255.0, green: 176.0/255.0, blue: 47.0/255.0, alpha: 1.0)
+
+        // multiple grays
         static let wooGreyLight          = UIColor(red: 247.0/255.0, green: 247.0/255.0, blue: 247.0/255.0, alpha: 1.0)
         static let wooGreyBorder         = UIColor(red: 230.0/255.0, green: 230.0/255.0, blue: 230.0/255.0, alpha: 1.0)
         static let wooWhite              = UIColor.white
         static let wooGreyMid            = UIColor(red: 150.0/255.0, green: 150.0/255.0, blue: 150.0/255.0, alpha: 1.0)
         static let wooGreyTextMin        = UIColor(red: 89.0/255.0, green: 89.0/255.0, blue: 89.0/255.0, alpha: 1.0)
+
+        static let goldStarColor         = UIColor(red: 238.0/255.0, green: 180.0/255.0, blue: 34.0/255.0, alpha: 1.0)
+        static let grayStarColor         = UIColor(red: 0, green: 0, blue: 0, alpha: 0.54)
     }
 }
 
@@ -306,6 +321,10 @@ class StyleManager {
 
     static var wooWhite: UIColor {
         return active.wooWhite
+    }
+
+    static var grayStarColor: UIColor {
+        return active.grayStarColor
     }
 
     // MARK: - NavBar

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -153,7 +153,7 @@ private extension DefaultStyle {
         static let wooGreyTextMin        = UIColor(red: 89.0/255.0, green: 89.0/255.0, blue: 89.0/255.0, alpha: 1.0)
 
         static let goldStarColor         = UIColor(red: 238.0/255.0, green: 180.0/255.0, blue: 34.0/255.0, alpha: 1.0)
-        static let grayStarColor         = UIColor(red: 0, green: 0, blue: 0, alpha: 0.54)
+        static let grayStarColor         = UIColor(red: 89.0/255.0, green: 89.0/255.0, blue: 89.0/255.0, alpha: 1.0)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Gridicons
 import SafariServices
 
+
 class PrivacySettingsViewController: UIViewController {
 
     /// Main TableView

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -24,6 +24,8 @@ class ProductReviewsTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        reviewLabel.applyBodyStyle()
+        reviewTotalsLabel.applyBodyStyle()
         configureStarView()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -40,12 +40,12 @@ class ProductReviewsTableViewCell: UITableViewCell {
 //
 private extension ProductReviewsTableViewCell {
     enum Star {
-        static let size = Double(13)
+        static let size = Double(20)
         static let filledImage = Gridicon.iconOfType(.star,
                                                      withSize: CGSize(width: Star.size, height: Star.size)
-            ).imageWithTintColor(StyleManager.defaultTextColor)
-        static let emptyImage = Gridicon.iconOfType(.star,
+            ).imageWithTintColor(StyleManager.grayStarColor)
+        static let emptyImage = Gridicon.iconOfType(.starOutline,
                                                     withSize: CGSize(width: Star.size, height: Star.size)
-            ).imageWithTintColor(.clear)
+            ).imageWithTintColor(StyleManager.grayStarColor)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -1,0 +1,49 @@
+import UIKit
+import Gridicons
+
+
+// MARK: - ProductReviewsTableViewCell
+//
+class ProductReviewsTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var reviewLabel: UILabel!
+    @IBOutlet weak var reviewTotalsLabel: UILabel!
+    @IBOutlet weak var starRatingView: RatingView!
+
+    var starRating: Int? {
+        didSet {
+            guard let starRating = starRating else {
+                starRatingView.isHidden = true
+                return
+            }
+
+            starRatingView.rating = CGFloat(starRating)
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureStarView()
+    }
+
+    func configureStarView() {
+        starRatingView.starImage = Star.filledImage
+        starRatingView.emptyStarImage = Star.emptyImage
+    }
+}
+
+
+// MARK: - Constants
+//
+private extension ProductReviewsTableViewCell {
+    enum Star {
+        static let size = Double(13)
+        static let filledImage = Gridicon.iconOfType(.star,
+                                                     withSize: CGSize(width: Star.size, height: Star.size)
+            ).imageWithTintColor(StyleManager.defaultTextColor)
+        static let emptyImage = Gridicon.iconOfType(.star,
+                                                    withSize: CGSize(width: Star.size, height: Star.size)
+            ).imageWithTintColor(.clear)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -4,7 +4,7 @@ import Gridicons
 
 // MARK: - ProductReviewsTableViewCell
 //
-class ProductReviewsTableViewCell: UITableViewCell {
+final class ProductReviewsTableViewCell: UITableViewCell {
 
     @IBOutlet weak var reviewLabel: UILabel!
     @IBOutlet weak var reviewTotalsLabel: UILabel!
@@ -24,9 +24,13 @@ class ProductReviewsTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureLabels()
+        configureStarView()
+    }
+
+    func configureLabels() {
         reviewLabel.applyBodyStyle()
         reviewTotalsLabel.applyBodyStyle()
-        configureStarView()
     }
 
     func configureStarView() {
@@ -40,12 +44,12 @@ class ProductReviewsTableViewCell: UITableViewCell {
 //
 private extension ProductReviewsTableViewCell {
     enum Star {
-        static let size = Double(20)
+        static let size = CGSize(width: 20, height: 20)
         static let filledImage = Gridicon.iconOfType(.star,
-                                                     withSize: CGSize(width: Star.size, height: Star.size)
+                                                     withSize: Star.size
             ).imageWithTintColor(StyleManager.grayStarColor)
         static let emptyImage = Gridicon.iconOfType(.starOutline,
-                                                    withSize: CGSize(width: Star.size, height: Star.size)
+                                                    withSize: Star.size
             ).imageWithTintColor(StyleManager.grayStarColor)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.xib
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ProductReviewsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3X1-Tq-m8c">
+                        <rect key="frame" x="16" y="11" width="288" height="22"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vqh-zX-MRV">
+                                <rect key="frame" x="0.0" y="0.0" width="42" height="22"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fO6-L6-6dK">
+                                <rect key="frame" x="50" y="0.0" width="154" height="22"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CZP-oo-f9a">
+                                <rect key="frame" x="212" y="0.0" width="42" height="22"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8uK-v8-jD2">
+                                <rect key="frame" x="262" y="0.0" width="26" height="22"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="3X1-Tq-m8c" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="PY0-JL-OpD"/>
+                    <constraint firstItem="3X1-Tq-m8c" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="RQf-5E-F1G"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="3X1-Tq-m8c" secondAttribute="trailing" id="SRN-3q-qp0"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="3X1-Tq-m8c" secondAttribute="bottom" id="qV3-Vu-zUg"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="137.68115942028987" y="99.776785714285708"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.xib
@@ -7,6 +7,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,45 +16,65 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ProductReviewsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3X1-Tq-m8c">
-                        <rect key="frame" x="16" y="11" width="288" height="22"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="3X1-Tq-m8c">
+                        <rect key="frame" x="16" y="15" width="296" height="14"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vqh-zX-MRV">
-                                <rect key="frame" x="0.0" y="0.0" width="42" height="22"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reviews" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vqh-zX-MRV">
+                                <rect key="frame" x="0.0" y="0.0" width="63" height="14"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fO6-L6-6dK">
-                                <rect key="frame" x="50" y="0.0" width="154" height="22"/>
+                            <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fO6-L6-6dK" userLabel="Spacer">
+                                <rect key="frame" x="71" y="0.0" width="109.5" height="14"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CZP-oo-f9a">
-                                <rect key="frame" x="212" y="0.0" width="42" height="22"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="260" text="20k" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CZP-oo-f9a">
+                                <rect key="frame" x="188.5" y="0.0" width="29.5" height="14"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8uK-v8-jD2">
-                                <rect key="frame" x="262" y="0.0" width="26" height="22"/>
+                            <view contentMode="scaleToFill" horizontalHuggingPriority="260" verticalHuggingPriority="260" translatesAutoresizingMaskIntoConstraints="NO" id="8uK-v8-jD2" userLabel="Star View" customClass="RatingView" customModule="WooCommerce" customModuleProvider="target">
+                                <rect key="frame" x="226" y="0.0" width="70" height="14"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="14" id="BQT-I1-qKW"/>
+                                    <constraint firstAttribute="width" constant="70" id="pDH-Qa-WoB"/>
+                                </constraints>
                             </view>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="8uK-v8-jD2" secondAttribute="bottom" id="BBg-ur-mLM"/>
+                            <constraint firstItem="Vqh-zX-MRV" firstAttribute="top" secondItem="3X1-Tq-m8c" secondAttribute="top" id="BXi-Q3-dkh"/>
+                            <constraint firstItem="8uK-v8-jD2" firstAttribute="leading" secondItem="CZP-oo-f9a" secondAttribute="trailing" constant="8" id="Gl5-8T-Sg2"/>
+                            <constraint firstAttribute="trailing" secondItem="8uK-v8-jD2" secondAttribute="trailing" id="LWO-dP-gj1"/>
+                            <constraint firstAttribute="bottom" secondItem="Vqh-zX-MRV" secondAttribute="bottom" id="Lve-tI-gqP"/>
+                            <constraint firstItem="fO6-L6-6dK" firstAttribute="top" secondItem="3X1-Tq-m8c" secondAttribute="top" id="Qmh-23-ozV"/>
+                            <constraint firstAttribute="bottom" secondItem="fO6-L6-6dK" secondAttribute="bottom" id="RRE-wH-DSD"/>
+                            <constraint firstItem="8uK-v8-jD2" firstAttribute="top" secondItem="3X1-Tq-m8c" secondAttribute="top" id="c38-8W-EUz"/>
+                            <constraint firstItem="fO6-L6-6dK" firstAttribute="leading" secondItem="Vqh-zX-MRV" secondAttribute="trailing" constant="8" id="euZ-oJ-HVD"/>
+                            <constraint firstItem="Vqh-zX-MRV" firstAttribute="leading" secondItem="3X1-Tq-m8c" secondAttribute="leading" id="frH-kN-47b"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
                     <constraint firstItem="3X1-Tq-m8c" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="PY0-JL-OpD"/>
-                    <constraint firstItem="3X1-Tq-m8c" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="RQf-5E-F1G"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="3X1-Tq-m8c" secondAttribute="trailing" id="SRN-3q-qp0"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="3X1-Tq-m8c" secondAttribute="bottom" id="qV3-Vu-zUg"/>
+                    <constraint firstAttribute="trailing" secondItem="3X1-Tq-m8c" secondAttribute="trailing" constant="8" id="SRN-3q-qp0"/>
+                    <constraint firstItem="3X1-Tq-m8c" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="pAb-ya-dvK"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
-            <point key="canvasLocation" x="137.68115942028987" y="99.776785714285708"/>
+            <connections>
+                <outlet property="reviewLabel" destination="Vqh-zX-MRV" id="7vZ-iC-dDP"/>
+                <outlet property="reviewTotalsLabel" destination="CZP-oo-f9a" id="2tv-yE-nUn"/>
+                <outlet property="starRatingView" destination="8uK-v8-jD2" id="XrQ-cz-f39"/>
+            </connections>
+            <point key="canvasLocation" x="225" y="99"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.xib
@@ -21,30 +21,30 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="3X1-Tq-m8c">
-                        <rect key="frame" x="16" y="15" width="296" height="14"/>
+                        <rect key="frame" x="16" y="11" width="288" height="22"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reviews" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vqh-zX-MRV">
-                                <rect key="frame" x="0.0" y="0.0" width="63" height="14"/>
+                                <rect key="frame" x="0.0" y="0.0" width="63" height="22"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fO6-L6-6dK" userLabel="Spacer">
-                                <rect key="frame" x="71" y="0.0" width="109.5" height="14"/>
+                                <rect key="frame" x="71" y="0.0" width="71.5" height="22"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="260" text="20k" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CZP-oo-f9a">
-                                <rect key="frame" x="188.5" y="0.0" width="29.5" height="14"/>
+                                <rect key="frame" x="150.5" y="0.0" width="29.5" height="22"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" horizontalHuggingPriority="260" verticalHuggingPriority="260" translatesAutoresizingMaskIntoConstraints="NO" id="8uK-v8-jD2" userLabel="Star View" customClass="RatingView" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="226" y="0.0" width="70" height="14"/>
+                                <rect key="frame" x="188" y="0.0" width="100" height="22"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="14" id="BQT-I1-qKW"/>
-                                    <constraint firstAttribute="width" constant="70" id="pDH-Qa-WoB"/>
+                                    <constraint firstAttribute="height" constant="22" id="BQT-I1-qKW"/>
+                                    <constraint firstAttribute="width" constant="100" id="pDH-Qa-WoB"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -63,8 +63,8 @@
                     </stackView>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailingMargin" secondItem="3X1-Tq-m8c" secondAttribute="trailing" id="9w3-h1-wXn"/>
                     <constraint firstItem="3X1-Tq-m8c" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="PY0-JL-OpD"/>
-                    <constraint firstAttribute="trailing" secondItem="3X1-Tq-m8c" secondAttribute="trailing" constant="8" id="SRN-3q-qp0"/>
                     <constraint firstItem="3X1-Tq-m8c" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="pAb-ya-dvK"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -266,12 +266,12 @@ private extension ProductDetailsViewController {
             mainImageView.image = StyleManager.wooWhite.image(size)
         }
 
-//        if product.productStatus != .publish {
+        if product.productStatus != .publish {
             cell.textBadge?.applyPaddedLabelSubheadStyles()
             cell.textBadge?.layer.backgroundColor = StyleManager.defaultTextColor.cgColor
             cell.textBadge?.textColor = StyleManager.wooWhite
             cell.textBadge?.text = product.productStatus.description
-//        }
+        }
     }
 
     func configureProductName(cell: TitleBodyTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -131,7 +131,8 @@ private extension ProductDetailsViewController {
     func registerTableViewCells() {
         let cells = [
             LargeImageTableViewCell.self,
-            TitleBodyTableViewCell.self
+            TitleBodyTableViewCell.self,
+            TwoColumnTableViewCell.self
         ]
 
         for cell in cells {
@@ -235,6 +236,8 @@ private extension ProductDetailsViewController {
             configureProductImage(cell: cell)
         case let cell as TitleBodyTableViewCell:
             configureProductName(cell: cell)
+        case let cell as TwoColumnTableViewCell where row == .totalOrders:
+            configureTotalOrders(cell: cell)
         default:
             fatalError("Unidentified row type")
         }
@@ -260,6 +263,11 @@ private extension ProductDetailsViewController {
         cell.selectionStyle = .none
         cell.titleLabel?.text = NSLocalizedString("Title", comment: "Product details screen — product title descriptive label")
         cell.bodyLabel?.text = product.name
+    }
+
+    func configureTotalOrders(cell: TwoColumnTableViewCell) {
+        cell.leftLabel?.text = NSLocalizedString("Total Orders", comment: "Product details screen - total orders descriptive label")
+        cell.rightLabel?.text = String(product.totalSales)
     }
 }
 
@@ -364,7 +372,24 @@ private extension ProductDetailsViewController {
     /// Rebuild the section struct
     ///
     func reloadSections() {
-        let summary = Section(rows: [.productSummary, .productName])
+        var rows: [Row] = [.productSummary, .productName]
+
+        switch product.productType {
+        case .simple:
+            rows.append(.totalOrders)
+        case .grouped:
+            rows.append(.totalOrders)
+        case .external:  // affiliate
+            break
+        case .variable:
+            rows.append(.totalOrders)
+        case .variation:
+            rows.append(.totalOrders)
+        case .custom(_):
+            break
+        }
+
+        let summary = Section(rows: rows)
         sections = [summary].compactMap { $0 }
     }
 }
@@ -402,6 +427,7 @@ private extension ProductDetailsViewController {
     enum Row {
         case productSummary
         case productName
+        case totalOrders
 
         var reuseIdentifier: String {
             switch self {
@@ -409,6 +435,8 @@ private extension ProductDetailsViewController {
                 return LargeImageTableViewCell.reuseIdentifier
             case .productName:
                 return TitleBodyTableViewCell.reuseIdentifier
+            case .totalOrders:
+                return TwoColumnTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -271,12 +271,14 @@ private extension ProductDetailsViewController {
         cell.accessoryType = .none
         cell.selectionStyle = .none
         cell.titleLabel?.text = NSLocalizedString("Title", comment: "Product details screen — product title descriptive label")
+        cell.bodyLabel?.applySecondaryBodyStyle()
         cell.bodyLabel?.text = product.name
     }
 
     func configureTotalOrders(cell: TwoColumnTableViewCell) {
         cell.selectionStyle = .none
         cell.leftLabel?.text = NSLocalizedString("Total Orders", comment: "Product details screen - total orders descriptive label")
+        cell.rightLabel?.applySecondaryBodyStyle()
         cell.rightLabel.textInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 2)
         cell.rightLabel?.text = String(product.totalSales)
     }
@@ -285,6 +287,7 @@ private extension ProductDetailsViewController {
         cell.selectionStyle = .none
         cell.reviewLabel?.text = NSLocalizedString("Reviews", comment: "Reviews descriptive label")
 
+        cell.reviewTotalsLabel?.applySecondaryBodyStyle()
         // 🖐🏼 I solemnly swear I'm not converting currency values to a Double.
         let ratingCount = Double(product.ratingCount)
         cell.reviewTotalsLabel?.text = ratingCount.humanReadableString()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Yosemite
+import Gridicons
 
 
 /// ProductDetailsViewController: Displays the details for a given Product.
@@ -133,7 +134,8 @@ private extension ProductDetailsViewController {
             LargeImageTableViewCell.self,
             TitleBodyTableViewCell.self,
             TwoColumnTableViewCell.self,
-            ProductReviewsTableViewCell.self
+            ProductReviewsTableViewCell.self,
+            BasicTableViewCell.self
         ]
 
         for cell in cells {
@@ -241,6 +243,10 @@ private extension ProductDetailsViewController {
             configureTotalOrders(cell: cell)
         case let cell as ProductReviewsTableViewCell:
             configureReviews(cell: cell)
+        case let cell as BasicTableViewCell where row == .productLink:
+            configureProductLink(cell: cell)
+        case let cell as BasicTableViewCell where row == .affiliateLink:
+            configureAffiliateLink(cell: cell)
         default:
             fatalError("Unidentified row type")
         }
@@ -269,11 +275,13 @@ private extension ProductDetailsViewController {
     }
 
     func configureTotalOrders(cell: TwoColumnTableViewCell) {
+        cell.selectionStyle = .none
         cell.leftLabel?.text = NSLocalizedString("Total Orders", comment: "Product details screen - total orders descriptive label")
         cell.rightLabel?.text = String(product.totalSales)
     }
 
     func configureReviews(cell: ProductReviewsTableViewCell) {
+        cell.selectionStyle = .none
         cell.reviewLabel?.text = NSLocalizedString("Reviews", comment: "Reviews descriptive label")
 
         // 🖐🏼 I solemnly swear I'm not converting currency values to a Double.
@@ -281,6 +289,30 @@ private extension ProductDetailsViewController {
         cell.reviewTotalsLabel?.text = ratingCount.humanReadableString()
         let averageRating = Double(product.averageRating)
         cell.starRatingView.rating = CGFloat(averageRating ?? 0)
+    }
+
+    func configureProductLink(cell: BasicTableViewCell) {
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("View product on store", comment: "The descriptive label. Tapping the row will open the product's page in a web view.")
+
+        let accessoryImage = Gridicon.iconOfType(.external)
+        let accessoryImageView = UIImageView(image: accessoryImage)
+        accessoryImageView.tintColor = StyleManager.buttonPrimaryColor
+
+        cell.accessoryView = accessoryImageView
+        cell.textLabel?.textColor = StyleManager.buttonPrimaryColor
+    }
+
+    func configureAffiliateLink(cell: BasicTableViewCell) {
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("View affiliate product", comment: "The descriptive label. Tapping the row will open the affliate product's link in a web view.")
+
+        let accessoryImage = Gridicon.iconOfType(.external)
+        let accessoryImageView = UIImageView(image: accessoryImage)
+        accessoryImageView.tintColor = StyleManager.buttonPrimaryColor
+
+        cell.accessoryView = accessoryImageView
+        cell.textLabel?.textColor = StyleManager.buttonPrimaryColor
     }
 }
 
@@ -403,6 +435,7 @@ private extension ProductDetailsViewController {
         }
 
         rows.append(.reviews)
+        rows.append(.productLink)
 
         let summary = Section(rows: rows)
         sections = [summary].compactMap { $0 }
@@ -444,6 +477,8 @@ private extension ProductDetailsViewController {
         case productName
         case totalOrders
         case reviews
+        case productLink
+        case affiliateLink
 
         var reuseIdentifier: String {
             switch self {
@@ -455,6 +490,10 @@ private extension ProductDetailsViewController {
                 return TwoColumnTableViewCell.reuseIdentifier
             case .reviews:
                 return ProductReviewsTableViewCell.reuseIdentifier
+            case .productLink:
+                return BasicTableViewCell.reuseIdentifier
+            case .affiliateLink:
+                return BasicTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -286,7 +286,7 @@ private extension ProductDetailsViewController {
         cell.selectionStyle = .none
         cell.leftLabel?.text = NSLocalizedString("Total Orders", comment: "Product details screen - total orders descriptive label")
         cell.rightLabel?.applySecondaryBodyStyle()
-        cell.rightLabel.textInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 2)
+        cell.rightLabel.textInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
         cell.rightLabel?.text = String(product.totalSales)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -265,6 +265,13 @@ private extension ProductDetailsViewController {
             let size = CGSize(width: tableView.frame.width, height: Metrics.emptyProductImageHeight)
             mainImageView.image = StyleManager.wooWhite.image(size)
         }
+
+//        if product.productStatus != .publish {
+            cell.textBadge?.applyPaddedLabelSubheadStyles()
+            cell.textBadge?.layer.backgroundColor = StyleManager.defaultTextColor.cgColor
+            cell.textBadge?.textColor = StyleManager.wooWhite
+            cell.textBadge?.text = product.productStatus.description
+//        }
     }
 
     func configureProductName(cell: TitleBodyTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Yosemite
 import Gridicons
+import SafariServices
 
 
 /// ProductDetailsViewController: Displays the details for a given Product.
@@ -379,12 +380,16 @@ extension ProductDetailsViewController: UITableViewDelegate {
         switch rowAtIndexPath(indexPath) {
         case .permalink:
             if let url = URL(string: product.permalink) {
-                UIApplication.shared.open(url)
+                let safariViewController = SFSafariViewController(url: url)
+                safariViewController.modalPresentationStyle = .pageSheet
+                present(safariViewController, animated: true, completion: nil)
             }
         case .affiliateLink:
             if let externalUrlString = product.externalURL,
                 let url = URL(string: externalUrlString) {
-                UIApplication.shared.open(url)
+                let safariViewController = SFSafariViewController(url: url)
+                safariViewController.modalPresentationStyle = .pageSheet
+                present(safariViewController, animated: true, completion: nil)
             }
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -277,6 +277,7 @@ private extension ProductDetailsViewController {
     func configureTotalOrders(cell: TwoColumnTableViewCell) {
         cell.selectionStyle = .none
         cell.leftLabel?.text = NSLocalizedString("Total Orders", comment: "Product details screen - total orders descriptive label")
+        cell.rightLabel.textInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 2)
         cell.rightLabel?.text = String(product.totalSales)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -132,7 +132,8 @@ private extension ProductDetailsViewController {
         let cells = [
             LargeImageTableViewCell.self,
             TitleBodyTableViewCell.self,
-            TwoColumnTableViewCell.self
+            TwoColumnTableViewCell.self,
+            ProductReviewsTableViewCell.self
         ]
 
         for cell in cells {
@@ -238,6 +239,8 @@ private extension ProductDetailsViewController {
             configureProductName(cell: cell)
         case let cell as TwoColumnTableViewCell where row == .totalOrders:
             configureTotalOrders(cell: cell)
+        case let cell as ProductReviewsTableViewCell:
+            configureReviews(cell: cell)
         default:
             fatalError("Unidentified row type")
         }
@@ -268,6 +271,16 @@ private extension ProductDetailsViewController {
     func configureTotalOrders(cell: TwoColumnTableViewCell) {
         cell.leftLabel?.text = NSLocalizedString("Total Orders", comment: "Product details screen - total orders descriptive label")
         cell.rightLabel?.text = String(product.totalSales)
+    }
+
+    func configureReviews(cell: ProductReviewsTableViewCell) {
+        cell.reviewLabel?.text = NSLocalizedString("Reviews", comment: "Reviews descriptive label")
+
+        // 🖐🏼 I solemnly swear I'm not converting currency values to a Double.
+        let ratingCount = Double(product.ratingCount)
+        cell.reviewTotalsLabel?.text = ratingCount.humanReadableString()
+        let averageRating = Double(product.averageRating)
+        cell.starRatingView.rating = CGFloat(averageRating ?? 0)
     }
 }
 
@@ -389,6 +402,8 @@ private extension ProductDetailsViewController {
             break
         }
 
+        rows.append(.reviews)
+
         let summary = Section(rows: rows)
         sections = [summary].compactMap { $0 }
     }
@@ -428,6 +443,7 @@ private extension ProductDetailsViewController {
         case productSummary
         case productName
         case totalOrders
+        case reviews
 
         var reuseIdentifier: String {
             switch self {
@@ -437,6 +453,8 @@ private extension ProductDetailsViewController {
                 return TitleBodyTableViewCell.reuseIdentifier
             case .totalOrders:
                 return TwoColumnTableViewCell.reuseIdentifier
+            case .reviews:
+                return ProductReviewsTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -243,8 +243,8 @@ private extension ProductDetailsViewController {
             configureTotalOrders(cell: cell)
         case let cell as ProductReviewsTableViewCell:
             configureReviews(cell: cell)
-        case let cell as BasicTableViewCell where row == .productLink:
-            configureProductLink(cell: cell)
+        case let cell as BasicTableViewCell where row == .permalink:
+            configurePermalink(cell: cell)
         case let cell as BasicTableViewCell where row == .affiliateLink:
             configureAffiliateLink(cell: cell)
         default:
@@ -295,7 +295,7 @@ private extension ProductDetailsViewController {
         cell.starRatingView.rating = CGFloat(averageRating ?? 0)
     }
 
-    func configureProductLink(cell: BasicTableViewCell) {
+    func configurePermalink(cell: BasicTableViewCell) {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("View product on store", comment: "The descriptive label. Tapping the row will open the product's page in a web view.")
 
@@ -384,6 +384,15 @@ extension ProductDetailsViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         switch rowAtIndexPath(indexPath) {
+        case .permalink:
+            if let url = URL(string: product.permalink) {
+                UIApplication.shared.open(url)
+            }
+        case .affiliateLink:
+            if let externalUrlString = product.externalURL,
+                let url = URL(string: externalUrlString) {
+                UIApplication.shared.open(url)
+            }
         default:
             break
         }
@@ -422,24 +431,24 @@ private extension ProductDetailsViewController {
     ///
     func reloadSections() {
         var rows: [Row] = [.productSummary, .productName]
+        var customContent = [Row]()
 
         switch product.productType {
         case .simple:
-            rows.append(.totalOrders)
+            customContent = [.totalOrders, .reviews, .permalink]
         case .grouped:
-            rows.append(.totalOrders)
-        case .external:  // affiliate
-            break
+            customContent = [.totalOrders, .reviews, .permalink]
+        case .external:  // affiliate product
+            customContent = [.totalOrders, .reviews, .permalink, .affiliateLink]
         case .variable:
-            rows.append(.totalOrders)
+            customContent = [.totalOrders, .reviews, .permalink]
         case .variation:
-            rows.append(.totalOrders)
+            customContent = [.totalOrders, .reviews, .permalink]
         case .custom(_):
-            break
+            customContent = [.totalOrders, .reviews, .permalink]
         }
 
-        rows.append(.reviews)
-        rows.append(.productLink)
+        rows.append(contentsOf: customContent)
 
         let summary = Section(rows: rows)
         sections = [summary].compactMap { $0 }
@@ -481,7 +490,7 @@ private extension ProductDetailsViewController {
         case productName
         case totalOrders
         case reviews
-        case productLink
+        case permalink
         case affiliateLink
 
         var reuseIdentifier: String {
@@ -494,7 +503,7 @@ private extension ProductDetailsViewController {
                 return TwoColumnTableViewCell.reuseIdentifier
             case .reviews:
                 return ProductReviewsTableViewCell.reuseIdentifier
-            case .productLink:
+            case .permalink:
                 return BasicTableViewCell.reuseIdentifier
             case .affiliateLink:
                 return BasicTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -135,7 +135,7 @@ private extension ProductDetailsViewController {
             TitleBodyTableViewCell.self,
             TwoColumnTableViewCell.self,
             ProductReviewsTableViewCell.self,
-            BasicTableViewCell.self
+            WooBasicTableViewCell.self
         ]
 
         for cell in cells {
@@ -243,9 +243,9 @@ private extension ProductDetailsViewController {
             configureTotalOrders(cell: cell)
         case let cell as ProductReviewsTableViewCell:
             configureReviews(cell: cell)
-        case let cell as BasicTableViewCell where row == .permalink:
+        case let cell as WooBasicTableViewCell where row == .permalink:
             configurePermalink(cell: cell)
-        case let cell as BasicTableViewCell where row == .affiliateLink:
+        case let cell as WooBasicTableViewCell where row == .affiliateLink:
             configureAffiliateLink(cell: cell)
         default:
             fatalError("Unidentified row type")
@@ -302,28 +302,14 @@ private extension ProductDetailsViewController {
         cell.starRatingView.rating = CGFloat(averageRating ?? 0)
     }
 
-    func configurePermalink(cell: BasicTableViewCell) {
-        cell.selectionStyle = .default
+    func configurePermalink(cell: WooBasicTableViewCell) {
         cell.textLabel?.text = NSLocalizedString("View product on store", comment: "The descriptive label. Tapping the row will open the product's page in a web view.")
-
-        let accessoryImage = Gridicon.iconOfType(.external)
-        let accessoryImageView = UIImageView(image: accessoryImage)
-        accessoryImageView.tintColor = StyleManager.buttonPrimaryColor
-
-        cell.accessoryView = accessoryImageView
-        cell.textLabel?.textColor = StyleManager.buttonPrimaryColor
+        cell.accessoryImage = Gridicon.iconOfType(.external)
     }
 
-    func configureAffiliateLink(cell: BasicTableViewCell) {
-        cell.selectionStyle = .default
+    func configureAffiliateLink(cell: WooBasicTableViewCell) {
         cell.textLabel?.text = NSLocalizedString("View affiliate product", comment: "The descriptive label. Tapping the row will open the affliate product's link in a web view.")
-
-        let accessoryImage = Gridicon.iconOfType(.external)
-        let accessoryImageView = UIImageView(image: accessoryImage)
-        accessoryImageView.tintColor = StyleManager.buttonPrimaryColor
-
-        cell.accessoryView = accessoryImageView
-        cell.textLabel?.textColor = StyleManager.buttonPrimaryColor
+        cell.accessoryImage = Gridicon.iconOfType(.external)
     }
 }
 
@@ -511,9 +497,9 @@ private extension ProductDetailsViewController {
             case .reviews:
                 return ProductReviewsTableViewCell.reuseIdentifier
             case .permalink:
-                return BasicTableViewCell.reuseIdentifier
+                return WooBasicTableViewCell.reuseIdentifier
             case .affiliateLink:
-                return BasicTableViewCell.reuseIdentifier
+                return WooBasicTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LargeImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LargeImageTableViewCell.swift
@@ -5,6 +5,7 @@ class LargeImageTableViewCell: UITableViewCell {
     @IBOutlet weak var heightConstraint: NSLayoutConstraint!
     @IBOutlet weak var topConstraint: NSLayoutConstraint!
     @IBOutlet weak var mainImageView: UIImageView!
+    @IBOutlet weak var textBadge: PaddedLabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LargeImageTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LargeImageTableViewCell.xib
@@ -26,7 +26,17 @@
                             <constraint firstAttribute="height" priority="999" constant="374" id="mUj-Z1-BpJ"/>
                         </constraints>
                     </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuO-D4-4LU" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                        <rect key="frame" x="16" y="355.5" width="0.0" height="0.0"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="EuO-D4-4LU" secondAttribute="bottom" constant="16" id="HQT-he-9R3"/>
+                    <constraint firstItem="EuO-D4-4LU" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="v86-NX-R8M"/>
+                </constraints>
             </tableViewCellContentView>
             <constraints>
                 <constraint firstItem="ncP-hz-Oe9" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailing" id="EnE-Ci-tdt"/>
@@ -37,6 +47,7 @@
             <connections>
                 <outlet property="heightConstraint" destination="mUj-Z1-BpJ" id="KSx-cm-gQP"/>
                 <outlet property="mainImageView" destination="ncP-hz-Oe9" id="Bi5-iL-CTO"/>
+                <outlet property="textBadge" destination="EuO-D4-4LU" id="fzc-Cf-06q"/>
                 <outlet property="topConstraint" destination="oFt-gA-BbB" id="iXf-N6-UnK"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="262.5"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
@@ -9,5 +9,8 @@ final class TwoColumnTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        leftLabel.applyBodyStyle()
+        rightLabel.applyBodyStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
@@ -5,7 +5,7 @@ import UIKit
 final class TwoColumnTableViewCell: UITableViewCell {
 
     @IBOutlet weak var leftLabel: UILabel!
-    @IBOutlet weak var rightLabel: UILabel!
+    @IBOutlet weak var rightLabel: PaddedLabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+/// A two column table view cell with Body styling.
+///
+final class TwoColumnTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var leftLabel: UILabel!
+    @IBOutlet weak var rightLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.xib
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="TwoColumnTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="TS0-RN-yRd">
+                        <rect key="frame" x="16" y="55.5" width="288" height="20.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="749" text="Total Orders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EjV-xl-7FC">
+                                <rect key="frame" x="0.0" y="0.0" width="260.5" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="27" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIm-Dq-v75">
+                                <rect key="frame" x="268.5" y="0.0" width="19.5" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="TS0-RN-yRd" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" id="1WV-UH-LOh"/>
+                    <constraint firstItem="TS0-RN-yRd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Shc-Ob-j77"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="TS0-RN-yRd" secondAttribute="trailing" id="eQN-5v-SU8"/>
+                    <constraint firstItem="TS0-RN-yRd" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="xsd-um-vdB"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="leftLabel" destination="EjV-xl-7FC" id="Zs1-dd-aqT"/>
+                <outlet property="rightLabel" destination="RIm-Dq-v75" id="C5Q-2A-jmu"/>
+            </connections>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.xib
@@ -7,7 +7,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,20 +15,20 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="TwoColumnTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="TS0-RN-yRd">
-                        <rect key="frame" x="16" y="55.5" width="288" height="20.5"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TS0-RN-yRd">
+                        <rect key="frame" x="16" y="11.5" width="288" height="20.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="749" text="Total Orders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EjV-xl-7FC">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" text="Total Orders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EjV-xl-7FC">
                                 <rect key="frame" x="0.0" y="0.0" width="260.5" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="27" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIm-Dq-v75">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="27" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIm-Dq-v75">
                                 <rect key="frame" x="268.5" y="0.0" width="19.5" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
@@ -39,10 +38,9 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="TS0-RN-yRd" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottomMargin" id="1WV-UH-LOh"/>
-                    <constraint firstItem="TS0-RN-yRd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Shc-Ob-j77"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="TS0-RN-yRd" secondAttribute="trailing" id="eQN-5v-SU8"/>
-                    <constraint firstItem="TS0-RN-yRd" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="xsd-um-vdB"/>
+                    <constraint firstItem="TS0-RN-yRd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Afb-U8-LpU"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="TS0-RN-yRd" secondAttribute="trailing" id="ad4-2X-vMr"/>
+                    <constraint firstItem="TS0-RN-yRd" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="hpA-I2-ccI"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.xib
@@ -28,7 +28,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="27" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIm-Dq-v75">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="27" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RIm-Dq-v75" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
                                 <rect key="frame" x="268.5" y="0.0" width="19.5" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+
+// MARK: - WooBasicTableViewCell
+
+/// A subclassed BasicTableViewCell
+/// with bonus purple Woo styling.
+///
+class WooBasicTableViewCell: BasicTableViewCell {
+
+    public var accessoryImage: UIImage? {
+        didSet {
+            configureAccessoryView()
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureSelectionStyle()
+        configureLabels()
+    }
+
+    /// Set up the cell selection style
+    ///
+    func configureSelectionStyle() {
+        selectionStyle = .default
+    }
+
+    /// Style the label(s)
+    ///
+    func configureLabels() {
+        textLabel?.textColor = StyleManager.buttonPrimaryColor
+    }
+
+    /// Add the accessoryView image, if any
+    ///
+    func configureAccessoryView() {
+        let accessoryImageView = UIImageView(image: accessoryImage)
+        accessoryImageView.tintColor = StyleManager.buttonPrimaryColor
+        accessoryView = accessoryImageView
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.xib
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="DWF-Gf-NQJ" style="IBUITableViewCellStyleDefault" id="yLa-Up-o0U" customClass="WooBasicTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yLa-Up-o0U" id="0OS-SE-j2i">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DWF-Gf-NQJ">
+                        <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="29" y="-23"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -258,6 +258,8 @@
 		CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21B3DE20FFC59700A259D5 /* ProductDetailsTableViewCell.swift */; };
 		CE21B3E120FFC59700A259D5 /* ProductDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE21B3DF20FFC59700A259D5 /* ProductDetailsTableViewCell.xib */; };
 		CE22571B20E16FBC0037F478 /* LeftImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1EC8EB20B8A3FF009762BF /* LeftImageTableViewCell.xib */; };
+		CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227096228F152400C0626C /* WooBasicTableViewCell.swift */; };
+		CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE227098228F180B00C0626C /* WooBasicTableViewCell.xib */; };
 		CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */; };
 		CE22E3FB21714776005A6BEF /* TopLeftImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE22E3F921714776005A6BEF /* TopLeftImageTableViewCell.swift */; };
 		CE22E3FC21714776005A6BEF /* TopLeftImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE22E3FA21714776005A6BEF /* TopLeftImageTableViewCell.xib */; };
@@ -642,6 +644,8 @@
 		CE21B3DC20FF9BC200A259D5 /* ProductListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListViewController.swift; sourceTree = "<group>"; };
 		CE21B3DE20FFC59700A259D5 /* ProductDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		CE21B3DF20FFC59700A259D5 /* ProductDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductDetailsTableViewCell.xib; sourceTree = "<group>"; };
+		CE227096228F152400C0626C /* WooBasicTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooBasicTableViewCell.swift; sourceTree = "<group>"; };
+		CE227098228F180B00C0626C /* WooBasicTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WooBasicTableViewCell.xib; sourceTree = "<group>"; };
 		CE22E3F62170E23C005A6BEF /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
 		CE22E3F921714776005A6BEF /* TopLeftImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TopLeftImageTableViewCell.swift; path = Classes/ViewRelated/ReusableViews/TopLeftImageTableViewCell.swift; sourceTree = SOURCE_ROOT; };
 		CE22E3FA21714776005A6BEF /* TopLeftImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = TopLeftImageTableViewCell.xib; path = Classes/ViewRelated/ReusableViews/TopLeftImageTableViewCell.xib; sourceTree = SOURCE_ROOT; };
@@ -1491,6 +1495,8 @@
 				B5A56BEF219F2CE90065A902 /* VerticalButton.swift */,
 				D81F2D36225F0D160084BF9C /* EmptyListMessageWithActionView.swift */,
 				D81F2D34225F0CF70084BF9C /* EmptyListMessageWithActionView.xib */,
+				CE227096228F152400C0626C /* WooBasicTableViewCell.swift */,
+				CE227098228F180B00C0626C /* WooBasicTableViewCell.xib */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -1693,6 +1699,7 @@
 				CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */,
 				B57C744320F54F1C00EEFC87 /* AccountHeaderView.xib in Resources */,
 				D843D5D422485009001BFA55 /* ShipmentProvidersViewController.xib in Resources */,
+				CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */,
 				B557DA1620979904005962F4 /* CustomerNoteTableViewCell.xib in Resources */,
 				93BCF01F20DC2CE200EBF7A1 /* bash_secrets.tpl in Resources */,
 				B56DB3D42049BFAA00D4AA8E /* Assets.xcassets in Resources */,
@@ -2020,6 +2027,7 @@
 				B57C5C9221B80E3C00FF82B2 /* APNSDevice+Woo.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
+				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
 				B5F8B7E02194759100DAB7E2 /* NotificationDetailsViewController.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -237,6 +237,8 @@
 		CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1AFE612200B1BD00432745 /* ApplicationLogDetailViewController.swift */; };
 		CE1CCB402056F21C000EE3AC /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB3F2056F21C000EE3AC /* Style.swift */; };
 		CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */; };
+		CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1D5A53228A0AD200DF3715 /* TwoColumnTableViewCell.swift */; };
+		CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1D5A54228A0AD200DF3715 /* TwoColumnTableViewCell.xib */; };
 		CE1EC8C520B46819009762BF /* PaymentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */; };
 		CE1EC8C620B46819009762BF /* PaymentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1EC8C420B46819009762BF /* PaymentTableViewCell.xib */; };
 		CE1EC8C820B478B6009762BF /* TwoColumnLabelView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1EC8C720B478B6009762BF /* TwoColumnLabelView.xib */; };
@@ -617,6 +619,8 @@
 		CE1AFE612200B1BD00432745 /* ApplicationLogDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogDetailViewController.swift; sourceTree = "<group>"; };
 		CE1CCB3F2056F21C000EE3AC /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTableViewCell.swift; sourceTree = "<group>"; };
+		CE1D5A53228A0AD200DF3715 /* TwoColumnTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnTableViewCell.swift; sourceTree = "<group>"; };
+		CE1D5A54228A0AD200DF3715 /* TwoColumnTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnTableViewCell.xib; sourceTree = "<group>"; };
 		CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentTableViewCell.swift; sourceTree = "<group>"; };
 		CE1EC8C420B46819009762BF /* PaymentTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PaymentTableViewCell.xib; sourceTree = "<group>"; };
 		CE1EC8C720B478B6009762BF /* TwoColumnLabelView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnLabelView.xib; sourceTree = "<group>"; };
@@ -1474,6 +1478,8 @@
 				CE1EC8C720B478B6009762BF /* TwoColumnLabelView.xib */,
 				CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */,
 				CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */,
+				CE1D5A53228A0AD200DF3715 /* TwoColumnTableViewCell.swift */,
+				CE1D5A54228A0AD200DF3715 /* TwoColumnTableViewCell.xib */,
 				CE27257D21925AE8002B22EB /* ValueOneTableViewCell.swift */,
 				CE27257E21925AE8002B22EB /* ValueOneTableViewCell.xib */,
 				B5A56BEF219F2CE90065A902 /* VerticalButton.swift */,
@@ -1677,6 +1683,7 @@
 				74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */,
 				B5F571B021BF149D0010D1B8 /* o.caf in Resources */,
 				B5D1AFC820BC7B9600DB0E8C /* StorePickerViewController.xib in Resources */,
+				CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */,
 				B57C744320F54F1C00EEFC87 /* AccountHeaderView.xib in Resources */,
 				D843D5D422485009001BFA55 /* ShipmentProvidersViewController.xib in Resources */,
 				B557DA1620979904005962F4 /* CustomerNoteTableViewCell.xib in Resources */,
@@ -1940,6 +1947,7 @@
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,
 				B5DB01B52114AB2D00A4F797 /* FabricManager.swift in Sources */,
 				7459A6C621B0680300F83A78 /* RequirementsChecker.swift in Sources */,
+				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,
 				74460D4222289C7A00D7316A /* StorePickerCoordinator.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -239,6 +239,8 @@
 		CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */; };
 		CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1D5A53228A0AD200DF3715 /* TwoColumnTableViewCell.swift */; };
 		CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1D5A54228A0AD200DF3715 /* TwoColumnTableViewCell.xib */; };
+		CE1D5A59228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1D5A57228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift */; };
+		CE1D5A5A228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1D5A58228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib */; };
 		CE1EC8C520B46819009762BF /* PaymentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */; };
 		CE1EC8C620B46819009762BF /* PaymentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1EC8C420B46819009762BF /* PaymentTableViewCell.xib */; };
 		CE1EC8C820B478B6009762BF /* TwoColumnLabelView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1EC8C720B478B6009762BF /* TwoColumnLabelView.xib */; };
@@ -621,6 +623,8 @@
 		CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTableViewCell.swift; sourceTree = "<group>"; };
 		CE1D5A53228A0AD200DF3715 /* TwoColumnTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnTableViewCell.swift; sourceTree = "<group>"; };
 		CE1D5A54228A0AD200DF3715 /* TwoColumnTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnTableViewCell.xib; sourceTree = "<group>"; };
+		CE1D5A57228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewsTableViewCell.swift; sourceTree = "<group>"; };
+		CE1D5A58228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductReviewsTableViewCell.xib; sourceTree = "<group>"; };
 		CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentTableViewCell.swift; sourceTree = "<group>"; };
 		CE1EC8C420B46819009762BF /* PaymentTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PaymentTableViewCell.xib; sourceTree = "<group>"; };
 		CE1EC8C720B478B6009762BF /* TwoColumnLabelView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnLabelView.xib; sourceTree = "<group>"; };
@@ -785,6 +789,8 @@
 			children = (
 				7441EBC7226A71AA008BF83D /* TitleBodyTableViewCell.swift */,
 				7441EBC8226A71AA008BF83D /* TitleBodyTableViewCell.xib */,
+				CE1D5A57228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift */,
+				CE1D5A58228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -1679,6 +1685,7 @@
 				CE583A0C2107937F00D73C1C /* TextViewTableViewCell.xib in Resources */,
 				D843D5CC22437E59001BFA55 /* TitleAndEditableValueTableViewCell.xib in Resources */,
 				B560D68A2195BD100027BB7E /* NoteDetailsCommentTableViewCell.xib in Resources */,
+				CE1D5A5A228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib in Resources */,
 				B5A8F8AF20B88DCC00D211DE /* LoginPrologueViewController.xib in Resources */,
 				74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */,
 				B5F571B021BF149D0010D1B8 /* o.caf in Resources */,
@@ -2117,6 +2124,7 @@
 				B5AA7B3D20ED5D15004DA14F /* SessionManager.swift in Sources */,
 				74C6FEA521C2F1FA009286B6 /* AboutViewController.swift in Sources */,
 				B53B3F37219C75AC00DF1EB6 /* OrderLoaderViewController.swift in Sources */,
+				CE1D5A59228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				B53B898D20D462A000EDB467 /* StoresManager.swift in Sources */,
 				B5D1AFC020BC67C200DB0E8C /* WooConstants.swift in Sources */,


### PR DESCRIPTION
Closes #856.

This PR displays basic information in the first section of the Product Details screen. Depending on if the product type is Grouped, Affiliate, Variable, or Basic, it will display an image, a title, total orders, review stats, and external link(s).

Since affiliate products aren't purchased directly through a user's store, I can't currently show a screenshot of this type of product in the app. It can be tested by overriding the code.
Hi-res still image:
<img src="https://user-images.githubusercontent.com/1062444/57881088-00232f00-77e6-11e9-9954-fe40b1518bd6.png" width="350" />

Animated gif:
![product-details-basics-section](https://user-images.githubusercontent.com/1062444/57880725-17155180-77e5-11e9-8b5e-49d5ff5faa69.gif)



Example of what the Status Badge will look like. (Ignore that it says "Publish" and imagine it says "Private" or "Draft".)
<img src="https://user-images.githubusercontent.com/1062444/57880452-6909a780-77e4-11e9-9a70-e9b274482807.png" width="350" />

## To test
- navigate to an order 
- fulfill the order
- select the product row
- wait for the product details view controller to load
- observe new rows (varies based on product type)

@kyleaparker some concerns: 
1. Is jumping out to Safari okay for the product permalink? I can change this to be a in-app web view (like Settings > Privacy Settings > Learn more does). I made it jump to safari in case they want to start editing the product in /wp-admin/. A web view has limitations (like poor JavaScript execution) that would slow the user down if the do access /wp-admin/ from that web page.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
