### PR TITLE
Order fulfillment: rename Tracks events for manual tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -144,6 +144,7 @@ public enum WooAnalyticsStat: String {
     case orderFulfillmentAddTrackingButtonTapped = "order_fulfillment_tracking_add_tracking_button_tapped"
     case orderMarkedCompleteUndoButtonTapped    = "snack_order_marked_complete_undo_button_tapped"
     case orderShareStoreButtonTapped            = "orders_list_share_your_store_button_tapped"
+    case orderShipmentTrackingAddButtonTapped = "order_shipment_tracking_add_button_tapped"
     case orderShipmentTrackingCarrierSelected = "order_shipment_tracking_carrier_selected"
     case orderShipmentTrackingCustomProviderSelected = "order_shipment_tracking_custom_provider_selected"
     case orderStatusDialogApplyButtonTapped     = "set_order_status_dialog_apply_button_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -166,6 +166,9 @@ public enum WooAnalyticsStat: String {
     case orderTrackingAddFailed                 = "order_tracking_add_failed"
     case orderTrackingLoaded                    = "order_tracking_loaded"
     case orderTrackingAddSuccess                = "order_tracking_add_success"
+    case orderTrackingDelete                    = "order_tracking_delete"
+    case orderTrackingDeleteFailed              = "order_tracking_delete_failed"
+    case orderTrackingDeleteSuccess             = "order_tracking_delete_success"
 
     // Push Notifications Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -142,9 +142,9 @@ public enum WooAnalyticsStat: String {
     case orderDetailTrackPackageButtonTapped    = "order_detail_track_package_button_tapped"
     case orderFulfillmentCompleteButtonTapped   = "order_fulfillment_mark_order_complete_button_tapped"
     case orderFulfillmentAddTrackingButtonTapped = "order_fulfillment_tracking_add_tracking_button_tapped"
-    case orderFulfillmentTrackingCarrierSelected = "order_fulfillment_tracking_carrier_selected"
     case orderMarkedCompleteUndoButtonTapped    = "snack_order_marked_complete_undo_button_tapped"
     case orderShareStoreButtonTapped            = "orders_list_share_your_store_button_tapped"
+    case orderShipmentTrackingCarrierSelected = "order_shipment_tracking_carrier_selected"
     case orderStatusDialogApplyButtonTapped     = "set_order_status_dialog_apply_button_tapped"
 
     // Order Data/Action Events
@@ -162,9 +162,9 @@ public enum WooAnalyticsStat: String {
     case orderStatusChangeFailed                = "order_status_change_failed"
     case orderStatusChangeUndo                  = "order_status_change_undo"
     case orderTrackingAdd                       = "order_tracking_add"
-    case orderTrackingFailed                    = "order_tracking_failed"
+    case orderTrackingAddFailed                 = "order_tracking_add_failed"
     case orderTrackingLoaded                    = "order_tracking_loaded"
-    case orderTrackingSuccess                   = "order_tracking_success"
+    case orderTrackingAddSuccess                = "order_tracking_add_success"
 
     // Push Notifications Events
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -145,6 +145,7 @@ public enum WooAnalyticsStat: String {
     case orderMarkedCompleteUndoButtonTapped    = "snack_order_marked_complete_undo_button_tapped"
     case orderShareStoreButtonTapped            = "orders_list_share_your_store_button_tapped"
     case orderShipmentTrackingCarrierSelected = "order_shipment_tracking_carrier_selected"
+    case orderShipmentTrackingCustomProviderSelected = "order_shipment_tracking_custom_provider_selected"
     case orderStatusDialogApplyButtonTapped     = "set_order_status_dialog_apply_button_tapped"
 
     // Order Data/Action Events

--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -474,18 +474,27 @@ private extension FulfillViewController {
         let orderID = order.orderID
         let trackingID = tracking.trackingID
 
+        let statusKey = order.statusKey
+        let providerName = tracking.trackingProvider ?? ""
+
+        WooAnalytics.shared.track(.orderTrackingDelete, withProperties: ["id": orderID,
+                                                                         "status": statusKey,
+                                                                         "carrier": providerName])
+
         let deleteTrackingAction = ShipmentAction.deleteTracking(siteID: siteID,
                                                                  orderID: orderID,
                                                                  trackingID: trackingID) { [weak self] error in
                                                                     if let error = error {
                                                                         DDLogError("⛔️ Delete Tracking Failure: orderID \(orderID). Error: \(error)")
 
+                                                                        WooAnalytics.shared.track(.orderTrackingDeleteFailed,
+                                                                                                  withError: error)
                                                                         self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
                                                                         return
                                                                     }
 
+                                                                    WooAnalytics.shared.track(.orderTrackingDeleteSuccess)
                                                                     self?.syncTrackingsHiddingAddButtonIfNecessary()
-
         }
 
         StoresManager.shared.dispatch(deleteTrackingAction)

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -140,6 +140,7 @@ private extension ManualTrackingViewController {
     }
 
     @objc func primaryButtonTapped() {
+        WooAnalytics.shared.track(.orderShipmentTrackingAddButtonTapped)
         viewModel.isCustom ? addCustomTracking() : addTracking()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -393,7 +393,7 @@ private extension ManualTrackingViewController {
 //
 extension ManualTrackingViewController: ShipmentProviderListDelegate {
     func shipmentProviderList(_ list: ShipmentProvidersViewController, didSelect: Yosemite.ShipmentTrackingProvider, groupName: String) {
-        WooAnalytics.shared.track(.orderFulfillmentTrackingCarrierSelected,
+        WooAnalytics.shared.track(.orderShipmentTrackingCarrierSelected,
                                   withProperties: ["option": didSelect.name])
 
         viewModel.shipmentProvider = didSelect
@@ -478,7 +478,7 @@ private extension ManualTrackingViewController {
                                                             if let error = error {
                                                                 DDLogError("⛔️ Add Tracking Failure: orderID \(orderID). Error: \(error)")
 
-                                                                WooAnalytics.shared.track(.orderTrackingFailed,
+                                                                WooAnalytics.shared.track(.orderTrackingAddFailed,
                                                                                           withError: error)
 
                                                                 self?.configureForEditingTracking()
@@ -487,7 +487,7 @@ private extension ManualTrackingViewController {
                                                                 return
                                                             }
 
-                                                        WooAnalytics.shared.track(.orderTrackingSuccess)
+                                                        WooAnalytics.shared.track(.orderTrackingAddSuccess)
 
                                                             self?.dismiss()
         }
@@ -525,7 +525,7 @@ private extension ManualTrackingViewController {
                                                         if let error = error {
                                                             DDLogError("⛔️ Add Tracking Failure: orderID \(orderID). Error: \(error)")
 
-                                                            WooAnalytics.shared.track(.orderTrackingFailed,
+                                                            WooAnalytics.shared.track(.orderTrackingAddFailed,
                                                                                       withError: error)
 
                                                             self?.configureForEditingTracking()
@@ -534,7 +534,7 @@ private extension ManualTrackingViewController {
                                                             return
                                                         }
 
-                                                        WooAnalytics.shared.track(.orderTrackingSuccess)
+                                                        WooAnalytics.shared.track(.orderTrackingAddSuccess)
 
                                                         self?.dismiss()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -664,15 +664,26 @@ private extension OrderDetailsViewController {
         let orderID = viewModel.order.orderID
         let trackingID = tracking.trackingID
 
+        let statusKey = viewModel.order.statusKey
+        let providerName = tracking.trackingProvider ?? ""
+
+        WooAnalytics.shared.track(.orderTrackingDelete, withProperties: ["id": orderID,
+                                                                         "status": statusKey,
+                                                                         "carrier": providerName])
+
         let deleteTrackingAction = ShipmentAction.deleteTracking(siteID: siteID,
                                                                  orderID: orderID,
                                                                  trackingID: trackingID) { [weak self] error in
                                                                     if let error = error {
                                                                         DDLogError("⛔️ Order Details - Delete Tracking: orderID \(orderID). Error: \(error)")
 
+                                                                        WooAnalytics.shared.track(.orderTrackingDeleteFailed,
+                                                                                                  withError: error)
                                                                         self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
                                                                         return
                                                                     }
+
+                                                                    WooAnalytics.shared.track(.orderTrackingDeleteSuccess)
                                                                     self?.reloadSections()
 
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -324,6 +324,8 @@ private extension ShipmentProvidersViewController {
     }
 
     func addCustomProvider() {
+        WooAnalytics.shared.track(.orderShipmentTrackingCustomProviderSelected)
+        
         let initialCustomProviderName = searchController.searchBar.text
         let addCustomTrackingViewModel = AddCustomTrackingViewModel(order: viewModel.order,
                                                                     initialName: initialCustomProviderName)

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -327,7 +327,7 @@ private extension ShipmentProvidersViewController {
 
     func addCustomProvider() {
         WooAnalytics.shared.track(.orderShipmentTrackingCustomProviderSelected)
-        
+
         let initialCustomProviderName = searchController.searchBar.text
         let addCustomTrackingViewModel = AddCustomTrackingViewModel(order: viewModel.order,
                                                                     initialName: initialCustomProviderName)


### PR DESCRIPTION
Closes #967 

This PR renames some Tracks events, and adds a few.

Events renamed:

| Old event name | New event name |
| -------------- | -------------- |
| *_order_fulfillment_tracking_carrier_selected | *_order_shipment_tracking_carrier_selected |
| *_order_tracking_failed | *_order_tracking_add_failed |
| *_order_tracking_success | *_order_tracking_add_success |

New events added:
```
*_order_tracking_delete
*_order_tracking_delete_failed
*_order_tracking_delete_success

*_order_shipment_tracking_add_button_tapped
*_order_shipment_tracking_custom_provider_selected
```

## Changes
- Updated `WooAnanlyticsStat`
- Added events to `FullfillViewController`, `OrderDetailsViewController`,  `ManualTrackingViewController` and `ShipmentProvidersViewController`

## Testing
1. Run the branch and navigate to an order > Fulfill Order > Add Tracking > Select a tracking provider. The log should show something similar to:
```
2019-05-17 11:08:49.775376+0800 WooCommerce[7021:156174] 🔵 Tracked order_shipment_tracking_carrier_selected, properties: [AnyHashable("option"): "Fastway Couriers", AnyHashable("blog_id"): 156590080, AnyHashable("is_wpcom_store"): true]
```
2. Navigate to an order > Fulfill Order > Add Tracking. Tap the "Add" button at the right of the top navigation bar. The log should show something similar to:
```
2019-05-17 11:10:55.465806+0800 WooCommerce[7162:158629] 🔵 Tracked order_shipment_tracking_add_button_tapped, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 156590080]
```
3. Now, in the Fulfill Order screen, tap the X icon to the right of a tracking and delete it. There should be two new entries in the log (if the deletion succeeds):
```
2019-05-17 11:12:00.179152+0800 WooCommerce[7162:160200] 🔵 Tracked order_tracking_delete, properties: [AnyHashable("blog_id"): 156590080, AnyHashable("status"): "processing", AnyHashable("carrier"): "Fastway Couriers", AnyHashable("is_wpcom_store"): true, AnyHashable("id"): 33]
2019-05-17 11:12:00.715685+0800 WooCommerce[7162:160201] 🔵 Tracked order_tracking_delete_success, properties: [AnyHashable("blog_id"): 156590080, AnyHashable("is_wpcom_store"): true]
```

4. Go back to the Order details screen. If there are any other trackings available, tap the ellipsis icon and delete it. The following events should be logged:
```
2019-05-17 11:14:01.429618+0800 WooCommerce[7162:162056] 🔵 Tracked order_tracking_delete, properties: [AnyHashable("blog_id"): 156590080, AnyHashable("is_wpcom_store"): true, AnyHashable("status"): "processing", AnyHashable("id"): 33, AnyHashable("carrier"): "Fastway Couriers"]
2019-05-17 11:14:01.935494+0800 WooCommerce[7162:162235] 🔵 Tracked order_tracking_delete_success, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): 156590080]
```

If any of the deletion sequences fails, the second event logged should be order_tracking_delete_failed


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.