### PR TITLE
Order fulfillment: Pop the list of shipment providers when selecting one

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -241,10 +241,6 @@ extension ShipmentProvidersViewController: UITableViewDelegate {
 
         delegate?.shipmentProviderList(self, didSelect: provider, groupName: groupName)
 
-        navigateBack()
-    }
-
-    private func navigateBack() {
         navigationController?.popViewController(animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -240,6 +240,12 @@ extension ShipmentProvidersViewController: UITableViewDelegate {
         }
 
         delegate?.shipmentProviderList(self, didSelect: provider, groupName: groupName)
+
+        navigateBack()
+    }
+
+    private func navigateBack() {
+        navigationController?.popViewController(animated: true)
     }
 }
 


### PR DESCRIPTION
Fixes #963 

Pop the navigation controller when users select a tracking provider, as mentioned in [this Android issue](https://github.com/woocommerce/woocommerce-android/pull/1054#issuecomment-492285336) 

<img src="https://user-images.githubusercontent.com/2722505/57738638-e220d600-76e2-11e9-88e0-182a8334b362.gif" width = "300"/>

## Changes
- Pop the navigation controller on selection

## Testing
- Navigate to an order > Fulfill order > Add tracking
- Tap the "Shipping Provider" cell in the "add tracking form"
- Select a provider. The UI should navigate back to the "add tracking form"

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.