### PR TITLE
Download product images and display them everywhere

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -36,6 +36,28 @@ public class ProductsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Retrieves a specific list of `Product`s by `productID`.
+    ///
+    /// - Note: this method makes a single request for a list of products.
+    ///         It is NOT a wrapper for `loadProduct()`
+    ///
+    /// - Parameters:
+    ///     - siteID: We are fetching remote products for this site.
+    ///     - productIDs: The array of product IDs that are requested.
+    ///     - comletion: Closure to be executed upon completion.
+    ///
+    public func loadProducts(for siteID: Int, by productIDs: [Int], completion: @escaping ([Product]?, Error?) -> Void) {
+        let stringOfProductIDs = productIDs.map { String($0) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ",")
+        let parameters = [ ParameterKey.include: stringOfProductIDs ]
+        let path = Path.products
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
 
     /// Retrieves a specific `Product`.
     ///

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -20,23 +20,24 @@ public class ProductsRemote: Remote {
     ///
     public func loadAllProducts(for siteID: Int,
                                 context: String? = nil,
-                                pageNumber: Int = Defaults.pageNumber,
-                                pageSize: Int = Defaults.pageSize,
+                                pageNumber: Int = Default.pageNumber,
+                                pageSize: Int = Default.pageSize,
                                 completion: @escaping ([Product]?, Error?) -> Void) {
         let parameters = [
-            ParameterKeys.page: String(pageNumber),
-            ParameterKeys.perPage: String(pageSize),
-            ParameterKeys.contextKey: context ?? Defaults.context
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.contextKey: context ?? Default.context
         ]
 
-        let path = Paths.products
+        let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Retrieves a specific `Product`
+
+    /// Retrieves a specific `Product`.
     ///
     /// - Parameters:
     ///     - siteID: Site which hosts the Product.
@@ -44,7 +45,7 @@ public class ProductsRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadProduct(for siteID: Int, productID: Int, completion: @escaping (Product?, Error?) -> Void) {
-        let path = "\(Paths.products)/\(productID)"
+        let path = "\(Path.products)/\(productID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ProductMapper(siteID: siteID)
 
@@ -56,19 +57,20 @@ public class ProductsRemote: Remote {
 // MARK: - Constants
 //
 public extension ProductsRemote {
-    enum Defaults {
+    enum Default {
         public static let pageSize: Int   = 25
         public static let pageNumber: Int = 1
         public static let context: String = "view"
     }
 
-    private enum Paths {
+    private enum Path {
         static let products   = "products"
     }
 
-    private enum ParameterKeys {
+    private enum ParameterKey {
         static let page: String       = "page"
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
+        static let include: String    = "include"
     }
 }

--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -16,6 +16,7 @@ extension Array {
     }
 }
 
+
 extension Collection {
 
     /// Returns the element at the specified index if it is within bounds, otherwise nil.

--- a/WooCommerce/Classes/ViewModels/OrderItemViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderItemViewModel.swift
@@ -14,6 +14,10 @@ struct OrderItemViewModel {
     ///
     let currency: String
 
+    /// Yosemite.Product
+    ///
+    let product: Product?
+
     /// Item's Name
     ///
     var name: String {
@@ -64,9 +68,28 @@ struct OrderItemViewModel {
         return prefix + " " + sku
     }
 
-    init(item: OrderItem, currency: String, formatter: CurrencyFormatter = CurrencyFormatter()) {
+    /// Grab the first available image for a product.
+    ///
+    var imageURL: URL? {
+        guard let productImageURLString = product?.images.first?.src else {
+            return nil
+        }
+
+        return URL(string: productImageURLString)
+    }
+
+    /// Check to see if the product has an image URL.
+    ///
+    var productHasImage: Bool {
+        return imageURL != nil
+    }
+
+    init(item: OrderItem, currency: String,
+         formatter: CurrencyFormatter = CurrencyFormatter(),
+         product: Product? = nil) {
         self.item = item
         self.currency = currency
         self.currencyFormatter = formatter
+        self.product = product
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
@@ -85,7 +85,7 @@ class ProductDetailsTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        productImageView.image = Gridicon.iconOfType(.product)
+        productImageView.image = .productPlaceholderImage
         productImageView.tintColor = StyleManager.wooGreyBorder
         selectionStyle = .none
 
@@ -105,10 +105,16 @@ class ProductDetailsTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension ProductDetailsTableViewCell {
-    func configure(item: OrderItemViewModel, image: UIImage? = nil) {
-        if let itemImage = image {
-            productImageView.image = itemImage
+    func configure(item: OrderItemViewModel) {
+        if FeatureFlag.productDetails.enabled && item.productHasImage {
+            if let imageURL = item.imageURL {
+                productImageView.downloadImage(from: imageURL,
+                                               placeholderImage: UIImage.productPlaceholderImage)
+            }
+        } else {
+            productImageView.image = .productPlaceholderImage
         }
+
         name = item.name
         quantity = item.quantity
         price = item.price

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/Cells/PickListTableViewCell.swift
@@ -104,10 +104,16 @@ final class PickListTableViewCell: UITableViewCell {
 // MARK: - Public Methods
 //
 extension PickListTableViewCell {
-    func configure(item: OrderItemViewModel, image: UIImage? = nil) {
-        if let itemImage = image {
-            productImageView.image = itemImage
+    func configure(item: OrderItemViewModel) {
+        if FeatureFlag.productDetails.enabled && item.productHasImage {
+            if let imageURL = item.imageURL {
+                productImageView.downloadImage(from: imageURL,
+                                               placeholderImage: UIImage.productPlaceholderImage)
+            }
+        } else {
+            productImageView.image = .productPlaceholderImage
         }
+
         name = item.name
         quantity = item.quantity
         sku = item.sku

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -28,6 +28,10 @@ final class FulfillViewController: UIViewController {
     ///
     private let order: Order
 
+    /// Products in the Order
+    ///
+    private let products: [Product]?
+
     /// ResultsController fetching ShipemntTracking data
     ///
     private lazy var trackingResultsController: ResultsController<StorageShipmentTracking> = {
@@ -53,8 +57,9 @@ final class FulfillViewController: UIViewController {
 
     /// Designated Initializer
     ///
-    init(order: Order) {
+    init(order: Order, products: [Product]?) {
         self.order = order
+        self.products = products
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -311,11 +316,10 @@ private extension FulfillViewController {
             fatalError()
         }
 
-        let viewModel = OrderItemViewModel(item: item, currency: order.currency)
+        let product = lookUpProduct(by: item.productID)
+        let viewModel = OrderItemViewModel(item: item, currency: order.currency, product: product)
         cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
-        cell.name = viewModel.name
-        cell.quantity = viewModel.quantity
-        cell.sku = viewModel.sku
+        cell.configure(item: viewModel)
     }
 
     /// Setup: Note Cell
@@ -563,6 +567,18 @@ private extension FulfillViewController {
         }
 
         return orderTracking[orderIndex]
+    }
+
+    func lookUpProduct(by productID: Int) -> Product? {
+        guard let products = products else {
+            return nil
+        }
+
+        for product in products where product.productID == productID {
+            return product
+        }
+
+        return nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -570,15 +570,7 @@ private extension FulfillViewController {
     }
 
     func lookUpProduct(by productID: Int) -> Product? {
-        guard let products = products else {
-            return nil
-        }
-
-        for product in products where product.productID == productID {
-            return product
-        }
-
-        return nil
+        return products?.filter({ $0.productID == productID }).first
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -160,7 +160,7 @@ private extension OrderDetailsViewController {
     ///
     func configureEntityListener() {
         entityListener.onUpsert = { [weak self] order in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
 
@@ -169,7 +169,7 @@ private extension OrderDetailsViewController {
         }
 
         entityListener.onDelete = { [weak self] in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
 
@@ -651,7 +651,7 @@ private extension OrderDetailsViewController {
 private extension OrderDetailsViewController {
     func syncOrder(onCompletion: ((Error?) -> ())? = nil) {
         let action = OrderAction.retrieveOrder(siteID: viewModel.order.siteID, orderID: viewModel.order.orderID) { [weak self] (order, error) in
-            guard let `self` = self, let order = order else {
+            guard let self = self, let order = order else {
                 DDLogError("⛔️ Error synchronizing Order: \(error.debugDescription)")
                 onCompletion?(error)
                 return
@@ -844,7 +844,7 @@ extension OrderDetailsViewController: UITableViewDataSource {
         let image = displaysBillingDetails ? Gridicon.iconOfType(.chevronUp) : Gridicon.iconOfType(.chevronDown)
         cell.configure(text: footerText, image: image)
         cell.didSelectFooter = { [weak self] in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -734,7 +734,7 @@ private extension OrderDetailsViewController {
     }
 
     func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
-        let action = ProductAction.synchronizeProductsFor(viewModel.order) { (error) in
+        let action = ProductAction.requestMissingProducts(for: viewModel.order) { (error) in
             if let error = error {
                 DDLogError("⛔️ Error synchronizing Products: \(error)")
                 onCompletion?(error)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -1006,6 +1006,7 @@ extension OrderDetailsViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let productListViewController = segue.destination as? ProductListViewController {
             productListViewController.viewModel = viewModel
+            productListViewController.products = products
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -757,11 +757,7 @@ private extension OrderDetailsViewController {
     }
 
     func lookUpProduct(by productID: Int) -> Product? {
-        for product in products where product.productID == productID {
-            return product
-        }
-
-        return nil
+        return products.filter({ $0.productID == productID }).first
     }
 
     func deleteTracking(_ tracking: ShipmentTracking) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -56,6 +56,16 @@ final class OrderDetailsViewController: UIViewController {
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
+    /// Product ResultsController.
+    ///
+    private lazy var productResultsController: ResultsController<StorageProduct> = {
+        let storageManager = AppDelegate.shared.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+
+        return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
     /// Sections to be rendered
     ///
     private var sections = [Section]()
@@ -80,6 +90,12 @@ final class OrderDetailsViewController: UIViewController {
     ///
     private var orderTracking: [ShipmentTracking] {
         return trackingResultsController.fetchedObjects
+    }
+
+    /// Products from an Order
+    ///
+    private var products: [Product] {
+        return productResultsController.fetchedObjects
     }
 
     /// Indicates if we consider the shipment tracking plugin as reachable
@@ -109,11 +125,13 @@ final class OrderDetailsViewController: UIViewController {
         configureEntityListener()
         configureResultsController()
         configureTrackingResultsController()
+        configureProductResultsController()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         syncNotes()
+        syncProducts()
         syncTrackingsHidingAddButtonIfNecessary()
     }
 
@@ -194,6 +212,18 @@ private extension OrderDetailsViewController {
         }
 
         try? trackingResultsController.performFetch()
+    }
+
+    func configureProductResultsController() {
+        productResultsController.onDidChangeContent = { [weak self] in
+            self?.reloadTableViewSectionsAndData()
+        }
+
+        productResultsController.onDidResetContent = { [weak self] in
+            self?.reloadTableViewSectionsAndData()
+        }
+
+        try? productResultsController.performFetch()
     }
 
     /// Reloads the tableView's data, assuming the view has been loaded.
@@ -372,6 +402,11 @@ extension OrderDetailsViewController {
 
         group.enter()
         syncOrder { _ in
+            group.leave()
+        }
+
+        group.enter()
+        syncProducts() { _ in
             group.leave()
         }
 
@@ -566,12 +601,10 @@ private extension OrderDetailsViewController {
 
     func configureOrderItem(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
         let item = viewModel.items[indexPath.row]
-        let itemViewModel = OrderItemViewModel(item: item, currency: viewModel.order.currency)
+        let product = lookUpProduct(by: item.productID)
+        let itemViewModel = OrderItemViewModel(item: item, currency: viewModel.order.currency, product: product)
         cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
-        cell.name = itemViewModel.item.name
-        cell.quantity = itemViewModel.quantity
-        cell.price = itemViewModel.price
-        cell.sku = itemViewModel.sku
+        cell.configure(item: itemViewModel)
     }
 
     func configureFulfillmentButton(cell: FulfillButtonTableViewCell) {
@@ -700,9 +733,32 @@ private extension OrderDetailsViewController {
         StoresManager.shared.dispatch(action)
     }
 
+    func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
+        let action = ProductAction.synchronizeProductsFor(viewModel.order) { (error) in
+            if let error = error {
+                DDLogError("⛔️ Error synchronizing Products: \(error)")
+                onCompletion?(error)
+
+                return
+            }
+
+            onCompletion?(nil)
+        }
+
+        StoresManager.shared.dispatch(action)
+    }
+
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {
         for orderStatus in currentSiteStatuses where orderStatus.slug == order.statusKey {
             return orderStatus
+        }
+
+        return nil
+    }
+
+    func lookUpProduct(by productID: Int) -> Product? {
+        for product in products where product.productID == productID {
+            return product
         }
 
         return nil

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -814,7 +814,7 @@ private extension OrderDetailsViewController {
 
     func fulfillWasPressed() {
         WooAnalytics.shared.track(.orderDetailFulfillButtonTapped)
-        let fulfillViewController = FulfillViewController(order: viewModel.order)
+        let fulfillViewController = FulfillViewController(order: viewModel.order, products: products)
         navigationController?.pushViewController(fulfillViewController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderLoaderViewController.swift
@@ -81,7 +81,7 @@ private extension OrderLoaderViewController {
     ///
     func reloadOrder() {
         let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { [weak self] (order, error) in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -119,15 +119,7 @@ private extension ProductListViewController {
     }
 
     func lookUpProduct(by productID: Int) -> Product? {
-        guard let products = products else {
-            return nil
-        }
-
-        for product in products where product.productID == productID {
-            return product
-        }
-
-        return nil
+        return products?.filter({ $0.productID == productID }).first
     }
 
     /// Displays the product detail screen for the provided ProductID

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -7,6 +7,7 @@ class ProductListViewController: UIViewController {
     private var items = [OrderItem]()
 
     var viewModel: OrderDetailsViewModel!
+    var products: [Product]? = []
 
     // MARK: - View Lifecycle
 
@@ -43,8 +44,8 @@ private extension ProductListViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
 
-        let nib = ProductDetailsTableViewCell.loadNib()
-        tableView.register(nib, forCellReuseIdentifier: ProductDetailsTableViewCell.reuseIdentifier)
+        let nib = PickListTableViewCell.loadNib()
+        tableView.register(nib, forCellReuseIdentifier: PickListTableViewCell.reuseIdentifier)
 
         let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)
@@ -66,9 +67,12 @@ extension ProductListViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = itemAtIndexPath(indexPath)
-        let itemViewModel = OrderItemViewModel(item: item, currency: viewModel.order.currency)
-        let cellID = ProductDetailsTableViewCell.reuseIdentifier
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? ProductDetailsTableViewCell else {
+        let product = lookUpProduct(by: item.productID)
+        let itemViewModel = OrderItemViewModel(item: item,
+                                               currency: viewModel.order.currency,
+                                               product: product)
+        let cellID = PickListTableViewCell.reuseIdentifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? PickListTableViewCell else {
             fatalError()
         }
         cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
@@ -112,6 +116,18 @@ private extension ProductListViewController {
 
     func itemAtIndexPath(_ indexPath: IndexPath) -> OrderItem {
         return items[indexPath.row]
+    }
+
+    func lookUpProduct(by productID: Int) -> Product? {
+        guard let products = products else {
+            return nil
+        }
+
+        for product in products where product.productID == productID {
+            return product
+        }
+
+        return nil
     }
 
     /// Displays the product detail screen for the provided ProductID

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		CE3B7AD72225ECA90050FE4B /* OrderStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3B7AD62225ECA90050FE4B /* OrderStatusStore.swift */; };
 		CE3B7AD92229C3570050FE4B /* OrderStatus+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3B7AD82229C3570050FE4B /* OrderStatus+ReadOnlyType.swift */; };
 		CE43A90222A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE43A90122A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift */; };
+		CE5F9A7A22B2D455001755E8 /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */; };
 		D80F758A223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F7589223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift */; };
 		D80F758C223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */; };
 		D87F614A22657A690031A13B /* AppSettingsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F614922657A690031A13B /* AppSettingsAction.swift */; };
@@ -228,6 +229,7 @@
 		CE3B7AD62225ECA90050FE4B /* OrderStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatusStore.swift; sourceTree = "<group>"; };
 		CE3B7AD82229C3570050FE4B /* OrderStatus+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatus+ReadOnlyType.swift"; sourceTree = "<group>"; };
 		CE43A90122A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductDownload+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
 		D80F7589223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProvider+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D87F614922657A690031A13B /* AppSettingsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsAction.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 			isa = PBXGroup;
 			children = (
 				B5B5C796208E49B600642956 /* Action+Internal.swift */,
+				CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */,
 				B5C9DE142087FF0E006B910A /* Assert.swift */,
 				933A27342222352500C2143A /* Logging.swift */,
 				743057B2218B69D100441A76 /* Queue.swift */,
@@ -779,6 +782,7 @@
 				74A18C58211382A000DCF8A8 /* StatsAction.swift in Sources */,
 				7499936420EFBC1B00CF01CD /* OrderNoteAction.swift in Sources */,
 				7455D4692141B59E00FA8C1F /* TopEarnerStatsItem+ReadOnlyConvertible.swift in Sources */,
+				CE5F9A7A22B2D455001755E8 /* Array+Helpers.swift in Sources */,
 				743057B3218B69D100441A76 /* Queue.swift in Sources */,
 				7492FADB217FAE4D00ED2C69 /* SiteSetting+ReadOnlyType.swift in Sources */,
 				741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -14,6 +14,10 @@ public enum ProductAction: Action {
     ///
     case retrieveProduct(siteID: Int, productID: Int, onCompletion: (Product?, Error?) -> Void)
 
+    /// Retrieves a specified list of Products.
+    ///
+    case retrieveProducts(siteID: Int, productIDs: [Int], onCompletion: (Error?) -> Void)
+
     /// Deletes all of the cached products.
     ///
     case resetStoredProducts(onCompletion: () -> Void)

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -22,7 +22,7 @@ public enum ProductAction: Action {
     ///
     case resetStoredProducts(onCompletion: () -> Void)
 
-    /// Synchronizes the Products found in a specified Order.
+    /// Requests the Products found in a specified Order.
     ///
-    case synchronizeProductsFor(_ order: Order, onCompletion: (Error?) -> Void)
+    case requestMissingProducts(for: Order, onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -21,4 +21,8 @@ public enum ProductAction: Action {
     /// Deletes all of the cached products.
     ///
     case resetStoredProducts(onCompletion: () -> Void)
+
+    /// Synchronizes the Products found in a specified Order.
+    ///
+    case synchronizeProductsFor(_ order: Order, onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Internal/Array+Helpers.swift
+++ b/Yosemite/Yosemite/Internal/Array+Helpers.swift
@@ -1,11 +1,9 @@
 import Foundation
 
 
-/// Not mine. Sourced from: https://stackoverflow.com/a/46354989/4150507
-///
 public extension Array where Element: Hashable {
 
-    /// Non-mutation function that removes duplicates in an array.
+    /// Non-mutated function that removes duplicates in an array.
     ///
     func uniqued() -> [Element] {
         var seen = Set<Element>()

--- a/Yosemite/Yosemite/Internal/Array+Helpers.swift
+++ b/Yosemite/Yosemite/Internal/Array+Helpers.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+
+/// Not mine. Sourced from: https://stackoverflow.com/a/46354989/4150507
+///
+public extension Array where Element: Hashable {
+
+    /// Non-mutation function that removes duplicates in an array.
+    ///
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -108,14 +108,6 @@ private extension OrderStore {
 
             self?.upsertStoredOrdersInBackground(readOnlyOrders: [order]) {
                 onCompletion(order, nil)
-//                self?.ensureProductsAreSynchronized(for: order, onCompletion: { (products, error) in
-//                    // Even if there was an error while getting products, we want to continue.
-//                    if let error = error {
-//                        DDLogError("Error synchronizing Products for OrderID: \(order.orderID). \(error)")
-//                    }
-//
-//                    onCompletion(order, nil)
-//                })
             }
         }
     }
@@ -139,19 +131,6 @@ private extension OrderStore {
             onCompletion(error)
         }
     }
-}
-
-
-// MARK: - Private methods
-//
-private extension OrderStore {
-
-    /// Ensures Products are Synced for an Order.
-    ///
-//    func ensureProductsAreSynchronized(for order: Order, onCompletion: @escaping ([Product]?, Error?) -> Void) {
-//        let action = ProductAction.synchronizeProductsFor(order, onCompletion: onCompletion)
-//        dispatcher.dispatch(action)
-//    }
 }
 
 

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -107,14 +107,15 @@ private extension OrderStore {
             }
 
             self?.upsertStoredOrdersInBackground(readOnlyOrders: [order]) {
-                self?.ensureProductsAreSynchronized(for: order, onCompletion: { (error) in
-                    // Even if there was an error while getting products, we want to continue.
-                    if let error = error {
-                        DDLogError("Error synchronizing Products for OrderID: \(order.orderID). \(error)")
-                    }
-
-                    onCompletion(order, nil)
-                })
+                onCompletion(order, nil)
+//                self?.ensureProductsAreSynchronized(for: order, onCompletion: { (products, error) in
+//                    // Even if there was an error while getting products, we want to continue.
+//                    if let error = error {
+//                        DDLogError("Error synchronizing Products for OrderID: \(order.orderID). \(error)")
+//                    }
+//
+//                    onCompletion(order, nil)
+//                })
             }
         }
     }
@@ -147,10 +148,10 @@ private extension OrderStore {
 
     /// Ensures Products are Synced for an Order.
     ///
-    func ensureProductsAreSynchronized(for order: Order, onCompletion: @escaping (Error?) -> Void) {
-        let action = ProductAction.synchronizeProductsFor(order, onCompletion: onCompletion)
-        dispatcher.dispatch(action)
-    }
+//    func ensureProductsAreSynchronized(for order: Order, onCompletion: @escaping ([Product]?, Error?) -> Void) {
+//        let action = ProductAction.synchronizeProductsFor(order, onCompletion: onCompletion)
+//        dispatcher.dispatch(action)
+//    }
 }
 
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -77,7 +77,7 @@ private extension ProductStore {
     ///
     func synchronizeProductsFor(_ order: Order, onCompletion: @escaping (Error?) -> Void) {
         let itemIDs = order.items.map { $0.itemID }
-        let productIDs = itemIDs.uniqued()  // remove duplicates
+        let productIDs = itemIDs.uniqued()  // removes duplicate product IDs
 
         let storage = storageManager.viewStorage
         var missingIDs = [Int]()

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -34,8 +34,8 @@ public class ProductStore: Store {
             retrieveProducts(siteID: siteID, productIDs: productIDs, onCompletion: onCompletion)
         case .synchronizeProducts(let siteID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProducts(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .synchronizeProductsFor(let order, let onCompletion):
-            synchronizeProductsFor(order, onCompletion: onCompletion)
+        case .requestMissingProducts(let order, let onCompletion):
+            requestMissingProducts(for: order, onCompletion: onCompletion)
         }
     }
 }
@@ -75,7 +75,7 @@ private extension ProductStore {
 
     /// Synchronizes the Products found in a specified Order.
     ///
-    func synchronizeProductsFor(_ order: Order, onCompletion: @escaping (Error?) -> Void) {
+    func requestMissingProducts(for order: Order, onCompletion: @escaping (Error?) -> Void) {
         let itemIDs = order.items.map { $0.itemID }
         let productIDs = itemIDs.uniqued()  // removes duplicate product IDs
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -69,6 +69,26 @@ private extension ProductStore {
         }
     }
 
+    /// Retrieves multiple products with a given siteID + productIDs.
+    /// - Note: This is NOT a wrapper for retrieving a single product.
+    ///
+    func retrieveProducts(siteID: Int,
+                          productIDs: [Int],
+                          onCompletion: @escaping (Error?) -> Void) {
+        let remote = ProductsRemote(network: network)
+
+        remote.loadProducts(for: siteID, by: productIDs) { [weak self] (products, error) in
+            guard let products = products else {
+                onCompletion(error)
+                return
+            }
+
+            self?.upsertStoredProductsInBackground(readOnlyProducts: products, onCompletion: {
+                onCompletion(nil)
+            })
+        }
+    }
+
     /// Retrieves the product associated with a given siteID + productID (if any!).
     ///
     func retrieveProduct(siteID: Int, productID: Int, onCompletion: @escaping (Networking.Product?, Error?) -> Void) {

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -30,6 +30,8 @@ public class ProductStore: Store {
             resetStoredProducts(onCompletion: onCompletion)
         case .retrieveProduct(let siteID, let productID, let onCompletion):
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
+        case .retrieveProducts(let siteID, let productIDs, let onCompletion):
+            retrieveProducts(siteID: siteID, productIDs: productIDs, onCompletion: onCompletion)
         case .synchronizeProducts(let siteID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProducts(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         }


### PR DESCRIPTION
Closes #747.

This PR displays product images if / when an imageURL is available.

When a user navigates to an Order Details screen:
1.  An array of productIDs is created by looking for Order.orderItem.productID
2. syncProducts checks for existing Products, looking them up by the productID in the array
3. If no product is found in ProductStore, the productID is placed in the missingIDs array
4. A remote request is made (a **single** API request for all products in that order) for the missing products
5. If the request was successful, the products are upserted on a background thread
6. the productFetchedResultsController listener is notified that changes have occurred
7. the productFetchedResultsController event handlers then trigger a reloadTableViewSectionsAndData
8. the tableview refreshes with the product image URL sent to the table cells
9. the table cells async download the image

When a user navigates to the Fulfill screen:
1. existing products data is sent to the screen
2. the table cells async download the image (if the image hasn't already been downloaded)

When the user navigates to the ProductListViewController (tap on "Details" row on a completed order):
1. the existing products data is sent to the screen
2. the table cells async download the image (if the image hasn't already been downloaded)

I don't know if I approached the problem right. Instead of waiting for a remote request to GET Order by ID, I went ahead and used the order.orderItems.productIDs found in the viewModel.

There is probably a lot of mistakes, refactoring, and such that need done here. This rough draft is my first attempt to get all the details out of my head and down in code.

My animated .gifs are too big. It can be previewed here: https://cld.wthms.co/vv66qe

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
