### PR TITLE
Orders badge mark I: Networking

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -222,6 +222,8 @@
 		D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */ = {isa = PBXBuildFile; fileRef = D823D91322377EE600C90817 /* shipment_tracking_providers.json */; };
 		D8736B5C22F083C500A14A29 /* OrderCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5B22F083C500A14A29 /* OrderCount.swift */; };
 		D8736B5E22F0849700A14A29 /* OrderCountItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5D22F0849700A14A29 /* OrderCountItem.swift */; };
+		D8736B6022F0887900A14A29 /* OrderCountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5F22F0887900A14A29 /* OrderCountMapper.swift */; };
+		D8736B6222F089E200A14A29 /* orders-count.json in Resources */ = {isa = PBXBuildFile; fileRef = D8736B6122F089E200A14A29 /* orders-count.json */; };
 		D87F6151226591E10031A13B /* NullNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F6150226591E10031A13B /* NullNetwork.swift */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
@@ -471,6 +473,8 @@
 		D823D91322377EE600C90817 /* shipment_tracking_providers.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = shipment_tracking_providers.json; sourceTree = "<group>"; };
 		D8736B5B22F083C500A14A29 /* OrderCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCount.swift; sourceTree = "<group>"; };
 		D8736B5D22F0849700A14A29 /* OrderCountItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCountItem.swift; sourceTree = "<group>"; };
+		D8736B5F22F0887900A14A29 /* OrderCountMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCountMapper.swift; sourceTree = "<group>"; };
+		D8736B6122F089E200A14A29 /* orders-count.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "orders-count.json"; sourceTree = "<group>"; };
 		D87F6150226591E10031A13B /* NullNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullNetwork.swift; sourceTree = "<group>"; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
@@ -828,6 +832,7 @@
 				D8FBFF1422D3BE09006E3336 /* order-stats-v4-defaults.json */,
 				D8FBFF1722D4DDB9006E3336 /* order-stats-v4-hour.json */,
 				D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */,
+				D8736B6122F089E200A14A29 /* orders-count.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -843,6 +848,7 @@
 				B554FA8E2180BC7000C54DFF /* NoteHashListMapper.swift */,
 				B59325CB217E2B4C000B0E8E /* NoteListMapper.swift */,
 				B5C6FCD320A373BA00A4F8E4 /* OrderMapper.swift */,
+				D8736B5F22F0887900A14A29 /* OrderCountMapper.swift */,
 				B567AF2A20A0FA4200AB6C62 /* OrderListMapper.swift */,
 				74C8F06720EEB7BC00B6EDC9 /* OrderNotesMapper.swift */,
 				CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */,
@@ -1087,6 +1093,7 @@
 				743E84F422172D0A00FAC9D7 /* shipment_tracking_multiple.json in Resources */,
 				74AB5B4F21AF3F0E00859C12 /* site-api-no-woo.json in Resources */,
 				D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */,
+				D8736B6222F089E200A14A29 /* orders-count.json in Resources */,
 				D823D90B22376EFE00C90817 /* shipment_tracking_delete.json in Resources */,
 				74C947832193A6C70024CB60 /* comment-moderate-trash.json in Resources */,
 				B58D10CA2114D22E00107ED4 /* new-order-note.json in Resources */,
@@ -1246,6 +1253,7 @@
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
 				743E84EC22171F4600FAC9D7 /* ShipmentTracking.swift in Sources */,
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,
+				D8736B6022F0887900A14A29 /* OrderCountMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -220,6 +220,8 @@
 		D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */; };
 		D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D823D91122377DF200C90817 /* ShipmentTrackingProviderListMapper.swift */; };
 		D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */ = {isa = PBXBuildFile; fileRef = D823D91322377EE600C90817 /* shipment_tracking_providers.json */; };
+		D8736B5C22F083C500A14A29 /* OrderCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5B22F083C500A14A29 /* OrderCount.swift */; };
+		D8736B5E22F0849700A14A29 /* OrderCountItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5D22F0849700A14A29 /* OrderCountItem.swift */; };
 		D87F6151226591E10031A13B /* NullNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F6150226591E10031A13B /* NullNetwork.swift */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
@@ -467,6 +469,8 @@
 		D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipmentTrackingProviderGroup.swift; sourceTree = "<group>"; };
 		D823D91122377DF200C90817 /* ShipmentTrackingProviderListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipmentTrackingProviderListMapper.swift; sourceTree = "<group>"; };
 		D823D91322377EE600C90817 /* shipment_tracking_providers.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = shipment_tracking_providers.json; sourceTree = "<group>"; };
+		D8736B5B22F083C500A14A29 /* OrderCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCount.swift; sourceTree = "<group>"; };
+		D8736B5D22F0849700A14A29 /* OrderCountItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCountItem.swift; sourceTree = "<group>"; };
 		D87F6150226591E10031A13B /* NullNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullNetwork.swift; sourceTree = "<group>"; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
@@ -733,6 +737,8 @@
 				B59325D1217E4206000B0E8E /* NoteRange.swift */,
 				B554FA902180BCFC00C54DFF /* NoteHash.swift */,
 				B557DA1C20979E7D005962F4 /* Order.swift */,
