### PR TITLE
Bump Charts to 3.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -41,7 +41,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack', '~> 3.5'
   pod 'CocoaLumberjack/Swift', '~> 3.5'
   pod 'XLPagerTabStrip', '~> 9.0'
-  pod 'Charts', '~> 3.2'
+  pod 'Charts', '~> 3.3.0'
   pod 'ZendeskSDK', '~> 2.3.1'
 
   # Unit Tests

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,9 +6,9 @@ PODS:
     - Reachability (~> 3.1)
     - Sentry (~> 4)
     - UIDeviceIdentifier (~> 1.1.4)
-  - Charts (3.2.2):
-    - Charts/Core (= 3.2.2)
-  - Charts/Core (3.2.2)
+  - Charts (3.3.0):
+    - Charts/Core (= 3.3.0)
+  - Charts/Core (3.3.0)
   - CocoaLumberjack (3.5.3):
     - CocoaLumberjack/Core (= 3.5.3)
   - CocoaLumberjack/Core (3.5.3)
@@ -79,7 +79,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.7)
   - Automattic-Tracks-iOS (~> 0.4.0)
-  - Charts (~> 3.2)
+  - Charts (~> 3.3.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 0.18)
@@ -122,7 +122,7 @@ SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   Automattic-Tracks-iOS: f7a8284999a5ce2f4e768717d86a640a32f43b7c
-  Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
+  Charts: e0dd4cd8f257bccf98407b58183ddca8e8d5b578
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
@@ -145,6 +145,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
 
-PODFILE CHECKSUM: bd486a73d9f1ebe6caf5d144423f0b6fb6a243a8
+PODFILE CHECKSUM: fcc47540d20c678c319dcea7383704b77d855888
 
 COCOAPODS: 1.6.1

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -535,7 +535,7 @@ private extension PeriodDataViewController {
             barCount += 1
         }
 
-        let dataSet =  BarChartDataSet(values: dataEntries, label: "Data")
+        let dataSet =  BarChartDataSet(entries: dataEntries, label: "Data")
         dataSet.colors = barColors
         dataSet.highlightEnabled = true
         dataSet.highlightColor = StyleManager.wooCommerceBrandColor


### PR DESCRIPTION
Fix #1026 

Bump Charts to 3.3.0. The bump brings a breaking change that requires an update to the name of a parameter in an initialiser.

## Changes
- Update the pod version
- Update the name of a parameter

## Testing
- Clear all the things, specially derived data
- run `bundle exec pod install`
- Build and run. Check that stats still render
