### PR TITLE
Stats: add to the Storage layer for new stats

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -262,6 +262,12 @@
 		7471A518216CF12900219F7E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
+				D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
+				D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */,
+				D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
+				D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
+				D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
 				74938EC6216FA9B200540BA1 /* OrderStats+CoreDataClass.swift */,
 				74938EC7216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift */,
 				74938EC4216FA9B200540BA1 /* OrderStatsItem+CoreDataClass.swift */,
@@ -424,12 +430,6 @@
 				B5FD111C21D4046E00560344 /* OrderSearchResults+CoreDataProperties.swift */,
 				CE3B7AD02225E62C0050FE4B /* OrderStatus+CoreDataClass.swift */,
 				CE3B7AD12225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift */,
-				D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
-				D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
-				D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */,
-				D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
-				D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
-				D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
 				747453952242C85E00E0B5EE /* Product+CoreDataClass.swift */,
 				747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */,
 				7474538F2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -91,6 +91,12 @@
 		D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61542265AA900031A13B /* PListFileStorage.swift */; };
 		D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61562265AD980031A13B /* FileStorageTests.swift */; };
 		D87F615C2265AF190031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615B2265AF190031A13B /* shipment-provider.plist */; };
+		D8FBFF3122D63F97006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
+		D8FBFF3222D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
+		D8FBFF3322D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
+		D8FBFF3422D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
+		D8FBFF3522D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
+		D8FBFF3622D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +216,13 @@
 		D87F61542265AA900031A13B /* PListFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PListFileStorage.swift; sourceTree = "<group>"; };
 		D87F61562265AD980031A13B /* FileStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorageTests.swift; path = StorageTests/Tools/FileStorageTests.swift; sourceTree = SOURCE_ROOT; };
 		D87F615B2265AF190031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
+		D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 17.xcdatamodel"; sourceTree = "<group>"; };
+		D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Totals+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
+		D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Interval+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<absolute>"; };
+		D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift"; sourceTree = "<absolute>"; };
+		D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
+		D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Interval+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
+		D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Totals+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<absolute>"; };
 		DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -411,6 +424,12 @@
 				B5FD111C21D4046E00560344 /* OrderSearchResults+CoreDataProperties.swift */,
 				CE3B7AD02225E62C0050FE4B /* OrderStatus+CoreDataClass.swift */,
 				CE3B7AD12225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift */,
+				D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
+				D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
+				D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */,
+				D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
+				D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
+				D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
 				747453952242C85E00E0B5EE /* Product+CoreDataClass.swift */,
 				747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */,
 				7474538F2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift */,
@@ -683,6 +702,7 @@
 				747453A82242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift in Sources */,
 				7474539F2242C85E00E0B5EE /* ProductImage+CoreDataClass.swift in Sources */,
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
+				D8FBFF3622D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
 				937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */,
@@ -697,18 +717,23 @@
 				74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */,
 				D87F614E22657C2F0031A13B /* PreselectedProvider.swift in Sources */,
 				CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */,
+				D8FBFF3522D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				7474539B2242C85E00E0B5EE /* ProductDimensions+CoreDataClass.swift in Sources */,
 				B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */,
 				937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */,
 				B52B0F7B20AA28A800477698 /* Object.swift in Sources */,
+				D8FBFF3422D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */,
 				746A9D23214078080013F6FF /* TopEarnerStatsItem+CoreDataClass.swift in Sources */,
+				D8FBFF3222D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,
 				7499FA44221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift in Sources */,
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
+				D8FBFF3122D63F97006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,
+				D8FBFF3322D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
@@ -1010,6 +1035,7 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */,
 				CE43A8FA229F475400A4FF29 /* Model 16.xcdatamodel */,
 				CE6B4810227C915B00488C39 /* Model 15.xcdatamodel */,
 				93D8BBF9226A6B3200AD2EB3 /* Model 14.xcdatamodel */,
@@ -1027,7 +1053,7 @@
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = CE43A8FA229F475400A4FF29 /* Model 16.xcdatamodel */;
+			currentVersion = D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -91,12 +91,12 @@
 		D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61542265AA900031A13B /* PListFileStorage.swift */; };
 		D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61562265AD980031A13B /* FileStorageTests.swift */; };
 		D87F615C2265AF190031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615B2265AF190031A13B /* shipment-provider.plist */; };