+				D8736B5B22F083C500A14A29 /* OrderCount.swift */,
+				D8736B5D22F0849700A14A29 /* OrderCountItem.swift */,
 				741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */,
 				B5C6FCCE20A3592900A4F8E4 /* OrderItem.swift */,
 				74C8F06320EEB44800B6EDC9 /* OrderNote.swift */,
@@ -1225,6 +1231,7 @@
 				B5BB1D0C20A2050300112D92 /* DateFormatter+Woo.swift in Sources */,
 				743E84EE2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift in Sources */,
 				B567AF2520A0CCA300AB6C62 /* AuthenticatedRequest.swift in Sources */,
+				D8736B5C22F083C500A14A29 /* OrderCount.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockupNetwork.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
 				748D4248210F89ED00CF7D1B /* OrderStatsRemote.swift in Sources */,
@@ -1249,6 +1256,7 @@
 				CE50346021B5799F007573C6 /* SitePlan.swift in Sources */,
 				B59325CC217E2B4C000B0E8E /* NoteListMapper.swift in Sources */,
 				B505F6CD20BEE37E00BB1B69 /* AccountMapper.swift in Sources */,
+				D8736B5E22F0849700A14A29 /* OrderCountItem.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
 				B557DA0D20975DB1005962F4 /* WordPressAPIVersion.swift in Sources */,

--- a/Networking/Networking/Mapper/OrderCountMapper.swift
+++ b/Networking/Networking/Mapper/OrderCountMapper.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Mapper: Order count
 ///
 struct OrderCountMapper: Mapper {
-    
+
     /// Site Identifier associated to the order that will be parsed.
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
@@ -18,7 +18,7 @@ struct OrderCountMapper: Mapper {
         decoder.userInfo = [
             .siteID: siteID
         ]
-        
+
         return try decoder.decode(OrderCount.self, from: response)
     }
 }

--- a/Networking/Networking/Mapper/OrderCountMapper.swift
+++ b/Networking/Networking/Mapper/OrderCountMapper.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+
+/// Mapper: Order count
+///
+struct OrderCountMapper: Mapper {
+    
+    /// Site Identifier associated to the order that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
+    ///
+    let siteID: Int
+
+    /// (Attempts) to convert a dictionary into OrderCount.
+    ///
+    func map(response: Data) throws -> OrderCount {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+        
+        return try decoder.decode(OrderCount.self, from: response)
+    }
+}

