### PR TITLE
Settings: fix footer covered for larger font sizes

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableView+FooterHelpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+FooterHelpers.swift
@@ -1,13 +1,11 @@
 import UIKit
 
-extension UIViewController {
-    /// Called in `viewDidLayoutSubviews`. If input table view has a footer view, calculates the new height.
+extension UITableView {
+    /// Called in view controller's `viewDidLayoutSubviews`. If table view has a footer view, calculates the new height.
     /// If new height is different from current height, updates the footer view with the new height and reassigns the table footer view.
     /// Note: make sure the top-level footer view (`tableView.tableFooterView`) is frame based as a container of the Auto Layout based subview.
-    ///
-    /// - Parameter tableView: a table view that is a subview of the view controller.
-    func updateFooterHeight(for tableView: UITableView) {
-        if let footerView = tableView.tableFooterView {
+    func updateFooterHeight() {
+        if let footerView = tableFooterView {
             let targetSize = CGSize(width: footerView.frame.width, height: 0)
             let newSize = footerView.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: .required, verticalFittingPriority: .defaultLow)
             let newHeight = newSize.height
@@ -15,7 +13,7 @@ extension UIViewController {
             if newHeight != currentFrame.size.height {
                 currentFrame.size.height = newHeight
                 footerView.frame = currentFrame
-                tableView.tableFooterView = footerView
+                tableFooterView = footerView
             }
         }
     }

--- a/WooCommerce/Classes/Extensions/UIViewController+TableViewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+TableViewHelpers.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+extension UIViewController {
+    /// Called in `viewDidLayoutSubviews`. If input table view has a footer view, calculates the new height.
+    /// If new height is different from current height, updates the footer view with the new height and reassigns the table footer view.
+    /// Note: make sure the top-level footer view (`tableView.tableFooterView`) is frame based as a container of the Auto Layout based subview.
+    ///
+    /// - Parameter tableView: a table view that is a subview of the view controller.
+    func updateFooterHeight(for tableView: UITableView) {
+        if let footerView = tableView.tableFooterView {
+            let targetSize = CGSize(width: footerView.frame.width, height: 0)
+            let newSize = footerView.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: .required, verticalFittingPriority: .defaultLow)
+            let newHeight = newSize.height
+            var currentFrame = footerView.frame
+            if newHeight != currentFrame.size.height {
+                currentFrame.size.height = newHeight
+                footerView.frame = currentFrame
+                tableView.tableFooterView = footerView
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -70,7 +70,7 @@ class SettingsViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        updateFooterHeight(for: tableView)
+        tableView.updateFooterHeight()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -67,6 +67,11 @@ class SettingsViewController: UIViewController {
         super.viewWillAppear(animated)
         tableView.reloadData()
     }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateFooterHeight(for: tableView)
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -25,7 +25,7 @@
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="255" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RGI-pq-sH5">
-                    <rect key="frame" x="20" y="46" width="335" height="20.5"/>
+                    <rect key="frame" x="20" y="46" width="335" height="24"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -36,6 +36,7 @@
                 <constraint firstItem="qck-6N-xeW" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="20" id="3mL-e7-4IU"/>
                 <constraint firstItem="qck-6N-xeW" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="4mN-2A-P26"/>
                 <constraint firstItem="RGI-pq-sH5" firstAttribute="top" secondItem="qck-6N-xeW" secondAttribute="bottom" constant="2" id="N7c-ii-O7x"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="RGI-pq-sH5" secondAttribute="bottom" constant="20" id="WrQ-Om-baO"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="RGI-pq-sH5" secondAttribute="trailing" constant="20" id="lIo-kI-xxg"/>
                 <constraint firstItem="RGI-pq-sH5" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="nYW-ya-Vu0"/>
             </constraints>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		02820F3422C257B700DE0D37 /* UIViewController+TableViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UIViewController+TableViewHelpers.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -382,6 +383,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02820F3322C257B700DE0D37 /* UIViewController+TableViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+TableViewHelpers.swift"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -1391,6 +1393,7 @@
 				B586906521A5F4B1001F1EFC /* UINavigationController+Woo.swift */,
 				D8149F552251EE300006A245 /* UITextField+Helpers.swift */,
 				D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */,
+				02820F3322C257B700DE0D37 /* UIViewController+TableViewHelpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2060,6 +2063,7 @@
 				B541B21C2189F3D8008FE7C1 /* StringStyles.swift in Sources */,
 				B58B4AB82108F14700076FDD /* NoticeNotificationInfo.swift in Sources */,
 				CE24BCD8212F25D4001CD12E /* StorageOrder+Woo.swift in Sources */,
+				02820F3422C257B700DE0D37 /* UIViewController+TableViewHelpers.swift in Sources */,
 				B557DA1520979904005962F4 /* CustomerNoteTableViewCell.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -21,9 +21,9 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		02820F3422C257B700DE0D37 /* UIViewController+TableViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UIViewController+TableViewHelpers.swift */; };
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
+		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -385,9 +385,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		02820F3322C257B700DE0D37 /* UIViewController+TableViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+TableViewHelpers.swift"; sourceTree = "<group>"; };
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
+		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -1407,7 +1407,7 @@
 				B586906521A5F4B1001F1EFC /* UINavigationController+Woo.swift */,
 				D8149F552251EE300006A245 /* UITextField+Helpers.swift */,
 				D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */,
-				02820F3322C257B700DE0D37 /* UIViewController+TableViewHelpers.swift */,
+				02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2078,7 +2078,7 @@
 				B541B21C2189F3D8008FE7C1 /* StringStyles.swift in Sources */,
 				B58B4AB82108F14700076FDD /* NoticeNotificationInfo.swift in Sources */,
 				CE24BCD8212F25D4001CD12E /* StorageOrder+Woo.swift in Sources */,
-				02820F3422C257B700DE0D37 /* UIViewController+TableViewHelpers.swift in Sources */,
+				02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */,
 				B557DA1520979904005962F4 /* CustomerNoteTableViewCell.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,


### PR DESCRIPTION
Fixes #910 

## Changes
- Added a `UIViewController` extension to update height for table footer view. With a frame-based container view as `tableView.tableFooterView`, an Auto Layout based subview does not trigger its parent frame based view to update its height. From my experiments, it is necessary to calculate the table footer view height in view controller's `viewDidLayoutSubviews`, update the height and reassign the footer view if the new height is different
- Added an Auto Layout constraint to pin the footnote label's bottom to the footer view's bottom safe area with 20 spacing. Without this constraint, the calculated height for the footer view would be 0 as there is no constraint at the bottom

## Testing
- Launch the app with a store
- On "My store" tab, tap the Settings icon on the top right
- Scroll to the bottom where the footer is with `Made with Love by Automattic`
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the Settings footer view --> The view should not be covered with larger font sizes

## Example screenshots

portrait | landscape
--- | ---
![Simulator Screen Shot - iPhone Xʀ - 2019-06-25 at 09 38 51](https://user-images.githubusercontent.com/1945542/60104887-59a94280-9730-11e9-9d48-2bbc0e3d889a.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-06-25 at 09 38 54](https://user-images.githubusercontent.com/1945542/60104888-59a94280-9730-11e9-894a-b2a23babc3cc.png)
![Simulator Screen Shot - iPhone Xʀ - 2019-06-25 at 09 38 33](https://user-images.githubusercontent.com/1945542/60104925-675ec800-9730-11e9-8bc9-26c34b8082e3.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-06-25 at 09 38 36](https://user-images.githubusercontent.com/1945542/60104926-67f75e80-9730-11e9-9a22-b3d53927c0c2.png)
![Simulator Screen Shot - iPhone Xʀ - 2019-06-25 at 09 38 00](https://user-images.githubusercontent.com/1945542/60104954-70e83000-9730-11e9-8a02-461b3b3d5c06.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-06-25 at 09 38 04](https://user-images.githubusercontent.com/1945542/60104956-7180c680-9730-11e9-893e-742b4b2a9976.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
