### PR TITLE
Order Details > Shipment Tracking: add "Copy Tracking Number" to "more" action menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 2.3
 -----
 - Improvement: improved Dynamic Type support in the body of the notification in the Notifications tab.
-
+- New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.
  
 2.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -1117,6 +1117,10 @@ private extension OrderDetailsViewController {
 
         actionSheet.addCancelActionWithTitle(TrackingAction.dismiss)
 
+        actionSheet.addDefaultActionWithTitle(TrackingAction.copyTrackingNumber) { [weak self] _ in
+            self?.sendToPasteboard(tracking.trackingNumber, includeTrailingNewline: false)
+        }
+
         if tracking.trackingURL?.isEmpty == false {
             actionSheet.addDefaultActionWithTitle(TrackingAction.trackShipment) { [weak self] _ in
                 self?.openTrackingDetails(tracking)
@@ -1299,6 +1303,7 @@ private extension OrderDetailsViewController {
 
     enum TrackingAction {
         static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the shipment tracking action sheet")
+        static let copyTrackingNumber = NSLocalizedString("Copy Tracking Number", comment: "Copy tracking number button title")
         static let trackShipment = NSLocalizedString("Track Shipment", comment: "Track shipment button title")
         static let deleteTracking = NSLocalizedString("Delete Tracking", comment: "Delete tracking button title")
     }


### PR DESCRIPTION
Fixes #1073 

## Changes
- Added "Copy Tracking Number" to shipment tracking action sheet, and send the tracking number to pasteboard on tap.

## Testing
- Launch the app with a store that has at least one order with shipment tracking information
- On "Orders" tab, tap on an Order with shipment tracking
- On the Order details page, scroll to "TRACKING" section
- Tap on "..."
- Tap "Copy Tracking Number" --> the tracking number should be copied to the pasteboard
(I wish iOS has some feedback on text copied - like "Copied!" flash message)

## Example screenshot

![Simulator Screen Shot - iPhone SE - 2019-07-10 at 20 49 33](https://user-images.githubusercontent.com/1945542/61014203-3eefe400-a354-11e9-908d-ae0f2e121d35.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