-		D8FBFF3122D63F97006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
-		D8FBFF3222D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
-		D8FBFF3322D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
-		D8FBFF3422D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
-		D8FBFF3522D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
-		D8FBFF3622D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
+		D8FBFF3D22D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3722D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
+		D8FBFF3E22D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3822D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
+		D8FBFF3F22D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3922D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
+		D8FBFF4022D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3A22D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
+		D8FBFF4122D64091006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3B22D64091006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
+		D8FBFF4222D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3C22D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,12 +217,12 @@
 		D87F61562265AD980031A13B /* FileStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorageTests.swift; path = StorageTests/Tools/FileStorageTests.swift; sourceTree = SOURCE_ROOT; };
 		D87F615B2265AF190031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
 		D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 17.xcdatamodel"; sourceTree = "<group>"; };
-		D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Totals+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
-		D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Interval+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<absolute>"; };
-		D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift"; sourceTree = "<absolute>"; };
-		D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
-		D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Interval+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
-		D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "OrderStatsV4Totals+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<absolute>"; };
+		D8FBFF3722D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF3822D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF3922D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF3A22D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF3B22D64091006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF3C22D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -262,12 +262,12 @@
 		7471A518216CF12900219F7E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
-				D8FBFF3022D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
-				D8FBFF2B22D63F96006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
-				D8FBFF2D22D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift */,
-				D8FBFF2E22D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
-				D8FBFF2C22D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
-				D8FBFF2F22D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
+				D8FBFF3722D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
+				D8FBFF3822D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
+				D8FBFF3922D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
+				D8FBFF3A22D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
+				D8FBFF3B22D64091006E3336 /* OrderStatsV4+CoreDataClass.swift */,
+				D8FBFF3C22D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
 				74938EC6216FA9B200540BA1 /* OrderStats+CoreDataClass.swift */,
 				74938EC7216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift */,
 				74938EC4216FA9B200540BA1 /* OrderStatsItem+CoreDataClass.swift */,
@@ -667,11 +667,13 @@
 			files = (
 				B5B914C520EFF03500F2F832 /* Site+CoreDataClass.swift in Sources */,
 				74938EC9216FA9B200540BA1 /* OrderStatsItem+CoreDataProperties.swift in Sources */,
+				D8FBFF3F22D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				747453A02242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift in Sources */,
 				B54CA5BB20A4BD2800F38CD1 /* NSManagedObject+Object.swift in Sources */,
 				D821645D2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift in Sources */,
 				7471A514216CF0FE00219F7E /* SiteVisitStats+CoreDataClass.swift in Sources */,
 				7474539C2242C85E00E0B5EE /* ProductDimensions+CoreDataProperties.swift in Sources */,
+				D8FBFF3D22D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
 				74938ECB216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift in Sources */,
 				7426A05120F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift in Sources */,
 				747453A12242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift in Sources */,
@@ -699,10 +701,10 @@
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
+				D8FBFF4222D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				747453A82242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift in Sources */,
 				7474539F2242C85E00E0B5EE /* ProductImage+CoreDataClass.swift in Sources */,
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
-				D8FBFF3622D63F97006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
 				937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */,
@@ -715,30 +717,28 @@
 				7474539E2242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift in Sources */,
 				CE3B7AD22225E62C0050FE4B /* OrderStatus+CoreDataClass.swift in Sources */,
 				74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */,
+				D8FBFF4122D64091006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				D87F614E22657C2F0031A13B /* PreselectedProvider.swift in Sources */,
 				CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */,
-				D8FBFF3522D63F97006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				7474539B2242C85E00E0B5EE /* ProductDimensions+CoreDataClass.swift in Sources */,
 				B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */,
+				D8FBFF4022D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */,
 				B52B0F7B20AA28A800477698 /* Object.swift in Sources */,
-				D8FBFF3422D63F97006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */,
 				746A9D23214078080013F6FF /* TopEarnerStatsItem+CoreDataClass.swift in Sources */,
-				D8FBFF3222D63F97006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,
 				7499FA44221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift in Sources */,
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
-				D8FBFF3122D63F97006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,
-				D8FBFF3322D63F97006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,
 				CE43A8FE229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift in Sources */,
+				D8FBFF3E22D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
 				747453A22242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift in Sources */,
 				CE43A8FD229F498D00A4FF29 /* ProductDownload+CoreDataClass.swift in Sources */,
 			);

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -91,12 +91,12 @@
 		D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61542265AA900031A13B /* PListFileStorage.swift */; };
 		D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61562265AD980031A13B /* FileStorageTests.swift */; };
 		D87F615C2265AF190031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615B2265AF190031A13B /* shipment-provider.plist */; };
