### PR TITLE
Fix separator insets to L: 16 and R: 0, on OrderDetails and Product Details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -162,7 +162,6 @@ private extension OrderDetailsViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.refreshControl = refreshControl
-        tableView.separatorInset = .zero
     }
 
     /// Setup: Navigation

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QmM-AQ-tMl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QmM-AQ-tMl">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -59,6 +59,7 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hBh-xf-Cby">
                                 <rect key="frame" x="0.0" y="64" width="375" height="554"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dataSource" destination="IgL-pI-DQK" id="epc-hT-caY"/>
                                     <outlet property="delegate" destination="IgL-pI-DQK" id="z2y-Op-rg4"/>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.xib
@@ -24,7 +24,7 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="sWt-Ef-Hwo">
                     <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                    <inset key="separatorInset" minX="16" minY="0.0" maxX="16" maxY="0.0"/>
+                    <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="dtH-l3-88d"/>
                         <outlet property="delegate" destination="-1" id="5hl-Ok-FQ4"/>


### PR DESCRIPTION
Cell separators should be 16 points Left and 0 points Right for the Order Details, Order Fulfillment, Order Completed > Details ("pick list only") screen and Product Details. (Add Tracking and Shipping Providers already have the correct margins).

Order Details, a completed order, part 1
<img src="https://user-images.githubusercontent.com/1062444/59539163-d121db00-8ec1-11e9-8b9f-50273b38ea6a.png" width="350" />

Order Details, a completed order, part 2 - showing what Add Tracking and Add Note rows look like.
<img src="https://user-images.githubusercontent.com/1062444/59539179-e434ab00-8ec1-11e9-975e-ef7eeb38336d.png" width="350" />

Order Details, a completed order, tapping "Details" row ("pick list only" screen)
<img src="https://user-images.githubusercontent.com/1062444/59539225-062e2d80-8ec2-11e9-89e4-6ee66344b8a3.png" width="350" />

Order Details, a processing order
<img src="https://user-images.githubusercontent.com/1062444/59539260-1cd48480-8ec2-11e9-8865-1e5d63d73bc3.png" width="350" />

Order Details, a processing order, Fulfill Order screen
<img src="https://user-images.githubusercontent.com/1062444/59539288-34ac0880-8ec2-11e9-8bf8-7bbad6083edb.png" width="350" />

A Product Details screen
<img src="https://user-images.githubusercontent.com/1062444/59539304-455c7e80-8ec2-11e9-934e-1bf98314ca5a.png" width="350" />

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
