### PR TITLE
Release notes: move "copy tracking number" feature from release 2.3 to 2.4

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,12 +1,12 @@
 2.4
 -----
+- New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.
 - bugfix: when Jetpack site stats module is turned off, the generic error toast is not shown to the user anymore.
 
 2.3
 -----
 - Improvement: improved Dynamic Type support in the body of the notification in the Notifications tab.
-- New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.
- 
+
 2.2
 -----
 - improvement: opting out of Tracks syncs with WordPress.com


### PR DESCRIPTION
Fixes #1073 

Since https://github.com/woocommerce/woocommerce-ios/pull/1086 was originally intended for 2.3 but later merged to sprint 2.4, this PR moved the feature from 2.3 to 2.4 in release notes.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
