### PR TITLE
Order list: fix truncated payment status label for large font sizes

### DIFF
--- a/WooCommerce/Classes/Styles/PaddedLabel.swift
+++ b/WooCommerce/Classes/Styles/PaddedLabel.swift
@@ -16,13 +16,6 @@ class PaddedLabel: UILabel {
         super.drawText(in: rect.inset(by: textInsets))
     }
 
-    override var intrinsicContentSize: CGSize {
-        var intrinsicSuperViewContentSize = super.intrinsicContentSize
-        intrinsicSuperViewContentSize.height += textInsets.top + textInsets.bottom
-        intrinsicSuperViewContentSize.width += textInsets.left + textInsets.right
-        return intrinsicSuperViewContentSize
-    }
-
     override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
         let insetRect = bounds.inset(by: textInsets)
         let textRect = super.textRect(forBounds: insetRect, limitedToNumberOfLines: numberOfLines)

--- a/WooCommerce/Classes/Styles/PaddedLabel.swift
+++ b/WooCommerce/Classes/Styles/PaddedLabel.swift
@@ -22,6 +22,16 @@ class PaddedLabel: UILabel {
         intrinsicSuperViewContentSize.width += textInsets.left + textInsets.right
         return intrinsicSuperViewContentSize
     }
+
+    override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+        let insetRect = bounds.inset(by: textInsets)
+        let textRect = super.textRect(forBounds: insetRect, limitedToNumberOfLines: numberOfLines)
+        let invertedInsets = UIEdgeInsets(top: -textInsets.top,
+                                          left: -textInsets.left,
+                                          bottom: -textInsets.bottom,
+                                          right: -textInsets.right)
+        return textRect.inset(by: invertedInsets)
+    }
 }
 
 

--- a/WooCommerce/Classes/Styles/PaddedLabel.swift
+++ b/WooCommerce/Classes/Styles/PaddedLabel.swift
@@ -16,14 +16,11 @@ class PaddedLabel: UILabel {
         super.drawText(in: rect.inset(by: textInsets))
     }
 
