### PR TITLE
Fulfill order: allow any number of lines for shipping provider and tracking number

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/EditableOrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/EditableOrderTrackingTableViewCell.swift
@@ -55,10 +55,12 @@ final class EditableOrderTrackingTableViewCell: UITableViewCell {
 
     private func configureTopLine() {
         topLine.applyBodyStyle()
+        topLine.numberOfLines = 0
     }
 
     private func configureMiddleLine() {
         middleLine.applyHeadlineStyle()
+        middleLine.numberOfLines = 0
     }
 
     private func configureBottomLine() {


### PR DESCRIPTION
Fixes #1058  

## Changes
- Enabled any number of lines for the top line label to show the full shipping provider
- Enabled any number of lines for the middle line label to show the full shipment tracking number

## Testing
- Launch the app with a store that has at least one order with shipment tracking
- On "Orders" tab, tap on an Order with shipment tracking
- On the Order page, tap "Fulfill order" button
- Scroll to the section with shipment information
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the shipping provider and shipment tracking number --> Both labels should not be truncated at any font size

## Example screenshots

before | after
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-07-01 at 10 18 27](https://user-images.githubusercontent.com/1945542/60443605-9de18a80-9be9-11e9-898b-cef0fad1a96f.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-01 at 10 17 05](https://user-images.githubusercontent.com/1945542/60443627-a5089880-9be9-11e9-9dab-707959d2ad89.png)
![Simulator Screen Shot - iPhone SE - 2019-07-01 at 10 18 14](https://user-images.githubusercontent.com/1945542/60443663-b3ef4b00-9be9-11e9-8899-ad2c86c033ed.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-01 at 09 41 20](https://user-images.githubusercontent.com/1945542/60443673-b81b6880-9be9-11e9-86f6-3a799de97a25.png)
![Simulator Screen Shot - iPhone SE - 2019-07-01 at 10 17 58](https://user-images.githubusercontent.com/1945542/60443688-bf427680-9be9-11e9-8d5e-7d8363025d56.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-01 at 10 17 18](https://user-images.githubusercontent.com/1945542/60443694-c1a4d080-9be9-11e9-8dc7-15e45b6d4a08.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
