### PR TITLE
Order Fulfillment: pre-populate custom tracking provider name with last name entered by the user

### DIFF
--- a/Storage/Storage/Model/PreselectedProvider.swift
+++ b/Storage/Storage/Model/PreselectedProvider.swift
@@ -4,10 +4,12 @@
 public struct PreselectedProvider: Codable, Equatable {
     public let siteID: Int
     public let providerName: String
+    public let providerURL: String?
 
-    public init(siteID: Int, providerName: String) {
+    public init(siteID: Int, providerName: String, providerURL: String? = nil) {
         self.siteID = siteID
         self.providerName = providerName
+        self.providerURL = providerURL
     }
 
     public static func == (lhs: PreselectedProvider, rhs: PreselectedProvider) -> Bool {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		D87F614C22657B150031A13B /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F614B22657B150031A13B /* AppSettingsStore.swift */; };
 		D87F615E2265B1BC0031A13B /* AppSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F615D2265B1BC0031A13B /* AppSettingsStoreTests.swift */; };
 		D87F61602265B2400031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615F2265B2400031A13B /* shipment-provider.plist */; };
+		D8BD6A4C229D07C9007CAD6C /* custom-shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D8BD6A4B229D07C8007CAD6C /* custom-shipment-provider.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -231,6 +232,7 @@
 		D87F614B22657B150031A13B /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
 		D87F615D2265B1BC0031A13B /* AppSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStoreTests.swift; sourceTree = "<group>"; };
 		D87F615F2265B2400031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
+		D8BD6A4B229D07C8007CAD6C /* custom-shipment-provider.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "custom-shipment-provider.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -475,6 +477,7 @@
 		B5C9DE1D2087FF20006B910A /* Mockups */ = {
 			isa = PBXGroup;
 			children = (
+				D8BD6A4B229D07C8007CAD6C /* custom-shipment-provider.plist */,
 				D87F615F2265B2400031A13B /* shipment-provider.plist */,
 				B5C9DE1E2087FF20006B910A /* MockupProcessor.swift */,
 				B5C9DE202087FF20006B910A /* MockupAcount.swift */,
@@ -627,6 +630,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8BD6A4C229D07C9007CAD6C /* custom-shipment-provider.plist in Resources */,
 				B5BC71DD21139EDD005CF5AA /* Responses in Resources */,
 				D87F61602265B2400031A13B /* shipment-provider.plist in Resources */,
 			);

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -18,7 +18,7 @@ public enum AppSettingsAction: Action {
     ///
     case addCustomTrackingProvider(siteID: Int,
         providerName: String,
-        providerURL: String,
+        providerURL: String?,
         onCompletion: (Error?) -> Void)
 
     /// Loads the stored shipment tracking provider associated with the `siteID`

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -14,6 +14,18 @@ public enum AppSettingsAction: Action {
     case loadTrackingProvider(siteID: Int,
         onCompletion: (ShipmentTrackingProvider?, ShipmentTrackingProviderGroup?, Error?) -> Void)
 
+    /// Adds a custom shipment tracking provider with `providerName` and `providerURL` associated with the `siteID`
+    ///
+    case addCustomTrackingProvider(siteID: Int,
+        providerName: String,
+        providerURL: String,
+        onCompletion: (Error?) -> Void)
+
+    /// Loads the stored shipment tracking provider associated with the `siteID`
+    ///
+    case loadCustomTrackingProvider(siteID: Int,
+        onCompletion: (ShipmentTrackingProvider?, Error?) -> Void)
+
     /// Clears the stored providers
     ///
     case resetStoredProviders(onCompletion: ((Error?) -> Void)?)

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -84,30 +84,10 @@ private extension AppSettingsStore {
     func addTrackingProvider(siteID: Int,
                              providerName: String,
                              onCompletion: (Error?) -> Void) {
-        guard FileManager.default.fileExists(atPath: selectedProvidersURL.path) else {
-            insertNewProvider(siteID: siteID,
-                              providerName: providerName,
-                              toFileURL: selectedProvidersURL,
-                              onCompletion: onCompletion)
-            onCompletion(nil)
-            return
-        }
-
-        do {
-            let data = try fileStorage.data(for: selectedProvidersURL)
-            let decoder = PropertyListDecoder()
-            let settings = try decoder.decode([PreselectedProvider].self, from: data)
-            upsertTrackingProvider(siteID: siteID,
-                                   providerName: providerName,
-                                   preselectedData: settings,
-                                   toFileURL: selectedProvidersURL,
-                                   onCompletion: onCompletion)
-        } catch {
-            let error = AppSettingsStoreErrors.parsePreselectedProvider
-            onCompletion(error)
-
-            DDLogError("⛔️ Saving a tracking provider locally failed: siteID \(siteID). Error: \(error)")
-        }
+        addProvider(siteID: siteID,
+                    providerName: providerName,
+                    fileURL: selectedProvidersURL,
+                    onCompletion: onCompletion)
 
     }
 
@@ -115,25 +95,35 @@ private extension AppSettingsStore {
                              providerName: String,
                              providerURL: String,
                              onCompletion: (Error?) -> Void) {
-        guard FileManager.default.fileExists(atPath: customSelectedProvidersURL.path) else {
+        addProvider(siteID: siteID,
+                    providerName: providerName,
+                    providerURL: providerURL,
+                    fileURL: customSelectedProvidersURL,
+                    onCompletion: onCompletion)
+    }
+
+    func addProvider(siteID: Int,
+                     providerName: String,
+                     providerURL: String? = nil,
+                     fileURL: URL,
+                     onCompletion: (Error?) -> Void) {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
             insertNewProvider(siteID: siteID,
                               providerName: providerName,
-                              providerURL: providerURL,
-                              toFileURL: customSelectedProvidersURL,
+                              toFileURL: fileURL,
                               onCompletion: onCompletion)
             onCompletion(nil)
             return
         }
 
         do {
-            let data = try fileStorage.data(for: customSelectedProvidersURL)
+            let data = try fileStorage.data(for: fileURL)
             let decoder = PropertyListDecoder()
             let settings = try decoder.decode([PreselectedProvider].self, from: data)
             upsertTrackingProvider(siteID: siteID,
                                    providerName: providerName,
-                                   providerURL: providerURL,
                                    preselectedData: settings,
-                                   toFileURL: selectedProvidersURL,
+                                   toFileURL: fileURL,
                                    onCompletion: onCompletion)
         } catch {
             let error = AppSettingsStoreErrors.parsePreselectedProvider

--- a/Yosemite/YosemiteTests/Mockups/custom-shipment-provider.plist
+++ b/Yosemite/YosemiteTests/Mockups/custom-shipment-provider.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>providerURL</key>
+		<string>http://some.where</string>
+		<key>providerName</key>
+		<string>post.at</string>
+		<key>siteID</key>
+		<integer>156590080</integer>
+	</dict>
+	<dict>
+		<key>providerURL</key>
+		<string>http://some.where</string>		
+		<key>providerName</key>
+		<string>A mock provider</string>
+		<key>siteID</key>
+		<integer>1234</integer>
+	</dict>
+</array>
+</plist>

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -8,11 +8,15 @@ import XCTest
 private struct TestConstants {
     static let fileURL = Bundle(for: AppSettingsStoreTests.self)
         .url(forResource: "shipment-provider", withExtension: "plist")
+    static let customFileURL = Bundle(for: AppSettingsStoreTests.self)
+        .url(forResource: "custom-shipment-provider", withExtension: "plist")
     static let siteID = 156590080
     static let providerName = "post.at"
+    static let providerURL = "http://some.where"
 
     static let newSiteID = 1234
     static let newProviderName = "Some provider"
+    static let newProviderURL = "http://some.where"
 }
 
 
@@ -42,6 +46,7 @@ final class AppSettingsStoreTests: XCTestCase {
         fileStorage = MockFileLoader()
         subject = AppSettingsStore(dispatcher: dispatcher!, storageManager: storageManager!, fileStorage: fileStorage!)
         subject?.selectedProvidersURL = TestConstants.fileURL!
+        subject?.customSelectedProvidersURL = TestConstants.customFileURL!
     }
 
     override func tearDown() {
@@ -57,6 +62,23 @@ final class AppSettingsStoreTests: XCTestCase {
 
         let action = AppSettingsAction.addTrackingProvider(siteID: TestConstants.newSiteID,
                                                            providerName: TestConstants.newProviderName) { error in
+                                                            XCTAssertNil(error)
+
+                                                            if self.fileStorage?.dataWriteIsHit == true {
+                                                                expectation.fulfill()
+                                                            }
+        }
+
+        subject?.onAction(action)
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func testFileStorageIsRequestedToWriteWhenAddingANewCustomShipmentProvider() {
+        let expectation = self.expectation(description: "A write is requested")
+
+        let action = AppSettingsAction.addCustomTrackingProvider(siteID: TestConstants.newSiteID,
+                                                                 providerName: TestConstants.newProviderName, providerURL: TestConstants.newProviderURL) { error in
                                                             XCTAssertNil(error)
 
                                                             if self.fileStorage?.dataWriteIsHit == true {
@@ -86,12 +108,52 @@ final class AppSettingsStoreTests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
+    func testFileStorageIsRequestedToWriteWhenAddingACustomShipmentProviderForExistingSite() {
+        let expectation = self.expectation(description: "A write is requested")
+
+        let action = AppSettingsAction.addCustomTrackingProvider(siteID: TestConstants.siteID,
+                                                           providerName: TestConstants.providerName,
+                                                           providerURL: TestConstants.providerURL) { error in
+                                                            XCTAssertNil(error)
+
+                                                            if self.fileStorage?.dataWriteIsHit == true {
+                                                                expectation.fulfill()
+                                                            }
+        }
+
+        subject?.onAction(action)
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
     func testAddingNewProviderToExistingSiteUpdatesFile() {
         let expectation = self.expectation(description: "File is updated")
 
         let action = AppSettingsAction
             .addTrackingProvider(siteID: TestConstants.siteID,
                                  providerName: TestConstants.newProviderName) { error in
+                                    XCTAssertNil(error)
+                                    let fileData = self.fileStorage?.fileData
+                                    let updatedProvider = fileData?.filter({ $0.siteID == TestConstants.siteID}).first
+
+                                    if updatedProvider?.providerName == TestConstants.newProviderName {
+                                        expectation.fulfill()
+                                    }
+
+        }
+
+        subject?.onAction(action)
+
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func testAddingNewCustomProviderToExistingSiteUpdatesFile() {
+        let expectation = self.expectation(description: "File is updated")
+
+        let action = AppSettingsAction
+            .addCustomTrackingProvider(siteID: TestConstants.siteID,
+                                 providerName: TestConstants.newProviderName,
+                                 providerURL: TestConstants.newProviderURL) { error in
                                     XCTAssertNil(error)
                                     let fileData = self.fileStorage?.fileData
                                     let updatedProvider = fileData?.filter({ $0.siteID == TestConstants.siteID}).first

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -78,7 +78,8 @@ final class AppSettingsStoreTests: XCTestCase {
         let expectation = self.expectation(description: "A write is requested")
 
         let action = AppSettingsAction.addCustomTrackingProvider(siteID: TestConstants.newSiteID,
-                                                                 providerName: TestConstants.newProviderName, providerURL: TestConstants.newProviderURL) { error in
+                                                                 providerName: TestConstants.newProviderName,
+                                                                 providerURL: TestConstants.newProviderURL) { error in
                                                             XCTAssertNil(error)
 
                                                             if self.fileStorage?.dataWriteIsHit == true {


### PR DESCRIPTION
Fixes #945 

This PR is against the `release/1.9` branch

We are pre-populating the name o the provider for "regular" providers already, so this PR adds the same functionality to custom providers (also, for consistency with Android)

<img src="https://user-images.githubusercontent.com/2722505/58455705-ecb48400-8154-11e9-80b9-068ecfe6cdeb.gif" width="350"/>

## Changes
- Added domain methods to the `AppSettingsStore`
- Added tests to cover the new methods
- Save and read from `AddCustomTrackingViewModel`

## Testing
- Add regular and custom trackings to an order. 
- Check that the name is pre-populated with the last choice for both regular and custom tracking providers
- The plist files should be cleared on log out

## Testflight release notes
- The name of the shipment tracking provider is pre-populated with the latest name used also for custom providers