### PR TITLE
Dashboard: show/hide visitor stats when Jetpack module is turned on/off

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 2.4
 -----
 - New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.
-- bugfix: when Jetpack site stats module is turned off, the generic error toast is not shown to the user anymore.
+- bugfix & improvement: when Jetpack site stats module is turned off, the generic error toast is not shown to the user anymore. Additionally, the visitors stats UI is shown/hidden when the Jetpack module is activated/deactivated respectively.
 
 2.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -242,6 +242,8 @@ private extension DashboardViewController {
             if let error = reloadError {
                 DDLogError("⛔️ Error loading dashboard: \(error)")
                 self?.handleSyncError(error: error)
+            } else {
+                self?.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: true)
             }
         }
     }
@@ -283,7 +285,7 @@ private extension DashboardViewController {
     private func handleSiteVisitStatsStoreError(error: SiteVisitStatsStoreError) {
         switch error {
         case .statsModuleDisabled:
-            break
+            updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: false)
         default:
             displaySyncingErrorNotice()
         }
@@ -299,6 +301,10 @@ private extension DashboardViewController {
         }
 
         AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+    }
+
+    private func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
+        storeStatsViewController.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -18,6 +18,7 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
 
     // MARK: - Private Properties
 
+    @IBOutlet private weak var visitorsStackView: UIStackView!
     @IBOutlet private weak var visitorsTitle: UILabel!
     @IBOutlet private weak var visitorsData: UILabel!
     @IBOutlet private weak var ordersTitle: UILabel!
@@ -142,6 +143,10 @@ extension PeriodDataViewController {
     func clearAllFields() {
         barChartView?.clear()
         reloadAllFields(animateChart: false)
+    }
+
+    func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
+        visitorsStackView?.isHidden = !shouldShowSiteVisitStats
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -16,6 +16,12 @@ class PeriodDataViewController: UIViewController, IndicatorInfoProvider {
         return siteStatsResultsController.fetchedObjects.first
     }
 
+    var shouldShowSiteVisitStats: Bool = true {
+        didSet {
+            updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
+        }
+    }
+
     // MARK: - Private Properties
 
     @IBOutlet private weak var visitorsStackView: UIStackView!
@@ -144,10 +150,6 @@ extension PeriodDataViewController {
         barChartView?.clear()
         reloadAllFields(animateChart: false)
     }
-
-    func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
-        visitorsStackView?.isHidden = !shouldShowSiteVisitStats
-    }
 }
 
 
@@ -238,6 +240,9 @@ private extension PeriodDataViewController {
         lastUpdated.font = UIFont.footnote
         lastUpdated.textColor = StyleManager.wooGreyMid
 
+        // Visibility
+        updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
+
         // Accessibility elements
         xAxisAccessibilityView.isAccessibilityElement = true
         xAxisAccessibilityView.accessibilityTraits = .staticText
@@ -303,6 +308,13 @@ private extension PeriodDataViewController {
     }
 }
 
+// MARK: - UI Updates
+//
+private extension PeriodDataViewController {
+    func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
+        visitorsStackView?.isHidden = !shouldShowSiteVisitStats
+    }
+}
 
 // MARK: - IndicatorInfoProvider Conformance (Tab Bar)
 //
@@ -461,16 +473,16 @@ private extension PeriodDataViewController {
         reloadSiteFields()
         reloadChart(animateChart: animateChart)
         reloadLastUpdatedField()
-        view.accessibilityElements = [visitorsTitle as Any,
-                                      visitorsData as Any,
-                                      ordersTitle as Any,
-                                      ordersData as Any,
-                                      revenueTitle as Any,
-                                      revenueData as Any,
-                                      lastUpdated as Any,
-                                      yAxisAccessibilityView as Any,
-                                      xAxisAccessibilityView as Any,
-                                      chartAccessibilityView as Any]
+        let visitStatsElements = shouldShowSiteVisitStats ? [visitorsTitle as Any,
+                                                             visitorsData as Any]: []
+        view.accessibilityElements = visitStatsElements + [ordersTitle as Any,
+                                                           ordersData as Any,
+                                                           revenueTitle as Any,
+                                                           revenueData as Any,
+                                                           lastUpdated as Any,
+                                                           yAxisAccessibilityView as Any,
+                                                           xAxisAccessibilityView as Any,
+                                                           chartAccessibilityView as Any]
     }
 
     func reloadOrderFields() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,6 +22,7 @@
                 <outlet property="revenueTitle" destination="Sam-pk-BxI" id="HI1-z6-dRL"/>
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
                 <outlet property="visitorsData" destination="SZF-f7-8Va" id="ZY0-s6-PDq"/>
+                <outlet property="visitorsStackView" destination="e8D-G2-abm" id="4R3-bN-edz"/>
                 <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
                 <outlet property="xAxisAccessibilityView" destination="TTF-Fx-NHe" id="cdX-lJ-DWe"/>
                 <outlet property="yAxisAccessibilityView" destination="yvj-Kj-G3f" id="MRf-C4-jUk"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -116,6 +116,12 @@ extension StoreStatsViewController {
             onCompletion?(syncError)
         }
     }
+
+    func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
+        for periodVC in periodVCs {
+            periodVC.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
+        }
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -119,7 +119,7 @@ extension StoreStatsViewController {
 
     func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
         for periodVC in periodVCs {
-            periodVC.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
+            periodVC.shouldShowSiteVisitStats = shouldShowSiteVisitStats
         }
     }
 }


### PR DESCRIPTION
Fixes #838 

## Changes
- Added `visitorsStackView` outlet to `PeriodDataViewController`. Created a private function to update `visitorsStackView` visibility, which is called when:
  - public variable `shouldShowSiteVisitStats: Bool` did get set
  - configuring view controller's view in `configureView`
- In the mid level `StoreStatsViewController`, added a public function `updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool)` to update the visitor stats visibility of all `PeriodDataViewController`s (with different time granularity)
- In the top level view controller `DashboardViewController` that handles the error, updated its `StoreStatsViewController`'s visitor stats visibility on error AND no error

## Testing
- Prerequisite: have a store with Jetpack installed
- Go to Jetpack modules settings page at your store's `/wp-admin/admin.php?page=jetpack_modules`, and find the "site stats" module
- Deactivate the "site stats" module
- Launch the app with the store --> the "Visitors" stats UI should not appear on the Dashboard for all time frames (Days/Weeks/Months/Years)
- Go back to the website with Jetpack modules settings, and reactivate the "site stats" module
- Pull down to refresh the Dashboard screen --> the "Visitors" stats UI should now appear on the Dashboard and the stats UI should be accessible for all time frames (Days/Weeks/Months/Years)

## Example screenshots

Jetpack site stats module is on | Jetpack site stats module is off
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-07-16 at 17 33 22](https://user-images.githubusercontent.com/1945542/61331392-e7d48e00-a7ef-11e9-8de5-0ba2db3f8b43.png) | ![Simulator Screen Shot - iPhone SE - 2019-07-16 at 17 33 39](https://user-images.githubusercontent.com/1945542/61331396-ea36e800-a7ef-11e9-847f-13d0db53cc06.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
