### PR TITLE
 Fulfillment: Add Tracking row appears during view transition animation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -79,8 +79,8 @@ final class FulfillViewController: UIViewController {
         reloadSections()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         syncTrackingsHiddingAddButtonIfNecessary()
     }
 


### PR DESCRIPTION
Fixes #922 

<img src = "https://user-images.githubusercontent.com/2722505/57823299-89783880-77c9-11e9-9a21-3b87f4a79957.gif" width = "350"/>

## Changes
- Trigger the sync of trackings on `viewDidAppear` instead of `viewWillAppear`

## Testing
- Build and run on the simulator. 
- Navigate to an order in Processing status
- Activate the slow animations in the simulator (Command+T)
- Tap the Fulfill Order button
- Check that the Add Tracking button is not displayed until after the transition animation has been completed

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.