-		D8FBFF4922D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4322D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
-		D8FBFF4A22D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4422D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
-		D8FBFF4B22D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4522D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
-		D8FBFF4C22D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4622D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
-		D8FBFF4D22D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4722D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
-		D8FBFF4E22D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4822D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
+		D8FBFF5522D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
+		D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
+		D8FBFF5722D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5122D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
+		D8FBFF5822D66A06006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5222D66A06006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
+		D8FBFF5922D66A06006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5322D66A06006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
+		D8FBFF5A22D66A06006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5422D66A06006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,12 +217,12 @@
 		D87F61562265AD980031A13B /* FileStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorageTests.swift; path = StorageTests/Tools/FileStorageTests.swift; sourceTree = SOURCE_ROOT; };
 		D87F615B2265AF190031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
 		D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 17.xcdatamodel"; sourceTree = "<group>"; };
-		D8FBFF4322D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D8FBFF4422D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		D8FBFF4522D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D8FBFF4622D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		D8FBFF4722D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D8FBFF4822D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF5122D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF5222D66A06006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF5322D66A06006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF5422D66A06006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -262,12 +262,12 @@
 		7471A518216CF12900219F7E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
-				D8FBFF4322D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift */,
-				D8FBFF4422D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
-				D8FBFF4522D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
-				D8FBFF4622D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
-				D8FBFF4722D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
-				D8FBFF4822D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
+				D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
+				D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
+				D8FBFF5122D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
+				D8FBFF5222D66A06006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
+				D8FBFF5322D66A06006E3336 /* OrderStatsV4+CoreDataClass.swift */,
+				D8FBFF5422D66A06006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
 				74938EC6216FA9B200540BA1 /* OrderStats+CoreDataClass.swift */,
 				74938EC7216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift */,
 				74938EC4216FA9B200540BA1 /* OrderStatsItem+CoreDataClass.swift */,
@@ -671,7 +671,7 @@
 				B54CA5BB20A4BD2800F38CD1 /* NSManagedObject+Object.swift in Sources */,
 				D821645D2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift in Sources */,
 				7471A514216CF0FE00219F7E /* SiteVisitStats+CoreDataClass.swift in Sources */,
-				D8FBFF4B22D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
+				D8FBFF5722D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
 				7474539C2242C85E00E0B5EE /* ProductDimensions+CoreDataProperties.swift in Sources */,
 				74938ECB216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift in Sources */,
 				7426A05120F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift in Sources */,
@@ -701,11 +701,11 @@
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
 				747453A82242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift in Sources */,
+				D8FBFF5A22D66A06006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				7474539F2242C85E00E0B5EE /* ProductImage+CoreDataClass.swift in Sources */,
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
 				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
-				D8FBFF4922D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */,
 				74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */,
 				CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */,
@@ -714,9 +714,10 @@
 				7471A516216CF0FE00219F7E /* SiteVisitStatsItem+CoreDataClass.swift in Sources */,
 				B505F6DA20BEEA3200BB1B69 /* Account+CoreDataProperties.swift in Sources */,
 				7474539E2242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift in Sources */,
-				D8FBFF4C22D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
-				D8FBFF4A22D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
+				D8FBFF5522D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
+				D8FBFF5822D66A06006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
 				CE3B7AD22225E62C0050FE4B /* OrderStatus+CoreDataClass.swift in Sources */,
+				D8FBFF5922D66A06006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */,
 				D87F614E22657C2F0031A13B /* PreselectedProvider.swift in Sources */,
 				CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */,
@@ -729,12 +730,11 @@
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,
 				7499FA44221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift in Sources */,
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
+				D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
-				D8FBFF4D22D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
-				D8FBFF4E22D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -91,12 +91,12 @@
 		D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61542265AA900031A13B /* PListFileStorage.swift */; };
 		D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61562265AD980031A13B /* FileStorageTests.swift */; };
 		D87F615C2265AF190031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615B2265AF190031A13B /* shipment-provider.plist */; };
