### PR TITLE
Stats: Tabs are ordered backwards in RTL languages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.1
 -----
+- improvement: improved support for RTL languages in the Dashboard
  
 2.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -234,11 +234,6 @@ private extension StoreStatsViewController {
 // MARK: - Private Helpers
 //
 private extension StoreStatsViewController {
-
-    func periodDataVC(for granularity: StatGranularity) -> PeriodDataViewController? {
-        return periodVCs.filter({ $0.granularity == granularity }).first
-    }
-
     func quantity(for granularity: StatGranularity) -> Int {
         switch granularity {
         case .day:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -41,6 +41,17 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
         ensureGhostContentIsAnimated()
     }
 
+    // MARK: - RTL support
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        /// ButtonBarView is a collection view, and it should flip to support
+        /// RTL languages automatically. And yet it doesn't.
+        /// So, for RTL languages, we flip it. This also flips the cells
+        if traitCollection.layoutDirection == .rightToLeft {
+            buttonBarView.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
+    }
 
     // MARK: - PagerTabStripDataSource
 
@@ -52,6 +63,11 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
         /// Hide the ImageView:
         /// We don't use it, and if / when "Ghostified" produces a quite awful placeholder UI!
         cell.imageView.isHidden = true
+
+        /// Flip the cells back to their proper state for RTL languages.
+        if traitCollection.layoutDirection == .rightToLeft {
+            cell.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -42,7 +42,7 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
     }
 
     // MARK: - RTL support
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         /// ButtonBarView is a collection view, and it should flip to support

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -39,6 +39,17 @@ class TopPerformersViewController: ButtonBarPagerTabStripViewController {
         ensureGhostContentIsAnimated()
     }
 
+    // MARK: - RTL support
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        /// ButtonBarView is a collection view, and it should flip to support
+        /// RTL languages automatically. And yet it doesn't.
+        /// So, for RTL languages, we flip it. This also flips the cells
+        if traitCollection.layoutDirection == .rightToLeft {
+            buttonBarView.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
+    }
 
     // MARK: - PagerTabStripDataSource
 
@@ -50,6 +61,11 @@ class TopPerformersViewController: ButtonBarPagerTabStripViewController {
         /// Hide the ImageView:
         /// We don't use it, and if / when "Ghostified" produces a quite awful placeholder UI!
         cell.imageView.isHidden = true
+
+        /// Flip the cells back to their proper state for RTL languages.
+        if traitCollection.layoutDirection == .rightToLeft {
+            cell.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #800 

The fix in Arabic (red rectangles added to emphasise the areas changed):
<img src="https://user-images.githubusercontent.com/2722505/59324998-dc370880-8d13-11e9-8acf-76df318d8ae8.png" width="350"/>

The fix in pseudo-rtf language:
<img src="https://user-images.githubusercontent.com/2722505/59325018-fec92180-8d13-11e9-8715-241d3f06588f.png" width="250"/>

The solution implemented, no matter how tacky it can be, follows [our own recommendations for WordPress iOS](https://github.com/wordpress-mobile/WordPress-iOS/wiki/Right-to-Left-layout-support-guideline#be-careful-with-horizontal-scroll-views). In a nutshell, we flip the view that renders the tabs, and then flip back the individual labels.

In this particular case, I don't think we can actually do much more than what we are doing here. The tabs are a collection view created by the third party library we are using to render the charts, so until we contribute a long term solution to that library, we might need to go with this.

## Changes
- Updated `StoreStatsViewController`and `TopPerformersViewController` to flip their inherited `buttonBarView` horizontally for RTL languages. 
- Flipped the individual cells.

## Testing
- Checkout the branch.
- Edit the WooCommerce scheme and change the application language to a RTL language (i.e. Right-To-Left Pseudolanguage)
<img width="350" alt="Screenshot 2019-06-12 at 1 08 23 PM" src="https://user-images.githubusercontent.com/2722505/59325145-77c87900-8d14-11e9-82b5-1edce995757f.png">
- Build and run. Check that both tabs are flipped in the Dashboard

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.