### PR TITLE
Update Storage.md and Yosemite.md

### DIFF
--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -19,6 +19,11 @@ When clients of this class request a `StorageType`, `CoreDataManager` will retur
 
 When `CoreDataManager` is requested a  `viewContext`, it will provide  the persistent container’s `viewContext` . When it is requested a `newDerivedStorage` it will return a new child context with  a private dispatch queue.
 
+## File storage
+The Storage module also explose a protocol, called `FileStorage` to abstract saving and reading data to and from local storage. 
+
+The default implementation of this protocol, `PListFileStorage` provided support for `.plist` files.  
+
 ## Model objects
 This module also provides extensions to make the model objects declared in the `Networking` module coredata-compliant.  
 

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -20,7 +20,7 @@ When clients of this class request a `StorageType`, `CoreDataManager` will retur
 When `CoreDataManager` is requested a  `viewContext`, it will provide  the persistent container’s `viewContext` . When it is requested a `newDerivedStorage` it will return a new child context with  a private dispatch queue.
 
 ## File storage
-The Storage module also explose a protocol, called `FileStorage` to abstract saving and reading data to and from local storage. 
+The Storage module also exposes a protocol, called `FileStorage` to abstract saving and reading data to and from local storage. 
 
 The default implementation of this protocol, `PListFileStorage` provided support for `.plist` files.  
 

--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -43,7 +43,7 @@ At the moment, we provide the following subclasses of `Store`:
 * `OrderNoteStore`. Business logic pertaining order notes. Registers and responds to operation declared in `OrderNoteAction`
 * `OrderStatusStore`. Business logic related to order payment statuses, implementing operations declared in `OrderStatusAction`
 * `SettingStore` registers and responds to operations declared in `SettingAction`
-* `ShipmentStore` implements support for the operations declared in `SettingAction`
+* `ShipmentStore` implements support for the operations declared in `ShipmentAction`
 * Finally, `StatStore`implements the logic to present statistics, supporting operations declared in `StatsAction`
 
 ## Operations with domain level concerns. Action

--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -36,6 +36,7 @@ That set of actions is declared in an implementation of the `Action` protocol. W
 
 At the moment, we provide the following subclasses of `Store`:
 * `AccountStore`. Registers `AccountAction` with the `Dispatcher`.  It implements the business logic necessary to manage an account (load an account, load a site, synchronise account information…)
+* `AppSettingsStore`. Registers and responds to actions declared in `AppSettingsAction`. It implements the logic to save and retrieve application settings.
 * `CommentStore`.  Registers and responds to actions declared in `CommentAction` It implements the business logic pertaining comments.
 * `NotificationStore`. Registers  and responds to`NotificationAction` 
 * `OrderStore`. Registers `OrderAction` with the `Dispatcher` and responds to the actions declared in it.


### PR DESCRIPTION
Fixes #1111 

Now that the documentation has been moved to the docs folder, it is time to give it some more love. Starting with...

## Changes
- Update Storage.md to mention the preferred way to handle local files via the `FileStorage` protocol
- Update Yosemite.md to reference the `AppSettingsStore`