### PR TITLE
Fix Crash on StoresManager.needsDefaultStore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - bugfix: fixes "Unable to load content" error message when attempting to get Top Performers content.
 - bugfix: fixes Store Picker: some users are unable to continue after logging in.
+- bugfix: fixes a crash when the network connection is slow
  
 1.8
 -----

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -11,7 +11,7 @@ class StoresManager {
     ///
     static var shared = StoresManager(sessionManager: .standard)
 
-    private let sessionManagerlockQueue = DispatchQueue(label: "StoresManager.sessionManagerLockQueue")
+    private let sessionManagerLockQueue = DispatchQueue(label: "StoresManager.sessionManagerLockQueue")
 
     /// SessionManager: Persistent Storage for Session-Y Properties.
     /// Private property. To be only accessed through `sessionManager` to make
@@ -25,13 +25,13 @@ class StoresManager {
     /// This property is thread safe
     private(set) var sessionManager: SessionManager {
         get {
-            return sessionManagerlockQueue.sync {
+            return sessionManagerLockQueue.sync {
                 return _sessionManager
             }
         }
 
         set {
-            sessionManagerlockQueue.sync {
+            sessionManagerLockQueue.sync {
                 _sessionManager = newValue
             }
         }


### PR DESCRIPTION
Fixes #878 

I grabbed this ticket because it seems to be [appearing in the logs](https://github.com/woocommerce/woocommerce-ios/issues/878#issuecomment-492248040)

The crash happens at `StoresManager.needsDefaultStore`, with this message:

`Thread 1: Simultaneous accesses to <MEMORY_ADDRESS>, but modification requires exclusive access`

Digging in the Debug navigator, I can see that happening because `OrdersViewController.defaultAccountWasUpdated` starts a read right after `StoresManager.synchronizeAccount` starts a modification triggered by `AccountStore.synchronizeAccount`

## Changes
- Lock read/write access to sessionManager via a DispatchQueue.
- Which requires adding a property to actually retain he reference to `SessionManager` and turn the old `sessionManager` property into a calculated one.

## Testing
- [The original issue](https://github.com/woocommerce/woocommerce-ios/issues/878) contains steps for reproduction. I can not reproduce the crash anymore following those steps.
- I have tried to log in and out, switch stores, and everything seems to work fine.
- I don't have any other suggestions for testing better than those.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.