### PR TITLE
Bump WordPressAuthenticator to 1.5.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -25,12 +25,12 @@ target 'WooCommerce' do
   
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
-  pod 'WordPressAuthenticator', '~> 1.4.0'
+  pod 'WordPressAuthenticator', '~> 1.5.2'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
-  pod 'WordPressShared', '~> 1.7'
+  pod 'WordPressShared', '~> 1.8.2'
   
-  pod 'WordPressUI', '~> 1.2'
+  pod 'WordPressUI', '~> 1.3.3'
 
 
   # External Libraries
@@ -41,7 +41,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
   pod 'XLPagerTabStrip', '~> 9.0'
-  pod 'Charts', '~> 3.2'
+  pod 'Charts', '~> 3.2.0'
   pod 'ZendeskSDK', '~> 2.3.1'
 
   # Unit Tests

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ PODS:
   - Sentry/Core (4.3.4)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressAuthenticator (1.4.1):
+  - WordPressAuthenticator (1.5.2):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -50,20 +50,20 @@ PODS:
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.1.0-beta)
-    - WordPressShared (~> 1.7.5-beta.1)
-    - WordPressUI (~> 1.0)
-  - WordPressKit (4.1.0):
+    - WordPressKit (~> 4.1)
+    - WordPressShared (~> 1.8)
+    - WordPressUI (~> 1.3)
+  - WordPressKit (4.1.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
-    - WordPressShared (~> 1.4)
+    - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.7.5):
+  - WordPressShared (1.8.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.2.0)
+  - WordPressUI (1.3.4)
   - wpxmlrpc (0.8.4)
   - XLPagerTabStrip (9.0.0)
   - ZendeskSDK (2.3.1):
@@ -79,14 +79,14 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.7)
   - Automattic-Tracks-iOS (~> 0.4.0)
-  - Charts (~> 3.2)
+  - Charts (~> 3.2.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 0.18)
   - KeychainAccess (~> 3.2)
-  - WordPressAuthenticator (~> 1.4.0)
-  - WordPressShared (~> 1.7)
-  - WordPressUI (~> 1.2)
+  - WordPressAuthenticator (~> 1.5.2)
+  - WordPressShared (~> 1.8.2)
+  - WordPressUI (~> 1.3.3)
   - XLPagerTabStrip (~> 9.0)
   - ZendeskSDK (~> 2.3.1)
 
@@ -137,14 +137,14 @@ SPEC CHECKSUMS:
   Sentry: 26f0e6492b103e87434d1a5eea2d241a36f2c2a2
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressAuthenticator: 1741b00c58c4e57a0505cbff32528c7a049b24e6
-  WordPressKit: 78208a27c24f4f6eaf6bcfdf0ed4978de3bd080a
-  WordPressShared: 2389d30388fd89660aeb4ae26bd28484639db959
-  WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
+  WordPressAuthenticator: e8617f67da0cb013ffaade1f4410f8cfbbe30d97
+  WordPressKit: 09a28afc17dc63d35b6bd76c69fa94a7049183eb
+  WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
+  WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
 
-PODFILE CHECKSUM: bd486a73d9f1ebe6caf5d144423f0b6fb6a243a8
+PODFILE CHECKSUM: e04c2bc2a7e84a33efc342056dcd1c4aef7805c5
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
Fixes #1025 
Bumping the dependency to improve support for dynamic type in login flow. 

As mentioned in the comments to [this thread](https://wp.me/p5T066-S0-p2) there are parts of WordPressAuthenticator that were not providing great support for dynamic type. 

I've presumed it does not hurt to update our dependencies to the latest and greatest, specially if those dependencies are with libraries developed in house.

## Changes
- Updated WordPressAuthenticator to 1.5.2, and the rest of the internal dependencies to match the required dependency graph.
- Pinned Charts to 3.2.0 (as 3.3.0 includes a breaking change). Follow up: #1026 

## Testing
- Checkout branch
- Remove the contents of the Pod folder, and run `bundle exec pod install`
- Build the project and run the tests
- Log out and then back in. Make sure all log in paths still work

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
