### PR TITLE
Switch order of custom provider and store country sections in list of tracking providers

### DIFF
--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -184,7 +184,13 @@ extension ShippingProvidersViewModel {
     }
 
     func numberOfRowsInSection(_ section: Int) -> Int {
-        if section == Constants.customSectionIndex {
+        if !storeCountryHasProviders &&
+            section == 0 {
+            return 1
+        }
+
+        if storeCountryHasProviders &&
+            section == Constants.customSectionIndex {
             return 1
         }
 
@@ -199,7 +205,13 @@ extension ShippingProvidersViewModel {
     }
 
     func titleForCellAt(_ indexPath: IndexPath) -> String {
-        if indexPath.section == Constants.customSectionIndex {
+        if !storeCountryHasProviders &&
+            indexPath.section == 0 {
+            return Constants.customProvider
+        }
+
+        if storeCountryHasProviders &&
+            indexPath.section == Constants.customSectionIndex {
             return Constants.customProvider
         }
 
@@ -215,7 +227,13 @@ extension ShippingProvidersViewModel {
     }
 
     func titleForHeaderInSection(_ section: Int) -> String {
-        if section == Constants.customSectionIndex {
+        if !storeCountryHasProviders &&
+            section == 0 {
+            return Constants.customGroup
+        }
+
+        if storeCountryHasProviders &&
+            section == Constants.customSectionIndex {
             return Constants.customGroup
         }
 
@@ -246,6 +264,10 @@ extension ShippingProvidersViewModel {
     /// Indicates if the item at a given IndexPath is a custom shipment provider
     ///
     func isCustom(indexPath: IndexPath) -> Bool {
+        if !storeCountryHasProviders {
+            return indexPath.section == 0
+        }
+
         return indexPath.section == Constants.customSectionIndex
     }
 
@@ -294,8 +316,8 @@ private enum ResultsControllerConstants {
 }
 
 private enum Constants {
-    static let customSectionIndex = 0
-    static let countrySectionIndex = 1
+    static let countrySectionIndex = 0
+    static let customSectionIndex = 1
     static let specialSectionsCount = 2
     static let customGroup = NSLocalizedString("Custom",
                                                comment: "Name of the section for custom shipment tracking providers")


### PR DESCRIPTION
Fix #991 

The "Custom" section should be second in the list, after the "store country" section.

This PR is against the `release/1.9` branch

Before and after for a store in the United States:

<img src="https://user-images.githubusercontent.com/2722505/58442989-ad207480-8121-11e9-9f62-d3fd84fe8c66.jpg" width="350"/>

## Changes
- Updated the view model to change the index of the custom and store country sections
- Updated some more methods in the view model to account for the fact that now the first section can be either the store country or the custom provider

## Testflight release notes
- Fix a bug in the ordering of the list of shipment tracking providers