### PR TITLE
Fulfill Order: fix shipment date clipped for larger font sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/EditableOrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/EditableOrderTrackingTableViewCell.swift
@@ -63,6 +63,7 @@ final class EditableOrderTrackingTableViewCell: UITableViewCell {
 
     private func configureBottomLine() {
         bottomLine.applyBodyStyle()
+        bottomLine.numberOfLines = 0
     }
 
     private func configureActionButton() {


### PR DESCRIPTION
Fixes #905 

## Changes
- Enabled any number of lines for the bottom line label to show full shipment date

## Testing
- Launch the app with a store that has at least one order with shipment tracking
- On "Orders" tab, tap on an Order with shipment tracking
- On the Order page, tap "Fulfill order" button
- Scroll to the section with shipment information
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the shipment date --> The date should not be truncated at any font size

## Example screenshots

before | after
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-06-28 at 16 00 05](https://user-images.githubusercontent.com/1945542/60368744-a8204080-99bf-11e9-8873-5ca5d5b557ba.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-28 at 16 05 55](https://user-images.githubusercontent.com/1945542/60368745-a8204080-99bf-11e9-8b7f-636deb51f84a.png)
![Simulator Screen Shot - iPhone SE - 2019-06-28 at 16 18 06](https://user-images.githubusercontent.com/1945542/60369021-5926db00-99c0-11e9-979f-8ace5a07f285.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-28 at 16 15 28](https://user-images.githubusercontent.com/1945542/60369029-5fb55280-99c0-11e9-965c-07ea478438fd.png)
![Simulator Screen Shot - iPhone SE - 2019-06-28 at 16 17 06](https://user-images.githubusercontent.com/1945542/60369040-69d75100-99c0-11e9-9c38-a7d7e746a843.png) | ![Simulator Screen Shot - iPhone SE - 2019-06-28 at 16 16 13](https://user-images.githubusercontent.com/1945542/60369041-6c39ab00-99c0-11e9-9786-7317d91c3db9.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.