### PR TITLE
Order Details > Shipment Tracking: fix provider name and shipment date truncated when using larger font sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
@@ -51,6 +51,7 @@ final class OrderTrackingTableViewCell: UITableViewCell {
 
     private func configureTopLine() {
         topLine.applySubheadlineStyle()
+        topLine.numberOfLines = 0
     }
 
     private func configureMiddleLine() {
@@ -59,6 +60,7 @@ final class OrderTrackingTableViewCell: UITableViewCell {
 
     private func configureBottomLine() {
         bottomLine.applySubheadlineStyle()
+        bottomLine.numberOfLines = 0
     }
 
     private func configureActionButton() {


### PR DESCRIPTION
Fixes #1072 

## Changes
- Allowed any number of lines for the top (shipping provider) and bottom (shipment date) labels in `OrderTrackingTableViewCell`.

## Testing
- Launch the app with a store that has at least one order with shipment tracking information
- On "Orders" tab, tap on an Order
- On the Order details page, scroll to "TRACKING" section
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the shipping provider and shipment date --> both labels should not be truncated

## Example screenshots

before | after
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-07-10 at 20 18 35](https://user-images.githubusercontent.com/1945542/61013617-6b563100-a351-11e9-95c6-1b0c9816ddea.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-10 at 20 21 56](https://user-images.githubusercontent.com/1945542/61013618-6b563100-a351-11e9-9db3-de8d8d941d60.png)
![Simulator Screen Shot - iPhone SE - 2019-07-10 at 20 27 53](https://user-images.githubusercontent.com/1945542/61013636-7c9f3d80-a351-11e9-987c-76ea95dbc14b.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-10 at 20 22 53](https://user-images.githubusercontent.com/1945542/61013642-7f019780-a351-11e9-8e86-9b2f0056c691.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
