### PR TITLE
Order list search: fix no results text clipped with larger font sizes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
@@ -171,6 +171,8 @@ private extension OrderSearchViewController {
         emptyStateLabel.text = NSLocalizedString("No Orders found", comment: "Search Orders (Empty State)")
         emptyStateLabel.textColor = StyleManager.wooGreyMid
         emptyStateLabel.font = .headline
+        emptyStateLabel.adjustsFontForContentSizeCategory = true
+        emptyStateLabel.numberOfLines = 0
     }
 
     /// Setup: Results Controller


### PR DESCRIPTION
Fixes #1062 

## Changes
- Enabled any number of lines for the order list search empty state label. Also, allowed the label to adjust font size with Dynamic Type.

## Testing
- Launch the app with a store that has at least one order
- On "Orders" tab, tap on the search icon in the navigation bar
- In the search bar, type some query that has no search results
- Turn on dynamic type (device Settings > General > Accessibility > Larger Text > turn it on) and adjust the device to different font sizes via the slider, and observe the no results text as in the screenshot below

## Example screenshots

before | after
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-07-12 at 15 31 52](https://user-images.githubusercontent.com/1945542/61154409-09660a80-a4bc-11e9-9e37-7180634eb2ea.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-12 at 15 46 00](https://user-images.githubusercontent.com/1945542/61154463-30bcd780-a4bc-11e9-84a0-e4876ca0c4f3.png)



Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
