### PR TITLE
Dashboard: expose `You have X orders to fulfill` section to VoiceOver

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -41,6 +41,7 @@ class NewOrdersViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureView()
+        configureActionButtonForVoiceOver()
     }
 
     override func viewDidLayoutSubviews() {
@@ -96,6 +97,11 @@ private extension NewOrdersViewController {
             comment: "Description text used on the UI element displayed when a user has pending orders to process."
         )
         chevronImageView.image = UIImage.chevronImage.imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    func configureActionButtonForVoiceOver() {
+        actionButton.accessibilityLabel = descriptionLabel.text
+        actionButton.accessibilityHint = titleLabel.text
     }
 }
 


### PR DESCRIPTION
Fixes #913 

## Changes
- Set the action button's accessibility label to action description and accessibility hint to the title (`You have %d orders to fulfill`) following the [official doc](https://developer.apple.com/documentation/uikit/accessibility/supporting_voiceover_in_your_app) (any other suggestions are welcome!)
> The `accessibilityLabel` property provides descriptive text that VoiceOver reads when the user selects an element.
> The `accessibilityHint` property provides additional context (or actions) for the selected element.

## Testing
- On a physical device (VoiceOver is not supported on simulators): turn on VoiceOver (device Settings > General > Accessibility > VoiceOver > turn it on)
- Launch the app with a store that has at least one new order
- Tap on the view that says `You have X orders to fulfill` - `Review, prepare, and ship these pending orders`

Before this PR: VoiceOver says: `Button`
Expected: VoiceOver says: `Review, prepare, and ship these pending orders` - `Button` - `You have X orders to fulfill`

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
