### PR TITLE
Automatic dSYM upload to Sentry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
       xcodeproj (>= 1.5.7, < 2.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-sentry (1.5.0)
     fourflusher (2.2.0)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -221,9 +222,10 @@ DEPENDENCIES
   cocoapods-repo-update (~> 0.0.4)!
   dotenv!
   fastlane
+  fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   rake!
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -195,7 +195,13 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     
     testflight(skip_waiting_for_build_processing: true)
     sh("cd .. && rm WooCommerce.ipa")
-    upload_symbols_to_crashlytics(dsym_path: "./WooCommerce.app.dSYM.zip", api_token: ENV["FABRIC_APP_TOKEN"])
+
+    sentry_upload_dsym(
+      auth_token: ENV["SENTRY_AUTH_TOKEN"],
+      org_slug: 'a8c',
+      project_slug: 'woocommerce-ios',
+      dsym_path: "./WooCommerce.app.dSYM.zip",
+    )
     sh("cd .. && rm WooCommerce.app.dSYM.zip")
   end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,3 +3,4 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.2.0'
+gem 'fastlane-plugin-sentry'

--- a/fastlane/env.example
+++ b/fastlane/env.example
@@ -1,1 +1,2 @@
 GHHELPER_ACCESS=<GitHub access token>
+SENTRY_AUTH_TOKEN=<Sentry auth token>


### PR DESCRIPTION
This PR replaces Fabric with Sentry in `Fastfile`.

# To test:
1. Run `bundle install`.
2. Add the `SENTRY_AUTH_TOKEN=` entry to your `~/.wcios-env-default`.
2. Update the version name in `Version.Public.xcconfig` to something not used in production (change the last number, or add another .0, or something like that).
3. Run `bundle exec fastlane build_and_upload_itc` and verify that the dSYM is uploaded to Sentry.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
