### PR TITLE
Add Tracking view: UI fixes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -273,6 +273,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
 
         cell.value.isEnabled = false
         cell.accessoryType = .none
+
+        cell.separatorInset = datePickerVisible ? Constants.cellSeparatorInset : .zero
     }
 
     private func configureSecondaryAction(cell: BasicTableViewCell) {
@@ -287,6 +289,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
             self?.viewModel.shipmentDate = date
             self?.reloadDate()
         }
+
+        cell.separatorInset = .zero
     }
 }
 
@@ -577,6 +581,7 @@ private struct Constants {
     static let pickerRowHeight = CGFloat(216)
     static let disabledAlpha = CGFloat(0.7)
     static let enabledAlpha = CGFloat(1.0)
+    static let cellSeparatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,9 +21,9 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="7jr-lt-rR6">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7jr-lt-rR6">
                     <rect key="frame" x="0.0" y="20" width="375" height="647"/>
-                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </tableView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
@@ -6,11 +6,23 @@ final class DatePickerTableViewCell: UITableViewCell {
 
     var onDateSelected: ((Date) -> Void)?
     @IBOutlet private weak var picker: UIDatePicker!
-
+    
+    @IBOutlet weak var bottomBorder: UIView!
+    
     @IBAction func dateChanged(_ sender: UIDatePicker) {
         onDateSelected?(sender.date)
     }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureBottomBorder()
+    }
+
+    private func configureBottomBorder() {
+        bottomBorder.backgroundColor = StyleManager.wooGreyBorder
+    }
 }
+
 
 extension DatePickerTableViewCell {
     func getPicker() -> UIDatePicker {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
@@ -6,9 +6,9 @@ final class DatePickerTableViewCell: UITableViewCell {
 
     var onDateSelected: ((Date) -> Void)?
     @IBOutlet private weak var picker: UIDatePicker!
-    
+
     @IBOutlet weak var bottomBorder: UIView!
-    
+
     @IBAction func dateChanged(_ sender: UIDatePicker) {
         onDateSelected?(sender.date)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,18 +28,30 @@
                             <action selector="dateChanged:" destination="KGk-i7-Jjw" eventType="valueChanged" id="5QC-MP-oPB"/>
                         </connections>
                     </datePicker>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r88-F3-jXj">
+                        <rect key="frame" x="0.0" y="215" width="320" height="1"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" id="OQ8-I9-Tcy"/>
+                        </constraints>
+                    </view>
                 </subviews>
             </tableViewCellContentView>
             <constraints>
+                <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="r88-F3-jXj" secondAttribute="trailing" id="3xc-ca-Hpe"/>
                 <constraint firstItem="Jym-fu-gTL" firstAttribute="top" secondItem="njF-e1-oar" secondAttribute="top" id="916-d2-5BV"/>
+                <constraint firstItem="r88-F3-jXj" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" id="JFR-2h-1fi"/>
                 <constraint firstItem="njF-e1-oar" firstAttribute="bottom" secondItem="Jym-fu-gTL" secondAttribute="bottom" id="NMK-Zt-uDN"/>
                 <constraint firstItem="Jym-fu-gTL" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" id="Ra1-Po-U9n"/>
                 <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="Jym-fu-gTL" secondAttribute="trailing" id="YY6-YI-s0p"/>
+                <constraint firstItem="njF-e1-oar" firstAttribute="bottom" secondItem="r88-F3-jXj" secondAttribute="bottom" id="bIp-SK-JvX"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomBorder" destination="r88-F3-jXj" id="6I7-ce-JED"/>
                 <outlet property="picker" destination="Jym-fu-gTL" id="sId-5O-xO6"/>
             </connections>
+            <point key="canvasLocation" x="137.59999999999999" y="118.74062968515743"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
Fixes #965 

Fix issues with the UI to add shipment trackings [mentioned during the review](https://github.com/woocommerce/woocommerce-ios/pull/964#pullrequestreview-237555521) of PR #964 

- [x] The spacing at the top of the Add Tracking screen should be reduced to match the design
- [x] The border below the shipping date should extend to the left edge

Before and after:

<image src="https://user-images.githubusercontent.com/2722505/57755945-b9213500-7724-11e9-8c15-571dfc7c2f96.jpg" width = "800"/>

When the date picker is visible:
<image src="https://user-images.githubusercontent.com/2722505/57756000-e2da5c00-7724-11e9-854f-0c28e187f816.png" width = "600"/>

## Changes
- Set the table style as plain instead of grouped.
- Manually set the cell inset to .zero for the date cell. Add a bottom border to the picker cell

## Testing
- Select an Order > Fulfill > Add Tracking
- Notice the bottom cell.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.