### PR TITLE
Change order of sections in Order Details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -257,15 +257,6 @@ private extension OrderDetailsViewController {
             return Section(title: Title.product, rightTitle: Title.quantity, rows: rows)
         }()
 
-        let tracking: Section? = {
-            guard orderTracking.count > 0 else {
-                return nil
-            }
-
-            let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
-            return Section(title: Title.tracking, rows: rows)
-        }()
-
         let customerNote: Section? = {
             guard viewModel.customerNote.isEmpty == false else {
                 return nil
@@ -297,12 +288,21 @@ private extension OrderDetailsViewController {
 
         let payment = Section(title: Title.payment, row: .payment)
 
+        let tracking: Section? = {
+            guard orderTracking.count > 0 else {
+                return nil
+            }
+
+            let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
+            return Section(title: Title.tracking, rows: rows)
+        }()
+
         let notes: Section = {
             let rows = [.addOrderNote] + Array(repeating: Row.orderNote, count: orderNotes.count)
             return Section(title: Title.notes, rows: rows)
         }()
 
-        sections = [summary, products, tracking, customerNote, customerInformation, payment, notes].compactMap { $0 }
+        sections = [summary, products, customerNote, customerInformation, payment, tracking, notes].compactMap { $0 }
     }
 }
 


### PR DESCRIPTION
Fixes #990 

As pointed out in #990, the Tracking section was shown right after Products, when it should be displayed right after Payments.

This PR is against the `release/1.9` branch

Before and after:
<img src="https://user-images.githubusercontent.com/2722505/58442275-3cc32480-811c-11e9-939d-e1e4c9f5912b.jpg" width="350"/>

## Changes
- Update the order of the table view sections. The new order is, from top to bottom: `summary, products, customerNote, customerInformation, payment, tracking, notes`

## Testing
- Checkout the branch, navigate to an order that contains shipment trackings. Note the placement of the "Trackings" section

## Testfilght release notes:
- Move the Tracking section in the Order Details screen below the Payment section