-		D8FBFF3D22D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3722D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
-		D8FBFF3E22D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3822D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
-		D8FBFF3F22D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3922D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
-		D8FBFF4022D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3A22D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
-		D8FBFF4122D64091006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3B22D64091006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
-		D8FBFF4222D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF3C22D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
+		D8FBFF4922D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4322D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift */; };
+		D8FBFF4A22D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4422D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift */; };
+		D8FBFF4B22D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4522D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
+		D8FBFF4C22D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4622D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */; };
+		D8FBFF4D22D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4722D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
+		D8FBFF4E22D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4822D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,12 +217,12 @@
 		D87F61562265AD980031A13B /* FileStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorageTests.swift; path = StorageTests/Tools/FileStorageTests.swift; sourceTree = SOURCE_ROOT; };
 		D87F615B2265AF190031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
 		D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 17.xcdatamodel"; sourceTree = "<group>"; };
-		D8FBFF3722D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D8FBFF3822D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		D8FBFF3922D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D8FBFF3A22D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		D8FBFF3B22D64091006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataClass.swift"; sourceTree = "<group>"; };
-		D8FBFF3C22D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF4322D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF4422D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF4522D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF4622D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Totals+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8FBFF4722D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
+		D8FBFF4822D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Storage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -262,12 +262,12 @@
 		7471A518216CF12900219F7E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
-				D8FBFF3722D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
-				D8FBFF3822D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
-				D8FBFF3922D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
-				D8FBFF3A22D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
-				D8FBFF3B22D64091006E3336 /* OrderStatsV4+CoreDataClass.swift */,
-				D8FBFF3C22D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
+				D8FBFF4322D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift */,
+				D8FBFF4422D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift */,
+				D8FBFF4522D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */,
+				D8FBFF4622D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift */,
+				D8FBFF4722D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */,
+				D8FBFF4822D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */,
 				74938EC6216FA9B200540BA1 /* OrderStats+CoreDataClass.swift */,
 				74938EC7216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift */,
 				74938EC4216FA9B200540BA1 /* OrderStatsItem+CoreDataClass.swift */,
@@ -667,13 +667,12 @@
 			files = (
 				B5B914C520EFF03500F2F832 /* Site+CoreDataClass.swift in Sources */,
 				74938EC9216FA9B200540BA1 /* OrderStatsItem+CoreDataProperties.swift in Sources */,
-				D8FBFF3F22D64091006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				747453A02242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift in Sources */,
 				B54CA5BB20A4BD2800F38CD1 /* NSManagedObject+Object.swift in Sources */,
 				D821645D2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift in Sources */,
 				7471A514216CF0FE00219F7E /* SiteVisitStats+CoreDataClass.swift in Sources */,
+				D8FBFF4B22D667A0006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
 				7474539C2242C85E00E0B5EE /* ProductDimensions+CoreDataProperties.swift in Sources */,
-				D8FBFF3D22D64091006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */,
 				74938ECB216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift in Sources */,
 				7426A05120F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift in Sources */,
 				747453A12242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift in Sources */,
@@ -701,12 +700,12 @@
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
-				D8FBFF4222D64091006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				747453A82242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift in Sources */,
 				7474539F2242C85E00E0B5EE /* ProductImage+CoreDataClass.swift in Sources */,
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
 				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
+				D8FBFF4922D667A0006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */,
 				74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */,
 				CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */,
@@ -715,14 +714,14 @@
 				7471A516216CF0FE00219F7E /* SiteVisitStatsItem+CoreDataClass.swift in Sources */,
 				B505F6DA20BEEA3200BB1B69 /* Account+CoreDataProperties.swift in Sources */,
 				7474539E2242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift in Sources */,
+				D8FBFF4C22D667A0006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
+				D8FBFF4A22D667A0006E3336 /* OrderStatsV4+CoreDataProperties.swift in Sources */,
 				CE3B7AD22225E62C0050FE4B /* OrderStatus+CoreDataClass.swift in Sources */,
 				74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */,
-				D8FBFF4122D64091006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				D87F614E22657C2F0031A13B /* PreselectedProvider.swift in Sources */,
 				CE12FBCF221F0E1A00C59248 /* Order+CoreDataProperties.swift in Sources */,
 				7474539B2242C85E00E0B5EE /* ProductDimensions+CoreDataClass.swift in Sources */,
 				B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */,
-				D8FBFF4022D64091006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */,
 				B52B0F7B20AA28A800477698 /* Object.swift in Sources */,
 				7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */,
@@ -732,13 +731,14 @@
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
+				D8FBFF4D22D667A0006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
+				D8FBFF4E22D667A0006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,
 				CE43A8FE229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift in Sources */,
-				D8FBFF3E22D64091006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
 				747453A22242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift in Sources */,
 				CE43A8FD229F498D00A4FF29 /* ProductDownload+CoreDataClass.swift in Sources */,
 			);

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,12 @@
 
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 17 (Release 2.3.0.0)
+- @ctarda 2019-07-10
+    - Add `OrderStatsV4` entity
+    - Add `OrderStatsV4Totals` entity
+    - Add `OrderStatsV4Interval` entity
+
 ## Model 16 (Release 2.0.0.0)
 - @mindgraffiti 2019-05-29
     - Add `ProductDownload` entity

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
@@ -1,11 +1,3 @@
-//
-//  OrderStatsV4+CoreDataClass.swift
-//  
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  OrderStatsV4+CoreDataClass.swift
+//  
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(OrderStatsV4)
+public class OrderStatsV4: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
@@ -1,3 +1,12 @@
+//
+//  OrderStatsV4+CoreDataClass.swift
+//  Storage
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+//
+
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift
@@ -1,12 +1,3 @@
-//
-//  OrderStatsV4+CoreDataClass.swift
-//  Storage
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
@@ -1,0 +1,21 @@
+//
+//  OrderStatsV4+CoreDataProperties.swift
+//  
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension OrderStatsV4 {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<OrderStatsV4> {
+        return NSFetchRequest<OrderStatsV4>(entityName: "OrderStatsV4")
+    }
+
+    @NSManaged public var totals: OrderStatsV4Totals?
+
+}

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
@@ -1,12 +1,3 @@
-//
-//  OrderStatsV4+CoreDataProperties.swift
-//  Storage
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-//
-
 import Foundation
 import CoreData
 
