### PR TITLE
Fulfill Order: fix "Mark as complete" button title truncated for larger font sizes

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -15,6 +15,8 @@ extension UIButton {
         layer.borderWidth = Style.defaultBorderWidth
         layer.cornerRadius = Style.defaultCornerRadius
         titleLabel?.applyHeadlineStyle()
+        enableMultipleLines()
+        titleLabel?.textAlignment = .center
     }
 
     /// Applies the Secondary Button Style: Clear BG / Bordered Outline

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -89,6 +89,11 @@ final class FulfillViewController: UIViewController {
         syncTrackingsHiddingAddButtonIfNecessary()
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.updateFooterHeight()
+    }
+
     private func syncTrackingsHiddingAddButtonIfNecessary() {
         syncTracking { [weak self] error in
             if error == nil {
@@ -122,7 +127,11 @@ private extension FulfillViewController {
     /// Setup: TableView
     ///
     func setupTableView() {
-        tableView.tableFooterView = actionView
+        let container = UIView(frame: CGRect(origin: .zero, size: CGSize(width: tableView.frame.width, height: 0)))
+        container.addSubview(actionView)
+        actionView.translatesAutoresizingMaskIntoConstraints = false
+        container.pinSubviewToAllEdges(actionView)
+        tableView.tableFooterView = container
     }
 
     ///Setup: Action Button!


### PR DESCRIPTION
Fixes #907  

## Changes
- Enabled any number of lines for primary button style
- Added frame based container view for Auto Layout based action view as table footer view, and updated table footer height in view controller's `viewDidLayoutSubviews`

## Testing
- Launch the app with a store that has at least one order not fulfilled yet
- On "Orders" tab, tap on an open Order
- On the Order page, tap "Fulfill order" button
- Scroll to the bottom where the footer is with `Mark as complete`
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the footer view --> The button should have 64px margin to the bottom with full title shown

## Example screenshots

before | after
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-06-28 at 11 23 10](https://user-images.githubusercontent.com/1945542/60353758-b149e700-9998-11e9-8895-89a800df5b76.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-28 at 11 16 54](https://user-images.githubusercontent.com/1945542/60353690-8eb7ce00-9998-11e9-83b7-d1eae31c5981.png)
![Simulator Screen Shot - iPhone SE - 2019-06-28 at 11 22 58](https://user-images.githubusercontent.com/1945542/60353733-a68f5200-9998-11e9-85f9-23721643efdc.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-28 at 11 16 29](https://user-images.githubusercontent.com/1945542/60353738-a98a4280-9998-11e9-9574-6fcdd85cc5dc.png)
![Simulator Screen Shot - iPhone SE - 2019-06-28 at 11 22 46](https://user-images.githubusercontent.com/1945542/60353804-d2aad300-9998-11e9-8a2c-9909c859e3e0.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-28 at 11 17 07](https://user-images.githubusercontent.com/1945542/60353818-d8081d80-9998-11e9-839d-d4f50f001d21.png)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
