### PR TITLE
Update the Settings footer to promote hiring

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.
 - bugfix & improvement: when Jetpack site stats module is turned off, the generic error toast is not shown to the user anymore. Additionally, the visitors stats UI is shown/hidden when the Jetpack module is activated/deactivated respectively.
+- Enhancement: updated the footer in Settings to inform users that we're hiring.
 
 2.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 2.4
 -----
 - New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.
-- bugfix & improvement: when Jetpack site stats module is turned off, the generic error toast is not shown to the user anymore. Additionally, the visitors stats UI is shown/hidden when the Jetpack module is activated/deactivated respectively.
 - Enhancement: updated the footer in Settings to inform users that we're hiring.
 - bugfix & improvement: when Jetpack site stats module is turned off or when user has no permission to view site stats, the generic error toast is not shown to the user anymore. Additionally, the visitors stats UI is shown/hidden when the Jetpack module is activated/deactivated respectively.
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -117,6 +117,7 @@ public enum WooAnalyticsStat: String {
 
     case settingsLogoutTapped                   = "settings_logout_button_tapped"
     case settingsLogoutConfirmation             = "settings_logout_confirmation_dialog_result"
+    case settingsWereHiringTapped               = "settings_we_are_hiring_button_tapped"
 
     // Order View Events
     //

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -33,7 +33,7 @@ extension UIButton {
         titleLabel?.textAlignment = .center
     }
 
-    /// Applies the Terciary Button Style: Clear BG / Top Outline
+    /// Applies the Tertiary Button Style: Clear BG / Top Outline
     ///
     func applyTertiaryButtonStyle() {
         backgroundColor = .clear

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -89,7 +89,6 @@ class DefaultStyle: Style {
     let thinCaptionFont                 = DefaultStyle.fontForTextStyle(.caption1,
                                                                         weight: .thin,
                                                                         maximumPointSize: DefaultStyle.maxFontSize)
-    //let footerLabelFont                 = UIFont.font(forStyle: .footnote, weight: .regular)
     let footerLabelFont                 = DefaultStyle.fontForTextStyle(.footnote,
                                                                         weight: .regular,
                                                                         maximumPointSize: DefaultStyle.maxFontSize)

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -89,7 +89,10 @@ class DefaultStyle: Style {
     let thinCaptionFont                 = DefaultStyle.fontForTextStyle(.caption1,
                                                                         weight: .thin,
                                                                         maximumPointSize: DefaultStyle.maxFontSize)
-    let footerLabelFont                 = UIFont.font(forStyle: .footnote, weight: .regular)
+    //let footerLabelFont                 = UIFont.font(forStyle: .footnote, weight: .regular)
+    let footerLabelFont                 = DefaultStyle.fontForTextStyle(.footnote,
+                                                                        weight: .regular,
+                                                                        maximumPointSize: DefaultStyle.maxFontSize)
 
     /// Colors!
     ///

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -15,6 +15,7 @@ protocol Style {
     var subheadlineFont: UIFont { get }
     var subheadlineBoldFont: UIFont { get }
     var thinCaptionFont: UIFont { get }
+    var footerLabelFont: UIFont { get }
 
     /// Colors
     ///
@@ -88,10 +89,11 @@ class DefaultStyle: Style {
     let thinCaptionFont                 = DefaultStyle.fontForTextStyle(.caption1,
                                                                         weight: .thin,
                                                                         maximumPointSize: DefaultStyle.maxFontSize)
+    let footerLabelFont                 = UIFont.font(forStyle: .footnote, weight: .regular)
 
     /// Colors!
     ///
-    let buttonPrimaryColor              = UIColor(red: 0x96/255.0, green: 0x58/255.0, blue: 0x8A/255.0, alpha: 0xFF/255.0)
+    let buttonPrimaryColor              = HandbookColors.wooPrimary
     let buttonPrimaryHighlightedColor   = UIColor(red: 0x6E/255.0, green: 0x29/255.0, blue: 0x67/255.0, alpha: 0xFF/255.0)
     let buttonPrimaryTitleColor         = HandbookColors.wooWhite
     let buttonSecondaryColor            = HandbookColors.wooWhite
@@ -243,6 +245,10 @@ class StyleManager {
 
     static var thinCaptionFont: UIFont {
         return active.thinCaptionFont
+    }
+
+    static var footerLabelFont: UIFont {
+        return active.footerLabelFont
     }
 
     // MARK: - Colors

--- a/WooCommerce/Classes/Tools/WebviewHelper.swift
+++ b/WooCommerce/Classes/Tools/WebviewHelper.swift
@@ -17,6 +17,16 @@ final class WebviewHelper {
                 return
         }
 
+        launch(url, with: sender)
+    }
+
+    /// Launch webview URLs using a common style.
+    ///
+    /// - Parameters:
+    ///   - URL: the URL
+    ///   - sender: the view controller that will present the webview
+    ///
+    static func launch(_ url: URL, with sender: UIViewController) {
         let safariViewController = SFSafariViewController(url: url)
         safariViewController.modalPresentationStyle = .pageSheet
         sender.present(safariViewController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -93,6 +93,8 @@ private extension AboutViewController {
         /// Hence the container view with a defined frame.
         let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
+        footerView.footnoteText = footerTitleText
+        footerView.footnoteColor = StyleManager.wooGreyMid
         tableView.tableFooterView = footerContainer
         footerContainer.addSubview(footerView)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -93,8 +93,6 @@ private extension AboutViewController {
         /// Hence the container view with a defined frame.
         let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
-        footerView.footnoteText = footerTitleText
-        footerView.footnoteColor = StyleManager.wooGreyMid
         tableView.tableFooterView = footerContainer
         footerContainer.addSubview(footerView)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -93,8 +93,9 @@ private extension AboutViewController {
         /// Hence the container view with a defined frame.
         let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
-        footerView.footnoteText = footerTitleText
-        footerView.footnoteColor = StyleManager.wooGreyMid
+        footerView.footnote.attributedText = nil
+        footerView.footnote.text = footerTitleText
+        footerView.footnote.textColor = StyleManager.wooGreyMid
         tableView.tableFooterView = footerContainer
         footerContainer.addSubview(footerView)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -112,7 +112,9 @@ private extension SettingsViewController {
         let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
         footerView.iconImage = .heartOutlineImage
+        footerView.footnote.attributedText = hiringAttributedText
         footerView.iconColor = StyleManager.wooCommerceBrandColor
+        footerView.footnote.textAlignment = .center
         footerView.footnote.delegate = self
 
         tableView.tableFooterView = footerContainer
@@ -471,4 +473,30 @@ private struct Segues {
     static let helpSupportSegue = "ShowHelpAndSupportViewController"
     static let aboutSegue       = "ShowAboutViewController"
     static let licensesSegue    = "ShowLicensesViewController"
+}
+
+
+// MARK: - Footer
+//
+private extension SettingsViewController {
+
+    /// Returns the Settings Footer Attributed Text
+    /// (which contains a link to the "Work with us" URL)
+    ///
+    var hiringAttributedText: NSAttributedString {
+        let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
+                                           comment: "Made with love tagline and we're hiring promotional blurb. It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
+        )
+        let hiringAttributes: [NSAttributedString.Key: Any] = [
+            .font: StyleManager.footerLabelFont,
+            .foregroundColor: StyleManager.wooGreyMid
+        ]
+
+        let hiringAttrText = NSMutableAttributedString()
+        hiringAttrText.append(hiringText.htmlToAttributedString)
+        let range = NSRange(location: 0, length: hiringAttrText.length)
+        hiringAttrText.addAttributes(hiringAttributes, range: range)
+
+        return hiringAttrText
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -485,7 +485,7 @@ private extension SettingsViewController {
     ///
     var hiringAttributedText: NSAttributedString {
         let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                           comment: "It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
+                                           comment: "It reads: 'Made with love by Automattic. We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -485,7 +485,7 @@ private extension SettingsViewController {
     ///
     var hiringAttributedText: NSAttributedString {
         let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                           comment: "It reads: 'Made with love by Automattic. We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
+                                           comment: "It reads: 'Made with love by Automattic. We’re hiring!'. Place, \'We’re hiring!' between `<a` tag and `</a>` tags."
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -485,7 +485,7 @@ private extension SettingsViewController {
     ///
     var hiringAttributedText: NSAttributedString {
         let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                           comment: "Made with love tagline and we're hiring promotional blurb. It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
+                                           comment: "It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -112,12 +112,9 @@ private extension SettingsViewController {
         let footerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Constants.footerHeight))
         let footerView = TableFooterView.instantiateFromNib() as TableFooterView
         footerView.iconImage = .heartOutlineImage
-        footerView.iconColor = StyleManager.wooGreyMid
-        footerView.footnoteText = NSLocalizedString(
-            "Made with love by Automattic",
-            comment: "Tagline after the heart icon, displayed to the user"
-        )
-        footerView.footnoteColor = StyleManager.wooGreyMid
+        footerView.iconColor = StyleManager.wooCommerceBrandColor
+        footerView.footnote.delegate = self
+
         tableView.tableFooterView = footerContainer
         footerContainer.addSubview(footerView)
     }
@@ -316,6 +313,26 @@ private extension SettingsViewController {
     func logOutUser() {
         StoresManager.shared.deauthenticate()
         navigationController?.popToRootViewController(animated: true)
+    }
+
+    func weAreHiringWasPressed(url: URL) {
+        WooAnalytics.shared.track(.loginPrologueJetpackInstructions)
+
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        present(safariViewController, animated: true, completion: nil)
+    }
+}
+
+
+// MARK: - UITextViewDeletgate Conformance
+//
+extension SettingsViewController: UITextViewDelegate {
+
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL,
+                  in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        weAreHiringWasPressed(url: URL)
+        return false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -318,9 +318,7 @@ private extension SettingsViewController {
     func weAreHiringWasPressed(url: URL) {
         WooAnalytics.shared.track(.settingsWereHiringTapped)
 
-        let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
-        present(safariViewController, animated: true, completion: nil)
+        WebviewHelper.launch(url, with: self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -485,7 +485,7 @@ private extension SettingsViewController {
     ///
     var hiringAttributedText: NSAttributedString {
         let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                           comment: "It reads: 'Made with love by Automattic. We’re hiring!'. Place, \'We’re hiring!' between `<a` tag and `</a>` tags."
+                                           comment: "It reads 'Made with love by Automattic. We’re hiring!'. Place \'We’re hiring!' between `<a>` and `</a>`"
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -316,7 +316,7 @@ private extension SettingsViewController {
     }
 
     func weAreHiringWasPressed(url: URL) {
-        WooAnalytics.shared.track(.loginPrologueJetpackInstructions)
+        WooAnalytics.shared.track(.settingsWereHiringTapped)
 
         let safariViewController = SFSafariViewController(url: url)
         safariViewController.modalPresentationStyle = .pageSheet

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -16,7 +16,7 @@ final class TableFooterView: UIView {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        setupFootnoteLabel()
+        setupFootnoteTextView()
     }
 
     override func layoutSubviews() {
@@ -58,7 +58,7 @@ extension TableFooterView {
 
     /// Initialization method for footnote textview
     ///
-    func setupFootnoteLabel() {
+    func setupFootnoteTextView() {
         footnote.attributedText = hiringAttributedText
         footnote.adjustsFontForContentSizeCategory = true
         footnote.textContainerInset = .zero

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -7,7 +7,7 @@ import UIKit
 final class TableFooterView: UIView {
 
     @IBOutlet private var icon: UIImageView!
-    @IBOutlet public var footnote: UITextView!
+    @IBOutlet var footnote: UITextView!
     @IBOutlet private var iconHeight: NSLayoutConstraint!
     @IBOutlet private var iconWidth: NSLayoutConstraint!
 
@@ -53,29 +53,6 @@ extension TableFooterView {
         }
         set {
             icon?.tintColor = newValue
-        }
-    }
-
-    /// Footnote label text.
-    ///
-    var footnoteText: String? {
-        get {
-            return footnote?.text
-        }
-        set {
-            footnote.attributedText = nil
-            footnote?.text = newValue
-        }
-    }
-
-    /// Footnote label color.
-    ///
-    var footnoteColor: UIColor? {
-        get {
-            return footnote?.textColor
-        }
-        set {
-            footnote?.textColor = newValue
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -59,7 +59,6 @@ extension TableFooterView {
     /// Initialization method for footnote textview
     ///
     func setupFootnoteTextView() {
-        footnote.attributedText = hiringAttributedText
         footnote.adjustsFontForContentSizeCategory = true
         footnote.textContainerInset = .zero
         footnote.textAlignment = .center
@@ -68,31 +67,5 @@ extension TableFooterView {
             .underlineColor: UIColor.clear,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
-    }
-}
-
-
-// MARK: - Private methods
-//
-private extension TableFooterView {
-
-    /// Returns the Settings Footer Attributed Text
-    /// (which contains a link to the "Work with us" URL)
-    ///
-    var hiringAttributedText: NSAttributedString {
-        let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                               comment: "Made with love tagline and we're hiring promotional blurb. It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
-        )
-        let hiringAttributes: [NSAttributedString.Key: Any] = [
-            .font: StyleManager.footerLabelFont,
-            .foregroundColor: StyleManager.wooGreyMid
-        ]
-
-        let hiringAttrText = NSMutableAttributedString()
-        hiringAttrText.append(hiringText.htmlToAttributedString)
-        let range = NSRange(location: 0, length: hiringAttrText.length)
-        hiringAttrText.addAttributes(hiringAttributes, range: range)
-
-        return hiringAttrText
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -1,12 +1,14 @@
 import Foundation
 import UIKit
+import SafariServices
+
 
 // MARK: - TableFooterView
 //
-class TableFooterView: UIView {
+final class TableFooterView: UIView {
 
     @IBOutlet private var icon: UIImageView!
-    @IBOutlet private var footnote: UILabel!
+    @IBOutlet public var footnote: UITextView!
     @IBOutlet private var iconHeight: NSLayoutConstraint!
     @IBOutlet private var iconWidth: NSLayoutConstraint!
 
@@ -15,7 +17,7 @@ class TableFooterView: UIView {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        footnote.applyFootnoteStyle()
+        setupFootnoteLabel()
     }
 
     override func layoutSubviews() {
@@ -55,25 +57,43 @@ extension TableFooterView {
         }
     }
 
-    /// Footnote label text.
+    /// Initialization method for footnote textview
     ///
-    var footnoteText: String? {
-        get {
-            return footnote?.text
-        }
-        set {
-            footnote?.text = newValue
-        }
+    func setupFootnoteLabel() {
+        footnote.attributedText = hiringAttributedText
+        footnote.adjustsFontForContentSizeCategory = true
+        footnote.textContainerInset = .zero
+        footnote.textAlignment = .center
+        footnote.linkTextAttributes = [
+            .foregroundColor: StyleManager.wooCommerceBrandColor,
+            .underlineColor: StyleManager.wooCommerceBrandColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
     }
+}
 
-    /// Footnote label color.
+
+// MARK - Private methods
+//
+private extension TableFooterView {
+
+    /// Returns the Settings Footer Attributed Text
+    /// (which contains a link to the "Work with us" URL)
     ///
-    var footnoteColor: UIColor? {
-        get {
-            return footnote?.textColor
-        }
-        set {
-            footnote?.textColor = newValue
-        }
+    var hiringAttributedText: NSAttributedString {
+        let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
+                                               comment: "Made with love tagline and we're hiring promotional blurb. It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'We’re hiring!' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: we are hiring page' or any alternative that sounds natural in your language."
+        )
+        let hiringAttributes: [NSAttributedString.Key: Any] = [
+            .font: StyleManager.footerLabelFont,
+            .foregroundColor: StyleManager.wooGreyMid
+        ]
+
+        let hiringAttrText = NSMutableAttributedString()
+        hiringAttrText.append(hiringText.htmlToAttributedString)
+        let range = NSRange(location: 0, length: hiringAttrText.length)
+        hiringAttrText.addAttributes(hiringAttributes, range: range)
+
+        return hiringAttrText
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -56,6 +56,29 @@ extension TableFooterView {
         }
     }
 
+    /// Footnote label text.
+    ///
+    var footnoteText: String? {
+        get {
+            return footnote?.text
+        }
+        set {
+            footnote.attributedText = nil
+            footnote?.text = newValue
+        }
+    }
+
+    /// Footnote label color.
+    ///
+    var footnoteColor: UIColor? {
+        get {
+            return footnote?.textColor
+        }
+        set {
+            footnote?.textColor = newValue
+        }
+    }
+
     /// Initialization method for footnote textview
     ///
     func setupFootnoteLabel() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import SafariServices
 
 
 // MARK: - TableFooterView

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -72,7 +72,7 @@ extension TableFooterView {
 }
 
 
-// MARK - Private methods
+// MARK: - Private methods
 //
 private extension TableFooterView {
 
@@ -81,7 +81,7 @@ private extension TableFooterView {
     ///
     var hiringAttributedText: NSAttributedString {
         let hiringText = NSLocalizedString("Made with love by Automattic. <a href=\"https://automattic.com/work-with-us/\">We’re hiring!</a>",
-                                               comment: "Made with love tagline and we're hiring promotional blurb. It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'We’re hiring!' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: we are hiring page' or any alternative that sounds natural in your language."
+                                               comment: "Made with love tagline and we're hiring promotional blurb. It reads: 'Made with love by Automattic. We’re hiring!' and it links to a web page on the words 'We’re hiring!'. Place the phrase, \'We’re hiring!' between the opening `<a` tag and the closing `</a>` tags."
         )
         let hiringAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.footerLabelFont,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.swift
@@ -65,7 +65,7 @@ extension TableFooterView {
         footnote.textAlignment = .center
         footnote.linkTextAttributes = [
             .foregroundColor: StyleManager.wooCommerceBrandColor,
-            .underlineColor: StyleManager.wooCommerceBrandColor,
+            .underlineColor: UIColor.clear,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
@@ -24,26 +24,29 @@
                         <constraint firstAttribute="width" secondItem="qck-6N-xeW" secondAttribute="height" multiplier="1:1" id="weW-Ke-vLj"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="255" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RGI-pq-sH5">
-                    <rect key="frame" x="20" y="46" width="335" height="24"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" text="textview" textAlignment="center" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rC7-Y4-ujS">
+                    <rect key="frame" x="20" y="48" width="335" height="22"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="22" id="nwW-E2-abh"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                </textView>
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="qck-6N-xeW" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="20" id="3mL-e7-4IU"/>
                 <constraint firstItem="qck-6N-xeW" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="4mN-2A-P26"/>
-                <constraint firstItem="RGI-pq-sH5" firstAttribute="top" secondItem="qck-6N-xeW" secondAttribute="bottom" constant="2" id="N7c-ii-O7x"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="RGI-pq-sH5" secondAttribute="bottom" constant="20" id="WrQ-Om-baO"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="RGI-pq-sH5" secondAttribute="trailing" constant="20" id="lIo-kI-xxg"/>
-                <constraint firstItem="RGI-pq-sH5" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="nYW-ya-Vu0"/>
+                <constraint firstItem="rC7-Y4-ujS" firstAttribute="top" secondItem="qck-6N-xeW" secondAttribute="bottom" constant="4" id="6QX-Rw-ukm"/>
+                <constraint firstItem="rC7-Y4-ujS" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="VCe-0w-MuS"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="rC7-Y4-ujS" secondAttribute="bottom" constant="20" id="Y7B-XW-EQ0"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="rC7-Y4-ujS" secondAttribute="trailing" constant="20" id="gR3-Ym-ZLn"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
-                <outlet property="footnote" destination="RGI-pq-sH5" id="Ego-sT-zU8"/>
+                <outlet property="footnote" destination="rC7-Y4-ujS" id="YTn-cq-hj4"/>
                 <outlet property="icon" destination="qck-6N-xeW" id="1n6-wT-2wz"/>
                 <outlet property="iconHeight" destination="6vf-8G-WP0" id="aqq-7v-Dbe"/>
                 <outlet property="iconWidth" destination="92h-oq-4J9" id="zSS-WZ-CGW"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
@@ -26,10 +26,7 @@
                 </imageView>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" text="textview" textAlignment="center" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rC7-Y4-ujS">
                     <rect key="frame" x="20" y="48" width="335" height="22"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="22" id="nwW-E2-abh"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     <dataDetectorType key="dataDetectorTypes" link="YES"/>
                 </textView>


### PR DESCRIPTION
Closes #1083. 

In this PR we're promoting hiring within the apps! 

![we-are-hiring](https://user-images.githubusercontent.com/1062444/61552880-9d852400-aa1e-11e9-99a5-e47645b8059f.gif)

## To test
- Check out the PR branch
- Run the app
- Tap the My store "gear" icon to find the Settings page.
- Scroll to the bottom. Ensure the footer looks like the design mock.
- Tap the "We're hiring!" link. Expected behavior: a Safari web viewer is presented as a modal view in the app, with a "done" button to dismiss it. If it pops out of the app, that's a bug.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