@@ -54,5 +45,4 @@ extension OrderStatsV4 {
 
     @objc(removeIntervals:)
     @NSManaged public func removeFromIntervals(_ values: NSOrderedSet)
-
 }

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
@@ -1,11 +1,3 @@
-//
-//  OrderStatsV4+CoreDataProperties.swift
-//  
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
@@ -8,6 +8,8 @@ extension OrderStatsV4 {
         return NSFetchRequest<OrderStatsV4>(entityName: "OrderStatsV4")
     }
 
+    @NSManaged public var siteID: Int
+    @NSManaged public var granularity: String
     @NSManaged public var totals: OrderStatsV4Totals?
     @NSManaged public var intervals: NSOrderedSet?
 

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
@@ -1,3 +1,12 @@
+//
+//  OrderStatsV4+CoreDataProperties.swift
+//  Storage
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+//
+
 import Foundation
 import CoreData
 
@@ -9,5 +18,41 @@ extension OrderStatsV4 {
     }
 
     @NSManaged public var totals: OrderStatsV4Totals?
+    @NSManaged public var intervals: NSOrderedSet?
+
+}
+
+// MARK: Generated accessors for intervals
+extension OrderStatsV4 {
+
+    @objc(insertObject:inIntervalsAtIndex:)
+    @NSManaged public func insertIntoIntervals(_ value: OrderStatsV4Interval, at idx: Int)
+
+    @objc(removeObjectFromIntervalsAtIndex:)
+    @NSManaged public func removeFromIntervals(at idx: Int)
+
+    @objc(insertIntervals:atIndexes:)
+    @NSManaged public func insertIntoIntervals(_ values: [OrderStatsV4Interval], at indexes: NSIndexSet)
+
+    @objc(removeIntervalsAtIndexes:)
+    @NSManaged public func removeFromIntervals(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInIntervalsAtIndex:withObject:)
+    @NSManaged public func replaceIntervals(at idx: Int, with value: OrderStatsV4Interval)
+
+    @objc(replaceIntervalsAtIndexes:withIntervals:)
+    @NSManaged public func replaceIntervals(at indexes: NSIndexSet, with values: [OrderStatsV4Interval])
+
+    @objc(addIntervalsObject:)
+    @NSManaged public func addToIntervals(_ value: OrderStatsV4Interval)
+
+    @objc(removeIntervalsObject:)
+    @NSManaged public func removeFromIntervals(_ value: OrderStatsV4Interval)
+
+    @objc(addIntervals:)
+    @NSManaged public func addToIntervals(_ values: NSOrderedSet)
+
+    @objc(removeIntervals:)
+    @NSManaged public func removeFromIntervals(_ values: NSOrderedSet)
 
 }

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
@@ -1,3 +1,12 @@
+//
+//  OrderStatsV4Interval+CoreDataClass.swift
+//  Storage
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+//
+
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
@@ -1,11 +1,3 @@
-//
-//  OrderStatsV4Interval+CoreDataClass.swift
-//  
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
@@ -1,12 +1,3 @@
-//
-//  OrderStatsV4Interval+CoreDataClass.swift
-//  Storage
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  OrderStatsV4Interval+CoreDataClass.swift
+//  
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(OrderStatsV4Interval)
+public class OrderStatsV4Interval: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
@@ -1,12 +1,3 @@
-//
-//  OrderStatsV4Interval+CoreDataProperties.swift
-//  Storage
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-//
-
 import Foundation
 import CoreData
 
