### PR TITLE
Adjust space between trackings and "add tracking" button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/FulfillViewController.swift
@@ -265,7 +265,8 @@ extension FulfillViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let section = sections[section]
 
-        guard let leftTitle = section.title else {
+        guard let leftTitle = section.title,
+            leftTitle.isEmpty != true  else {
             return nil
         }
 
@@ -610,7 +611,7 @@ private extension FulfillViewController {
                 return nil
             }
 
-            let title = orderTracking.count == 0 ? NSLocalizedString("Optional Tracking Information", comment: "") : ""
+            let title = orderTracking.count == 0 ? NSLocalizedString("Optional Tracking Information", comment: "") : nil
             let row = Row.trackingAdd
 
             return Section(title: title, secondaryTitle: nil, rows: [row])


### PR DESCRIPTION
Fixes #926 

Adjust the space between the cells containing shipment trackings and the "Add Tracking" button.

Before and after:
<img src="https://user-images.githubusercontent.com/2722505/57912569-3b446180-78bd-11e9-8052-9e00f28c48ed.jpg" width="450"/>

## Changes
- Pass a `nil` instead of an empty string as title of the section containing the "Add Tracking" button when there are more than zero shipment trackings
- Return a nil header when the section does have a nil or an empty title.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.