### PR TITLE
Custom shipping provider: fix clipped action button text when no shipping provider search results

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
@@ -19,7 +19,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="uQE-ll-SpT">
                     <rect key="frame" x="0.0" y="135" width="375" height="92.5"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldr-2h-SOT">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldr-2h-SOT">
                             <rect key="frame" x="166.5" y="0.0" width="42" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
@@ -28,8 +28,8 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lfm-8q-CzH" customClass="BordersView" customModule="WooCommerce" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="44.5" width="375" height="48"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mgi-it-aQ1">
-                                    <rect key="frame" x="16" y="14" width="343" height="21"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mgi-it-aQ1">
+                                    <rect key="frame" x="16" y="14" width="343" height="23"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
@@ -39,7 +39,6 @@
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="Mgi-it-aQ1" secondAttribute="trailing" constant="16" id="fDu-ac-2KI"/>
                                 <constraint firstItem="Mgi-it-aQ1" firstAttribute="top" secondItem="Lfm-8q-CzH" secondAttribute="top" constant="14" id="iZo-y8-TIo"/>
-                                <constraint firstAttribute="height" constant="48" id="jtx-gb-DND"/>
                                 <constraint firstAttribute="bottom" secondItem="Mgi-it-aQ1" secondAttribute="bottom" constant="13" id="ltl-Gt-ebO"/>
                                 <constraint firstItem="Mgi-it-aQ1" firstAttribute="leading" secondItem="Lfm-8q-CzH" secondAttribute="leading" constant="16" id="ubc-Eh-WQT"/>
                             </constraints>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyListMessageWithActionView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="uQE-ll-SpT">
-                    <rect key="frame" x="0.0" y="135" width="375" height="92.5"/>
+                    <rect key="frame" x="0.0" y="135" width="375" height="94.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldr-2h-SOT">
                             <rect key="frame" x="166.5" y="0.0" width="42" height="20.5"/>
@@ -26,7 +26,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lfm-8q-CzH" customClass="BordersView" customModule="WooCommerce" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="44.5" width="375" height="48"/>
+                            <rect key="frame" x="0.0" y="44.5" width="375" height="50"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mgi-it-aQ1">
                                     <rect key="frame" x="16" y="14" width="343" height="23"/>


### PR DESCRIPTION
Fixes #908 

## Changes
- Removed constraint that sets 48px height to action button (setting constant height is discouraged as its content could have dynamic height)
- Set action message label's `verticalCompressionResistancePriority` to `default low` so that its content height is at a lower priority than others. Out of the two UI elements on this message+action view, I think it's more important to show the full text of the action button than that of the message label (but lemme know there is a better design like shrinking text down to a min font size)
- Set action button label to have any number of lines
- Miscellaneous IB diffs from previous updates

## Testing
- Launch the app with a store that has at least one order
- Go to 'Orders' tab
- Click on an order
- Click on 'Fulfill Order'
- Scroll down to '+ Add Tracking' (if you don't see this, make sure you have the [Shipping Tracking extension](https://woocommerce.com/products/shipment-tracking/) installed and activated)
- Click on 'Shipping provider' row
- Search for a shipping provider not in the list (e.g. `Fedox`)
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the 'Custom provider' action button --> The button text should not be clipped with larger font sizes

## Example screenshots

before | after
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-06-25 at 13 57 24](https://user-images.githubusercontent.com/1945542/60123412-6b511100-9755-11e9-9be2-76ed47d7e028.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-25 at 13 49 10](https://user-images.githubusercontent.com/1945542/60123421-6ee49800-9755-11e9-97d9-0c6c0b05326b.png)
![Simulator Screen Shot - iPhone SE - 2019-06-25 at 13 57 10](https://user-images.githubusercontent.com/1945542/60123435-773cd300-9755-11e9-95ee-1b9ce8811214.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-25 at 13 54 52](https://user-images.githubusercontent.com/1945542/60123440-7a37c380-9755-11e9-9a9f-b5b2171b1a62.png)
![Simulator Screen Shot - iPhone SE - 2019-06-25 at 13 56 39](https://user-images.githubusercontent.com/1945542/60123483-8d4a9380-9755-11e9-8262-4b8a1d3937be.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-25 at 13 55 47](https://user-images.githubusercontent.com/1945542/60123487-8faced80-9755-11e9-80a0-c116dfe7fa5d.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