--- a/Networking/Networking/Model/OrderCount.swift
+++ b/Networking/Networking/Model/OrderCount.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// Represents an OrderCount Entity.
+/// An OrderCount contains an array of OrderCountItem.
+/// Each OrderCountItem representes the number of Orders for a given status
+///
 public struct OrderCount: Decodable {
     public let siteID: Int
     public let items: [OrderCountItem]
@@ -22,6 +26,8 @@ public struct OrderCount: Decodable {
         self.init(siteID: siteID, items: items)
     }
 
+    /// Returns the first OrderCountItem mathing a order status slug
+    ///
     public subscript(slug: String) -> OrderCountItem? {
         get {
             return items.filter {

--- a/Networking/Networking/Model/OrderCount.swift
+++ b/Networking/Networking/Model/OrderCount.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct OrderCount: Decodable {
+    public let items: [OrderCountItem]
+
+    public subscript(slug: String) -> OrderCountItem? {
+        get {
+            return items.filter {
+                $0.slug == slug
+            }.first
+        }
+        set {
+        }
+    }
+}

--- a/Networking/Networking/Model/OrderCount.swift
+++ b/Networking/Networking/Model/OrderCount.swift
@@ -1,7 +1,26 @@
 import Foundation
 
 public struct OrderCount: Decodable {
+    public let siteID: Int
     public let items: [OrderCountItem]
+
+    public init(siteID: Int, items: [OrderCountItem]) {
+        self.siteID = siteID
+        self.items = items
+    }
+
+    /// The public initializer for OrderCount.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+            throw OrderCountError.missingSiteID
+        }
+
+        let container = try decoder.singleValueContainer()
+        let items = try container.decode([OrderCountItem].self)
+
+        self.init(siteID: siteID, items: items)
+    }
 
     public subscript(slug: String) -> OrderCountItem? {
         get {
@@ -12,4 +31,11 @@ public struct OrderCount: Decodable {
         set {
         }
     }
+}
+
+
+// MARK: - Decoding Errors
+//
+enum OrderCountError: Error {
+    case missingSiteID
 }

--- a/Networking/Networking/Model/OrderCount.swift
+++ b/Networking/Networking/Model/OrderCount.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents an OrderCount Entity.
 /// An OrderCount contains an array of OrderCountItem.
-/// Each OrderCountItem representes the number of Orders for a given status
+/// Each OrderCountItem represents the number of Orders for a given status
 ///
 public struct OrderCount: Decodable {
     public let siteID: Int
@@ -26,16 +26,12 @@ public struct OrderCount: Decodable {
         self.init(siteID: siteID, items: items)
     }
 
-    /// Returns the first OrderCountItem mathing a order status slug
+    /// Returns the first OrderCountItem matching a order status slug
     ///
     public subscript(slug: String) -> OrderCountItem? {
-        get {
-            return items.filter {
-                $0.slug == slug
+        return items.filter {
+            $0.slug == slug
             }.first
-        }
-        set {
-        }
     }
 }
 

--- a/Networking/Networking/Model/OrderCountItem.swift
+++ b/Networking/Networking/Model/OrderCountItem.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct OrderCountItem: Decodable {
+    public let slug: String
+    public let name: String
+    public let total: Int
+}
+
+
+extension OrderCountItem: Comparable {
+    public static func == (lhs: OrderCountItem, rhs: OrderCountItem) -> Bool {
+        return lhs.slug == rhs.slug &&
+            lhs.name == rhs.name &&
+            lhs.total == rhs.total
+    }
+
+    public static func < (lhs: OrderCountItem, rhs: OrderCountItem) -> Bool {
+        return lhs.slug == rhs.slug &&
+            lhs.name == rhs.name &&
+            lhs.total < rhs.total
+    }
+}

--- a/Networking/Networking/Model/OrderCountItem.swift
+++ b/Networking/Networking/Model/OrderCountItem.swift
@@ -4,6 +4,34 @@ public struct OrderCountItem: Decodable {
     public let slug: String
     public let name: String
     public let total: Int
+
+    public init(slug: String, name: String, total: Int) {
+        self.slug = slug
+        self.name = name
+        self.total = total
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let slug = try container.decode(String.self, forKey: .slug)
+        let name = try container.decode(String.self, forKey: .name)
+        let total = try container.decode(Int.self, forKey: .total)
+
+        self.init(slug: slug, name: name, total: total)
+    }
+}
+
+
+/// Defines all of the OrderCountItem CodingKeys
+///
+private extension OrderCountItem {
+
+    enum CodingKeys: String, CodingKey {
+        case slug
+        case name
+        case total
+    }
 }
 
 

--- a/Networking/Networking/Model/OrderCountItem.swift
+++ b/Networking/Networking/Model/OrderCountItem.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Represents an OrderCountItem Entity.
+/// OrderCountItem represents the number of Orders for a given status
+///
 public struct OrderCountItem: Decodable {
     public let slug: String
     public let name: String
@@ -11,6 +14,7 @@ public struct OrderCountItem: Decodable {
         self.total = total
     }
 
+    /// Public initialiser
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -34,8 +38,10 @@ private extension OrderCountItem {
     }
 }
 
-
+// MARK: - Comparable Conformance
+//
 extension OrderCountItem: Comparable {
+
     public static func == (lhs: OrderCountItem, rhs: OrderCountItem) -> Bool {
         return lhs.slug == rhs.slug &&
             lhs.name == rhs.name &&

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -134,6 +134,10 @@ public class OrdersRemote: Remote {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    public func countOrders(for siteID: Int, statusKey: String) {
+        
+    }
 }
 
 

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -143,7 +143,7 @@ public class OrdersRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func countOrders(for siteID: Int, statusKey: String, completion: @escaping (OrderCount?, Error?) -> Void) {
-        let path = "\(Constants.ordersPath)/" + "\(Constants.totalsPath)"
+        let path = "\(Constants.totalsPath)"
         let parameters = [ParameterKeys.statusKey: statusKey]
 
         let mapper = OrderCountMapper(siteID: siteID)
@@ -166,7 +166,7 @@ public extension OrdersRemote {
     private enum Constants {
         static let ordersPath: String       = "orders"
         static let notesPath: String        = "notes"
-        static let totalsPath: String       = "totals"
+        static let totalsPath: String       = "reports/orders/totals"
     }
 
     private enum ParameterKeys {

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -143,12 +143,11 @@ public class OrdersRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func countOrders(for siteID: Int, statusKey: String, completion: @escaping (OrderCount?, Error?) -> Void) {
-        let path = "\(Constants.totalsPath)"
         let parameters = [ParameterKeys.statusKey: statusKey]
 
         let mapper = OrderCountMapper(siteID: siteID)
 
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: Constants.totalsPath, parameters: parameters)
         enqueue(request, mapper: mapper, completion: completion)
     }
 }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -135,8 +135,21 @@ public class OrdersRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    public func countOrders(for siteID: Int, statusKey: String) {
-        
+    /// Retrieves the number of Orders available for all order statuses
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch the order count.
+    ///     - ststusKey: the order status slug
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func countOrders(for siteID: Int, statusKey: String, completion: @escaping (OrderCount?, Error?) -> Void) {
+        let path = "\(Constants.ordersPath)/" + "\(Constants.totalsPath)"
+        let parameters = [ParameterKeys.statusKey: statusKey]
+
+        let mapper = OrderCountMapper(siteID: siteID)
+
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        enqueue(request, mapper: mapper, completion: completion)
     }
 }
 
@@ -153,6 +166,7 @@ public extension OrdersRemote {
     private enum Constants {
         static let ordersPath: String       = "orders"
         static let notesPath: String        = "notes"
+        static let totalsPath: String       = "totals"
     }
 
     private enum ParameterKeys {

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -247,7 +247,7 @@ final class OrdersRemoteTests: XCTestCase {
                             XCTAssertNil(error)
                             XCTAssertNotNil(orderCount)
 
-                            // Take the opportunity to test the customvsubscript works
+                            // Take the opportunity to test the custom subscript works
                             let numberOfProcessingOrders = orderCount!["processing"]?.total
 
                             XCTAssertEqual(numberOfProcessingOrders, 1)

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -240,7 +240,7 @@ final class OrdersRemoteTests: XCTestCase {
         let remote = OrdersRemote(network: network)
         let expectation = self.expectation(description: "Count Orders")
 
-        network.simulateResponse(requestUrlSuffix: "orders/totals", filename: "orders-count")
+        network.simulateResponse(requestUrlSuffix: "reports/orders/totals", filename: "orders-count")
 
         remote.countOrders(for: sampleSiteID,
                            statusKey: "processing") { orderCount, error in

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// OrdersRemoteTests:
 ///
-class OrdersRemoteTests: XCTestCase {
+final class OrdersRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
@@ -228,6 +228,51 @@ class OrdersRemoteTests: XCTestCase {
             XCTAssertNotNil(orderNote)
             expectation.fulfill()
         }
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+
+    // MARK: - Count Orders Tests
+
+    /// Verifies that countOrders properly parses response.
+    ///
+    func testCountOrdersProperlyReturnsParsedOrderCount() {
+        let remote = OrdersRemote(network: network)
+        let expectation = self.expectation(description: "Count Orders")
+
+        network.simulateResponse(requestUrlSuffix: "orders/totals", filename: "orders-count")
+
+        remote.countOrders(for: sampleSiteID,
+                           statusKey: "processing") { orderCount, error in
+                            XCTAssertNil(error)
+                            XCTAssertNotNil(orderCount)
+
+                            // Take the opportunity to test the customvsubscript works
+                            let numberOfProcessingOrders = orderCount!["processing"]?.total
+
+                            XCTAssertEqual(numberOfProcessingOrders, 1)
+
+                            expectation.fulfill()
+
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that countOrders properly relays Networking Layer errors.
+    ///
+    func testCountOrdersProperlyRelaysNetwokingErrors() {
+        let remote = OrdersRemote(network: network)
+        let expectation = self.expectation(description: "Count Orders")
+
+        remote.countOrders(for: sampleSiteID,
+                           statusKey: "processing") { orderCount, error in
+                            XCTAssertNil(orderCount)
+                            XCTAssertNotNil(error)
+                            expectation.fulfill()
+
+        }
+
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 }

--- a/Networking/NetworkingTests/Responses/orders-count.json
+++ b/Networking/NetworkingTests/Responses/orders-count.json
@@ -1,0 +1,37 @@
+[
+    {
+        "slug": "pending",
+        "name": "Pending payment",
+        "total": 0
+    },
+    {
+        "slug": "processing",
+        "name": "Processing",
+        "total": 1
+    },
+    {
+        "slug": "on-hold",
+        "name": "On hold",
+        "total": 0
+    },
+    {
+        "slug": "completed",
+        "name": "Completed",
+        "total": 1
+    },
+    {
+        "slug": "cancelled",
+        "name": "Cancelled",
+        "total": 0
+    },
+    {
+        "slug": "refunded",
+        "name": "Refunded",
+        "total": 0
+    },
+    {
+        "slug": "failed",
+        "name": "Failed",
+        "total": 0
+    }
+]


### PR DESCRIPTION
Fixes #1137

To avoid submitting yet another PR that is too large, I will be breaking down the implementation of the Orders badge in several parts. This is the first one.

## Changes
- Added a method to the `OrdersRemote`
- Added model objects 
- Added Mapper for the response.
- Unit tests

## Testing
- 👀  at the code
- ✅  the unit tests, in particular the additions to OrdersRemoteTests