### PR TITLE
Add "Add Tracking" button to Order Details screen

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -130,6 +130,7 @@ public enum WooAnalyticsStat: String {
     case orderDetailPulledToRefresh             = "order_detail_pulled_to_refresh"
     case orderNoteAddButtonTapped               = "add_order_note_add_button_tapped"
     case orderNoteEmailCustomerToggled          = "add_order_note_email_note_to_customer_toggled"
+    case orderDetailAddTrackingButtonTapped = "order_detail_tracking_add_tracking_button_tapped"
     case orderDetailShowBillingTapped           = "order_detail_customer_info_show_billing_tapped"
     case orderDetailHideBillingTapped           = "order_detail_customer_info_hide_billing_tapped"
     case orderDetailFulfillButtonTapped         = "order_detail_fulfill_order_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -8,7 +8,7 @@ import SafariServices
 
 // MARK: - OrderDetailsViewController: Displays the details for a given Order.
 //
-class OrderDetailsViewController: UIViewController {
+final class OrderDetailsViewController: UIViewController {
 
     /// Main TableView.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -804,11 +804,6 @@ extension OrderDetailsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if sections[section].title == nil {
-            // iOS 11 table bug. Must return a tiny value to collapse `nil` or `empty` section headers.
-            return .leastNonzeroMagnitude
-        }
-
         return UITableView.automaticDimension
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -273,28 +273,6 @@ private extension OrderDetailsViewController {
             return Section(title: Title.product, rightTitle: Title.quantity, rows: rows)
         }()
 
-        let tracking: Section? = {
-            guard orderTracking.count > 0 else {
-                return nil
-            }
-
-            let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
-            return Section(title: Title.tracking, rows: rows)
-        }()
-
-        let addTracking: Section? = {
-            // Hide the section if the shipment
-            // tracking plugin is not installed
-            guard trackingIsReachable else {
-                return nil
-            }
-
-            let title = orderTracking.count == 0 ? NSLocalizedString("Optional Tracking Information", comment: "") : nil
-            let row = Row.trackingAdd
-
-            return Section(title: title, secondaryTitle: nil, rows: [row])
-        }()
-
         let customerNote: Section? = {
             guard viewModel.customerNote.isEmpty == false else {
                 return nil
@@ -326,12 +304,34 @@ private extension OrderDetailsViewController {
 
         let payment = Section(title: Title.payment, row: .payment)
 
+        let tracking: Section? = {
+            guard orderTracking.count > 0 else {
+                return nil
+            }
+
+            let rows: [Row] = Array(repeating: .tracking, count: orderTracking.count)
+            return Section(title: Title.tracking, rows: rows)
+        }()
+
+        let addTracking: Section? = {
+            // Hide the section if the shipment
+            // tracking plugin is not installed
+            guard trackingIsReachable else {
+                return nil
+            }
+
+            let title = orderTracking.count == 0 ? NSLocalizedString("Optional Tracking Information", comment: "") : nil
+            let row = Row.trackingAdd
+
+            return Section(title: title, rightTitle: nil, rows: [row])
+        }()
+
         let notes: Section = {
             let rows = [.addOrderNote] + Array(repeating: Row.orderNote, count: orderNotes.count)
             return Section(title: Title.notes, rows: rows)
         }()
 
-        sections = [summary, products, tracking, customerNote, customerInformation, payment, notes].compactMap { $0 }
+        sections = [summary, products, customerNote, customerInformation, payment, tracking, addTracking, notes].compactMap { $0 }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -875,7 +875,7 @@ extension OrderDetailsViewController: UITableViewDelegate {
             present(navController, animated: true, completion: nil)
 
         case .trackingAdd:
-            //WooAnalytics.shared.track(.orderDetailAddT)
+            WooAnalytics.shared.track(.orderDetailAddTrackingButtonTapped)
 
             let addTrackingViewModel = AddTrackingViewModel(order: viewModel.order)
             let addTracking = ManualTrackingViewController(viewModel: addTrackingViewModel)


### PR DESCRIPTION
Fixes #996 

This PR is against the `release/1.9` branch.

As mentioned in [this thread](https://wp.me/p99K0U-1gs-p2) we were missing the "Add Tracking" button from the Order Details screen.

Also, the Tracking section is displayed right after the Product section, where according to the i8 designs it should be displayed right above the order notes.

Before:
<img src="https://user-images.githubusercontent.com/2722505/58523996-3f477c00-81f9-11e9-8b09-d44ed20076cd.png" width="350"/>

After:
<img src="https://user-images.githubusercontent.com/2722505/58524074-89c8f880-81f9-11e9-8138-7075758ded49.png" width="350"/>

## Changes
- Add the "Add tracking" section to `OrderDetailsViewController`
- Add logic to display the section only if the plugin endpoints reachable (the same way we did in `FulfillViewController`)
- Change the order of the sections to display the tracking right above the order notes
- Remove a restriction to the height of the section headers that was forcing them to be zero when empty
- Added a Tracks event: `order_detail_tracking_add_tracking_button_tapped`

## Testing
- Navigate to an order. Check the button is visible if the api is reachable
- Attempt to add a shipment tracking from the Order Details screen
- Check the right tracks event is submitted when tapping the "Add Tracking" button

## Testflight release notes
- Shipment tracking can also be added from the Order Details screen
