### PR TITLE
Zendesk: show alert if email is a8c.com/automattic.com

### DIFF
--- a/WooCommerce/Classes/Tools/Developer/DeveloperEmailChecker.swift
+++ b/WooCommerce/Classes/Tools/Developer/DeveloperEmailChecker.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 struct DeveloperEmailChecker {
-    private static let developerEmails = ["@automattic.com", "@a8c.com"]
+    private let developerEmails = ["@automattic.com", "@a8c.com"]
 
     /// Checks if an email belongs to app developer (Automattic).
     ///
-    static func isDeveloperEmail(email: String) -> Bool {
+    func isDeveloperEmail(email: String) -> Bool {
         return (developerEmails.first { email.contains($0) }) != nil
     }
 }

--- a/WooCommerce/Classes/Tools/Developer/DeveloperEmailChecker.swift
+++ b/WooCommerce/Classes/Tools/Developer/DeveloperEmailChecker.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct DeveloperEmailChecker {
+    private static let developerEmails = ["@automattic.com", "@a8c.com"]
+
+    /// Checks if an email belongs to app developer (Automattic).
+    ///
+    static func isDeveloperEmail(email: String) -> Bool {
+        return (developerEmails.first { email.contains($0) }) != nil
+    }
+}

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -21,6 +21,8 @@ class ZendeskManager: NSObject {
     ///
     static let shared = ZendeskManager()
 
+    typealias UserInformationCompletion = (_ success: Bool, _ email: String?) -> Void
+
     /// Indicates if Zendesk is Enabled (or not)
     ///
     private (set) var zendeskEnabled = false {
@@ -156,7 +158,7 @@ class ZendeskManager: NSObject {
 
     /// Displays an alert allowing the user to change their Support email address.
     ///
-    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping (Bool) -> Void) {
+    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping UserInformationCompletion) {
         WooAnalytics.shared.track(.supportIdentityFormViewed)
         presentInController = controller
 
@@ -166,8 +168,8 @@ class ZendeskManager: NSObject {
             withName = false
         }
 
-        getUserInformationAndShowPrompt(withName: withName, from: controller) { success in
-            completion(success)
+        getUserInformationAndShowPrompt(withName: withName, from: controller) { (success, email) in
+            completion(success, email)
         }
     }
 
@@ -351,7 +353,7 @@ private extension ZendeskManager {
             }
         }
 
-        getUserInformationAndShowPrompt(withName: true, from: viewController) { success in
+        getUserInformationAndShowPrompt(withName: true, from: viewController) { (success, _) in
             if success {
                 self.registerDeviceTokenIfNeeded()
             }
@@ -360,25 +362,25 @@ private extension ZendeskManager {
         }
     }
 
-    func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+    func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping UserInformationCompletion) {
         getUserInformationIfAvailable()
-        promptUserForInformation(withName: withName, from: viewController) { success in
+        promptUserForInformation(withName: withName, from: viewController) { (success, email) in
             guard success else {
                 DDLogInfo("No user information to create Zendesk identity with.")
-                completion(false)
+                completion(false, nil)
                 return
             }
 
             self.createZendeskIdentity { success in
                 guard success else {
                     DDLogInfo("Creating Zendesk identity failed.")
-                    completion(false)
+                    completion(false, nil)
                     return
                 }
 
                 DDLogDebug("Using information from prompt for Zendesk identity.")
                 self.haveUserIdentity = true
-                completion(true)
+                completion(true, email)
                 return
             }
         }
@@ -589,21 +591,21 @@ private extension ZendeskManager {
 
     // MARK: - User Information Prompt
     //
-    func promptUserForInformation(withName: Bool, from viewController: UIViewController, completion: @escaping (Bool) -> Void) {
+    func promptUserForInformation(withName: Bool, from viewController: UIViewController, completion: @escaping UserInformationCompletion) {
 
         let alertMessage = withName ? LocalizedText.alertMessageWithName : LocalizedText.alertMessage
         let alertController = UIAlertController(title: nil, message: alertMessage, preferredStyle: .alert)
 
         // Cancel Action
         alertController.addCancelActionWithTitle(LocalizedText.alertCancel) { _ in
-            completion(false)
+            completion(false, nil)
             return
         }
 
         // Submit Action
         let submitAction = alertController.addDefaultActionWithTitle(LocalizedText.alertSubmit) { [weak alertController] _ in
             guard let email = alertController?.textFields?.first?.text else {
-                completion(false)
+                completion(false, nil)
                 return
             }
 
@@ -614,7 +616,7 @@ private extension ZendeskManager {
             }
 
             self.saveUserProfile()
-            completion(true)
+            completion(true, email)
             return
         }
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -21,7 +21,7 @@ class ZendeskManager: NSObject {
     ///
     static let shared = ZendeskManager()
 
-    typealias UserInformationCompletion = (_ success: Bool, _ email: String?) -> Void
+    typealias onUserInformationCompletion = (_ success: Bool, _ email: String?) -> Void
 
     /// Indicates if Zendesk is Enabled (or not)
     ///
@@ -158,7 +158,7 @@ class ZendeskManager: NSObject {
 
     /// Displays an alert allowing the user to change their Support email address.
     ///
-    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping UserInformationCompletion) {
+    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping onUserInformationCompletion) {
         WooAnalytics.shared.track(.supportIdentityFormViewed)
         presentInController = controller
 
@@ -362,7 +362,7 @@ private extension ZendeskManager {
         }
     }
 
-    func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping UserInformationCompletion) {
+    func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping onUserInformationCompletion) {
         getUserInformationIfAvailable()
         promptUserForInformation(withName: withName, from: viewController) { (success, email) in
             guard success else {
@@ -591,7 +591,7 @@ private extension ZendeskManager {
 
     // MARK: - User Information Prompt
     //
-    func promptUserForInformation(withName: Bool, from viewController: UIViewController, completion: @escaping UserInformationCompletion) {
+    func promptUserForInformation(withName: Bool, from viewController: UIViewController, completion: @escaping onUserInformationCompletion) {
 
         let alertMessage = withName ? LocalizedText.alertMessageWithName : LocalizedText.alertMessage
         let alertController = UIAlertController(title: nil, message: alertMessage, preferredStyle: .alert)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -248,10 +248,17 @@ private extension HelpAndSupportViewController {
             return
         }
 
-        ZendeskManager.shared.showSupportEmailPrompt(from: navController) { success in
+        ZendeskManager.shared.showSupportEmailPrompt(from: navController) { [weak self] (success, email) in
             guard success else {
                 return
             }
+
+            guard let self = self else {
+                return
+            }
+
+            self.warnDeveloperIfNeeded()
+
             // Tracking when the dialog's "OK" button is pressed, not necessarily if the value changed.
             WooAnalytics.shared.track(.supportIdentitySet)
             self.tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -117,7 +117,7 @@ private extension HelpAndSupportViewController {
     /// Warn devs that logged in with an Automattic email.
     ///
     func warnDeveloperIfNeeded() {
-        guard accountEmail.contains(Constants.devEmail) else {
+        guard DeveloperEmailChecker.isDeveloperEmail(email: accountEmail) else {
             return
         }
 
@@ -333,7 +333,6 @@ extension HelpAndSupportViewController: UITableViewDelegate {
 private struct Constants {
     static let rowHeight = CGFloat(44)
     static let footerHeight = 44
-    static let devEmail = "@automattic.com"
     static let appLogSegue = "ShowApplicationLogViewController"
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -117,7 +117,8 @@ private extension HelpAndSupportViewController {
     /// Warn devs that logged in with an Automattic email.
     ///
     func warnDeveloperIfNeeded() {
-        guard DeveloperEmailChecker.isDeveloperEmail(email: accountEmail) else {
+        let developerEmailChecker = DeveloperEmailChecker()
+        guard developerEmailChecker.isDeveloperEmail(email: accountEmail) else {
             return
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
+		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -382,6 +384,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
+		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -763,6 +767,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		024A543222BA6DD500F4F38E /* Developer */ = {
+			isa = PBXGroup;
+			children = (
+				024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */,
+			);
+			path = Developer;
+			sourceTree = "<group>";
+		};
 		74036CBE211B87FD00E462C2 /* MyStore */ = {
 			isa = PBXGroup;
 			children = (
@@ -911,6 +923,7 @@
 				CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */,
 				CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */,
 				D8AB131D225DC25F002BB5D1 /* MockOrders.swift */,
+				024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -975,6 +988,7 @@
 			children = (
 				CEEC9B6121E79EBF0055EEF0 /* AppRatings */,
 				CE9B7E3021C94685000F971C /* Currency */,
+				024A543222BA6DD500F4F38E /* Developer */,
 				B5A03699214C0E7000774E2C /* Logging */,
 				B58B4ABC2108F7F800076FDD /* Notices */,
 				B541B2182189F387008FE7C1 /* StringFormatter */,
@@ -2021,6 +2035,7 @@
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				748C7780211E18A600814F2C /* OrderStats+Woo.swift in Sources */,
+				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				CE4DA5C621DD755E00074607 /* CurrencyFormatter.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */,
@@ -2187,6 +2202,7 @@
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
+				024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */,
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/DeveloperEmailCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DeveloperEmailCheckerTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import WooCommerce
+
+class DeveloperEmailCheckerTests: XCTestCase {
+    func testAutomatticEmail() {
+        let email = "dev@automattic.com"
+        XCTAssertTrue(DeveloperEmailChecker.isDeveloperEmail(email: email))
+    }
+
+    func testA8cEmail() {
+        let email = "dev@a8c.com"
+        XCTAssertTrue(DeveloperEmailChecker.isDeveloperEmail(email: email))
+    }
+
+    func testGmail() {
+        let email = "dev@gmail.com"
+        XCTAssertFalse(DeveloperEmailChecker.isDeveloperEmail(email: email))
+    }
+}

--- a/WooCommerce/WooCommerceTests/Tools/DeveloperEmailCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DeveloperEmailCheckerTests.swift
@@ -2,18 +2,20 @@ import XCTest
 @testable import WooCommerce
 
 class DeveloperEmailCheckerTests: XCTestCase {
+    private let developerEmailChecker = DeveloperEmailChecker()
+
     func testAutomatticEmail() {
         let email = "dev@automattic.com"
-        XCTAssertTrue(DeveloperEmailChecker.isDeveloperEmail(email: email))
+        XCTAssertTrue(developerEmailChecker.isDeveloperEmail(email: email))
     }
 
     func testA8cEmail() {
         let email = "dev@a8c.com"
-        XCTAssertTrue(DeveloperEmailChecker.isDeveloperEmail(email: email))
+        XCTAssertTrue(developerEmailChecker.isDeveloperEmail(email: email))
     }
 
     func testGmail() {
         let email = "dev@gmail.com"
-        XCTAssertFalse(DeveloperEmailChecker.isDeveloperEmail(email: email))
+        XCTAssertFalse(developerEmailChecker.isDeveloperEmail(email: email))
     }
 }


### PR DESCRIPTION
Fixes #921

Since developers cannot send support tickets in the app, there are two places in Help/Support where we want to show warning for developer with an @automattic.com or @a8c.com email address.

- When the Support view is initially shown (already implemented before this PR)
- When the user changes their email via Contact Email (implemented in this PR)

## Changes
- Updated `getUserInformationAndShowPrompt` completion block to the new completion type: `UserInformationCompletion = (_ success: Bool, _ email: String?) -> Void` so that email is available for upstream completion handler (`HelpAndSupportViewController`) to show warning if the email is a developer email
- Created `DeveloperEmailChecker` to check if an email has @automattic.com or @a8c.com domain + basic tests

## Testing
Prerequisites: if the contact email in Help & Support is currently set to a developer email, update email to a non-developer email like gmail by going to My store > Settings > Help & Support > Contact Email.
- Go to My store
- Go to Settings > Help & Support
- Set the contact email address row to @a8c.com and @automattic.com --> An alert should immediately be shown

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
