### PR TITLE
Notifications: support multiple lines of Share Store button in case of large text

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -39,6 +39,14 @@ extension UIButton {
         titleLabel?.applySubheadlineStyle()
         titleLabel?.textAlignment = .natural
     }
+
+    /// Supports title of multiple lines, either from longer text than allocated width or text with line breaks.
+    func enableMultipleLines() {
+        titleLabel?.lineBreakMode = .byWordWrapping
+        if let label = titleLabel {
+            pinSubviewToAllEdgeMargins(label)
+        }
+    }
 }
 
 

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -27,6 +27,8 @@ extension UIButton {
         layer.borderWidth = Style.defaultBorderWidth
         layer.cornerRadius = Style.defaultCornerRadius
         titleLabel?.applyHeadlineStyle()
+        enableMultipleLines()
+        titleLabel?.textAlignment = .center
     }
 
     /// Applies the Terciary Button Style: Clear BG / Top Outline

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -43,7 +43,7 @@ extension UIButton {
     }
 
     /// Supports title of multiple lines, either from longer text than allocated width or text with line breaks.
-    func enableMultipleLines() {
+    private func enableMultipleLines() {
         titleLabel?.lineBreakMode = .byWordWrapping
         if let label = titleLabel {
             pinSubviewToAllEdgeMargins(label)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.swift
@@ -83,8 +83,6 @@ class OverlayMessageView: UIView {
         backgroundColor = StyleManager.tableViewBackgroundColor
         messageLabel.applyBodyStyle()
         actionButton.applySecondaryButtonStyle()
-        actionButton.enableMultipleLines()
-        actionButton.titleLabel?.textAlignment = .center
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.swift
@@ -83,6 +83,8 @@ class OverlayMessageView: UIView {
         backgroundColor = StyleManager.tableViewBackgroundColor
         messageLabel.applyBodyStyle()
         actionButton.applySecondaryButtonStyle()
+        actionButton.enableMultipleLines()
+        actionButton.titleLabel?.textAlignment = .center
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,6 +36,7 @@
                         </button>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="JeL-xN-0dT" firstAttribute="width" relation="lessThanOrEqual" secondItem="2w1-dg-Nr4" secondAttribute="width" multiplier="0.9" id="4jz-mr-Qpg"/>
                         <constraint firstItem="w9L-0o-W8W" firstAttribute="leading" secondItem="2w1-dg-Nr4" secondAttribute="leading" constant="20" id="HPA-Dl-PzX"/>
                         <constraint firstAttribute="trailing" secondItem="3Ng-em-fRz" secondAttribute="trailing" id="Tav-gc-Sxc"/>
                         <constraint firstAttribute="trailing" secondItem="w9L-0o-W8W" secondAttribute="trailing" constant="20" id="fqi-J2-lSY"/>


### PR DESCRIPTION
Fixes #909 

## Changes
- Added `UIButton` helper `enableMultipleLines` to support button title of multiple lines, either from explicit line breaks (like `\n`) or longer text than allocated width. Applied this helper to action button in `OverlayMessageView`
- Center aligned action button title in `OverlayMessageView`
- Added an AutoLayout constraint for action button to have <= 90% width of `OverlayMessageView` (lemme know if there's a padding style convention that we use) 

## Testing
Prerequisites: log in to a store without notifications.
- Go to Notifications tab
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe "Share your Store" button on Notifications tab --> The button should not be truncated

## Example screenshots

portrait | landscape
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-06-20 at 13 17 37](https://user-images.githubusercontent.com/1945542/59868769-b509b800-935f-11e9-8b48-c7500bd4682f.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-20 at 13 17 58](https://user-images.githubusercontent.com/1945542/59868770-b509b800-935f-11e9-97b2-46abef97fb30.png)
![Simulator Screen Shot - iPhone SE - 2019-06-20 at 13 18 41](https://user-images.githubusercontent.com/1945542/59868771-b5a24e80-935f-11e9-9a8a-5c006bde18d6.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-20 at 13 18 44](https://user-images.githubusercontent.com/1945542/59868772-b5a24e80-935f-11e9-9922-c6892de4c6d4.png)
![Simulator Screen Shot - iPhone SE - 2019-06-20 at 13 19 01](https://user-images.githubusercontent.com/1945542/59868773-b5a24e80-935f-11e9-9d69-421b8cc919d7.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-20 at 13 19 04](https://user-images.githubusercontent.com/1945542/59868774-b5a24e80-935f-11e9-8d33-4b4e5dcd41c7.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