@@ -22,5 +13,4 @@ extension OrderStatsV4Interval {
     @NSManaged public var dateEnd: String?
     @NSManaged public var subtotals: OrderStatsV4Totals?
     @NSManaged public var stats: OrderStatsV4?
-
 }

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
@@ -1,0 +1,24 @@
+//
+//  OrderStatsV4Interval+CoreDataProperties.swift
+//  
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension OrderStatsV4Interval {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<OrderStatsV4Interval> {
+        return NSFetchRequest<OrderStatsV4Interval>(entityName: "OrderStatsV4Interval")
+    }
+
+    @NSManaged public var interval: String?
+    @NSManaged public var dateStart: String?
+    @NSManaged public var dateEnd: String?
+    @NSManaged public var subtotals: OrderStatsV4Totals?
+
+}

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
@@ -1,11 +1,3 @@
-//
-//  OrderStatsV4Interval+CoreDataProperties.swift
-//  
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift
@@ -1,3 +1,12 @@
+//
+//  OrderStatsV4Interval+CoreDataProperties.swift
+//  Storage
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+//
+
 import Foundation
 import CoreData
 
@@ -12,5 +21,6 @@ extension OrderStatsV4Interval {
     @NSManaged public var dateStart: String?
     @NSManaged public var dateEnd: String?
     @NSManaged public var subtotals: OrderStatsV4Totals?
+    @NSManaged public var stats: OrderStatsV4?
 
 }

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  OrderStatsV4Totals+CoreDataClass.swift
+//  
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(OrderStatsV4Totals)
+public class OrderStatsV4Totals: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
@@ -1,12 +1,3 @@
-//
-//  OrderStatsV4Totals+CoreDataClass.swift
-//  Storage
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
@@ -1,11 +1,3 @@
-//
-//  OrderStatsV4Totals+CoreDataClass.swift
-//  
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift
@@ -1,3 +1,12 @@
+//
+//  OrderStatsV4Totals+CoreDataClass.swift
+//  Storage
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+//
+
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
@@ -1,12 +1,3 @@
-//
-//  OrderStatsV4Totals+CoreDataProperties.swift
-//  Storage
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//  Copyright © 2019 Automattic. All rights reserved.
-//
-//
-
 import Foundation
 import CoreData
 
@@ -29,5 +20,4 @@ extension OrderStatsV4Totals {
     @NSManaged public var products: Int64
     @NSManaged public var interval: OrderStatsV4Interval?
     @NSManaged public var stats: OrderStatsV4?
-
 }

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
@@ -1,3 +1,12 @@
+//
+//  OrderStatsV4Totals+CoreDataProperties.swift
+//  Storage
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//  Copyright © 2019 Automattic. All rights reserved.
+//
+//
+
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
@@ -10,13 +10,13 @@ extension OrderStatsV4Totals {
 
     @NSManaged public var orders: Int64
     @NSManaged public var itemsSold: Int64
-    @NSManaged public var grossRevenue: Double
-    @NSManaged public var couponDiscount: Double
+    @NSManaged public var grossRevenue: Decimal
+    @NSManaged public var couponDiscount: Decimal
     @NSManaged public var coupons: Int64
-    @NSManaged public var refunds: Double
-    @NSManaged public var taxes: Double
-    @NSManaged public var shipping: Double
-    @NSManaged public var netRevenue: Double
+    @NSManaged public var refunds: Decimal
+    @NSManaged public var taxes: Decimal
+    @NSManaged public var shipping: Decimal
+    @NSManaged public var netRevenue: Decimal
     @NSManaged public var products: Int64
     @NSManaged public var interval: OrderStatsV4Interval?
     @NSManaged public var stats: OrderStatsV4?

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
@@ -8,16 +8,16 @@ extension OrderStatsV4Totals {
         return NSFetchRequest<OrderStatsV4Totals>(entityName: "OrderStatsV4Totals")
     }
 
-    @NSManaged public var orders: Int64
-    @NSManaged public var itemsSold: Int64
+    @NSManaged public var totalOrders: Int64
+    @NSManaged public var totalItemsSold: Int64
     @NSManaged public var grossRevenue: Decimal
     @NSManaged public var couponDiscount: Decimal
-    @NSManaged public var coupons: Int64
+    @NSManaged public var totalCoupons: Int64
     @NSManaged public var refunds: Decimal
     @NSManaged public var taxes: Decimal
     @NSManaged public var shipping: Decimal
     @NSManaged public var netRevenue: Decimal
-    @NSManaged public var products: Int64
+    @NSManaged public var totalProducts: Int64
     @NSManaged public var interval: OrderStatsV4Interval?
     @NSManaged public var stats: OrderStatsV4?
 }

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
@@ -1,0 +1,32 @@
+//
+//  OrderStatsV4Totals+CoreDataProperties.swift
+//  
+//
+//  Created by Cesar Tardaguila on 10/7/2019.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension OrderStatsV4Totals {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<OrderStatsV4Totals> {
+        return NSFetchRequest<OrderStatsV4Totals>(entityName: "OrderStatsV4Totals")
+    }
+
+    @NSManaged public var orders: Int64
+    @NSManaged public var itemsSold: Int64
+    @NSManaged public var grossRevenue: Double
+    @NSManaged public var couponDiscount: Double
+    @NSManaged public var coupons: Int64
+    @NSManaged public var refunds: Double
+    @NSManaged public var taxes: Double
+    @NSManaged public var shipping: Double
+    @NSManaged public var netRevenue: Double
+    @NSManaged public var products: Int64
+    @NSManaged public var interval: OrderStatsV4Interval?
+    @NSManaged public var stats: OrderStatsV4?
+
+}

