### PR TITLE
Remove feature flag for products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.1
 -----
 - improvement: improved support for RTL languages in the Dashboard
+- enhancement: You can now view product images on orders. Tapping on Products in Orders will present a view-only version of the Product's Details.
  
 2.0
 -----

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -6,16 +6,10 @@ enum FeatureFlag: Int {
     /// `An enum with no cases cannot declare a raw type`
     case null
 
-    /// Enable the new product details screen (via `FulfillViewController` or `ProductListViewController`)
-    ///
-    case productDetails
-
     /// Returns a boolean indicating if the feature is enabled
     ///
     var enabled: Bool {
         switch self {
-        case .productDetails:
-            return BuildConfiguration.current == .localDeveloper
         default:
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
@@ -106,7 +106,7 @@ class ProductDetailsTableViewCell: UITableViewCell {
 //
 extension ProductDetailsTableViewCell {
     func configure(item: OrderItemViewModel) {
-        if FeatureFlag.productDetails.enabled && item.productHasImage {
+        if item.productHasImage {
             if let imageURL = item.imageURL {
                 productImageView.downloadImage(from: imageURL,
                                                placeholderImage: UIImage.productPlaceholderImage)

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/Cells/PickListTableViewCell.swift
@@ -105,11 +105,10 @@ final class PickListTableViewCell: UITableViewCell {
 //
 extension PickListTableViewCell {
     func configure(item: OrderItemViewModel) {
-        if FeatureFlag.productDetails.enabled && item.productHasImage {
-            if let imageURL = item.imageURL {
+        if item.productHasImage,
+        let imageURL = item.imageURL {
                 productImageView.downloadImage(from: imageURL,
                                                placeholderImage: UIImage.productPlaceholderImage)
-            }
         } else {
             productImageView.image = .productPlaceholderImage
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -318,7 +318,7 @@ private extension FulfillViewController {
 
         let product = lookUpProduct(by: item.productID)
         let viewModel = OrderItemViewModel(item: item, currency: order.currency, product: product)
-        cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
+        cell.selectionStyle = .default
         cell.configure(item: viewModel)
     }
 
@@ -430,10 +430,8 @@ extension FulfillViewController: UITableViewDelegate {
             present(navController, animated: true, completion: nil)
 
         case .product(let item):
-            if FeatureFlag.productDetails.enabled {
-                let productIDToLoad = item.variationID == 0 ? item.productID : item.variationID
-                productWasPressed(for: productIDToLoad)
-            }
+            let productIDToLoad = item.variationID == 0 ? item.productID : item.variationID
+            productWasPressed(for: productIDToLoad)
 
         case .tracking:
             break

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -603,7 +603,7 @@ private extension OrderDetailsViewController {
         let item = viewModel.items[indexPath.row]
         let product = lookUpProduct(by: item.productID)
         let itemViewModel = OrderItemViewModel(item: item, currency: viewModel.order.currency, product: product)
-        cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
+        cell.selectionStyle = .default
         cell.configure(item: itemViewModel)
     }
 
@@ -935,14 +935,12 @@ extension OrderDetailsViewController: UITableViewDelegate {
             let navController = WooNavigationController(rootViewController: addTracking)
             present(navController, animated: true, completion: nil)
         case .orderItem:
-            if FeatureFlag.productDetails.enabled {
-                let item = viewModel.order.items[indexPath.row]
-                let productID = item.variationID == 0 ? item.productID : item.variationID
-                let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                       siteID: viewModel.order.siteID)
-                let navController = WooNavigationController(rootViewController: loaderViewController)
-                present(navController, animated: true, completion: nil)
-            }
+            let item = viewModel.order.items[indexPath.row]
+            let productID = item.variationID == 0 ? item.productID : item.variationID
+            let loaderViewController = ProductLoaderViewController(productID: productID,
+                                                                   siteID: viewModel.order.siteID)
+            let navController = WooNavigationController(rootViewController: loaderViewController)
+            present(navController, animated: true, completion: nil)
         case .details:
             WooAnalytics.shared.track(.orderDetailProductDetailTapped)
             performSegue(withIdentifier: Constants.productDetailsSegue, sender: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -75,7 +75,7 @@ extension ProductListViewController: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? PickListTableViewCell else {
             fatalError()
         }
-        cell.selectionStyle = FeatureFlag.productDetails.enabled ? .default : .none
+        cell.selectionStyle = .default
         cell.configure(item: itemViewModel)
 
         return cell
@@ -101,11 +101,9 @@ extension ProductListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        if FeatureFlag.productDetails.enabled {
-            let orderItem = itemAtIndexPath(indexPath)
-            let productIDToLoad = orderItem.variationID == 0 ? orderItem.productID : orderItem.variationID
-            productWasPressed(for: productIDToLoad)
-        }
+        let orderItem = itemAtIndexPath(indexPath)
+        let productIDToLoad = orderItem.variationID == 0 ? orderItem.productID : orderItem.variationID
+        productWasPressed(for: productIDToLoad)
     }
 }
 


### PR DESCRIPTION
Time to release Products to the public!

## To test
- Navigate to Orders > choose an order that's processing. (It's not perfect, but you should see some images download.)
- Refresh the Order details screen. A few more images should load.
- Choose a product that hasn't loaded the image yet.
- Tap on that product. Wait for the image to load. Dismiss the product details screen.
- Since the image downloaded from product details, it should appear in the Order details screen.
- Navigate to fulfill an order. Notice that this isn't a pull-to-refresh screen. It takes the data from Order details and repackages it.
- Back out of the processing order. Choose an order that's completed.
- Tap on a product to verify the product details screen is presented and loads well.
- Dismiss the product details screen. Tap on the "Details" row.
- A different screen the "pick list" screen, should appear. 

Known issues: tapping on a product cell in My store > Dashboard > Top Performers doesn't work. It has a separate issue filed (#1034).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
