### PR TITLE
Product Details: bug fix for product image

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -293,10 +293,6 @@ extension ProductDetailsViewModel {
         if productHasImage {
             cell.heightConstraint.constant = Metrics.productImageHeight
             mainImageView.downloadImage(from: imageURL, placeholderImage: UIImage.productPlaceholderImage)
-        } else {
-            cell.heightConstraint.constant = Metrics.emptyProductImageHeight
-            let size = CGSize(width: cell.frame.width, height: Metrics.emptyProductImageHeight)
-            mainImageView.image = StyleManager.wooWhite.image(size)
         }
 
         if product.productStatus != .publish {
@@ -595,7 +591,11 @@ extension ProductDetailsViewModel {
 
     /// Large photo section.
     ///
-    func configurePhoto() -> Section {
+    func configurePhoto() -> Section? {
+        if !productHasImage && product.productStatus == .publish {
+            return nil
+        }
+
         return Section(row: .productPhoto)
     }
 


### PR DESCRIPTION
Fixes #1017.

Bug fix screenshot:
<img src="https://user-images.githubusercontent.com/1062444/59044370-a55c8080-8843-11e9-8f6a-f3932da636a3.png" width="350" />

## To test
1. Check out this PR
2. On your test site, find a product that doesn't have an image and the status is "Published"
3. On your test site, order the product
4. On the app, navigate to the product by going to Orders > Order number > select the product in the details view.
5. The Product Details view should have no space between the navigation bar and the product Title cell.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