--- a/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift
@@ -1,11 +1,3 @@
-//
-//  OrderStatsV4Totals+CoreDataProperties.swift
-//  
-//
-//  Created by Cesar Tardaguila on 10/7/2019.
-//
-//
-
 import Foundation
 import CoreData
 

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 16.xcdatamodel</string>
+	<string>Model 17.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
@@ -160,15 +160,15 @@
     </entity>
     <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
         <attribute name="couponDiscount" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
-        <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="grossRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
-        <attribute name="itemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="netRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
-        <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="refunds" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="shipping" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="taxes" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="totalCoupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalItemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4" syncable="YES"/>
     </entity>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
@@ -149,14 +149,14 @@
         <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
         <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
     </entity>
-    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES" codeGenerationType="class">
+    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES">
         <attribute name="dateEnd" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="dateStart" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="interval" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="intervals" inverseEntity="OrderStatsV4" syncable="YES"/>
         <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
     </entity>
-    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES" codeGenerationType="class">
+    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
         <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="grossRevenue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
@@ -146,6 +146,8 @@
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStats" inverseName="items" inverseEntity="OrderStats" syncable="YES"/>
     </entity>
     <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <attribute name="granularity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
         <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
     </entity>
@@ -357,6 +359,9 @@
         <element name="OrderSearchResults" positionX="144.44140625" positionY="743.43359375" width="128" height="75"/>
         <element name="OrderStats" positionX="137.859375" positionY="388.33203125" width="128" height="225"/>
         <element name="OrderStatsItem" positionX="321.74609375" positionY="425.51171875" width="128" height="330"/>
+        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="105"/>
+        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
+        <element name="OrderStatsV4Totals" positionX="-684" positionY="45" width="128" height="225"/>
         <element name="OrderStatus" positionX="-29.671875" positionY="781.29296875" width="128" height="105"/>
         <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="900"/>
         <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
@@ -375,8 +380,5 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
-        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="75"/>
-        <element name="OrderStatsV4Totals" positionX="-684" positionY="45" width="128" height="225"/>
-        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.98" systemVersion="18F132" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="subtype" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timestamp" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="number" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem" syncable="YES"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote" syncable="YES"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults" syncable="YES"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="note" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String" syncable="YES"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderStats" representedClassName="OrderStats" syncable="YES">
+        <attribute name="averageGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageNetSales" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageOrders" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageProducts" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalNetSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderStatsItem" inverseName="stats" inverseEntity="OrderStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsItem" representedClassName="OrderStatsItem" syncable="YES">
+        <attribute name="avgOrderValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="avgProductsPerOrder" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="grossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="netSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShipping" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStats" inverseName="items" inverseEntity="OrderStats" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES" codeGenerationType="class">
+        <attribute name="dateEnd" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateStart" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="interval" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES" codeGenerationType="class">
+        <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="grossRevenue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="itemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="netRevenue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="refunds" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shipping" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="taxes" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String" syncable="YES"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersKey" attributeType="String" syncable="YES"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="catalogVisibilityKey" attributeType="String" syncable="YES"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="permalink" attributeType="String" syncable="YES"/>
+        <attribute name="price" attributeType="String" syncable="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productTypeKey" attributeType="String" syncable="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="stockStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductCategory" inverseName="product" inverseEntity="ProductCategory" syncable="YES"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute" syncable="YES"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions" syncable="YES"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload" syncable="YES"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage" syncable="YES"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag" syncable="YES"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="categories" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String" syncable="YES"/>
+        <attribute name="length" attributeType="String" syncable="YES"/>
+        <attribute name="width" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
+        <attribute name="downloadID" attributeType="String" syncable="YES"/>
+        <attribute name="fileURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="src" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="trackingID" attributeType="String" syncable="YES"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider" syncable="YES"/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="plan" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="limit" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
+        <element name="AccountSettings" positionX="-846" positionY="270" width="128" height="75"/>
+        <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
+        <element name="Order" positionX="-20" positionY="27" width="128" height="720"/>
+        <element name="OrderCoupon" positionX="-206.01953125" positionY="379.74609375" width="128" height="120"/>
+        <element name="OrderItem" positionX="-364.890625" positionY="379.453125" width="128" height="240"/>
+        <element name="OrderNote" positionX="-365.16796875" positionY="630.2109375" width="128" height="135"/>
+        <element name="OrderSearchResults" positionX="144.44140625" positionY="743.43359375" width="128" height="75"/>
+        <element name="OrderStats" positionX="137.859375" positionY="388.33203125" width="128" height="225"/>
+        <element name="OrderStatsItem" positionX="321.74609375" positionY="425.51171875" width="128" height="330"/>
+        <element name="OrderStatus" positionX="-29.671875" positionY="781.29296875" width="128" height="105"/>
+        <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="900"/>
+        <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
+        <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
+        <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
+        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="105"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
+        <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
+        <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
+        <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
+        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="150"/>
+        <element name="SiteSetting" positionX="-362.54296875" positionY="217.9921875" width="128" height="135"/>
+        <element name="SiteVisitStats" positionX="134.515625" positionY="224.62109375" width="128" height="90"/>
+        <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
+        <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
+        <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="60"/>
+        <element name="OrderStatsV4Totals" positionX="-684" positionY="45" width="128" height="225"/>
+        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="105"/>
+    </elements>
+</model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
@@ -146,12 +146,14 @@
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStats" inverseName="items" inverseEntity="OrderStats" syncable="YES"/>
     </entity>
     <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
         <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
     </entity>
     <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES" codeGenerationType="class">
         <attribute name="dateEnd" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="dateStart" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="interval" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="intervals" inverseEntity="OrderStatsV4" syncable="YES"/>
         <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
     </entity>
     <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES" codeGenerationType="class">
