### PR TITLE
Gridicons: All gridicons should be stored in the `UIImage+Woo` extension

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
@@ -86,6 +86,6 @@ class StoreTableViewCell: UITableViewCell {
     /// Displays a Checkmark (or not) based on the `displaysCheckmark` property.
     ///
     private func refreshCheckmarkImage() {
-        checkmarkImageView.image = displaysCheckmark ? .checkmarkImage : nil
+        checkmarkImageView.image = displaysCheckmark ? .checkmarkStyledImage : nil
     }
 }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -136,6 +136,12 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Filter icon
+    ///
+    static var filterImage: UIImage {
+        return Gridicon.iconOfType(.filter)
+    }
+
     /// Search icon
     ///
     static var searchImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -201,9 +201,16 @@ extension UIImage {
     }
 
     /// Stats Alt icon
+    ///
     static var statsAltImage: UIImage {
         return Gridicon.iconOfType(.statsAlt)
         .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Trash can icon
+    ///
+    static var trashImage: UIImage {
+        return Gridicon.iconOfType(.trash)
     }
 
     /// Creates a bitmap image of the Woo "bubble" logo based on a vector image in our asset catalog.

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -205,6 +205,20 @@ extension UIImage {
             .imageWithTintColor(tintColor)!
     }
 
+    /// Returns a star outline icon with the given size and color
+    ///
+    /// - Parameters:
+    ///   - size: desired size of the resulting star icon
+    ///   - tintColor: desired tint color of the resulting icon
+    /// - Returns: a bitmap image
+    ///
+    static func starOutlineImage(size: Double, tintColor: UIColor) -> UIImage {
+        let starSize = CGSize(width: size, height: size)
+        return Gridicon.iconOfType(.starOutline,
+                                   withSize: starSize)
+            .imageWithTintColor(tintColor)!
+    }
+
     /// Stats Icon
     ///
     static var statsImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -7,6 +7,11 @@ import Gridicons
 ///
 extension UIImage {
 
+    static var asideImage: UIImage {
+        return Gridicon.iconOfType(.aside)
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// WooCommerce Styled Checkmark
     ///
     static var checkmarkImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -20,6 +20,12 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Bell Icon
+    ///
+    static var bellImage: UIImage {
+        return Gridicon.iconOfType(.bell)
+    }
+
     /// Camera Icon
     ///
     static var cameraImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -46,32 +46,32 @@ extension UIImage {
         return checkmarkImage.imageWithTintColor(tintColor)!
     }
 
-    /// Chevron pointing right
+    /// Chevron Pointing Right
     ///
     static var chevronImage: UIImage {
         let tintColor = StyleManager.wooGreyMid
         return Gridicon.iconOfType(.chevronRight).imageWithTintColor(tintColor)!
     }
 
-    /// Chevron pointing down
+    /// Chevron Pointing Down
     ///
     static var chevronDownImage: UIImage {
         return Gridicon.iconOfType(.chevronDown)
     }
 
-    /// Chevron pointing up
+    /// Chevron Pointing Up
     ///
     static var chevronUpImage: UIImage {
         return Gridicon.iconOfType(.chevronUp)
     }
 
-    /// Cog image
+    /// Cog Icon
     ///
     static var cogImage: UIImage {
         return Gridicon.iconOfType(.cog)
     }
 
-    /// Delete icon
+    /// Delete Icon
     ///
     static var deleteImage: UIImage {
         let tintColor = StyleManager.wooCommerceBrandColor
@@ -80,7 +80,7 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Ellipsis icon
+    /// Ellipsis Icon
     ///
     static var ellipsisImage: UIImage {
         return Gridicon.iconOfType(.ellipsis)
@@ -93,14 +93,14 @@ extension UIImage {
         return UIImage(named: "woo-error-state")!
     }
 
-    /// External link Icon
+    /// External Link Icon
     ///
     static var externalImage: UIImage {
         return Gridicon.iconOfType(.external)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Filter icon
+    /// Filter Icon
     ///
     static var filterImage: UIImage {
         return Gridicon.iconOfType(.filter)
@@ -112,7 +112,7 @@ extension UIImage {
         return UIImage(named: "gravatar")!
     }
 
-    /// Heart outline
+    /// Heart Outline
     ///
     static var heartOutlineImage: UIImage {
         return Gridicon.iconOfType(.heartOutline)
@@ -124,19 +124,19 @@ extension UIImage {
         return UIImage(named: "icon-jetpack-gray")!
     }
 
-    /// Invisible image
+    /// Invisible Image
     ///
     static var invisibleImage: UIImage {
         return Gridicon.iconOfType(.image)
     }
 
-    /// Mail icon
+    /// Mail Icon
     ///
     static var mailImage: UIImage {
         return Gridicon.iconOfType(.mail)
     }
 
-    /// More icon
+    /// More Icon
     ///
     static var moreImage: UIImage {
         let tintColor = StyleManager.wooCommerceBrandColor
@@ -171,21 +171,21 @@ extension UIImage {
         return Gridicon.iconOfType(.quote)
     }
 
-    /// Pages icon
+    /// Pages Icon
     ///
     static var pagesImage: UIImage {
         return Gridicon.iconOfType(.pages)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Search icon
+    /// Search Icon
     ///
     static var searchImage: UIImage {
         return Gridicon.iconOfType(.search)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Spam icon
+    /// Spam Icon
     ///
     static var spamImage: UIImage {
         return Gridicon.iconOfType(.spam)
@@ -205,21 +205,21 @@ extension UIImage {
             .imageWithTintColor(tintColor)!
     }
 
-    /// Stats icon
+    /// Stats Icon
     ///
     static var statsImage: UIImage {
         return Gridicon.iconOfType(.stats)
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Stats Alt icon
+    /// Stats Alt Icon
     ///
     static var statsAltImage: UIImage {
         return Gridicon.iconOfType(.statsAlt)
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Trash can icon
+    /// Trash Can Icon
     ///
     static var trashImage: UIImage {
         return Gridicon.iconOfType(.trash)

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -7,10 +7,23 @@ import Gridicons
 ///
 extension UIImage {
 
+    /// Add Icon
+    ///
+    static var addOutlineImage: UIImage {
+        return Gridicon.iconOfType(.addOutline)
+    }
+
     /// Aside Image
     ///
     static var asideImage: UIImage {
         return Gridicon.iconOfType(.aside)
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Camera Icon
+    ///
+    static var cameraImage: UIImage {
+        return Gridicon.iconOfType(.camera)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
@@ -40,32 +53,10 @@ extension UIImage {
         return Gridicon.iconOfType(.chevronUp)
     }
 
-    /// Product Placeholder Image
+    /// Cog image
     ///
-    static var productPlaceholderImage: UIImage {
-        let tintColor = StyleManager.wooGreyLight
-        return Gridicon.iconOfType(.product).imageWithTintColor(tintColor)!
-    }
-
-    /// Product Image
-    ///
-    static var productImage: UIImage {
-        return Gridicon.iconOfType(.product)
-    }
-
-    /// Gravatar Placeholder Image
-    ///
-    static var gravatarPlaceholderImage: UIImage {
-        return UIImage(named: "gravatar")!
-    }
-
-    /// Pencil Icon
-    ///
-    static var pencilImage: UIImage {
-        let tintColor = StyleManager.wooCommerceBrandColor
-        return Gridicon.iconOfType(.pencil)
-            .imageWithTintColor(tintColor)!
-            .imageFlippedForRightToLeftLayoutDirection()
+    static var cogImage: UIImage {
+        return Gridicon.iconOfType(.cog)
     }
 
     /// Delete icon
@@ -84,66 +75,10 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// More icon
-    ///
-    static var moreImage: UIImage {
-        let tintColor = StyleManager.wooCommerceBrandColor
-        return ellipsisImage.imageWithTintColor(tintColor)!
-    }
-
-    /// Jetpack Logo Image
-    ///
-    static var jetpackLogoImage: UIImage {
-        return UIImage(named: "icon-jetpack-gray")!
-    }
-
-    /// Creates a bitmap image of the Woo "bubble" logo based on a vector image in our asset catalog.
-    ///
-    /// - Parameters:
-    ///   - size: desired size of the resulting bitmap image
-    ///   - tintColor: desired tint color of the resulting bitmap image
-    /// - Returns: a bitmap image
-    ///
-    static func wooLogoImage(withSize size: CGSize = Metrics.defaultWooLogoSize, tintColor: UIColor = .white) -> UIImage? {
-        let rect = CGRect(origin: .zero, size: size)
-        let vectorImage = UIImage(named: "woo-logo")!
-        let renderer = UIGraphicsImageRenderer(size: size)
-        let im2 = renderer.image { ctx in
-            vectorImage.draw(in: rect)
-        }
-
-        return im2.imageWithTintColor(tintColor)
-    }
-
     /// Error State Image
     ///
     static var errorStateImage: UIImage {
         return UIImage(named: "woo-error-state")!
-    }
-
-    /// Waiting for Customers Image
-    ///
-    static var waitingForCustomersImage: UIImage {
-        return UIImage(named: "woo-waiting-customers")!
-    }
-
-    /// Quote Image
-    ///
-    static var quoteImage: UIImage {
-        return Gridicon.iconOfType(.quote)
-    }
-
-    /// Add Icon
-    ///
-    static var addOutlineImage: UIImage {
-        return Gridicon.iconOfType(.addOutline)
-    }
-
-    /// Camera Icon
-    ///
-    static var cameraImage: UIImage {
-        return Gridicon.iconOfType(.camera)
-            .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// External link Icon
@@ -159,10 +94,69 @@ extension UIImage {
         return Gridicon.iconOfType(.filter)
     }
 
+    /// Gravatar Placeholder Image
+    ///
+    static var gravatarPlaceholderImage: UIImage {
+        return UIImage(named: "gravatar")!
+    }
+
+    /// Heart outline
+    ///
+    static var heartOutlineImage: UIImage {
+        return Gridicon.iconOfType(.heartOutline)
+    }
+
+    /// Jetpack Logo Image
+    ///
+    static var jetpackLogoImage: UIImage {
+        return UIImage(named: "icon-jetpack-gray")!
+    }
+
+    /// Invisible image
+    ///
+    static var invisibleImage: UIImage {
+        return Gridicon.iconOfType(.image)
+    }
+
     /// Mail icon
     ///
     static var mailImage: UIImage {
         return Gridicon.iconOfType(.mail)
+    }
+
+    /// More icon
+    ///
+    static var moreImage: UIImage {
+        let tintColor = StyleManager.wooCommerceBrandColor
+        return ellipsisImage.imageWithTintColor(tintColor)!
+    }
+
+    /// Product Placeholder Image
+    ///
+    static var productPlaceholderImage: UIImage {
+        let tintColor = StyleManager.wooGreyLight
+        return Gridicon.iconOfType(.product).imageWithTintColor(tintColor)!
+    }
+
+    /// Product Image
+    ///
+    static var productImage: UIImage {
+        return Gridicon.iconOfType(.product)
+    }
+
+    /// Pencil Icon
+    ///
+    static var pencilImage: UIImage {
+        let tintColor = StyleManager.wooCommerceBrandColor
+        return Gridicon.iconOfType(.pencil)
+            .imageWithTintColor(tintColor)!
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Quote Image
+    ///
+    static var quoteImage: UIImage {
+        return Gridicon.iconOfType(.quote)
     }
 
     /// Pages icon
@@ -192,20 +186,28 @@ extension UIImage {
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    static var cogImage: UIImage {
-        return Gridicon.iconOfType(.cog)
+    /// Creates a bitmap image of the Woo "bubble" logo based on a vector image in our asset catalog.
+    ///
+    /// - Parameters:
+    ///   - size: desired size of the resulting bitmap image
+    ///   - tintColor: desired tint color of the resulting bitmap image
+    /// - Returns: a bitmap image
+    ///
+    static func wooLogoImage(withSize size: CGSize = Metrics.defaultWooLogoSize, tintColor: UIColor = .white) -> UIImage? {
+        let rect = CGRect(origin: .zero, size: size)
+        let vectorImage = UIImage(named: "woo-logo")!
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let im2 = renderer.image { ctx in
+            vectorImage.draw(in: rect)
+        }
+
+        return im2.imageWithTintColor(tintColor)
     }
 
-    /// Invisible image
+    /// Waiting for Customers Image
     ///
-    static var invisibleImage: UIImage {
-        return Gridicon.iconOfType(.image)
-    }
-
-    /// Heart outline
-    ///
-    static var heartOutlineImage: UIImage {
-        return Gridicon.iconOfType(.heartOutline)
+    static var waitingForCustomersImage: UIImage {
+        return UIImage(named: "woo-waiting-customers")!
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -136,6 +136,12 @@ extension UIImage {
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Stats Alt icon
+    static var statsAltImage: UIImage {
+        return Gridicon.iconOfType(.statsAlt)
+        .imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// Invisible image
     ///
     static var invisibleImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -135,6 +135,12 @@ extension UIImage {
         return Gridicon.iconOfType(.stats)
         .imageFlippedForRightToLeftLayoutDirection()
     }
+
+    /// Invisible image
+    ///
+    static var invisibleImage: UIImage {
+        return Gridicon.iconOfType(.image)
+    }
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -115,6 +115,12 @@ extension UIImage {
         return Gridicon.iconOfType(.camera)
             .imageFlippedForRightToLeftLayoutDirection()
     }
+
+    /// External link Icon
+    static var external: UIImage {
+        return Gridicon.iconOfType(.external)
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -173,6 +173,12 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Spam icon
+    ///
+    static var spamImage: UIImage {
+        return Gridicon.iconOfType(.spam)
+    }
+
     /// Returns a star icon with the given size and color
     ///
     /// - Parameters:

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -142,6 +142,13 @@ extension UIImage {
         return Gridicon.iconOfType(.filter)
     }
 
+    /// Pages icon
+    ///
+    static var pagesImage: UIImage {
+        return Gridicon.iconOfType(.pages)
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// Search icon
     ///
     static var searchImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -142,6 +142,12 @@ extension UIImage {
         return Gridicon.iconOfType(.filter)
     }
 
+    /// Mail icon
+    ///
+    static var mailImage: UIImage {
+        return Gridicon.iconOfType(.mail)
+    }
+
     /// Pages icon
     ///
     static var pagesImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -141,6 +141,12 @@ extension UIImage {
     static var invisibleImage: UIImage {
         return Gridicon.iconOfType(.image)
     }
+
+    /// Heart outline
+    ///
+    static var heartOutlineImage: UIImage {
+        return Gridicon.iconOfType(.heartOutline)
+    }
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -7,6 +7,8 @@ import Gridicons
 ///
 extension UIImage {
 
+    /// Aside Image
+    ///
     static var asideImage: UIImage {
         return Gridicon.iconOfType(.aside)
             .imageFlippedForRightToLeftLayoutDirection()
@@ -131,6 +133,13 @@ extension UIImage {
     ///
     static var externalImage: UIImage {
         return Gridicon.iconOfType(.external)
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Search icon
+    ///
+    static var searchImage: UIImage {
+        return Gridicon.iconOfType(.search)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -142,6 +142,10 @@ extension UIImage {
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    static var cogImage: UIImage {
+        return Gridicon.iconOfType(.cog)
+    }
+
     /// Invisible image
     ///
     static var invisibleImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -28,6 +28,18 @@ extension UIImage {
         return Gridicon.iconOfType(.chevronRight).imageWithTintColor(tintColor)!
     }
 
+    /// Chevron pointing down
+    ///
+    static var chevronDownImage: UIImage {
+        return Gridicon.iconOfType(.chevronDown)
+    }
+
+    /// Chevron pointing up
+    ///
+    static var chevronUpImage: UIImage {
+        return Gridicon.iconOfType(.chevronUp)
+    }
+
     /// Product Placeholder Image
     ///
     static var productPlaceholderImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -117,7 +117,7 @@ extension UIImage {
     }
 
     /// External link Icon
-    static var external: UIImage {
+    static var externalImage: UIImage {
         return Gridicon.iconOfType(.external)
             .imageFlippedForRightToLeftLayoutDirection()
     }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -123,9 +123,17 @@ extension UIImage {
     }
 
     /// External link Icon
+    ///
     static var externalImage: UIImage {
         return Gridicon.iconOfType(.external)
             .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Stats icon
+    ///
+    static var statsImage: UIImage {
+        return Gridicon.iconOfType(.stats)
+        .imageFlippedForRightToLeftLayoutDirection()
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -28,6 +28,12 @@ extension UIImage {
         return Gridicon.iconOfType(.product).imageWithTintColor(tintColor)!
     }
 
+    /// Product Image
+    ///
+    static var productImage: UIImage {
+        return Gridicon.iconOfType(.product)
+    }
+
     /// Gravatar Placeholder Image
     ///
     static var gravatarPlaceholderImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -65,13 +65,18 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Ellipsis icon
+    ///
+    static var ellipsisImage: UIImage {
+        return Gridicon.iconOfType(.ellipsis)
+            .imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// More icon
     ///
     static var moreImage: UIImage {
         let tintColor = StyleManager.wooCommerceBrandColor
-        return Gridicon.iconOfType(.ellipsis)
-            .imageWithTintColor(tintColor)!
-            .imageFlippedForRightToLeftLayoutDirection()
+        return ellipsisImage.imageWithTintColor(tintColor)!
     }
 
     /// Jetpack Logo Image

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -173,6 +173,20 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Returns a star icon with the given size and color
+    ///
+    /// - Parameters:
+    ///   - size: desired size of the resulting star icon
+    ///   - tintColor: desired tint color of the resulting icon
+    /// - Returns: a bitmap image
+    ///
+    static func starImage(size: Double, tintColor: UIColor) -> UIImage {
+        let starSize = CGSize(width: size, height: size)
+        return Gridicon.iconOfType(.star,
+                                   withSize: starSize)
+            .imageWithTintColor(tintColor)!
+    }
+
     /// Stats icon
     ///
     static var statsImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -27,11 +27,17 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Checkmark image, no style applied
+    ///
+    static var checkmarkImage: UIImage {
+        return Gridicon.iconOfType(.checkmark)
+    }
+
     /// WooCommerce Styled Checkmark
     ///
     static var checkmarkStyledImage: UIImage {
         let tintColor = StyleManager.wooCommerceBrandColor
-        return Gridicon.iconOfType(.checkmark).imageWithTintColor(tintColor)!
+        return checkmarkImage.imageWithTintColor(tintColor)!
     }
 
     /// Chevron pointing right

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -29,7 +29,7 @@ extension UIImage {
 
     /// WooCommerce Styled Checkmark
     ///
-    static var checkmarkImage: UIImage {
+    static var checkmarkStyledImage: UIImage {
         let tintColor = StyleManager.wooCommerceBrandColor
         return Gridicon.iconOfType(.checkmark).imageWithTintColor(tintColor)!
     }

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel.swift
@@ -138,7 +138,7 @@ class OrderDetailsViewModel {
     /// Order Notes Button
     /// - icon and text
     ///
-    let addNoteIcon = Gridicon.iconOfType(.addOutline)
+    let addNoteIcon = UIImage.addOutlineImage
 
     let addNoteText = NSLocalizedString("Add a note", comment: "Button text for adding a new order note")
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -344,7 +344,7 @@ extension ProductDetailsViewModel {
     func configurePermalink(_ cell: WooBasicTableViewCell) {
         cell.bodyLabel?.text = NSLocalizedString("View product on store",
                                                  comment: "The descriptive label. Tapping the row will open the product's page in a web view.")
-        cell.accessoryImage = Gridicon.iconOfType(.external)
+        cell.accessoryImage = .external
     }
 
     /// Affiliate (External) link cell.
@@ -352,7 +352,7 @@ extension ProductDetailsViewModel {
     func configureAffiliateLink(_ cell: WooBasicTableViewCell) {
         cell.bodyLabel?.text = NSLocalizedString("View affiliate product",
                                                  comment: "The descriptive label. Tapping the row will open the affliate product's link in a web view.")
-        cell.accessoryImage = Gridicon.iconOfType(.external)
+        cell.accessoryImage = .external
     }
 
     /// Price cell.

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -344,7 +344,7 @@ extension ProductDetailsViewModel {
     func configurePermalink(_ cell: WooBasicTableViewCell) {
         cell.bodyLabel?.text = NSLocalizedString("View product on store",
                                                  comment: "The descriptive label. Tapping the row will open the product's page in a web view.")
-        cell.accessoryImage = .external
+        cell.accessoryImage = .externalImage
     }
 
     /// Affiliate (External) link cell.
@@ -352,7 +352,7 @@ extension ProductDetailsViewModel {
     func configureAffiliateLink(_ cell: WooBasicTableViewCell) {
         cell.bodyLabel?.text = NSLocalizedString("View affiliate product",
                                                  comment: "The descriptive label. Tapping the row will open the affliate product's link in a web view.")
-        cell.accessoryImage = .external
+        cell.accessoryImage = .externalImage
     }
 
     /// Price cell.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -33,7 +33,7 @@ class DashboardViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         startListeningToNotifications()
-        tabBarItem.image = Gridicon.iconOfType(.statsAlt)
+        tabBarItem.image = .statsAltImage
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -105,7 +105,7 @@ private extension DashboardViewController {
     }
 
     private func configureNavigationItem() {
-        let rightBarButton = UIBarButtonItem(image: Gridicon.iconOfType(.cog),
+        let rightBarButton = UIBarButtonItem(image: .cogImage,
                                              style: .plain,
                                              target: self,
                                              action: #selector(settingsTapped))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -113,7 +113,7 @@ private extension PrivacySettingsViewController {
 
     func configureCollectInfo(cell: SwitchTableViewCell) {
         // image
-        cell.imageView?.image = Gridicon.iconOfType(.stats)
+        cell.imageView?.image = .statsImage
         cell.imageView?.tintColor = StyleManager.defaultTextColor
 
         // text

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -131,7 +131,7 @@ private extension PrivacySettingsViewController {
 
     func configureShareInfo(cell: TopLeftImageTableViewCell) {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
-        cell.imageView?.image = Gridicon.iconOfType(.image)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString(
             "Share information with our analytics tool about your use of services while logged in to your WordPress.com account.",
@@ -141,7 +141,7 @@ private extension PrivacySettingsViewController {
 
     func configureCookiePolicy(cell: BasicTableViewCell) {
         // To align the 'Learn more' cell to the others, add an "invisible" image.
-        cell.imageView?.image = Gridicon.iconOfType(.image)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString("Learn more", comment: "Settings > Privacy Settings. A text link to the cookie policy.")
         cell.textLabel?.textColor = StyleManager.wooCommerceBrandColor
@@ -149,7 +149,7 @@ private extension PrivacySettingsViewController {
 
     func configurePrivacyInfo(cell: TopLeftImageTableViewCell) {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
-        cell.imageView?.image = Gridicon.iconOfType(.image)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString(
             "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.",
@@ -159,7 +159,7 @@ private extension PrivacySettingsViewController {
 
     func configurePrivacyPolicy(cell: BasicTableViewCell) {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
-        cell.imageView?.image = Gridicon.iconOfType(.image)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString(
             "Read privacy policy",
@@ -170,7 +170,7 @@ private extension PrivacySettingsViewController {
 
     func configureCookieInfo(cell: TopLeftImageTableViewCell) {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
-        cell.imageView?.image = Gridicon.iconOfType(.image)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString(
             "We use other tracking tools, including some from third parties. Read about these and how to control them.",
@@ -180,7 +180,7 @@ private extension PrivacySettingsViewController {
 
     func configureReportCrashes(cell: SwitchTableViewCell) {
         // image
-        cell.imageView?.image = Gridicon.iconOfType(.bug)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = StyleManager.defaultTextColor
 
         // text
@@ -198,7 +198,7 @@ private extension PrivacySettingsViewController {
 
     func configureCrashInfo(cell: TopLeftImageTableViewCell) {
         // To align the 'Read privacy policy' cell to the others, add an "invisible" image.
-        cell.imageView?.image = Gridicon.iconOfType(.image)
+        cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString(
             "To help us improve the app’s performance and fix the occasional bug, enable automatic crash reports.",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -106,7 +106,7 @@ private extension SettingsViewController {
         //
         let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
-        footerView.iconImage = Gridicon.iconOfType(.heartOutline)
+        footerView.iconImage = .heartOutlineImage
         footerView.iconColor = StyleManager.wooGreyMid
         footerView.footnoteText = NSLocalizedString(
             "Made with love by Automattic",

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
@@ -295,6 +295,8 @@ private struct Approve {
 //
 private struct Star {
     static let size        = Double(18)
-    static let filledImage = Gridicon.iconOfType(.star, withSize: CGSize(width: Star.size, height: Star.size)).imageWithTintColor(StyleManager.goldStarColor)
-    static let emptyImage  = Gridicon.iconOfType(.star, withSize: CGSize(width: Star.size, height: Star.size)).imageWithTintColor(StyleManager.wooGreyLight)
+    static let filledImage = UIImage.starImage(size: Star.size,
+                                               tintColor: StyleManager.goldStarColor)
+    static let emptyImage = UIImage.starImage(size: Star.size,
+                                              tintColor: StyleManager.wooGreyLight)
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
@@ -176,8 +176,7 @@ private extension NoteDetailsCommentTableViewCell {
     /// Setup: Actions!
     ///
     func configureActionButtons() {
-        let spamImage = Gridicon.iconOfType(.spam)
-        spamButton.setImage(spamImage, for: .normal)
+        spamButton.setImage(.spamImage, for: .normal)
         spamButton.setTitle(Spam.normalTitle, for: .normal)
         spamButton.accessibilityLabel = Spam.normalLabel
         spamButton.accessibilityTraits = .button

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
@@ -181,8 +181,7 @@ private extension NoteDetailsCommentTableViewCell {
         spamButton.accessibilityLabel = Spam.normalLabel
         spamButton.accessibilityTraits = .button
 
-        let trashImage = Gridicon.iconOfType(.trash)
-        trashButton.setImage(trashImage, for: .normal)
+        trashButton.setImage(.trashImage, for: .normal)
         trashButton.setTitle(Trash.normalTitle, for: .normal)
         trashButton.accessibilityLabel = Trash.normalLabel
         trashButton.accessibilityTraits = .button

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
@@ -186,8 +186,7 @@ private extension NoteDetailsCommentTableViewCell {
         trashButton.accessibilityLabel = Trash.normalLabel
         trashButton.accessibilityTraits = .button
 
-        let checkmarkImage = Gridicon.iconOfType(.checkmark)
-        approvalButton.setImage(checkmarkImage, for: .normal)
+        approvalButton.setImage(.checkmarkImage, for: .normal)
         approvalButton.setTitle(Approve.normalTitle, for: .normal)
         approvalButton.setTitle(Approve.selectedTitle, for: .selected)
         approvalButton.accessibilityLabel = Approve.normalLabel

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.swift
@@ -140,11 +140,7 @@ private extension NoteTableViewCell {
 
     enum Star {
         static let size = Double(13)
-        static let filledImage = Gridicon.iconOfType(.star,
-                                                     withSize: CGSize(width: Star.size, height: Star.size)
-                                                    ).imageWithTintColor(StyleManager.defaultTextColor)
-        static let emptyImage = Gridicon.iconOfType(.star,
-                                                    withSize: CGSize(width: Star.size, height: Star.size)
-                                                    ).imageWithTintColor(.clear)
+        static let filledImage = UIImage.starImage(size: Star.size, tintColor: StyleManager.defaultTextColor)
+        static let emptyImage = UIImage.starImage(size: Star.size, tintColor: .clear)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -309,7 +309,7 @@ private extension NotificationDetailsViewController {
                 return
         }
 
-        headerCell.leftImage = Gridicon.iconOfType(.product)
+        headerCell.leftImage = .productImage
         headerCell.rightImage = .externalImage
         headerCell.plainText = title
     }

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -310,7 +310,7 @@ private extension NotificationDetailsViewController {
         }
 
         headerCell.leftImage = Gridicon.iconOfType(.product)
-        headerCell.rightImage = .external
+        headerCell.rightImage = .externalImage
         headerCell.plainText = title
     }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -310,7 +310,7 @@ private extension NotificationDetailsViewController {
         }
 
         headerCell.leftImage = Gridicon.iconOfType(.product)
-        headerCell.rightImage = Gridicon.iconOfType(.external)
+        headerCell.rightImage = .external
         headerCell.plainText = title
     }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -189,7 +189,7 @@ private extension NotificationsViewController {
     ///
     func configureTabBarItem() {
         tabBarItem.title = NSLocalizedString("Notifications", comment: "Title of the Notifications tab — plural form of Notification")
-        tabBarItem.image = Gridicon.iconOfType(.bell)
+        tabBarItem.image = .bellImage
     }
 
     /// Setup: Navigation

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -18,7 +18,7 @@ class NotificationsViewController: UIViewController {
     /// Mark all as read nav bar button
     ///
     private lazy var leftBarButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: Gridicon.iconOfType(.checkmark),
+        return UIBarButtonItem(image: .checkmarkImage,
                                style: .plain,
                                target: self,
                                action: #selector(markAllAsRead))

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -27,7 +27,7 @@ class NotificationsViewController: UIViewController {
     /// Filter nav bar button
     ///
     private lazy var rightBarButton: UIBarButtonItem = {
-        return UIBarButtonItem(image: Gridicon.iconOfType(.filter),
+        return UIBarButtonItem(image: .filterImage,
                                style: .plain,
                                target: self,
                                action: #selector(displayFiltersAlert))

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/CustomerNoteTableViewCell.swift
@@ -10,7 +10,7 @@ class CustomerNoteTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var iconImageView: UIImageView! {
         didSet {
-            iconImageView.image = Gridicon.iconOfType(.quote)
+            iconImageView.image = .quoteImage
             iconImageView.tintColor = .black
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
@@ -104,8 +104,7 @@ private extension OrderNoteTableViewCell {
     /// Setup: Icon Button
     ///
     func configureIconButton() {
-        let image = Gridicon.iconOfType(.aside)
-        iconButton.setImage(image, for: .normal)
+        iconButton.setImage(.asideImage, for: .normal)
         iconButton.layer.cornerRadius = iconButton.frame.width / 2
         iconButton.tintColor = .white
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
@@ -85,7 +85,7 @@ class ProductDetailsTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        productImageView.image = Gridicon.iconOfType(.product)
+        productImageView.image = .productImage
         productImageView.tintColor = StyleManager.wooGreyBorder
         selectionStyle = .none
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/Cells/PickListTableViewCell.swift
@@ -80,7 +80,7 @@ final class PickListTableViewCell: UITableViewCell {
     }
 
     func setupImageView() {
-        productImageView.image = Gridicon.iconOfType(.product)
+        productImageView.image = .productImage
         productImageView.tintColor = StyleManager.wooGreyBorder
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -127,7 +127,7 @@ private extension NewNoteViewController {
             fatalError()
         }
 
-        cell.iconImage = Gridicon.iconOfType(.aside)
+        cell.iconImage = .asideImage
         cell.iconTint = isCustomerNote ? StyleManager.statusPrimaryBoldColor : StyleManager.wooGreyMid
         cell.iconImage?.accessibilityLabel = isCustomerNote ?
             NSLocalizedString("Note to customer",

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -841,7 +841,7 @@ extension OrderDetailsViewController: UITableViewDataSource {
         }
 
         let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: ShowHideSectionFooter.reuseIdentifier) as! ShowHideSectionFooter
-        let image = displaysBillingDetails ? Gridicon.iconOfType(.chevronUp) : Gridicon.iconOfType(.chevronDown)
+        let image = displaysBillingDetails ? UIImage.chevronUpImage : UIImage.chevronDownImage
         cell.configure(text: footerText, image: image)
         cell.didSelectFooter = { [weak self] in
             guard let `self` = self else {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -448,7 +448,7 @@ private extension OrderDetailsViewController {
 
         cell.bodyLabel?.text = email
         cell.bodyLabel?.applyBodyStyle() // override the woo purple text
-        cell.accessoryImage = Gridicon.iconOfType(.mail)
+        cell.accessoryImage = .mailImage
 
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = .button

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -472,7 +472,7 @@ private extension OrderDetailsViewController {
 
         cell.bodyLabel?.text = phoneNumber
         cell.bodyLabel?.applyBodyStyle() // override the woo purple text
-        cell.accessoryImage = Gridicon.iconOfType(.ellipsis)
+        cell.accessoryImage = .ellipsisImage
 
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = .button

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -211,7 +211,7 @@ private extension OrdersViewController {
     ///
     func configureNavigation() {
         navigationItem.leftBarButtonItem = {
-            let button = UIBarButtonItem(image: Gridicon.iconOfType(.search),
+            let button = UIBarButtonItem(image: .searchImage,
                                          style: .plain,
                                          target: self,
                                          action: #selector(displaySearchOrders))

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -267,7 +267,7 @@ private extension OrdersViewController {
     ///
     func configureTabBarItem() {
         tabBarItem.title = NSLocalizedString("Orders", comment: "Title of the Orders tab — plural form of Order")
-        tabBarItem.image = Gridicon.iconOfType(.pages)
+        tabBarItem.image = .pagesImage
     }
 
     /// Setup: TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -227,7 +227,7 @@ private extension OrdersViewController {
         }()
 
         navigationItem.rightBarButtonItem = {
-            let button = UIBarButtonItem(image: Gridicon.iconOfType(.filter),
+            let button = UIBarButtonItem(image: .filterImage,
                                                  style: .plain,
                                                  target: self,
                                                  action: #selector(displayFiltersAlert))

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -44,12 +44,10 @@ final class ProductReviewsTableViewCell: UITableViewCell {
 //
 private extension ProductReviewsTableViewCell {
     enum Star {
-        static let size = CGSize(width: 20, height: 20)
-        static let filledImage = Gridicon.iconOfType(.star,
-                                                     withSize: Star.size
-            ).imageWithTintColor(StyleManager.grayStarColor)
-        static let emptyImage = Gridicon.iconOfType(.starOutline,
-                                                    withSize: Star.size
-            ).imageWithTintColor(StyleManager.grayStarColor)
+        static let size = Double(20)
+        static let filledImage = UIImage.starImage(size: Star.size,
+                                                   tintColor: StyleManager.grayStarColor)
+        static let emptyImage = UIImage.starImage(size: Star.size,
+                                                  tintColor: StyleManager.grayStarColor)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -47,7 +47,7 @@ private extension ProductReviewsTableViewCell {
         static let size = Double(20)
         static let filledImage = UIImage.starImage(size: Star.size,
                                                    tintColor: StyleManager.grayStarColor)
-        static let emptyImage = UIImage.starImage(size: Star.size,
-                                                  tintColor: StyleManager.grayStarColor)
+        static let emptyImage = UIImage.starOutlineImage(size: Star.size,
+                                                         tintColor: StyleManager.grayStarColor)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
+		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -736,6 +737,7 @@
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
+		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -893,6 +895,7 @@
 		B53A569521123D27000776C9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				D8F82AC422AF903700B67E4B /* IconsTests.swift */,
 				D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */,
 				D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */,
 				D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */,
@@ -2181,6 +2184,7 @@
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
+				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -120,6 +120,12 @@ final class IconsTests: XCTestCase {
         XCTAssertEqual(starImage.size, CGSize(width: size, height: size))
     }
 
+    func testStarOutlineImageMatchesExpectedSize() {
+        let size = Double(1)
+        let starOutlineImage = UIImage.starOutlineImage(size: size, tintColor: .clear)
+        XCTAssertEqual(starOutlineImage.size, CGSize(width: size, height: size))
+    }
+
     func testStatsImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.statsImage)
     }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import WooCommerce
+
+final class IconsTests: XCTestCase {
+    func testAddOutlineIconIsNotNil() {
+        XCTAssertNotNil(UIImage.addOutlineImage)
+    }
+
+    func testAsideIconIsNotNil() {
+        XCTAssertNotNil(UIImage.asideImage)
+    }
+
+    func testBellIconIsNotNil() {
+        XCTAssertNotNil(UIImage.bellImage)
+    }
+
+    func testCameraIconIsNotNil() {
+        XCTAssertNotNil(UIImage.cameraImage)
+    }
+
+    func testCheckmarkImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.checkmarkImage)
+    }
+
+    func testCheckmarkStyledImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.checkmarkStyledImage)
+    }
+
+    func testChevronImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.chevronImage)
+    }
+
+    func testChevronDownImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.chevronDownImage)
+    }
+
+    func testChevronUpImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.chevronUpImage)
+    }
+
+    func testCogImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.cogImage)
+    }
+
+    func testDeleteImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.deleteImage)
+    }
+
+    func testEllipsisImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.ellipsisImage)
+    }
+
+    func testErrorStateImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.errorStateImage)
+    }
+
+    func testExternalImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.externalImage)
+    }
+
+    func testFilterImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.filterImage)
+    }
+
+    func testHeartOutlineImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.heartOutlineImage)
+    }
+
+    func testJetpackLogoImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.jetpackLogoImage)
+    }
+
+    func testInvisibleImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.invisibleImage)
+    }
+
+    func testMailImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.mailImage)
+    }
+
+    func testMoreImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.moreImage)
+    }
+
+    func testProductPlaceholderImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.productPlaceholderImage)
+    }
+
+    func testProductImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.productImage)
+    }
+
+    func testPencilImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.pencilImage)
+    }
+
+    func testQuoteImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.quoteImage)
+    }
+
+    func testPagesImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.pagesImage)
+    }
+
+    func testSearchImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.searchImage)
+    }
+
+    func testSpamImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.spamImage)
+    }
+
+    func testStarImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.starImage(size: 1, tintColor: .clear))
+    }
+
+    func testStarImageMatchesExpectedSize() {
+        let size = Double(1)
+        let starImage = UIImage.starImage(size: size, tintColor: .clear)
+        XCTAssertEqual(starImage.size, CGSize(width: size, height: size))
+    }
+
+    func testStatsImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.statsImage)
+    }
+
+    func testStatsAltImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.statsAltImage)
+    }
+
+    func testTrashImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.trashImage)
+    }
+
+    func testWooLogoImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.wooLogoImage())
+    }
+
+    func testWooLogoImageMatchesExpectedSize() {
+        let size = CGSize(width: 20, height: 20)
+        let image = UIImage.wooLogoImage(withSize: size, tintColor: .clear)
+        XCTAssertEqual(size, image!.size)
+    }
+
+    func testWaitingForCustomersImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.waitingForCustomersImage)
+    }
+}


### PR DESCRIPTION
Fixes #746 

Encapsulate all access to GridIcons in the UIImage+Woo extension. Considering the announcements at WWDC, this seemed like the right moment to do this 😄 

## Changes
- Added vars to the images extension, and reordered the existing ones in alphabetical order (sorry about that 😊 )
- Added tests to ensure the integrity of the dependency

## Testing
- Checkout the branch, run the tests. The tests should pass
- Search the codebase for `Gridicon.iconOfType`. All occurrences should be only in `UIImage+Woo` (and a few results in Pods, out of the scope of this story)
- Navigate around, check that icons are still rendered and that I haven't messed up anything