### PR TITLE
Make three tests failing in HK pass

### DIFF
--- a/Networking/NetworkingTests/Extensions/DateFormatterWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/DateFormatterWooTests.swift
@@ -8,7 +8,7 @@ class DateFormatterWooTests: XCTestCase {
 
     /// Sample Date
     ///
-    let datetimeAsString = "2018-01-24T16:21:48"
+    let datetimeAsString = "2018-01-24T12:00:00"
 
 
     /// Verifies that a Woo Datetime is properly parsed by `DateFormatter.Defaults.dateTimeFormatter`.

--- a/Networking/NetworkingTests/Mapper/NoteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/NoteListMapperTests.swift
@@ -45,7 +45,7 @@ class NoteListMapperTests: XCTestCase {
         XCTAssertEqual(note.read, false)
         XCTAssert(note.icon == "https://gravatar.tld/some-hash")
         XCTAssert(note.noticon == "\u{f408}")
-        XCTAssertEqual(note.timestamp, "2018-10-22T18:51:33+00:00")
+        XCTAssertEqual(note.timestamp, "2018-10-22T12:00:00+00:00")
         XCTAssertEqual(note.type, "comment_like")
         XCTAssertEqual(note.kind, .commentLike)
         XCTAssert(note.url == "https://someurl.sometld")

--- a/Networking/NetworkingTests/Responses/notifications-load-all.json
+++ b/Networking/NetworkingTests/Responses/notifications-load-all.json
@@ -7,7 +7,7 @@
         "type": "comment_like",
         "read": false,
         "noticon": "\uf408",
-        "timestamp": "2018-10-22T18:51:33+00:00",
+        "timestamp": "2018-10-22T12:00:00+00:00",
         "icon": "https:\/\/gravatar.tld/some-hash",
         "url": "https:\/\/someurl.sometld",
         "subject": [{


### PR DESCRIPTION
Fixes #1001 

I am sorry PR 1000 is so mundane (and hacky) but this is a little annoyance that I have been wanting to look into for a few weeks. Also, I labelled it as Tooling for lack of a better tag.

Three tests are failing for me when running them in my machine in the afternoon of the HK timezone.

## Changes
- Modified the string representation of two mocked strings in the tests to make the tests pass on my machine.

## Testing
- Checkout the branch and run the tests. Hopefully they will pass for you as well.
- Check that the PR builds on CI.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.