@@ -373,8 +375,8 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
-        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="60"/>
+        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="75"/>
         <element name="OrderStatsV4Totals" positionX="-684" positionY="45" width="128" height="225"/>
-        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="105"/>
+        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 17.xcdatamodel/contents
@@ -159,16 +159,16 @@
         <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
     </entity>
     <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
-        <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="couponDiscount" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="grossRevenue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="grossRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="itemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="netRevenue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="netRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="refunds" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="shipping" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="taxes" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="refunds" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="shipping" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="taxes" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4" syncable="YES"/>
     </entity>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -92,7 +92,7 @@ public extension StorageType {
     /// Retrieves the Stored OrderStats for V4 API.
     ///
     func loadOrderStatsV4(siteID: String, granularity: String) -> OrderStatsV4? {
-        let predicate = NSPredicate(format: "siteID = %ld AND ==[c] %@", granularity)
+        let predicate = NSPredicate(format: "siteID = %ld AND granularity ==[c] %@", siteID, granularity)
         return firstObject(ofType: OrderStatsV4.self, matching: predicate)
     }
 

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -89,6 +89,13 @@ public extension StorageType {
         return firstObject(ofType: OrderStatsItem.self, matching: predicate)
     }
 
+    /// Retrieves the Stored OrderStats for V4 API.
+    ///
+    func loadOrderStatsV4(siteID: String, granularity: String) -> OrderStatsV4? {
+        let predicate = NSPredicate(format: "siteID = %ld AND ==[c] %@", granularity)
+        return firstObject(ofType: OrderStatsV4.self, matching: predicate)
+    }
+
     /// Retrieves all of the Stores OrderStatuses for the provided siteID.
     ///
     func loadOrderStatuses(siteID: Int) -> [OrderStatus]? {

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -2,24 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift">
-   </FileRef>
-   <FileRef
       location = "group:WooCommerce/WooCommerce.xcodeproj">
    </FileRef>
    <FileRef

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,24 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataClass.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Totals+CoreDataProperties.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataClass.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataClass.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/OrderStatsV4Interval+CoreDataProperties.swift">
+   </FileRef>
+   <FileRef
       location = "group:WooCommerce/WooCommerce.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
Fixes #1065 

Submitting as a draft PR, as it depends on PR #1082 to be reviewed and merged.

This PR adds stats V4 support to model v 17:

<img src="https://user-images.githubusercontent.com/2722505/61001130-025cc200-a32d-11e9-99c9-269e1a09d100.png" width="350"/>

## Changes
- New model version, with new entities.
- Generated subclasses
- Added a convenience method to the core data extensions

## Testing
- Checkout the branch, build and run the app, verify there are no coredata migration errors
- Run the test, verify they are ✅ 