-    override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
-        let insetRect = bounds.inset(by: textInsets)
-        let textRect = super.textRect(forBounds: insetRect, limitedToNumberOfLines: numberOfLines)
-        let invertedInsets = UIEdgeInsets(top: -textInsets.top,
-                                          left: -textInsets.left,
-                                          bottom: -textInsets.bottom,
-                                          right: -textInsets.right)
-        return textRect.inset(by: invertedInsets)
+    override var intrinsicContentSize: CGSize {
+        var intrinsicSuperViewContentSize = super.intrinsicContentSize
+        intrinsicSuperViewContentSize.height += textInsets.top + textInsets.bottom
+        intrinsicSuperViewContentSize.width += textInsets.left + textInsets.right
+        return intrinsicSuperViewContentSize
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -87,5 +87,6 @@ private extension OrderTableViewCell {
         titleLabel.applyHeadlineStyle()
         totalLabel.applyBodyStyle()
         paymentStatusLabel.applyFootnoteStyle()
+        paymentStatusLabel.numberOfLines = 0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -18,6 +18,8 @@ class OrderTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var paymentStatusLabel: PaddedLabel!
 
+    /// Top-level stack view that contains the stack view of title and payment status labels, and total price label.
+    ///
     @IBOutlet weak var contentStackView: UIStackView!
     
     /// Renders the specified Order ViewModel

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -18,7 +18,8 @@ class OrderTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var paymentStatusLabel: PaddedLabel!
 
-
+    @IBOutlet weak var contentStackView: UIStackView!
+    
     /// Renders the specified Order ViewModel
     ///
     func configureCell(viewModel: OrderDetailsViewModel) {
@@ -38,6 +39,14 @@ class OrderTableViewCell: UITableViewCell {
         }
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.preferredContentSizeCategory > .extraExtraLarge {
+            contentStackView.axis = .vertical
+        } else {
+            contentStackView.axis = .horizontal
+        }
+    }
 
     // MARK: - Overridden Methods
 
@@ -86,6 +95,7 @@ private extension OrderTableViewCell {
     func configureLabels() {
         titleLabel.applyHeadlineStyle()
         totalLabel.applyBodyStyle()
+        totalLabel.numberOfLines = 0
         paymentStatusLabel.applyFootnoteStyle()
         paymentStatusLabel.numberOfLines = 0
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -21,7 +21,7 @@ class OrderTableViewCell: UITableViewCell {
     /// Top-level stack view that contains the stack view of title and payment status labels, and total price label.
     ///
     @IBOutlet weak var contentStackView: UIStackView!
-    
+
     /// Renders the specified Order ViewModel
     ///
     func configureCell(viewModel: OrderDetailsViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="w2s-RF-ahH">
-                        <rect key="frame" x="16" y="19" width="317" height="48"/>
+                        <rect key="frame" x="16" y="19" width="325" height="48"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
                                 <rect key="frame" x="0.0" y="0.0" width="106" height="48"/>
@@ -39,7 +39,7 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" text="$75,894.63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oo-9a-Tey">
-                                <rect key="frame" x="228" y="0.0" width="89" height="48"/>
+                                <rect key="frame" x="236" y="0.0" width="89" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -50,7 +50,7 @@
                 <constraints>
                     <constraint firstItem="w2s-RF-ahH" firstAttribute="top" secondItem="C8B-hF-50d" secondAttribute="topMargin" constant="8" id="PYm-SD-sSv"/>
                     <constraint firstItem="w2s-RF-ahH" firstAttribute="leading" secondItem="C8B-hF-50d" secondAttribute="leadingMargin" id="Vj7-Ev-DBC"/>
-                    <constraint firstAttribute="trailing" secondItem="w2s-RF-ahH" secondAttribute="trailing" constant="8" id="Wgd-sx-xWk"/>
+                    <constraint firstAttribute="trailing" secondItem="w2s-RF-ahH" secondAttribute="trailing" id="Wgd-sx-xWk"/>
                     <constraint firstAttribute="bottomMargin" secondItem="w2s-RF-ahH" secondAttribute="bottom" constant="8" id="YAb-lm-rXp"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -18,39 +18,45 @@
                 <rect key="frame" x="0.0" y="0.0" width="341" height="85.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
-                        <rect key="frame" x="16" y="19" width="228" height="20.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="$75,894.63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oo-9a-Tey">
-                        <rect key="frame" x="252" y="32.5" width="89" height="20.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                        <rect key="frame" x="16" y="45.5" width="97.5" height="21.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="w2s-RF-ahH">
+                        <rect key="frame" x="16" y="19" width="317" height="48"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
+                                <rect key="frame" x="0.0" y="0.0" width="106" height="48"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
+                                        <rect key="frame" x="0.0" y="0.0" width="106" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="27.5" width="97.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" text="$75,894.63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oo-9a-Tey">
+                                <rect key="frame" x="228" y="0.0" width="89" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="9oo-9a-Tey" secondAttribute="trailing" id="4wV-3W-Gw5"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="6EE-dX-ERE" secondAttribute="bottom" constant="8" id="E7C-1I-fBa"/>
-                    <constraint firstItem="Nzo-QV-IP1" firstAttribute="leading" secondItem="C8B-hF-50d" secondAttribute="leadingMargin" id="Fyt-cN-Zuf"/>
-                    <constraint firstItem="9oo-9a-Tey" firstAttribute="leading" secondItem="Nzo-QV-IP1" secondAttribute="trailing" constant="8" id="Z3T-Yr-vpl"/>
-                    <constraint firstItem="9oo-9a-Tey" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6EE-dX-ERE" secondAttribute="trailing" id="bOm-Iy-5WN"/>
-                    <constraint firstItem="6EE-dX-ERE" firstAttribute="top" secondItem="Nzo-QV-IP1" secondAttribute="bottom" constant="6" id="cyW-pT-2Ky"/>
-                    <constraint firstItem="9oo-9a-Tey" firstAttribute="centerY" secondItem="C8B-hF-50d" secondAttribute="centerY" id="niS-lS-Ohf"/>
-                    <constraint firstItem="6EE-dX-ERE" firstAttribute="leading" secondItem="C8B-hF-50d" secondAttribute="leadingMargin" id="pGY-nk-6hr"/>
-                    <constraint firstItem="Nzo-QV-IP1" firstAttribute="top" secondItem="C8B-hF-50d" secondAttribute="topMargin" constant="8" id="vl2-TI-cVy"/>
+                    <constraint firstItem="w2s-RF-ahH" firstAttribute="top" secondItem="C8B-hF-50d" secondAttribute="topMargin" constant="8" id="PYm-SD-sSv"/>
+                    <constraint firstItem="w2s-RF-ahH" firstAttribute="leading" secondItem="C8B-hF-50d" secondAttribute="leadingMargin" id="Vj7-Ev-DBC"/>
+                    <constraint firstAttribute="trailing" secondItem="w2s-RF-ahH" secondAttribute="trailing" constant="8" id="Wgd-sx-xWk"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="w2s-RF-ahH" secondAttribute="bottom" constant="8" id="YAb-lm-rXp"/>
                 </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
+                <outlet property="contentStackView" destination="w2s-RF-ahH" id="ULq-Dn-l9Q"/>
                 <outlet property="paymentStatusLabel" destination="6EE-dX-ERE" id="9ur-nE-PKb"/>
                 <outlet property="titleLabel" destination="Nzo-QV-IP1" id="c4l-JL-JKc"/>
                 <outlet property="totalLabel" destination="9oo-9a-Tey" id="OzG-Y4-pOm"/>


### PR DESCRIPTION
Fixes #900 
Fixes #901 

## Changes (pass 1)
- Allowed any number of lines for payment status label
- After a few trials and errors, this [SO answer](https://stackoverflow.com/a/21267507) fixed the issue. First, with just `label.numberOfLines = 0` more of the text is shown but still truncated at the end. When I updated the `textInsets` to all 0s, the text is fully shown without insets as expected. Reading some other similar SO posts, I think the issue is that with `intrinsicContentSize` it doesn't know where to draw the text. [`textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int)`](https://developer.apple.com/documentation/uikit/uilabel/1620545-textrect) seems to be the method for that

## Changes (pass 2)
- Since the fix in pass 1 is quite hacky and no official backup, and after checking Apple Wallet and Stocks apps for their Dynamic Type practices with price label, we changed the design from horizontally stacked to vertically stacked over a certain font size

## Testing
- Prerequisites: log in to a store with some orders.

- Go to Orders tab
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the payment status text on the left side of the cell --> The text should not be truncated

## Example screenshots

UPDATED:

smaller font size | larger font size | largest font size
--- | --- | ---
![Simulator Screen Shot - iPhone SE - 2019-07-09 at 11 34 57](https://user-images.githubusercontent.com/1945542/60902989-8f751d80-a23e-11e9-9bbb-1144af9cc420.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-09 at 11 35 02](https://user-images.githubusercontent.com/1945542/60902992-8f751d80-a23e-11e9-8330-da9337c2b2c0.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-09 at 11 35 19](https://user-images.githubusercontent.com/1945542/60902994-8f751d80-a23e-11e9-8421-312a55cd909c.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
