### PR TITLE
 Extract viewmodel to configure PaymentTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
@@ -31,71 +31,71 @@ final class OrderDetailsDataSource: NSObject {
 
     var trackingIsReachable: Bool = false
 
-    private var subtotal: Decimal {
-        let subtotal = order.items.reduce(Decimal(0)) { (output, item) in
-            let itemSubtotal = Decimal(string: item.subtotal) ?? Decimal(0)
-            return output + itemSubtotal
-        }
+//    private var subtotal: Decimal {
+//        let subtotal = order.items.reduce(Decimal(0)) { (output, item) in
+//            let itemSubtotal = Decimal(string: item.subtotal) ?? Decimal(0)
+//            return output + itemSubtotal
+//        }
+//
+//        return subtotal
+//    }
+//
+//    private var subtotalValue: String {
+//        let subAmount = NSDecimalNumber(decimal: subtotal).stringValue
+//
+//        return CurrencyFormatter().formatAmount(subAmount, with: order.currency) ?? String()
+//    }
 
-        return subtotal
-    }
-
-    private var subtotalValue: String {
-        let subAmount = NSDecimalNumber(decimal: subtotal).stringValue
-
-        return CurrencyFormatter().formatAmount(subAmount, with: order.currency) ?? String()
-    }
-
-    /// Discounts
-    /// - returns: 'Discount' label and a list of discount codes, or nil if zero.
-    ///
-    private var discountText: String? {
-        return summarizeCoupons(from: couponLines)
-    }
-
-    private var discountValue: String? {
-        guard let discount = currencyFormatter.convertToDecimal(from: order.discountTotal), discount.isZero() == false else {
-            return nil
-        }
-
-        guard let formattedDiscount = currencyFormatter.formatAmount(order.discountTotal, with: order.currency) else {
-            return nil
-        }
-
-        return "-" + formattedDiscount
-    }
-
-    private var shippingValue: String {
-        return currencyFormatter.formatAmount(order.shippingTotal, with: order.currency) ?? String()
-    }
-
-    private var taxesValue: String? {
-        return currencyFormatter.formatAmount(order.totalTax, with: order.currency)
-    }
-
-    private var totalValue: String {
-        return currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
-    }
-
+//    /// Discounts
+//    /// - returns: 'Discount' label and a list of discount codes, or nil if zero.
+//    ///
+//    private var discountText: String? {
+//        return summarizeCoupons(from: couponLines)
+//    }
+//
+//    private var discountValue: String? {
+//        guard let discount = currencyFormatter.convertToDecimal(from: order.discountTotal), discount.isZero() == false else {
+//            return nil
+//        }
+//
+//        guard let formattedDiscount = currencyFormatter.formatAmount(order.discountTotal, with: order.currency) else {
+//            return nil
+//        }
+//
+//        return "-" + formattedDiscount
+//    }
+//
+//    private var shippingValue: String {
+//        return currencyFormatter.formatAmount(order.shippingTotal, with: order.currency) ?? String()
+//    }
+//
+//    private var taxesValue: String? {
+//        return currencyFormatter.formatAmount(order.totalTax, with: order.currency)
+//    }
+//
+//    private var totalValue: String {
+//        return currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
+//    }
+//
     /// Anything above 999.99 or below -999.99 should display a truncated amount
     ///
     var totalFriendlyString: String? {
         return currencyFormatter.formatHumanReadableAmount(order.total, with: order.currency, roundSmallNumbers: false) ?? String()
     }
-
-    /// Payment Summary
-    /// - returns: A full sentence summary of how much was paid and using what method.
-    ///
-    private var paymentSummary: String? {
-        if order.paymentMethodTitle.isEmpty {
-            return nil
-        }
-
-        return NSLocalizedString(
-            "Payment of \(totalValue) received via \(order.paymentMethodTitle)",
-            comment: "Payment of <currency symbol><payment total> received via (payment method title)"
-        )
-    }
+//
+//    /// Payment Summary
+//    /// - returns: A full sentence summary of how much was paid and using what method.
+//    ///
+//    private var paymentSummary: String? {
+//        if order.paymentMethodTitle.isEmpty {
+//            return nil
+//        }
+//
+//        return NSLocalizedString(
+//            "Payment of \(totalValue) received via \(order.paymentMethodTitle)",
+//            comment: "Payment of <currency symbol><payment total> received via (payment method title)"
+//        )
+//    }
 
     var summaryTitle: String? {
         if let billingAddress = order.billingAddress {
@@ -149,22 +149,22 @@ final class OrderDetailsDataSource: NSObject {
         resultsControllers.configureResultsControllers(onReload: onReload)
     }
 
-    private func summarizeCoupons(from lines: [OrderCouponLine]?) -> String? {
-        guard let couponLines = lines else {
-            return nil
-        }
-
-        let output = couponLines.reduce("") { (output, line) in
-            let prefix = output.isEmpty ? "" : ","
-            return output + prefix + line.code
-        }
-
-        guard !output.isEmpty else {
-            return nil
-        }
-
-        return NSLocalizedString("Discount", comment: "Discount label for payment view") + " (" + output + ")"
-    }
+//    private func summarizeCoupons(from lines: [OrderCouponLine]?) -> String? {
+//        guard let couponLines = lines else {
+//            return nil
+//        }
+//
+//        let output = couponLines.reduce("") { (output, line) in
+//            let prefix = output.isEmpty ? "" : ","
+//            return output + prefix + line.code
+//        }
+//
+//        guard !output.isEmpty else {
+//            return nil
+//        }
+//
+//        return NSLocalizedString("Discount", comment: "Discount label for payment view") + " (" + output + ")"
+//    }
 }
 
 
@@ -364,39 +364,41 @@ private extension OrderDetailsDataSource {
     }
 
     func configurePayment(cell: PaymentTableViewCell) {
-        cell.subtotalLabel.text = Titles.subtotalLabel
-        cell.subtotalValue.text = subtotalValue
-
-        cell.discountLabel.text = discountText
-        cell.discountValue.text = discountValue
-        cell.discountView.isHidden = discountValue == nil
-
-        cell.shippingLabel.text = Titles.shippingLabel
-        cell.shippingValue.text = shippingValue
-
-        cell.taxesLabel.text = Titles.taxesLabel
-        cell.taxesValue.text = taxesValue
-        cell.taxesView.isHidden = taxesValue == nil
-
-        cell.totalLabel.text = Titles.totalLabel
-        cell.totalValue.text = totalValue
-
-        cell.footerText = paymentSummary
-
-        cell.accessibilityElements = [cell.subtotalLabel as Any,
-                                      cell.subtotalValue as Any,
-                                      cell.discountLabel as Any,
-                                      cell.discountValue as Any,
-                                      cell.shippingLabel as Any,
-                                      cell.shippingValue as Any,
-                                      cell.taxesLabel as Any,
-                                      cell.taxesValue as Any,
-                                      cell.totalLabel as Any,
-                                      cell.totalValue as Any]
-
-        if let footerText = cell.footerText {
-            cell.accessibilityElements?.append(footerText)
-        }
+        let paymentViewModel = OrderPaymentDetailsViewModel(order: order)
+        cell.configure(with: paymentViewModel)
+//        cell.subtotalLabel.text = Titles.subtotalLabel
+//        cell.subtotalValue.text = subtotalValue
+//
+//        cell.discountLabel.text = discountText
+//        cell.discountValue.text = discountValue
+//        cell.discountView.isHidden = discountValue == nil
+//
+//        cell.shippingLabel.text = Titles.shippingLabel
+//        cell.shippingValue.text = shippingValue
+//
+//        cell.taxesLabel.text = Titles.taxesLabel
+//        cell.taxesValue.text = taxesValue
+//        cell.taxesView.isHidden = taxesValue == nil
+//
+//        cell.totalLabel.text = Titles.totalLabel
+//        cell.totalValue.text = totalValue
+//
+//        cell.footerText = paymentSummary
+//
+//        cell.accessibilityElements = [cell.subtotalLabel as Any,
+//                                      cell.subtotalValue as Any,
+//                                      cell.discountLabel as Any,
+//                                      cell.discountValue as Any,
+//                                      cell.shippingLabel as Any,
+//                                      cell.shippingValue as Any,
+//                                      cell.taxesLabel as Any,
+//                                      cell.taxesValue as Any,
+//                                      cell.totalLabel as Any,
+//                                      cell.totalValue as Any]
+//
+//        if let footerText = cell.footerText {
+//            cell.accessibilityElements?.append(footerText)
+//        }
     }
 
     func configureDetails(cell: WooBasicTableViewCell) {
@@ -781,16 +783,16 @@ private extension OrderDetailsDataSource {
                                                       comment: "The row label to tap for a detailed product list")
         static let fulfillTitle = NSLocalizedString("Fulfill order",
                                                     comment: "Fulfill order button title")
-        static let subtotalLabel = NSLocalizedString("Subtotal",
-                                                     comment: "Subtotal label for payment view")
+//        static let subtotalLabel = NSLocalizedString("Subtotal",
+//                                                     comment: "Subtotal label for payment view")
         static let addNoteText = NSLocalizedString("Add a note",
                                                    comment: "Button text for adding a new order note")
-        static let shippingLabel = NSLocalizedString("Shipping",
-                                                     comment: "Shipping label for payment view")
-        static let taxesLabel = NSLocalizedString("Taxes",
-                                                  comment: "Taxes label for payment view")
-        static let totalLabel = NSLocalizedString("Total",
-                                                  comment: "Total label for payment view")
+//        static let shippingLabel = NSLocalizedString("Shipping",
+//                                                     comment: "Shipping label for payment view")
+//        static let taxesLabel = NSLocalizedString("Taxes",
+//                                                  comment: "Taxes label for payment view")
+//        static let totalLabel = NSLocalizedString("Total",
+//                                                  comment: "Total label for payment view")
     }
 
     enum Icons {

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
@@ -31,71 +31,11 @@ final class OrderDetailsDataSource: NSObject {
 
     var trackingIsReachable: Bool = false
 
-//    private var subtotal: Decimal {
-//        let subtotal = order.items.reduce(Decimal(0)) { (output, item) in
-//            let itemSubtotal = Decimal(string: item.subtotal) ?? Decimal(0)
-//            return output + itemSubtotal
-//        }
-//
-//        return subtotal
-//    }
-//
-//    private var subtotalValue: String {
-//        let subAmount = NSDecimalNumber(decimal: subtotal).stringValue
-//
-//        return CurrencyFormatter().formatAmount(subAmount, with: order.currency) ?? String()
-//    }
-
-//    /// Discounts
-//    /// - returns: 'Discount' label and a list of discount codes, or nil if zero.
-//    ///
-//    private var discountText: String? {
-//        return summarizeCoupons(from: couponLines)
-//    }
-//
-//    private var discountValue: String? {
-//        guard let discount = currencyFormatter.convertToDecimal(from: order.discountTotal), discount.isZero() == false else {
-//            return nil
-//        }
-//
-//        guard let formattedDiscount = currencyFormatter.formatAmount(order.discountTotal, with: order.currency) else {
-//            return nil
-//        }
-//
-//        return "-" + formattedDiscount
-//    }
-//
-//    private var shippingValue: String {
-//        return currencyFormatter.formatAmount(order.shippingTotal, with: order.currency) ?? String()
-//    }
-//
-//    private var taxesValue: String? {
-//        return currencyFormatter.formatAmount(order.totalTax, with: order.currency)
-//    }
-//
-//    private var totalValue: String {
-//        return currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
-//    }
-//
     /// Anything above 999.99 or below -999.99 should display a truncated amount
     ///
     var totalFriendlyString: String? {
         return currencyFormatter.formatHumanReadableAmount(order.total, with: order.currency, roundSmallNumbers: false) ?? String()
     }
-//
-//    /// Payment Summary
-//    /// - returns: A full sentence summary of how much was paid and using what method.
-//    ///
-//    private var paymentSummary: String? {
-//        if order.paymentMethodTitle.isEmpty {
-//            return nil
-//        }
-//
-//        return NSLocalizedString(
-//            "Payment of \(totalValue) received via \(order.paymentMethodTitle)",
-//            comment: "Payment of <currency symbol><payment total> received via (payment method title)"
-//        )
-//    }
 
     var summaryTitle: String? {
         if let billingAddress = order.billingAddress {
@@ -148,23 +88,6 @@ final class OrderDetailsDataSource: NSObject {
     func configureResultsControllers(onReload: @escaping () -> Void) {
         resultsControllers.configureResultsControllers(onReload: onReload)
     }
-
-//    private func summarizeCoupons(from lines: [OrderCouponLine]?) -> String? {
-//        guard let couponLines = lines else {
-//            return nil
-//        }
-//
-//        let output = couponLines.reduce("") { (output, line) in
-//            let prefix = output.isEmpty ? "" : ","
-//            return output + prefix + line.code
-//        }
-//
-//        guard !output.isEmpty else {
-//            return nil
-//        }
-//
-//        return NSLocalizedString("Discount", comment: "Discount label for payment view") + " (" + output + ")"
-//    }
 }
 
 
@@ -366,39 +289,6 @@ private extension OrderDetailsDataSource {
     func configurePayment(cell: PaymentTableViewCell) {
         let paymentViewModel = OrderPaymentDetailsViewModel(order: order)
         cell.configure(with: paymentViewModel)
-//        cell.subtotalLabel.text = Titles.subtotalLabel
-//        cell.subtotalValue.text = subtotalValue
-//
-//        cell.discountLabel.text = discountText
-//        cell.discountValue.text = discountValue
-//        cell.discountView.isHidden = discountValue == nil
-//
-//        cell.shippingLabel.text = Titles.shippingLabel
-//        cell.shippingValue.text = shippingValue
-//
-//        cell.taxesLabel.text = Titles.taxesLabel
-//        cell.taxesValue.text = taxesValue
-//        cell.taxesView.isHidden = taxesValue == nil
-//
-//        cell.totalLabel.text = Titles.totalLabel
-//        cell.totalValue.text = totalValue
-//
-//        cell.footerText = paymentSummary
-//
-//        cell.accessibilityElements = [cell.subtotalLabel as Any,
-//                                      cell.subtotalValue as Any,
-//                                      cell.discountLabel as Any,
-//                                      cell.discountValue as Any,
-//                                      cell.shippingLabel as Any,
-//                                      cell.shippingValue as Any,
-//                                      cell.taxesLabel as Any,
-//                                      cell.taxesValue as Any,
-//                                      cell.totalLabel as Any,
-//                                      cell.totalValue as Any]
-//
-//        if let footerText = cell.footerText {
-//            cell.accessibilityElements?.append(footerText)
-//        }
     }
 
     func configureDetails(cell: WooBasicTableViewCell) {
@@ -783,16 +673,8 @@ private extension OrderDetailsDataSource {
                                                       comment: "The row label to tap for a detailed product list")
         static let fulfillTitle = NSLocalizedString("Fulfill order",
                                                     comment: "Fulfill order button title")
-//        static let subtotalLabel = NSLocalizedString("Subtotal",
-//                                                     comment: "Subtotal label for payment view")
         static let addNoteText = NSLocalizedString("Add a note",
                                                    comment: "Button text for adding a new order note")
-//        static let shippingLabel = NSLocalizedString("Shipping",
-//                                                     comment: "Shipping label for payment view")
-//        static let taxesLabel = NSLocalizedString("Taxes",
-//                                                  comment: "Taxes label for payment view")
-//        static let totalLabel = NSLocalizedString("Total",
-//                                                  comment: "Total label for payment view")
     }
 
     enum Icons {

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderPaymentDetailsViewModel.swift
@@ -51,12 +51,6 @@ final class OrderPaymentDetailsViewModel {
         return currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
     }
 
-//    /// Anything above 999.99 or below -999.99 should display a truncated amount
-//    ///
-//    var totalFriendlyString: String? {
-//        return currencyFormatter.formatHumanReadableAmount(order.total, with: order.currency, roundSmallNumbers: false) ?? String()
-//    }
-
     /// Payment Summary
     /// - returns: A full sentence summary of how much was paid and using what method.
     ///

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderPaymentDetailsViewModel.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Yosemite
+
+final class OrderPaymentDetailsViewModel {
+    private let order: Order
+    private let currencyFormatter = CurrencyFormatter()
+
+    var subtotal: Decimal {
+        let subtotal = order.items.reduce(Decimal(0)) { (output, item) in
+            let itemSubtotal = Decimal(string: item.subtotal) ?? Decimal(0)
+            return output + itemSubtotal
+        }
+
+        return subtotal
+    }
+
+    var subtotalValue: String {
+        let subAmount = NSDecimalNumber(decimal: subtotal).stringValue
+
+        return currencyFormatter.formatAmount(subAmount, with: order.currency) ?? String()
+    }
+
+    /// Discounts
+    /// - returns: 'Discount' label and a list of discount codes, or nil if zero.
+    ///
+    var discountText: String? {
+        return summarizeCoupons(from: couponLines)
+    }
+
+    var discountValue: String? {
+        guard let discount = currencyFormatter.convertToDecimal(from: order.discountTotal), discount.isZero() == false else {
+            return nil
+        }
+
+        guard let formattedDiscount = currencyFormatter.formatAmount(order.discountTotal, with: order.currency) else {
+            return nil
+        }
+
+        return "-" + formattedDiscount
+    }
+
+    var shippingValue: String {
+        return currencyFormatter.formatAmount(order.shippingTotal, with: order.currency) ?? String()
+    }
+
+    var taxesValue: String? {
+        return currencyFormatter.formatAmount(order.totalTax, with: order.currency)
+    }
+
+    var totalValue: String {
+        return currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
+    }
+
+//    /// Anything above 999.99 or below -999.99 should display a truncated amount
+//    ///
+//    var totalFriendlyString: String? {
+//        return currencyFormatter.formatHumanReadableAmount(order.total, with: order.currency, roundSmallNumbers: false) ?? String()
+//    }
+
+    /// Payment Summary
+    /// - returns: A full sentence summary of how much was paid and using what method.
+    ///
+    var paymentSummary: String? {
+        if order.paymentMethodTitle.isEmpty {
+            return nil
+        }
+
+        return NSLocalizedString(
+            "Payment of \(totalValue) received via \(order.paymentMethodTitle)",
+            comment: "Payment of <currency symbol><payment total> received via (payment method title)"
+        )
+    }
+
+    var couponLines: [OrderCouponLine] {
+        return order.coupons
+    }
+
+    init(order: Order) {
+        self.order = order
+    }
+
+    private func summarizeCoupons(from lines: [OrderCouponLine]?) -> String? {
+        guard let couponLines = lines else {
+            return nil
+        }
+
+        let output = couponLines.reduce("") { (output, line) in
+            let prefix = output.isEmpty ? "" : ","
+            return output + prefix + line.code
+        }
+
+        guard !output.isEmpty else {
+            return nil
+        }
+
+        return NSLocalizedString("Discount", comment: "Discount label for payment view") + " (" + output + ")"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
@@ -3,31 +3,31 @@ import UIKit
 final class PaymentTableViewCell: UITableViewCell {
     @IBOutlet var verticalStackView: UIStackView!
     @IBOutlet var subtotalView: UIView!
-    @IBOutlet public weak var subtotalLabel: UILabel!
-    @IBOutlet public weak var subtotalValue: UILabel!
+    @IBOutlet private weak var subtotalLabel: UILabel!
+    @IBOutlet private weak var subtotalValue: UILabel!
 
-    @IBOutlet public var discountView: UIView!
-    @IBOutlet public weak var discountLabel: UILabel!
-    @IBOutlet public weak var discountValue: UILabel!
+    @IBOutlet private var discountView: UIView!
+    @IBOutlet private weak var discountLabel: UILabel!
+    @IBOutlet private weak var discountValue: UILabel!
 
-    @IBOutlet var shippingView: UIView!
-    @IBOutlet public weak var shippingLabel: UILabel!
-    @IBOutlet public weak var shippingValue: UILabel!
+    @IBOutlet private var shippingView: UIView!
+    @IBOutlet private weak var shippingLabel: UILabel!
+    @IBOutlet private weak var shippingValue: UILabel!
 
-    @IBOutlet public var taxesView: UIView!
-    @IBOutlet public weak var taxesLabel: UILabel!
-    @IBOutlet public weak var taxesValue: UILabel!
+    @IBOutlet private var taxesView: UIView!
+    @IBOutlet private weak var taxesLabel: UILabel!
+    @IBOutlet private weak var taxesValue: UILabel!
 
-    @IBOutlet var totalView: UIView!
-    @IBOutlet public weak var totalLabel: UILabel!
-    @IBOutlet public weak var totalValue: UILabel!
+    @IBOutlet private var totalView: UIView!
+    @IBOutlet private weak var totalLabel: UILabel!
+    @IBOutlet private weak var totalValue: UILabel!
 
     @IBOutlet private var footerView: UIView?
     @IBOutlet private weak var separatorLine: UIView?
     @IBOutlet private weak var footerLabel: UILabel?
     @IBOutlet private weak var totalBottomConstraint: NSLayoutConstraint?
 
-    public var footerText: String? {
+    private var footerText: String? {
         get {
             return footerLabel?.text
         }
@@ -109,5 +109,53 @@ private extension PaymentTableViewCell {
                                                   comment: "Taxes label for payment view")
         static let totalLabel = NSLocalizedString("Total",
                                                   comment: "Total label for payment view")
+    }
+}
+
+
+// Indirectly expose outlets for tests
+extension PaymentTableViewCell {
+    func getSubtotalLabel() -> UILabel {
+        return subtotalLabel
+    }
+
+    func getSubtotalValue() -> UILabel {
+        return subtotalValue
+    }
+
+    func getDiscountLabel() -> UILabel {
+        return discountLabel
+    }
+
+    func getDiscountValue() -> UILabel {
+        return discountValue
+    }
+
+    func getShippingLabel() -> UILabel {
+        return shippingLabel
+    }
+
+    func getShippingValue() -> UILabel {
+        return shippingValue
+    }
+
+    func getTaxesLabel() -> UILabel {
+        return taxesLabel
+    }
+
+    func getTaxesValue() -> UILabel {
+        return taxesValue
+    }
+
+    func getTotalLabel() -> UILabel {
+        return totalLabel
+    }
+
+    func getTotalValue() -> UILabel {
+        return totalValue
+    }
+
+    func getFooterText() -> String? {
+        return footerText
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class PaymentTableViewCell: UITableViewCell {
+final class PaymentTableViewCell: UITableViewCell {
     @IBOutlet var verticalStackView: UIStackView!
     @IBOutlet var subtotalView: UIView!
     @IBOutlet public weak var subtotalLabel: UILabel!
@@ -59,5 +59,55 @@ class PaymentTableViewCell: UITableViewCell {
         footerLabel?.text = nil
         footerLabel?.applyFootnoteStyle()
         separatorLine?.backgroundColor = StyleManager.cellSeparatorColor
+    }
+
+    func configure(with viewModel: OrderPaymentDetailsViewModel) {
+        subtotalLabel.text = Titles.subtotalLabel
+        subtotalValue.text = viewModel.subtotalValue
+
+        discountLabel.text = viewModel.discountText
+        discountValue.text = viewModel.discountValue
+        discountView.isHidden = viewModel.discountValue == nil
+
+        shippingLabel.text = Titles.shippingLabel
+        shippingValue.text = viewModel.shippingValue
+
+        taxesLabel.text = Titles.taxesLabel
+        taxesValue.text = viewModel.taxesValue
+        taxesView.isHidden = taxesValue == nil
+
+        totalLabel.text = Titles.totalLabel
+        totalValue.text = viewModel.totalValue
+
+        footerText = viewModel.paymentSummary
+
+        accessibilityElements = [subtotalLabel as Any,
+                                 subtotalValue as Any,
+                                 discountLabel as Any,
+                                 discountValue as Any,
+                                 shippingLabel as Any,
+                                 shippingValue as Any,
+                                 taxesLabel as Any,
+                                 taxesValue as Any,
+                                 totalLabel as Any,
+                                 totalValue as Any]
+
+        if let footerText = footerText {
+            accessibilityElements?.append(footerText)
+        }
+    }
+}
+
+
+private extension PaymentTableViewCell {
+    enum Titles {
+        static let subtotalLabel = NSLocalizedString("Subtotal",
+                                                     comment: "Subtotal label for payment view")
+        static let shippingLabel = NSLocalizedString("Shipping",
+                                                     comment: "Shipping label for payment view")
+        static let taxesLabel = NSLocalizedString("Taxes",
+                                                  comment: "Taxes label for payment view")
+        static let totalLabel = NSLocalizedString("Total",
+                                                  comment: "Total label for payment view")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
 		D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */; };
 		D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */; };
+		D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 /* End PBXBuildFile section */
@@ -753,6 +754,7 @@
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
 		D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsResultsControllers.swift; sourceTree = "<group>"; };
 		D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentDetailsViewModel.swift; sourceTree = "<group>"; };
+		D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderPaymentDetailsViewModelTests.swift; path = WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
@@ -921,6 +923,7 @@
 		B53A569521123D27000776C9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */,
 				D8F82AC422AF903700B67E4B /* IconsTests.swift */,
 				D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */,
 				D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */,
@@ -2218,6 +2221,7 @@
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				B555531321B57E8800449E71 /* MockupUserNotificationsCenterAdapter.swift in Sources */,
+				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,
 				D83F593D225B4B5000626E75 /* ManualTrackingViewControllerTests.swift in Sources */,
 				CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */,
 				B555531121B57E6F00449E71 /* MockupApplicationAdapter.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */; };
 		D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */; };
 		D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */; };
+		D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 /* End PBXBuildFile section */
@@ -755,6 +756,7 @@
 		D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsResultsControllers.swift; sourceTree = "<group>"; };
 		D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentDetailsViewModel.swift; sourceTree = "<group>"; };
 		D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderPaymentDetailsViewModelTests.swift; path = WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
+		D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
@@ -923,6 +925,7 @@
 		B53A569521123D27000776C9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */,
 				D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */,
 				D8F82AC422AF903700B67E4B /* IconsTests.swift */,
 				D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */,
@@ -2263,6 +2266,7 @@
 				746791662108D87B007CF1DC /* MockupAnalyticsProvider.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
+				D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
 		D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */; };
+		D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 /* End PBXBuildFile section */
@@ -751,6 +752,7 @@
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
 		D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsResultsControllers.swift; sourceTree = "<group>"; };
+		D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentDetailsViewModel.swift; sourceTree = "<group>"; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
@@ -1607,6 +1609,7 @@
 				D817586122BB64C300289CFE /* OrderDetailsNotices.swift */,
 				D817586322BDD81600289CFE /* OrderDetailsDataSource.swift */,
 				D8C11A4D22DD235F00D4A88D /* OrderDetailsResultsControllers.swift */,
+				D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */,
 			);
 			path = OrderDetailsViewModel;
 			sourceTree = "<group>";
@@ -2059,6 +2062,7 @@
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,
+				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
 				D843D5D322485009001BFA55 /* ShipmentProvidersViewController.swift in Sources */,
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -7,6 +7,7 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     private var subject: OrderPaymentDetailsViewModel?
 
     override func setUp() {
+        super.setUp()
         order = MockOrders().sampleOrder()
         subject = OrderPaymentDetailsViewModel(order: order!)
     }
@@ -14,6 +15,7 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     override func tearDown() {
         subject = nil
         order = nil
+        super.tearDown()
     }
 
     func testSubtotalMatchesExpectation() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -19,47 +19,48 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     }
 
     func testSubtotalMatchesExpectation() {
-        XCTAssertEqual(subject?.subtotal, 0)
+        XCTAssertEqual(subject.subtotal, 0)
     }
 
     func testSubtotalValueMatchesExpectation() {
-        let expectedValue = CurrencyFormatter().formatAmount(0, with: order!.currency) ?? String()
-        XCTAssertEqual(subject?.subtotalValue, expectedValue)
+        let expectedValue = CurrencyFormatter().formatAmount(0, with: order.currency) ?? String()
+        XCTAssertEqual(subject.subtotalValue, expectedValue)
     }
 
     func testDiscountTextMatchesExpectation() {
-        XCTAssertNil(subject?.discountText)
+        XCTAssertNil(subject.discountText)
     }
 
     func testDiscountValueMatchesExpectation() {
-        let expectedValue = "-" + CurrencyFormatter().formatAmount(order!.discountTotal, with: order!.currency)!
-        XCTAssertEqual(subject?.discountValue, expectedValue)
+        let expectedValue = "-" + CurrencyFormatter().formatAmount(order.discountTotal, with: order.currency)!
+        XCTAssertEqual(subject.discountValue, expectedValue)
     }
 
     func testShippingValueMatchesExpectation() {
-        let expectedValue = CurrencyFormatter().formatAmount(order!.shippingTotal, with: order!.currency)
-        XCTAssertEqual(subject?.shippingValue, expectedValue)
+        let expectedValue = CurrencyFormatter().formatAmount(order.shippingTotal, with: order.currency)
+        XCTAssertEqual(subject.shippingValue, expectedValue)
     }
 
     func testTaxesValueMatchesExpectation() {
-        let expectedValue = CurrencyFormatter().formatAmount(order!.totalTax, with: order!.currency)
-        XCTAssertEqual(subject?.taxesValue, expectedValue)
+        let expectedValue = CurrencyFormatter().formatAmount(order.totalTax, with: order.currency)
+        XCTAssertEqual(subject.taxesValue, expectedValue)
     }
 
     func testTotalValueMatchedExpectation() {
-        let expectedValue = CurrencyFormatter().formatAmount(order!.total, with: order!.currency)
-        XCTAssertEqual(subject?.totalValue, expectedValue)
+        let expectedValue = CurrencyFormatter().formatAmount(order.total,
+                                                             with: order.currency)
+        XCTAssertEqual(subject.totalValue, expectedValue)
     }
 
     func testPaymentSummaryMatchesExpectation() {
         let expectedValue = NSLocalizedString(
-            "Payment of \(subject!.totalValue) received via \(order!.paymentMethodTitle)",
+            "Payment of \(subject.totalValue) received via \(order.paymentMethodTitle)",
             comment: "Payment of <currency symbol><payment total> received via (payment method title)"
         )
-        XCTAssertEqual(subject?.paymentSummary, expectedValue)
+        XCTAssertEqual(subject.paymentSummary, expectedValue)
     }
 
     func testCouponLinesMatchesExpectation() {
-        XCTAssertEqual(subject?.couponLines, order?.coupons)
+        XCTAssertEqual(subject.couponLines, order.coupons)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -3,8 +3,8 @@ import XCTest
 @testable import Networking
 
 final class OrderPaymentDetailsViewModelTests: XCTestCase {
-    private var order: Order?
-    private var subject: OrderPaymentDetailsViewModel?
+    private var order: Order!
+    private var subject: OrderPaymentDetailsViewModel!
 
     override func setUp() {
         super.setUp()

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WooCommerce
+@testable import Networking
+
+final class OrderPaymentDetailsViewModelTests: XCTestCase {
+    private var order: Order?
+    private var subject: OrderPaymentDetailsViewModel?
+
+    override func setUp() {
+        order = MockOrders().sampleOrder()
+        subject = OrderPaymentDetailsViewModel(order: order!)
+    }
+
+    override func tearDown() {
+        subject = nil
+        order = nil
+    }
+
+    func testSubtotalMatchesExpectation() {
+        XCTAssertEqual(subject?.subtotal, 0)
+    }
+
+    func testSubtotalValueMatchesExpectation() {
+        let expectedValue = CurrencyFormatter().formatAmount(0, with: order!.currency) ?? String()
+        XCTAssertEqual(subject?.subtotalValue, expectedValue)
+    }
+
+    func testDiscountTextMatchesExpectation() {
+        XCTAssertNil(subject?.discountText)
+    }
+
+    func testDiscountValueMatchesExpectation() {
+        let expectedValue = "-" + CurrencyFormatter().formatAmount(order!.discountTotal, with: order!.currency)!
+        XCTAssertEqual(subject?.discountValue, expectedValue)
+    }
+
+    func testShippingValueMatchesExpectation() {
+        let expectedValue = CurrencyFormatter().formatAmount(order!.shippingTotal, with: order!.currency)
+        XCTAssertEqual(subject?.shippingValue, expectedValue)
+    }
+
+    func testTaxesValueMatchesExpectation() {
+        let expectedValue = CurrencyFormatter().formatAmount(order!.totalTax, with: order!.currency)
+        XCTAssertEqual(subject?.taxesValue, expectedValue)
+    }
+
+    func testTotalValueMatchedExpectation() {
+        let expectedValue = CurrencyFormatter().formatAmount(order!.total, with: order!.currency)
+        XCTAssertEqual(subject?.totalValue, expectedValue)
+    }
+
+    func testPaymentSummaryMatchesExpectation() {
+        let expectedValue = NSLocalizedString(
+            "Payment of \(subject!.totalValue) received via \(order!.paymentMethodTitle)",
+            comment: "Payment of <currency symbol><payment total> received via (payment method title)"
+        )
+        XCTAssertEqual(subject?.paymentSummary, expectedValue)
+    }
+
+    func testCouponLinesMatchesExpectation() {
+        XCTAssertEqual(subject?.couponLines, order?.coupons)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import WooCommerce
+@testable import Networking
+
+final class PaymentTableViewCellTests: XCTestCase {
+    private var cell: PaymentTableViewCell?
+    private var viewModel: OrderPaymentDetailsViewModel?
+    private var order: Order?
+
+    override func setUp() {
+        super.setUp()
+        order = MockOrders().sampleOrder()
+        viewModel = OrderPaymentDetailsViewModel(order: order!)
+
+        let nib = Bundle.main.loadNibNamed("PaymentTableViewCell", owner: self, options: nil)
+        cell = nib?.first as? PaymentTableViewCell
+
+        cell?.configure(with: viewModel!)
+    }
+
+    override func tearDown() {
+        cell = nil
+        viewModel = nil
+        order = nil
+        super.tearDown()
+    }
+
+    func testSubtotalLabelContainsExpectedText() {
+        let label = cell?.getSubtotalLabel()
+        XCTAssertEqual(label?.text, Titles.subtotalLabel)
+    }
+
+    func testSubtotalValueContainsExpectedText() {
+        let label = cell?.getSubtotalValue()
+        XCTAssertEqual(label?.text, viewModel?.subtotalValue)
+    }
+
+    func testDiscountLabelContainsExpectedText() {
+        let label = cell?.getDiscountLabel()
+        XCTAssertEqual(label?.text, viewModel?.discountText)
+    }
+
+    func testDiscountValueContainsExpectedText() {
+        let label = cell?.getDiscountValue()
+        XCTAssertEqual(label?.text, viewModel?.discountValue)
+    }
+
+    func testShippingLabelContainsExpectedText() {
+        let label = cell?.getShippingLabel()
+        XCTAssertEqual(label?.text, Titles.shippingLabel)
+    }
+
+    func testShippingValueContainsExpectedText() {
+        let label = cell?.getShippingValue()
+        XCTAssertEqual(label?.text, viewModel?.shippingValue)
+    }
+
+    func testTaxesLabelContainsExpectedText() {
+        let label = cell?.getTaxesLabel()
+        XCTAssertEqual(label?.text, Titles.taxesLabel)
+    }
+
+    func testTaxesValueContainsExpectedText() {
+        let label = cell?.getTaxesValue()
+        XCTAssertEqual(label?.text, viewModel?.taxesValue)
+    }
+
+    func testTotalLabelContainsExpectedText() {
+        let label = cell?.getTotalLabel()
+        XCTAssertEqual(label?.text, Titles.totalLabel)
+    }
+
+    func testTotalValueContainsExpectedText() {
+        let label = cell?.getTotalValue()
+        XCTAssertEqual(label?.text, viewModel?.totalValue)
+    }
+
+    func testFooterTextContainsExpectedText() {
+        XCTAssertEqual(cell?.getFooterText(), viewModel?.paymentSummary)
+    }
+}
+
+
+private extension PaymentTableViewCellTests {
+    enum Titles {
+        static let subtotalLabel = NSLocalizedString("Subtotal",
+                                                     comment: "Subtotal label for payment view")
+        static let shippingLabel = NSLocalizedString("Shipping",
+                                                     comment: "Shipping label for payment view")
+        static let taxesLabel = NSLocalizedString("Taxes",
+                                                  comment: "Taxes label for payment view")
+        static let totalLabel = NSLocalizedString("Total",
+                                                  comment: "Total label for payment view")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift
@@ -3,14 +3,14 @@ import XCTest
 @testable import Networking
 
 final class PaymentTableViewCellTests: XCTestCase {
-    private var cell: PaymentTableViewCell?
-    private var viewModel: OrderPaymentDetailsViewModel?
-    private var order: Order?
+    private var cell: PaymentTableViewCell!
+    private var viewModel: OrderPaymentDetailsViewModel!
+    private var order: Order!
 
     override func setUp() {
         super.setUp()
         order = MockOrders().sampleOrder()
-        viewModel = OrderPaymentDetailsViewModel(order: order!)
+        viewModel = OrderPaymentDetailsViewModel(order: order)
 
         let nib = Bundle.main.loadNibNamed("PaymentTableViewCell", owner: self, options: nil)
         cell = nib?.first as? PaymentTableViewCell
@@ -26,57 +26,57 @@ final class PaymentTableViewCellTests: XCTestCase {
     }
 
     func testSubtotalLabelContainsExpectedText() {
-        let label = cell?.getSubtotalLabel()
-        XCTAssertEqual(label?.text, Titles.subtotalLabel)
+        let label = cell.getSubtotalLabel()
+        XCTAssertEqual(label.text, Titles.subtotalLabel)
     }
 
     func testSubtotalValueContainsExpectedText() {
-        let label = cell?.getSubtotalValue()
-        XCTAssertEqual(label?.text, viewModel?.subtotalValue)
+        let label = cell.getSubtotalValue()
+        XCTAssertEqual(label.text, viewModel.subtotalValue)
     }
 
     func testDiscountLabelContainsExpectedText() {
-        let label = cell?.getDiscountLabel()
-        XCTAssertEqual(label?.text, viewModel?.discountText)
+        let label = cell.getDiscountLabel()
+        XCTAssertEqual(label.text, viewModel.discountText)
     }
 
     func testDiscountValueContainsExpectedText() {
-        let label = cell?.getDiscountValue()
-        XCTAssertEqual(label?.text, viewModel?.discountValue)
+        let label = cell.getDiscountValue()
+        XCTAssertEqual(label.text, viewModel.discountValue)
     }
 
     func testShippingLabelContainsExpectedText() {
-        let label = cell?.getShippingLabel()
-        XCTAssertEqual(label?.text, Titles.shippingLabel)
+        let label = cell.getShippingLabel()
+        XCTAssertEqual(label.text, Titles.shippingLabel)
     }
 
     func testShippingValueContainsExpectedText() {
-        let label = cell?.getShippingValue()
-        XCTAssertEqual(label?.text, viewModel?.shippingValue)
+        let label = cell.getShippingValue()
+        XCTAssertEqual(label.text, viewModel.shippingValue)
     }
 
     func testTaxesLabelContainsExpectedText() {
-        let label = cell?.getTaxesLabel()
-        XCTAssertEqual(label?.text, Titles.taxesLabel)
+        let label = cell.getTaxesLabel()
+        XCTAssertEqual(label.text, Titles.taxesLabel)
     }
 
     func testTaxesValueContainsExpectedText() {
-        let label = cell?.getTaxesValue()
-        XCTAssertEqual(label?.text, viewModel?.taxesValue)
+        let label = cell.getTaxesValue()
+        XCTAssertEqual(label.text, viewModel.taxesValue)
     }
 
     func testTotalLabelContainsExpectedText() {
-        let label = cell?.getTotalLabel()
-        XCTAssertEqual(label?.text, Titles.totalLabel)
+        let label = cell.getTotalLabel()
+        XCTAssertEqual(label.text, Titles.totalLabel)
     }
 
     func testTotalValueContainsExpectedText() {
-        let label = cell?.getTotalValue()
-        XCTAssertEqual(label?.text, viewModel?.totalValue)
+        let label = cell.getTotalValue()
+        XCTAssertEqual(label.text, viewModel.totalValue)
     }
 
     func testFooterTextContainsExpectedText() {
-        XCTAssertEqual(cell?.getFooterText(), viewModel?.paymentSummary)
+        XCTAssertEqual(cell.getFooterText(), viewModel.paymentSummary)
     }
 }
 


### PR DESCRIPTION
Fixes #1116 

As [mentioned in the review](https://github.com/woocommerce/woocommerce-ios/pull/1077#discussion_r304399578) of PR #1077, there is a significant amount of code in OrderDetailsDataSource that configures and populates cells, in particular `PaymentTableViewCell`

Before:
<img src="https://user-images.githubusercontent.com/2722505/61560580-ab48a280-aa3a-11e9-94e0-43dc2e18cfff.png" width="350"/>

And after:
<img src="https://user-images.githubusercontent.com/2722505/61560589-b00d5680-aa3a-11e9-9273-5d6bd9b3398b.png" width="350"/>

## Changes
- Add a `OrderPaymentDetailsViewModel` that encapsulates the data that is necessary to render the `PaymentTableViewCell`
- Unit tests

## Testing
- Run the tests, check that they are ✅ 
- Check that there are no changes to the way payment details are rendered.