### PR TITLE
Fix filters for list of shipment tracking providers

### DIFF
--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -136,14 +136,18 @@ final class ShippingProvidersViewModel {
     /// Filter results by text
     ///
     func filter(by text: String) {
-        let predicate = NSPredicate(format: "name CONTAINS[cd] %@", text)
-        providersExcludingStoreCountry.predicate = predicate
+        let nameFilter = NSPredicate(format: "name CONTAINS[cd] %@", text)
+        providersExcludingStoreCountry.predicate = predicateExcludingStoreCountry(predicate: nameFilter)
+        providersForStoreCountry.predicate = predicateMatchingStoreCountry(predicate: nameFilter)
     }
 
     /// Clear all filters
     ///
     func clearFilters() {
-        providersExcludingStoreCountry.predicate = nil
+        providersExcludingStoreCountry.predicate =
+            predicateExcludingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
+        providersForStoreCountry.predicate =
+            predicateMatchingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
     }
 
     private func dataWasUpdated() {

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -157,6 +157,7 @@ private extension ShipmentProvidersViewController {
     func startListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     /// Unregisters from the Notification Center
@@ -172,6 +173,13 @@ private extension ShipmentProvidersViewController {
 
         table.contentInset.bottom = bottomInset
         table.scrollIndicatorInsets.bottom = bottomInset
+    }
+
+    /// Executed whenever `UIResponder.keyboardWillhideNotification` note is posted
+    ///
+    @objc func keyboardWillHide(_ note: Notification) {
+        table.contentInset.bottom = .zero
+        table.scrollIndicatorInsets.bottom = .zero
     }
 
     /// Returns the Keyboard Height from a (hopefully) Keyboard Notification.


### PR DESCRIPTION
Fixes #984 

This PR is against `release/1.9`, not `develop`, as it was raised as part of [the call for testing for 1.9](https://wp.me/p5T066-RX-p2).

As reported in issue #984 , text typed in the search field of the list of shipment tracking providers was not filtering the providers in the section for the country associated to the store.

<img src="https://user-images.githubusercontent.com/2722505/58236247-134d7600-7d75-11e9-9f4d-3429016da31b.gif" width="350"/>

## Changes 
- Filter the section associated to the store country by the text entered in the search field
- For extra credit, fix the table view offset when the keyboard is dismissed.

## Testing
- Navigate to the list of providers, enter text in the search field, notice it filters also the providers associated to the store country, if available.
- For stores associated to countries that do not have shipment providers, filters should work on all countries.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.