### PR TITLE
Order details: Center “Show billing” and icon horizontally

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Views/ShowHideSectionFooter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Views/ShowHideSectionFooter.swift
@@ -3,7 +3,7 @@ import Gridicons
 
 // MARK: - ShowHideFooterCell
 //
-class ShowHideSectionFooter: UITableViewHeaderFooterView {
+final class ShowHideSectionFooter: UITableViewHeaderFooterView {
     @IBOutlet private weak var footerLabel: UILabel!
     @IBOutlet private weak var footerArrow: UIImageView!
     @IBOutlet private weak var footerButton: UIButton!

--- a/WooCommerce/Classes/ViewRelated/Orders/Views/ShowHideSectionFooter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Views/ShowHideSectionFooter.swift
@@ -15,8 +15,16 @@ class ShowHideSectionFooter: UITableViewHeaderFooterView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        styleLabel()
+        styleArrow()
+    }
+
+    private func styleLabel() {
         footerLabel.applyFootnoteStyle()
         footerLabel.textColor = StyleManager.sectionTitleColor
+    }
+
+    private func styleArrow() {
         footerArrow.tintColor = StyleManager.wooCommerceBrandColor
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Views/ShowHideSectionFooter.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Views/ShowHideSectionFooter.xib
@@ -19,20 +19,25 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ymV-Hu-zNF">
-                        <rect key="frame" x="176.5" y="10" width="20" height="20"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="20" id="3cv-Lf-djt"/>
-                            <constraint firstAttribute="height" constant="20" id="OpJ-Sz-1j6"/>
-                            <constraint firstAttribute="width" secondItem="ymV-Hu-zNF" secondAttribute="height" multiplier="1:1" id="WTD-DS-vw2"/>
-                        </constraints>
-                    </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iz3-cy-XKS">
-                        <rect key="frame" x="143.5" y="12" width="33" height="16"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aHP-sc-Yci">
+                        <rect key="frame" x="133.5" y="10" width="53" height="20"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iz3-cy-XKS">
+                                <rect key="frame" x="0.0" y="0.0" width="33" height="20"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ymV-Hu-zNF">
+                                <rect key="frame" x="33" y="0.0" width="20" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="20" id="3cv-Lf-djt"/>
+                                    <constraint firstAttribute="height" constant="20" id="OpJ-Sz-1j6"/>
+                                    <constraint firstAttribute="width" secondItem="ymV-Hu-zNF" secondAttribute="height" multiplier="1:1" id="WTD-DS-vw2"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                    </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B8O-JO-04S" userLabel="invisible button">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
                         <connections>
@@ -41,16 +46,16 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Iz3-cy-XKS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="0Tg-q3-4RV"/>
-                    <constraint firstItem="ymV-Hu-zNF" firstAttribute="leading" secondItem="Iz3-cy-XKS" secondAttribute="trailing" id="8vH-Gk-i8I"/>
                     <constraint firstItem="B8O-JO-04S" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Axh-5T-w7h"/>
                     <constraint firstAttribute="trailing" secondItem="B8O-JO-04S" secondAttribute="trailing" id="MZn-Th-qRi"/>
-                    <constraint firstItem="Iz3-cy-XKS" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="SKm-yU-3SV"/>
                     <constraint firstAttribute="bottom" secondItem="B8O-JO-04S" secondAttribute="bottom" id="hHd-q4-7fz"/>
                     <constraint firstItem="B8O-JO-04S" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="vJW-kO-VMn"/>
-                    <constraint firstItem="ymV-Hu-zNF" firstAttribute="centerY" secondItem="Iz3-cy-XKS" secondAttribute="centerY" id="yMo-eU-Wa1"/>
                 </constraints>
             </tableViewCellContentView>
+            <constraints>
+                <constraint firstItem="aHP-sc-Yci" firstAttribute="centerX" secondItem="njF-e1-oar" secondAttribute="centerX" id="DFE-dD-7kx"/>
+                <constraint firstItem="aHP-sc-Yci" firstAttribute="centerY" secondItem="njF-e1-oar" secondAttribute="centerY" id="jg9-Uk-lrn"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="footerArrow" destination="ymV-Hu-zNF" id="7hZ-gc-IGh"/>


### PR DESCRIPTION
Fixes #989 

Center the "Show Billing" button in the Order Details screen to the text + icon, instead of to the text only

Before and after
<img src="https://user-images.githubusercontent.com/2722505/59241963-51370f00-8c3c-11e9-9a7d-a6bd6ebe5d7e.jpg" width="350"/>

## Note:
I have noticed that expanding and collapsing the billing section triggers an autolayout error in the section headers, independently of the changes in this pull request. I have logged an issue for it: #1021 

## Changes
- In `ShowHideSectionFooter`, embed the label and icon  in a stack view
- Make the class final and extract a couple of methods (completely unnecessary, but 🤷‍♂ )

## Testing
- Checkout the branch
- Navigate to an Order Details screen
- Notice the placement of the "Show billing" button
Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.