### PR TITLE
Submit tracks event when loading list of shipment providers from the API

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -173,6 +173,7 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDelete                    = "order_tracking_delete"
     case orderTrackingDeleteFailed              = "order_tracking_delete_failed"
     case orderTrackingDeleteSuccess             = "order_tracking_delete_success"
+    case orderTrackingProvidersLoaded           = "order_tracking_providers_loaded"
 
     // Push Notifications Events
     //

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -87,6 +87,7 @@ private extension ShipmentProvidersViewController {
                                                                                     if let error = error {
                                                                                         self?.presentNotice(error)
                                                                                     }
+                                                                                    WooAnalytics.shared.track(.orderTrackingProvidersLoaded)
                                                                                     self?.footerSpinnerView.stopAnimating()
         }
 


### PR DESCRIPTION
Closes #1013 

Submit the `order_tracking_providers_loaded` when loading the list of shipment providers from the API.

The PR is against `develop` as it does not seem like a blocker, but if we wanted to get this in the 2.0  release we could just change the base branch.

## Changes 
- Added the event to the `WooAnalyticsStat` enumeration
- Submitted the event in `ShipmentProvidersViewController`

## Testing
- Navigate to an Order > Filfill > Add Tracking > Tap the tracking provider cell to navigate to the list of providers
- The following event should be logged in the console and submitted to Tracks:
```
2019-06-05 13:45:02.235586+0800 WooCommerce[19351:16168798] 🔵 Tracked order_tracking_providers_loaded, properties: [AnyHashable("is_wpcom_store"): true, AnyHashable("blog_id"): XXXXXXX]
```
