### PR TITLE
Settings: Update the store switcher presentation to be a modal overlay

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -70,7 +70,7 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
 private extension StorePickerCoordinator {
 
     func showStorePicker() {
-        if selectedConfiguration == .standard  {
+        if selectedConfiguration == .standard {
             navigationController.present(storePicker, animated: true)
         } else if selectedConfiguration == .switchingStores {
             let wrapper = UINavigationController(rootViewController: storePicker)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -70,8 +70,11 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
 private extension StorePickerCoordinator {
 
     func showStorePicker() {
-        if selectedConfiguration == .standard {
+        if selectedConfiguration == .standard  {
             navigationController.present(storePicker, animated: true)
+        } else if selectedConfiguration == .switchingStores {
+            let wrapper = UINavigationController(rootViewController: storePicker)
+            navigationController.present(wrapper, animated: true)
         } else {
             navigationController.pushViewController(storePicker, animated: true)
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -209,13 +209,11 @@ private extension StorePickerViewController {
 
     func setupNavigation() {
         title = NSLocalizedString("Select Store", comment: "Page title for the select a different store screen")
-        // Don't show the previous VC's title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        let dismissLiteral = NSLocalizedString("Dismiss", comment: "Dismiss button in store picker")
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: dismissLiteral,
+                                                           style: .plain,
+                                                           target: self,
+                                                           action: #selector(cleanupAndDismiss))
     }
 
     func setupViewForCurrentConfiguration() {
@@ -318,14 +316,15 @@ private extension StorePickerViewController {
 
     /// Dismiss this VC
     ///
-    func cleanupAndDismiss() {
+    @objc func cleanupAndDismiss() {
         if let siteID = currentlySelectedSite?.siteID {
             delegate?.didSelectStore(with: siteID)
         }
 
         switch configuration {
         case .switchingStores:
-            navigationController?.popViewController(animated: true)
+            //navigationController?.popViewController(animated: true)
+            dismiss(animated: true)
         default:
             dismiss(animated: true)
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -323,7 +323,6 @@ private extension StorePickerViewController {
 
         switch configuration {
         case .switchingStores:
-            //navigationController?.popViewController(animated: true)
             dismiss(animated: true)
         default:
             dismiss(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -179,7 +179,6 @@ private extension SettingsViewController {
     }
 
     func configureSwitchStore(cell: BasicTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString(
             "Switch Store",


### PR DESCRIPTION
Fixes #767 

Present the store switcher modally when initiated from the app settings.

<img src="https://user-images.githubusercontent.com/2722505/59246167-1b9b2180-8c4e-11e9-87ee-7c4b8937da6b.gif" width="350"/>

## Changes
- Modify StorePickerCoordinator to present modally instead of pushing into a navigation controller for the `.switchingStores` configuration
- Remove the disclose indicator from the cell in Settings

## Testing
- Switch stores. Check that the store switcher can be dismissed and that it actually works
- Check other instances of the store switcher to make sure that nothing else is broken.

Note: I did not add any release notes as this seemed like something not worth mentioning, but I'll be happy to add a line if we think it's worth it.