### PR TITLE
Purchase Details Mark II: Purchase Note cell

### DIFF
--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -31,7 +31,7 @@ extension String {
     /// - Returns: a string with the newline character removed, if the
     ///            newline character is the last character in the string.
     ///
-    func stripLastNewline(in string: String) -> String {
+    static func stripLastNewline(in string: String) -> String {
         var newText = string
         let lastChar = newText.suffix(1)
 

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -23,4 +23,23 @@ extension String {
             return String.localizedStringWithFormat(plural, count)
         }
     }
+
+    /// Helper method to remove the last newline character in a given string.
+    ///
+    /// - Parameters:
+    ///   - string: the string to format
+    /// - Returns: a string with the newline character removed, if the
+    ///            newline character is the last character in the string.
+    ///
+    func stripLastNewline(in string: String) -> String {
+        var newText = string
+        let lastChar = newText.suffix(1)
+
+        let newline = String(lastChar)
+        if newline == "\n" {
+            newText.removeSuffix(newline)
+        }
+
+        return newText
+    }
 }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import Yosemite
 import UIKit
 import Gridicons
+import WordPressShared
 
 
 // MARK: - Product details view model
@@ -254,8 +255,8 @@ extension ProductDetailsViewModel {
             configureShipping(cell)
         case let cell as TitleBodyTableViewCell where row == .downloads:
             configureDownloads(cell)
-        case _ as TitleBodyTableViewCell where row == .purchaseNote:
-            break
+        case let cell as TitleBodyTableViewCell where row == .purchaseNote:
+            configurePurchaseNote(cell)
         default:
             fatalError("Unidentified row type")
         }
@@ -513,6 +514,48 @@ extension ProductDetailsViewModel {
         let bodyText = numberOfFilesText + "\n" + limitText + "\n" + expirationText
         cell.titleLabel?.text = title
         cell.bodyLabel?.text = bodyText
+    }
+
+    /// Purchase Note cell.
+    ///
+    func configurePurchaseNote(_ cell: TitleBodyTableViewCell) {
+        cell.titleLabel?.text = NSLocalizedString("Purchase note",
+                                                  comment: "Product Details > Purchase Details > Purchase note cell title")
+
+        printTimeElapsedWhenRunningCode(title: "stripped HTML in purchase note") {
+            guard var cleanedString = product.purchaseNote?.strippedHTML else {
+                return
+            }
+
+//            let lastChar = cleanedString.suffix(1)
+//            let newline = String(lastChar)
+//            if newline == Constants.newline {
+//                cleanedString.removeSuffix(newline)
+//            }
+//
+//            cell.bodyLabel?.text = cleanedString
+        }
+
+        printTimeElapsedWhenRunningCode(title: "old fashioned strip HTML") {
+            guard var oldFashionedString = product.purchaseNote?.replacingOccurrences(of: "<[^>]+>", with: "") else {
+                return
+            }
+
+//            let lastChar = oldFashionedString.suffix(1)
+//            let newline = String(lastChar)
+//            if newline == Constants.newline {
+//                oldFashionedString.removeSuffix(newline)
+//            }
+//
+//            cell.bodyLabel?.text = oldFashionedString
+        }
+    }
+
+    func printTimeElapsedWhenRunningCode(title:String, operation:()->()) {
+        let startTime = CFAbsoluteTimeGetCurrent()
+        operation()
+        let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+        print("Time elapsed for \(title): \(timeElapsed) s.")
     }
 
 
@@ -796,5 +839,9 @@ extension ProductDetailsViewModel {
     enum Keys {
         static let weightUnit = "woocommerce_weight_unit"
         static let dimensionUnit = "woocommerce_dimension_unit"
+    }
+
+    enum Constants {
+        static let newline = "\n"
     }
 }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -519,43 +519,26 @@ extension ProductDetailsViewModel {
     /// Purchase Note cell.
     ///
     func configurePurchaseNote(_ cell: TitleBodyTableViewCell) {
+        guard var cleanedString = product.purchaseNote?.strippedHTML else {
+            return
+        }
+
+        let lastChar = cleanedString.suffix(1)
+        let newline = String(lastChar)
+        if newline == Constants.newline {
+            cleanedString.removeSuffix(newline)
+        }
+
         cell.titleLabel?.text = NSLocalizedString("Purchase note",
                                                   comment: "Product Details > Purchase Details > Purchase note cell title")
-
-        printTimeElapsedWhenRunningCode(title: "stripped HTML in purchase note") {
-            guard var cleanedString = product.purchaseNote?.strippedHTML else {
-                return
-            }
-
-//            let lastChar = cleanedString.suffix(1)
-//            let newline = String(lastChar)
-//            if newline == Constants.newline {
-//                cleanedString.removeSuffix(newline)
-//            }
-//
-//            cell.bodyLabel?.text = cleanedString
-        }
-
-        printTimeElapsedWhenRunningCode(title: "old fashioned strip HTML") {
-            guard var oldFashionedString = product.purchaseNote?.replacingOccurrences(of: "<[^>]+>", with: "") else {
-                return
-            }
-
-//            let lastChar = oldFashionedString.suffix(1)
-//            let newline = String(lastChar)
-//            if newline == Constants.newline {
-//                oldFashionedString.removeSuffix(newline)
-//            }
-//
-//            cell.bodyLabel?.text = oldFashionedString
-        }
+        cell.bodyLabel?.text = cleanedString
     }
 
-    func printTimeElapsedWhenRunningCode(title:String, operation:()->()) {
+    func printTimeElapsedWhenRunningCode(title: String, operation:()->()) {
         let startTime = CFAbsoluteTimeGetCurrent()
         operation()
         let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
-        print("Time elapsed for \(title): \(timeElapsed) s.")
+        print("Time elapsed for \(title): \(timeElapsed) sec.") // time in seconds
     }
 
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -531,14 +531,7 @@ extension ProductDetailsViewModel {
 
         cell.titleLabel?.text = NSLocalizedString("Purchase note",
                                                   comment: "Product Details > Purchase Details > Purchase note cell title")
-        cell.bodyLabel?.text = cleanedString
-    }
-
-    func printTimeElapsedWhenRunningCode(title: String, operation:()->()) {
-        let startTime = CFAbsoluteTimeGetCurrent()
-        operation()
-        let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
-        print("Time elapsed for \(title): \(timeElapsed) sec.") // time in seconds
+        cell.bodyLabel?.text = cleanedPurchaseNote
     }
 
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -9,11 +9,13 @@ import WordPressShared
 //
 final class ProductDetailsViewModel {
 
+    // MARK: - public variables
+
     /// Closures
     ///
     var onError: (() -> Void)?
     var onReload: (() -> Void)?
-    var onReloadRow: (() -> Void)?
+    var onPurchaseNoteTapped: (() -> Void)?
 
     /// Yosemite.Product
     ///
@@ -29,11 +31,32 @@ final class ProductDetailsViewModel {
         return product.name
     }
 
+    /// Purchase Note
+    /// - stripped of HTML
+    /// - no ending newline character
+    /// - cannot be a lazy var because it's a computed property
+    ///
+    var cleanedPurchaseNote: String? {
+        guard var cleanedString = product.purchaseNote?.strippedHTML else {
+            return nil
+        }
+
+        let lastChar = cleanedString.suffix(1)
+        let newline = String(lastChar)
+        if newline == Constants.newline {
+            cleanedString.removeSuffix(newline)
+        }
+
+        return cleanedString
+    }
+
     /// Product ID
     ///
     var productID: Int {
         return product.productID
     }
+
+    // MARK: - private variables
 
     /// Sections to be rendered
     ///
@@ -94,25 +117,6 @@ final class ProductDetailsViewModel {
     ///
     private var productImageHeight: CGFloat {
         return productHasImage ? Metrics.productImageHeight : Metrics.emptyProductImageHeight
-    }
-
-    /// Purchase Note
-    /// - stripped of HTML
-    /// - no ending newline character
-    /// - cannot be a lazy var because it's a computed property
-    ///
-    private var cleanedPurchaseNote: String? {
-        guard var cleanedString = product.purchaseNote?.strippedHTML else {
-            return nil
-        }
-
-        let lastChar = cleanedString.suffix(1)
-        let newline = String(lastChar)
-        if newline == Constants.newline {
-            cleanedString.removeSuffix(newline)
-        }
-
-        return cleanedString
     }
 
     /// Table section height.
@@ -556,27 +560,8 @@ extension ProductDetailsViewModel {
 
         cell.moreButton?.setTitle(readMoreTitle, for: .normal)
         cell.onMoreTouchUp = { [weak self] in
-            self?.toggleReadMore(cell)
-            DDLogInfo("Read more was tapped")
+            self?.onPurchaseNoteTapped?()
         }
-    }
-
-    func toggleReadMore(_ cell: ReadMoreTableViewCell) {
-        if readMoreExpanded == false {
-            cell.bodyLabel?.numberOfLines = 0
-            cell.bodyLabel?.lineBreakMode = .byWordWrapping
-            let readLessTitle = NSLocalizedString("Read less",
-                                                  comment: "Read less of the purchase note. All of the text is currently displayed.")
-            cell.moreButton.setTitle(readLessTitle, for: .normal)
-        } else {
-            cell.bodyLabel?.numberOfLines = 2
-            cell.bodyLabel?.lineBreakMode = .byTruncatingTail
-            let readMoreTitle = NSLocalizedString("Read more", comment: "Read more of the purchase note. Only the first two lines are displayed on the cell.")
-            cell.moreButton.setTitle(readMoreTitle, for: .normal)
-        }
-
-        onReloadRow?()
-        readMoreExpanded = !readMoreExpanded
     }
 
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -79,6 +79,7 @@ final class ProductDetailsViewModel {
         guard let productImageURLString = product.images.first?.src else {
             return nil
         }
+
         return URL(string: productImageURLString)
     }
 
@@ -183,7 +184,8 @@ extension ProductDetailsViewModel {
 
     func heightForHeader(in section: Int) -> CGFloat {
         if sections[section].title == nil {
-            // iOS 11 table bug. Must return a tiny value to collapse `nil` or `empty` section headers.
+            // iOS 11 table bug.
+            // Must return a tiny value to collapse `nil` or `empty` section headers.
             return .leastNonzeroMagnitude
         }
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -37,15 +37,10 @@ final class ProductDetailsViewModel {
     /// - cannot be a lazy var because it's a computed property
     ///
     var cleanedPurchaseNote: String? {
-        guard var cleanedString = product.purchaseNote?.strippedHTML else {
+        guard let noHTMLString = product.purchaseNote?.strippedHTML else {
             return nil
         }
-
-        let lastChar = cleanedString.suffix(1)
-        let newline = String(lastChar)
-        if newline == Constants.newline {
-            cleanedString.removeSuffix(newline)
-        }
+        let cleanedString = String.stripLastNewline(in: noHTMLString)
 
         return cleanedString
     }
@@ -130,10 +125,6 @@ final class ProductDetailsViewModel {
     var rowHeight: CGFloat {
         return Metrics.estimatedRowHeight
     }
-
-    /// Read more row is expanded?
-    ///
-    var readMoreExpanded = false
 
     /// Currency Formatter.
     ///
@@ -556,7 +547,6 @@ extension ProductDetailsViewModel {
 
         let readMoreTitle = NSLocalizedString("Read more",
                                               comment: "Read more of the purchase note. Only the first two lines of text are displayed.")
-        readMoreExpanded = false
 
         cell.moreButton?.setTitle(readMoreTitle, for: .normal)
         cell.onMoreTouchUp = { [weak self] in
@@ -845,9 +835,5 @@ extension ProductDetailsViewModel {
     enum Keys {
         static let weightUnit = "woocommerce_weight_unit"
         static let dimensionUnit = "woocommerce_dimension_unit"
-    }
-
-    enum Constants {
-        static let newline = "\n"
     }
 }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -95,6 +95,25 @@ final class ProductDetailsViewModel {
         return productHasImage ? Metrics.productImageHeight : Metrics.emptyProductImageHeight
     }
 
+    /// Purchase Note
+    /// - stripped of HTML
+    /// - no ending newline character
+    /// - cannot be a lazy var because it's a computed property
+    ///
+    private var cleanedPurchaseNote: String? {
+        guard var cleanedString = product.purchaseNote?.strippedHTML else {
+            return nil
+        }
+
+        let lastChar = cleanedString.suffix(1)
+        let newline = String(lastChar)
+        if newline == Constants.newline {
+            cleanedString.removeSuffix(newline)
+        }
+
+        return cleanedString
+    }
+
     /// Table section height.
     ///
     var sectionHeight: CGFloat {
@@ -521,16 +540,6 @@ extension ProductDetailsViewModel {
     /// Purchase Note cell.
     ///
     func configurePurchaseNote(_ cell: TitleBodyTableViewCell) {
-        guard var cleanedString = product.purchaseNote?.strippedHTML else {
-            return
-        }
-
-        let lastChar = cleanedString.suffix(1)
-        let newline = String(lastChar)
-        if newline == Constants.newline {
-            cleanedString.removeSuffix(newline)
-        }
-
         cell.titleLabel?.text = NSLocalizedString("Purchase note",
                                                   comment: "Product Details > Purchase Details > Purchase note cell title")
         cell.bodyLabel?.text = cleanedPurchaseNote

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertController+PurchaseNote.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertController+PurchaseNote.swift
@@ -1,0 +1,58 @@
+import Foundation
+import WordPressUI
+import SafariServices
+
+
+public extension FancyAlertViewController {
+
+    /// Create the fancy alert controller for displaying the full Purchase Note in Product Details.
+    ///
+    /// - Returns: FancyAlertViewController of the alert
+    ///
+    static func makePurchaseNoteAlertController(with bodyText: String?) -> FancyAlertViewController {
+        let dismissButton = makeDismissButtonConfig()
+        let config = FancyAlertViewController.Config(titleText: Strings.titleText,
+                                                     bodyText: bodyText,
+                                                     headerImage: nil,
+                                                     dividerPosition: .bottom,
+                                                     defaultButton: dismissButton,
+                                                     cancelButton: nil,
+                                                     moreInfoButton: nil,
+                                                     dismissAction: {})
+
+        let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
+        return controller
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension FancyAlertViewController {
+
+    static func makeDismissButtonConfig() -> FancyAlertViewController.Config.ButtonConfig {
+        return FancyAlertViewController.Config.ButtonConfig(Strings.dismissButtonText) { controller, _ in
+            controller.dismiss(animated: true)
+        }
+    }
+}
+
+
+// MARK: - Constants
+//
+private extension FancyAlertViewController {
+
+    struct Strings {
+        // Titles
+        static let titleText = NSLocalizedString(
+            "Purchase note",
+            comment: "Title for purchase note alert."
+        )
+
+        // UI Elements
+        static let dismissButtonText = NSLocalizedString(
+            "Dismiss",
+            comment: "Dismiss button title shown in an alert displaying full purchase note text."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -882,6 +882,15 @@ extension OrderDetailsViewController: UITableViewDelegate {
             let addTracking = ManualTrackingViewController(viewModel: addTrackingViewModel)
             let navController = WooNavigationController(rootViewController: addTracking)
             present(navController, animated: true, completion: nil)
+        case .orderItem:
+            if FeatureFlag.productDetails.enabled {
+                let item = viewModel.order.items[indexPath.row]
+                let productID = item.variationID == 0 ? item.productID : item.variationID
+                let loaderViewController = ProductLoaderViewController(productID: productID,
+                                                                       siteID: viewModel.order.siteID)
+                let navController = WooNavigationController(rootViewController: loaderViewController)
+                present(navController, animated: true, completion: nil)
+            }
         case .details:
             WooAnalytics.shared.track(.orderDetailProductDetailTapped)
             performSegue(withIdentifier: Constants.productDetailsSegue, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Yosemite
 import Gridicons
 import SafariServices
+import WordPressUI
 
 
 /// ProductDetailsViewController: Displays the details for a given Product.
@@ -104,8 +105,8 @@ private extension ProductDetailsViewController {
         viewModel.onReload = {  [weak self] in
             self?.reloadTableViewDataIfPossible()
         }
-        viewModel.onReloadRow = { [weak self] in
-            self?.reloadSelectedRowIfPossible()
+        viewModel.onPurchaseNoteTapped = { [weak self] in
+            self?.presentPurchaseNoteIfPossible()
         }
     }
 
@@ -267,15 +268,16 @@ private extension ProductDetailsViewController {
         tableView.reloadData()
     }
 
-    /// Reloads the tableView's rows
+    /// Displays the full purchase note
     ///
-    func reloadSelectedRowIfPossible() {
+    func presentPurchaseNoteIfPossible() {
         guard isViewLoaded else {
             return
         }
 
-        tableView.beginUpdates()
-        tableView.reloadSelectedRow()
-        tableView.endUpdates()
+        let fancyAlert = FancyAlertViewController.makePurchaseNoteAlertController(with: viewModel.cleanedPurchaseNote)
+        fancyAlert.modalPresentationStyle = .custom
+        fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
+        present(fancyAlert, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -104,6 +104,9 @@ private extension ProductDetailsViewController {
         viewModel.onReload = {  [weak self] in
             self?.reloadTableViewDataIfPossible()
         }
+        viewModel.onReloadRow = { [weak self] in
+            self?.reloadSelectedRowIfPossible()
+        }
     }
 
     /// Configure view model errors
@@ -123,7 +126,8 @@ private extension ProductDetailsViewController {
             TitleBodyTableViewCell.self,
             TwoColumnTableViewCell.self,
             ProductReviewsTableViewCell.self,
-            WooBasicTableViewCell.self
+            WooBasicTableViewCell.self,
+            ReadMoreTableViewCell.self
         ]
 
         for cell in cells {
@@ -261,5 +265,17 @@ private extension ProductDetailsViewController {
         }
 
         tableView.reloadData()
+    }
+
+    /// Reloads the tableView's rows
+    ///
+    func reloadSelectedRowIfPossible() {
+        guard isViewLoaded else {
+            return
+        }
+
+        tableView.beginUpdates()
+        tableView.reloadSelectedRow()
+        tableView.endUpdates()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ReadMoreTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ReadMoreTableViewCell.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+
+/// Represents a cell with a Title label, body label, and call-to-action button
+///
+final class ReadMoreTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var bodyLabel: UILabel!
+    @IBOutlet weak var moreButton: UIButton!
+
+    /// Closure to be executed whenever the edit button is tapped.
+    ///
+    var onMoreTouchUp: (() -> Void)?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureLabels()
+        configureMoreButton()
+    }
+
+    /// Configure the labels
+    ///
+    func configureLabels() {
+        titleLabel?.applyHeadlineStyle()
+        bodyLabel?.applySecondaryBodyStyle()
+    }
+
+    /// Configure the button
+    ///
+    func configureMoreButton() {
+        moreButton.tintColor = StyleManager.wooCommerceBrandColor
+        moreButton.addTarget(self, action: #selector(moreWasTapped), for: .touchUpInside)
+    }
+
+    @objc func moreWasTapped() {
+        onMoreTouchUp?()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ReadMoreTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ReadMoreTableViewCell.xib
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="110" id="KGk-i7-Jjw" customClass="ReadMoreTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="109.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c3u-QX-r6L">
+                        <rect key="frame" x="16" y="19" width="288" height="22"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="RNq-pr-xad"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Body label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TR3-UN-lJJ">
+                        <rect key="frame" x="16" y="45" width="288" height="20.5"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bUR-Jz-NR4">
+                        <rect key="frame" x="16" y="65.5" width="83" height="33.5"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <state key="normal" title="Read more"/>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="TR3-UN-lJJ" firstAttribute="top" secondItem="c3u-QX-r6L" secondAttribute="bottom" constant="4" id="4kr-Xm-8FQ"/>
+                    <constraint firstItem="c3u-QX-r6L" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="58H-LE-34s"/>
+                    <constraint firstItem="TR3-UN-lJJ" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Gmu-oF-jf9"/>
+                    <constraint firstItem="c3u-QX-r6L" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="Rfm-O3-bKg"/>
+                    <constraint firstItem="bUR-Jz-NR4" firstAttribute="top" secondItem="TR3-UN-lJJ" secondAttribute="bottom" id="eq2-ZM-oob"/>
+                    <constraint firstItem="TR3-UN-lJJ" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="iKx-iy-9Pv"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="bUR-Jz-NR4" secondAttribute="bottom" id="otB-H4-WHa"/>
+                    <constraint firstItem="bUR-Jz-NR4" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="qGO-Ss-cSR"/>
+                    <constraint firstItem="c3u-QX-r6L" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="sPh-p8-KnE"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="bodyLabel" destination="TR3-UN-lJJ" id="LfI-dp-bKQ"/>
+                <outlet property="moreButton" destination="bUR-Jz-NR4" id="f9e-Ok-xIk"/>
+                <outlet property="titleLabel" destination="c3u-QX-r6L" id="Psv-j9-6XC"/>
+            </connections>
+            <point key="canvasLocation" x="-54.399999999999999" y="80.059970014992516"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		CE021535215BE3AB00C19555 /* LoginNavigationController+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE021534215BE3AB00C19555 /* LoginNavigationController+Woo.swift */; };
 		CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */; };
 		CE0F17D022A8105800964A63 /* ReadMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */; };
+		CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0F17D122A8308900964A63 /* FancyAlertController+PurchaseNote.swift */; };
 		CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14452D2188C11700A991D8 /* ZendeskManager.swift */; };
 		CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */; };
 		CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */; };
@@ -621,6 +622,7 @@
 		CE021534215BE3AB00C19555 /* LoginNavigationController+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginNavigationController+Woo.swift"; sourceTree = "<group>"; };
 		CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMoreTableViewCell.swift; sourceTree = "<group>"; };
 		CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReadMoreTableViewCell.xib; sourceTree = "<group>"; };
+		CE0F17D122A8308900964A63 /* FancyAlertController+PurchaseNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertController+PurchaseNote.swift"; sourceTree = "<group>"; };
 		CE14452D2188C11700A991D8 /* ZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskManager.swift; sourceTree = "<group>"; };
 		CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewController.swift; sourceTree = "<group>"; };
 		CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationConstants.swift; sourceTree = "<group>"; };
@@ -792,6 +794,7 @@
 			isa = PBXGroup;
 			children = (
 				743E271F21AEF20100D6DC82 /* FancyAlertViewController+Upgrade.swift */,
+				CE0F17D122A8308900964A63 /* FancyAlertController+PurchaseNote.swift */,
 			);
 			path = "Fancy Alerts";
 			sourceTree = "<group>";
@@ -1993,6 +1996,7 @@
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
+				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
 				CE263DE6206ACD220015A693 /* NotificationsViewController.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		B5FD111621D3F13700560344 /* BordersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FD111521D3F13700560344 /* BordersView.swift */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
 		CE021535215BE3AB00C19555 /* LoginNavigationController+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE021534215BE3AB00C19555 /* LoginNavigationController+Woo.swift */; };
+		CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */; };
+		CE0F17D022A8105800964A63 /* ReadMoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */; };
 		CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14452D2188C11700A991D8 /* ZendeskManager.swift */; };
 		CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */; };
 		CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */; };
@@ -617,6 +619,8 @@
 		B5FD111521D3F13700560344 /* BordersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BordersView.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE021534215BE3AB00C19555 /* LoginNavigationController+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginNavigationController+Woo.swift"; sourceTree = "<group>"; };
+		CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadMoreTableViewCell.swift; sourceTree = "<group>"; };
+		CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReadMoreTableViewCell.xib; sourceTree = "<group>"; };
 		CE14452D2188C11700A991D8 /* ZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskManager.swift; sourceTree = "<group>"; };
 		CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewController.swift; sourceTree = "<group>"; };
 		CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationConstants.swift; sourceTree = "<group>"; };
@@ -1495,6 +1499,8 @@
 				CE1EC8EB20B8A3FF009762BF /* LeftImageTableViewCell.xib */,
 				B5BE75DA213F1D1E00909A14 /* OverlayMessageView.swift */,
 				B5BE75DC213F1D3D00909A14 /* OverlayMessageView.xib */,
+				CE0F17CD22A8105800964A63 /* ReadMoreTableViewCell.swift */,
+				CE0F17CE22A8105800964A63 /* ReadMoreTableViewCell.xib */,
 				744F00D121B582A9007EFA93 /* StarRatingView.swift */,
 				D85B8331222FABD1002168F3 /* StatusListTableViewCell.swift */,
 				D85B8332222FABD1002168F3 /* StatusListTableViewCell.xib */,
@@ -1713,6 +1719,7 @@
 				CE583A0C2107937F00D73C1C /* TextViewTableViewCell.xib in Resources */,
 				D843D5CC22437E59001BFA55 /* TitleAndEditableValueTableViewCell.xib in Resources */,
 				B560D68A2195BD100027BB7E /* NoteDetailsCommentTableViewCell.xib in Resources */,
+				CE0F17D022A8105800964A63 /* ReadMoreTableViewCell.xib in Resources */,
 				CE1D5A5A228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib in Resources */,
 				B5A8F8AF20B88DCC00D211DE /* LoginPrologueViewController.xib in Resources */,
 				74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */,
@@ -2144,6 +2151,7 @@
 				B57B678E21078C5400AF8905 /* OrderItemViewModel.swift in Sources */,
 				D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,
+				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				B5D1AFBA20BC515600DB0E8C /* UIColor+Woo.swift in Sources */,
 				CEEC9B5E21E79C330055EEF0 /* BuildConfiguration.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,


### PR DESCRIPTION
Closes #858.

This PR adds the Purchase note to Purchase Details if it exists. Previous PR #1009 contains screenshots for shipping detail and download cells.

A short purchase note
![short-purchase-note](https://user-images.githubusercontent.com/1062444/58977909-4ee23a00-8790-11e9-973a-771aec4d5f75.gif)

A long purchase note
![long-purchase-note](https://user-images.githubusercontent.com/1062444/58977939-65889100-8790-11e9-8b9f-cb5bb6b73e58.gif)


### To test
- Check out and build this branch
- Go to your testing store's website
- Navigate to a product and add a product note (it's in the "Advanced" tab on the left)
- Update the product
- Create an order with that product
- Go back to the app and navigate to the product details view: Orders > Order Number > Fulfill order > Product list 
- Select product in the list
- Scroll to the bottom to see the purchase details information
- Select the "read more" button
- a fancy alert with the full text should appear, with a "dismiss" button at the bottom of the alert

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
