### PR TITLE
Dashboard: move child view controller container views setup to code to enable Stats v3/v4 UI

### DIFF
--- a/WooCommerce/Classes/Extensions/UIStoryboard+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIStoryboard+Woo.swift
@@ -18,3 +18,14 @@ extension UIStoryboard {
         return UIStoryboard(name: "Orders", bundle: .main)
     }
 }
+
+// MARK: UIStoryboard Helpers
+//
+extension UIStoryboard {
+    /// Returns a view controller from a Storyboard assuming the identifier is the same as the class name.
+    ///
+    func instantiateViewController<T: NSObject>(ofClass classType: T.Type) -> T? {
+        let identifier = classType.classNameWithoutNamespaces
+        return instantiateViewController(withIdentifier: identifier) as? T
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -13,7 +13,7 @@
         <!--Store Stats View Controller-->
         <scene sceneID="gpf-E1-UPO">
             <objects>
-                <viewController id="zaY-no-5X6" customClass="StoreStatsViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="StoreStatsViewController" id="zaY-no-5X6" customClass="StoreStatsViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EgO-Cw-kVD">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="380"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -15,11 +15,11 @@
             <objects>
                 <viewController storyboardIdentifier="StoreStatsViewController" id="zaY-no-5X6" customClass="StoreStatsViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="EgO-Cw-kVD">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="380"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Y7g-5h-02N">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="380"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PBm-IO-eju">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
@@ -50,10 +50,10 @@
                                         </constraints>
                                     </view>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iZC-Gc-okA">
-                                        <rect key="frame" x="0.0" y="50" width="375" height="329"/>
+                                        <rect key="frame" x="0.0" y="50" width="375" height="596"/>
                                     </scrollView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kbr-bQ-njj">
-                                        <rect key="frame" x="0.0" y="379" width="375" height="1"/>
+                                        <rect key="frame" x="0.0" y="646" width="375" height="1"/>
                                         <color key="backgroundColor" red="0.98541599999999996" green="0.0" blue="0.98173999999999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="Co8-ct-oPM"/>
@@ -90,67 +90,7 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="1120"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Cz-cT-K5z">
-                                <rect key="frame" x="0.0" y="64" width="375" height="1007"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="c2q-ri-kSZ">
-                                        <rect key="frame" x="0.0" y="18" width="375" height="991"/>
-                                        <subviews>
-                                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bgR-ww-mDR">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="380"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="380" id="5lW-FM-zPi"/>
-                                                </constraints>
-                                                <connections>
-                                                    <segue destination="zaY-no-5X6" kind="embed" identifier="StoreStatsEmbedSegue" id="DIr-Go-f5K"/>
-                                                </connections>
-                                            </containerView>
-                                            <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C0r-mX-o7t">
-                                                <rect key="frame" x="0.0" y="380" width="375" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="nnZ-bG-12v"/>
-                                                </constraints>
-                                            </view>
-                                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NG7-v2-HCV">
-                                                <rect key="frame" x="0.0" y="398" width="375" height="128"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="80" id="NdA-x6-usn"/>
-                                                    <constraint firstAttribute="height" priority="250" constant="80" id="zqf-iK-TiH"/>
-                                                </constraints>
-                                                <connections>
-                                                    <segue destination="lX1-IT-Jsn" kind="embed" identifier="NewOrdersEmbedSegue" id="eBk-2G-rWy"/>
-                                                </connections>
-                                            </containerView>
-                                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5mn-wP-ueH">
-                                                <rect key="frame" x="0.0" y="526" width="375" height="465"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" priority="900" constant="465" id="GhH-0R-SZx"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="465" id="SIr-zN-m3B"/>
-                                                </constraints>
-                                                <connections>
-                                                    <segue destination="Djg-dC-a51" kind="embed" identifier="TopPerformersEmbedSegue" id="1gd-ia-ZTz"/>
-                                                </connections>
-                                            </containerView>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="c2q-ri-kSZ" firstAttribute="top" secondItem="5Cz-cT-K5z" secondAttribute="top" constant="18" id="BJN-aj-8ex"/>
-                                    <constraint firstItem="c2q-ri-kSZ" firstAttribute="width" secondItem="5Cz-cT-K5z" secondAttribute="width" id="PFr-H6-n9X"/>
-                                    <constraint firstItem="c2q-ri-kSZ" firstAttribute="leading" secondItem="5Cz-cT-K5z" secondAttribute="leading" id="Pjf-fU-Vrm"/>
-                                    <constraint firstAttribute="bottom" secondItem="c2q-ri-kSZ" secondAttribute="bottom" id="d8k-AC-mFj"/>
-                                    <constraint firstAttribute="trailing" secondItem="c2q-ri-kSZ" secondAttribute="trailing" id="jvW-Ck-iWJ"/>
-                                </constraints>
-                            </scrollView>
-                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="5Cz-cT-K5z" firstAttribute="trailing" secondItem="YDa-tX-s4d" secondAttribute="trailing" id="4u5-zG-2jR"/>
-                            <constraint firstItem="5Cz-cT-K5z" firstAttribute="bottom" secondItem="YDa-tX-s4d" secondAttribute="bottom" id="YLe-6O-2hS"/>
-                            <constraint firstItem="5Cz-cT-K5z" firstAttribute="top" secondItem="YDa-tX-s4d" secondAttribute="top" id="knX-PX-w35"/>
-                            <constraint firstItem="5Cz-cT-K5z" firstAttribute="leading" secondItem="YDa-tX-s4d" secondAttribute="leading" id="sD0-4h-t8r"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="YDa-tX-s4d"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Item" id="EUU-oD-ztb"/>
@@ -158,9 +98,6 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <size key="freeformSize" width="375" height="1120"/>
                     <connections>
-                        <outlet property="newOrdersContainerView" destination="NG7-v2-HCV" id="iHE-T1-Sum"/>
-                        <outlet property="newOrdersHeightConstraint" destination="zqf-iK-TiH" id="g32-8U-nYh"/>
-                        <outlet property="scrollView" destination="5Cz-cT-K5z" id="AiQ-Nv-JRm"/>
                         <segue destination="5Fc-gh-JKM" kind="show" identifier="ShowSettingsViewController" id="5OG-7I-yID"/>
                     </connections>
                 </viewController>
@@ -367,18 +304,18 @@
             <objects>
                 <viewController storyboardIdentifier="NewOrdersViewController" id="lX1-IT-Jsn" customClass="NewOrdersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8sG-kb-Kk9">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="128"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8jA-re-uJx">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="1"/>
                                 <color key="backgroundColor" red="0.98541599999999996" green="0.0" blue="0.98173999999999995" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="Vcs-aF-t4s"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="VYR-yM-cEa">
-                                <rect key="frame" x="0.0" y="1" width="375" height="110"/>
+                                <rect key="frame" x="0.0" y="21" width="375" height="629"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="LcR-e9-aXE">
                                         <rect key="frame" x="0.0" y="0.0" width="355" height="77"/>
@@ -398,7 +335,7 @@
                                         </subviews>
                                     </stackView>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="r52-GN-xeA">
-                                        <rect key="frame" x="355" y="0.0" width="20" height="110"/>
+                                        <rect key="frame" x="355" y="0.0" width="20" height="629"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="IWb-N8-kSs"/>
@@ -410,14 +347,14 @@
                                 </constraints>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p4s-ZW-Vui">
-                                <rect key="frame" x="0.0" y="127" width="377" height="1"/>
+                                <rect key="frame" x="0.0" y="666" width="377" height="1"/>
                                 <color key="backgroundColor" red="0.98541599999999996" green="0.0" blue="0.98173999999999995" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="rQ2-Uz-ZHT"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s9n-KV-6jV">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="128"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <connections>
                                     <action selector="buttonTouchDown:" destination="lX1-IT-Jsn" eventType="touchDown" id="rIo-QZ-BRU"/>
                                     <action selector="buttonTouchDragOutside:" destination="lX1-IT-Jsn" eventType="touchDragOutside" id="iJa-hU-1Ko"/>
@@ -463,11 +400,11 @@
             <objects>
                 <viewController storyboardIdentifier="TopPerformersViewController" id="Djg-dC-a51" customClass="TopPerformersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1eR-hd-IG4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="465"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="jSh-li-XP9">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="465"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0FA-ly-Gnf">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="55.5"/>
@@ -515,7 +452,7 @@
                                         </constraints>
                                     </view>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r3q-NT-5cw">
-                                        <rect key="frame" x="0.0" y="105.5" width="375" height="359.5"/>
+                                        <rect key="frame" x="0.0" y="105.5" width="375" height="541.5"/>
                                     </scrollView>
                                 </subviews>
                             </stackView>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -365,7 +365,7 @@
         <!--New Orders View Controller-->
         <scene sceneID="v0S-ON-fMC">
             <objects>
-                <viewController id="lX1-IT-Jsn" customClass="NewOrdersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NewOrdersViewController" id="lX1-IT-Jsn" customClass="NewOrdersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8sG-kb-Kk9">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="128"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -461,7 +461,7 @@
         <!--Top Performers View Controller-->
         <scene sceneID="cVB-Jf-xe7">
             <objects>
-                <viewController id="Djg-dC-a51" customClass="TopPerformersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TopPerformersViewController" id="Djg-dC-a51" customClass="TopPerformersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1eR-hd-IG4">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="465"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -107,6 +107,9 @@ private extension DashboardViewController {
         dashboardUI.onPullToRefresh = { [weak self] in
             self?.pullToRefresh()
         }
+        dashboardUI.displaySyncingErrorNotice = { [weak self] in
+            self?.displaySyncingErrorNotice()
+        }
     }
 }
 
@@ -160,6 +163,17 @@ private extension DashboardViewController {
     func pullToRefresh() {
         WooAnalytics.shared.track(.dashboardPulledToRefresh)
         reloadData()
+    }
+
+    func displaySyncingErrorNotice() {
+        let title = NSLocalizedString("My store", comment: "My Store Notice Title for loading error")
+        let message = NSLocalizedString("Unable to load content", comment: "Load Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: title, message: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            self?.reloadData()
+        }
+
+        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -9,22 +9,9 @@ import Yosemite
 class DashboardViewController: UIViewController {
 
     // MARK: Properties
+
     private var dashboardUI: DashboardUI = {
         return DashboardUIFactory.dashboardUI()
-    }()
-
-    @IBOutlet private weak var scrollView: UIScrollView!
-    @IBOutlet private weak var newOrdersContainerView: UIView!
-    @IBOutlet weak var newOrdersHeightConstraint: NSLayoutConstraint!
-
-    private var storeStatsViewController: StoreStatsViewController!
-    private var newOrdersViewController: NewOrdersViewController!
-    private var topPerformersViewController: TopPerformersViewController!
-
-    private lazy var refreshControl: UIRefreshControl = {
-        let refreshControl = UIRefreshControl()
-        refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
-        return refreshControl
     }()
 
     // MARK: View Lifecycle
@@ -44,8 +31,6 @@ class DashboardViewController: UIViewController {
         configureNavigation()
         configureView()
 
-        // `dashboardUI` could be showing Stats v3 or v4.
-        // TODO: remove existing content view from Storyboard and its code in this file.
         let contentViewController = dashboardUI
         add(contentViewController)
         let contentView = contentViewController.view!
@@ -55,6 +40,10 @@ class DashboardViewController: UIViewController {
             contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             ])
+
+        contentViewController.onPullToRefresh = { [weak self] in
+            self?.pullToRefresh()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -62,26 +51,6 @@ class DashboardViewController: UIViewController {
         // Reset title to prevent it from being empty right after login
         configureTitle()
         reloadData()
-    }
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let vc = segue.destination as? StoreStatsViewController, segue.identifier == Segues.storeStatsSegue {
-            storeStatsViewController = vc
-        }
-        if let vc = segue.destination as? NewOrdersViewController, segue.identifier == Segues.newOrdersSegue {
-            newOrdersViewController = vc
-            newOrdersViewController.delegate = self
-        }
-        if let vc = segue.destination as? TopPerformersViewController, segue.identifier == Segues.topPerformersSegue {
-            topPerformersViewController = vc
-        }
-    }
-
-    override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
-        super.preferredContentSizeDidChange(forChildContentContainer: container)
-        if let containerVC = container as? NewOrdersViewController {
-            newOrdersHeightConstraint?.constant = containerVC.preferredContentSize.height
-        }
     }
 }
 
@@ -92,8 +61,6 @@ private extension DashboardViewController {
 
     func configureView() {
         view.backgroundColor = StyleManager.tableViewBackgroundColor
-        scrollView.refreshControl = refreshControl
-        newOrdersContainerView.isHidden = true // Hide the new orders vc by default
     }
 
     func configureNavigation() {
@@ -164,15 +131,12 @@ extension DashboardViewController {
     /// Runs whenever the default Account is updated.
     ///
     @objc func defaultAccountWasUpdated() {
-        guard storeStatsViewController != nil, StoresManager.shared.isAuthenticated == false else {
+        guard isViewLoaded, StoresManager.shared.isAuthenticated == false else {
             return
         }
 
         resetTitle()
-
         dashboardUI.defaultAccountDidUpdate()
-        storeStatsViewController.clearAllFields()
-        applyHideAnimation(for: newOrdersContainerView)
     }
 }
 
@@ -194,156 +158,19 @@ private extension DashboardViewController {
         performSegue(withIdentifier: Segues.settingsSegue, sender: nil)
     }
 
-    @objc func pullToRefresh() {
+    func pullToRefresh() {
         WooAnalytics.shared.track(.dashboardPulledToRefresh)
-        applyHideAnimation(for: newOrdersContainerView)
         reloadData()
     }
 }
 
-
-// MARK: - NewOrdersDelegate Conformance
-//
-extension DashboardViewController: NewOrdersDelegate {
-    func didUpdateNewOrdersData(hasNewOrders: Bool) {
-        if hasNewOrders {
-            applyUnhideAnimation(for: newOrdersContainerView)
-            WooAnalytics.shared.track(.dashboardUnfulfilledOrdersLoaded, withProperties: ["has_unfulfilled_orders": "true"])
-        } else {
-            applyHideAnimation(for: newOrdersContainerView)
-            WooAnalytics.shared.track(.dashboardUnfulfilledOrdersLoaded, withProperties: ["has_unfulfilled_orders": "false"])
-        }
-    }
-}
-
-
 // MARK: - Private Helpers
 //
 private extension DashboardViewController {
-
     func reloadData() {
+        DDLogInfo("♻️ Requesting dashboard data be reloaded...")
         dashboardUI.reloadData(completion: { [weak self] in
             self?.configureTitle()
         })
-
-        DDLogInfo("♻️ Requesting dashboard data be reloaded...")
-        let group = DispatchGroup()
-
-        var reloadError: Error? = nil
-
-        group.enter()
-        storeStatsViewController.syncAllStats() { error in
-            if let error = error {
-                reloadError = error
-            }
-            group.leave()
-        }
-
-        group.enter()
-        newOrdersViewController.syncNewOrders() { error in
-            if let error = error {
-                reloadError = error
-            }
-            group.leave()
-        }
-
-        group.enter()
-        topPerformersViewController.syncTopPerformers() { error in
-            if let error = error {
-                reloadError = error
-            }
-            group.leave()
-        }
-
-        group.notify(queue: .main) { [weak self] in
-            self?.refreshControl.endRefreshing()
-            self?.configureTitle()
-
-            if let error = reloadError {
-                DDLogError("⛔️ Error loading dashboard: \(error)")
-                self?.handleSyncError(error: error)
-            } else {
-                self?.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: true)
-            }
-        }
-    }
-
-    func applyUnhideAnimation(for view: UIView) {
-        UIView.animate(withDuration: Constants.showAnimationDuration,
-                       delay: 0,
-                       usingSpringWithDamping: Constants.showSpringDamping,
-                       initialSpringVelocity: Constants.showSpringVelocity,
-                       options: .curveEaseOut,
-                       animations: {
-                        view.isHidden = false
-                        view.alpha = UIKitConstants.alphaFull
-        }) { _ in
-            view.isHidden = false
-            view.alpha = UIKitConstants.alphaFull
-        }
-    }
-
-    func applyHideAnimation(for view: UIView) {
-        UIView.animate(withDuration: Constants.hideAnimationDuration, animations: {
-            view.isHidden = true
-            view.alpha = UIKitConstants.alphaZero
-        }, completion: { _ in
-            view.isHidden = true
-            view.alpha = UIKitConstants.alphaZero
-        })
-    }
-
-    private func handleSyncError(error: Error) {
-        switch error {
-        case let siteVisitStatsStoreError as SiteVisitStatsStoreError:
-            handleSiteVisitStatsStoreError(error: siteVisitStatsStoreError)
-        default:
-            displaySyncingErrorNotice()
-        }
-    }
-
-    private func handleSiteVisitStatsStoreError(error: SiteVisitStatsStoreError) {
-        switch error {
-        case .statsModuleDisabled, .noPermission:
-            updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: false)
-        default:
-            displaySyncingErrorNotice()
-        }
-    }
-
-    private func displaySyncingErrorNotice() {
-        let title = NSLocalizedString("My store", comment: "My Store Notice Title for loading error")
-        let message = NSLocalizedString("Unable to load content", comment: "Load Action Failed")
-        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
-        let notice = Notice(title: title, message: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
-            self?.refreshControl.beginRefreshing()
-            self?.reloadData()
-        }
-
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
-    }
-
-    private func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
-        storeStatsViewController.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
-    }
-}
-
-
-// MARK: - Constants
-//
-private extension DashboardViewController {
-
-    struct Segues {
-        static let settingsSegue        = "ShowSettingsViewController"
-        static let storeStatsSegue      = "StoreStatsEmbedSegue"
-        static let newOrdersSegue       = "NewOrdersEmbedSegue"
-        static let topPerformersSegue   = "TopPerformersEmbedSegue"
-    }
-
-    struct Constants {
-        static let hideAnimationDuration: TimeInterval  = 0.25
-        static let showAnimationDuration: TimeInterval  = 0.50
-        static let showSpringDamping: CGFloat           = 0.7
-        static let showSpringVelocity: CGFloat          = 0.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -9,6 +9,9 @@ import Yosemite
 class DashboardViewController: UIViewController {
 
     // MARK: Properties
+    private var dashboardUI: DashboardUI = {
+        return DashboardUIFactory.dashboardUI()
+    }()
 
     @IBOutlet private weak var scrollView: UIScrollView!
     @IBOutlet private weak var newOrdersContainerView: UIView!
@@ -40,6 +43,18 @@ class DashboardViewController: UIViewController {
         super.viewDidLoad()
         configureNavigation()
         configureView()
+
+        // `dashboardUI` could be showing Stats v3 or v4.
+        // TODO: remove existing content view from Storyboard and its code in this file.
+        let contentViewController = dashboardUI
+        add(contentViewController)
+        let contentView = contentViewController.view!
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            ])
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -155,6 +170,7 @@ extension DashboardViewController {
 
         resetTitle()
 
+        dashboardUI.defaultAccountDidUpdate()
         storeStatsViewController.clearAllFields()
         applyHideAnimation(for: newOrdersContainerView)
     }
@@ -206,6 +222,10 @@ extension DashboardViewController: NewOrdersDelegate {
 private extension DashboardViewController {
 
     func reloadData() {
+        dashboardUI.reloadData(completion: { [weak self] in
+            self?.configureTitle()
+        })
+
         DDLogInfo("♻️ Requesting dashboard data be reloaded...")
         let group = DispatchGroup()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -10,9 +10,7 @@ class DashboardViewController: UIViewController {
 
     // MARK: Properties
 
-    private var dashboardUI: DashboardUI = {
-        return DashboardUIFactory.dashboardUI()
-    }()
+    private var dashboardUI: DashboardUI!
 
     // MARK: View Lifecycle
 
@@ -30,20 +28,7 @@ class DashboardViewController: UIViewController {
         super.viewDidLoad()
         configureNavigation()
         configureView()
-
-        let contentViewController = dashboardUI
-        add(contentViewController)
-        let contentView = contentViewController.view!
-        NSLayoutConstraint.activate([
-            contentView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            ])
-
-        contentViewController.onPullToRefresh = { [weak self] in
-            self?.pullToRefresh()
-        }
+        configureDashboardUI()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -108,8 +93,22 @@ private extension DashboardViewController {
 
         navigationItem.backBarButtonItem = backButton
     }
-}
 
+    func configureDashboardUI() {
+        dashboardUI = DashboardUIFactory.dashboardUI()
+        add(dashboardUI)
+        let contentView = dashboardUI.view!
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            ])
+        dashboardUI.onPullToRefresh = { [weak self] in
+            self?.pullToRefresh()
+        }
+    }
+}
 
 // MARK: - Notifications
 //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -174,3 +174,12 @@ private extension DashboardViewController {
         })
     }
 }
+
+// MARK: - Constants
+//
+private extension DashboardViewController {
+
+    struct Segues {
+        static let settingsSegue        = "ShowSettingsViewController"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -20,7 +20,7 @@ extension DashboardUI {
     }
 }
 
-class DashboardUIFactory: NSObject {
+final class DashboardUIFactory {
     static func dashboardUI() -> DashboardUI {
         return DashboardStatsV3ViewController(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -1,8 +1,10 @@
 import UIKit
 
+/// Contains all UI content to show on Dashboard
+///
 protocol DashboardUI: UIViewController {
-    /// For the user to refresh the Dashboard
-    var refreshControl: UIRefreshControl { get }
+    /// Called when the Dashboard should display syncing error
+    var displaySyncingErrorNotice: () -> Void { get set }
 
     /// Called when the user pulls to refresh
     var onPullToRefresh: () -> Void { get set }
@@ -14,20 +16,6 @@ protocol DashboardUI: UIViewController {
     ///
     /// - Parameter completion: called when Dashboard data reload finishes
     func reloadData(completion: @escaping () -> Void)
-}
-
-extension DashboardUI {
-    func displaySyncingErrorNotice() {
-        let title = NSLocalizedString("My store", comment: "My Store Notice Title for loading error")
-        let message = NSLocalizedString("Unable to load content", comment: "Load Action Failed")
-        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
-        let notice = Notice(title: title, message: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
-            self?.refreshControl.beginRefreshing()
-            self?.reloadData {}
-        }
-
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
-    }
 }
 
 final class DashboardUIFactory {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -1,8 +1,18 @@
 import UIKit
 
 protocol DashboardUI: UIViewController {
+    /// For the user to refresh the Dashboard
     var refreshControl: UIRefreshControl { get }
+
+    /// Called when the user pulls to refresh
+    var onPullToRefresh: () -> Void { get set }
+
+    /// Called when the default account was updated
     func defaultAccountDidUpdate()
+
+    /// Reloads data in Dashboard
+    ///
+    /// - Parameter completion: called when Dashboard data reload finishes
     func reloadData(completion: @escaping () -> Void)
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+protocol DashboardUI: UIViewController {
+    var refreshControl: UIRefreshControl { get }
+    func defaultAccountDidUpdate()
+    func reloadData(completion: @escaping () -> Void)
+}
+
+extension DashboardUI {
+    func displaySyncingErrorNotice() {
+        let title = NSLocalizedString("My store", comment: "My Store Notice Title for loading error")
+        let message = NSLocalizedString("Unable to load content", comment: "Load Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: title, message: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            self?.refreshControl.beginRefreshing()
+            self?.reloadData {}
+        }
+
+        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+    }
+}
+
+class DashboardUIFactory: NSObject {
+    static func dashboardUI() -> DashboardUI {
+        return DashboardStatsV3ViewController(nibName: nil, bundle: nil)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -41,6 +41,12 @@ class StoreStatsViewController: ButtonBarPagerTabStripViewController {
         ensureGhostContentIsAnimated()
     }
 
+    /// Note: Overrides this function to always trigger `updateContent()` to ensure the child view controller fills the container width.
+    /// This is probably only an issue when not using `ButtonBarPagerTabStripViewController` with Storyboard.
+    override func updateIfNeeded() {
+        updateContent()
+    }
+
     // MARK: - RTL support
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -39,6 +39,12 @@ class TopPerformersViewController: ButtonBarPagerTabStripViewController {
         ensureGhostContentIsAnimated()
     }
 
+    /// Note: Overrides this function to always trigger `updateContent()` to ensure the child view controller fills the container width.
+    /// This is probably only an issue when not using `ButtonBarPagerTabStripViewController` with Storyboard.
+    override func updateIfNeeded() {
+        updateContent()
+    }
+
     // MARK: - RTL support
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -130,21 +130,21 @@ extension DashboardStatsV3ViewController: DashboardUI {
                 DDLogError("⛔️ Error loading dashboard: \(error)")
                 self?.handleSyncError(error: error)
             } else {
-                self?.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: true)
+                self?.showSiteVisitors(true)
             }
         }
     }
 }
 
 private extension DashboardStatsV3ViewController {
-    func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
-        storeStatsViewController.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
+    func showSiteVisitors(_ shouldShowSiteVisitors: Bool) {
+        storeStatsViewController.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitors)
     }
 
     func handleSiteVisitStatsStoreError(error: SiteVisitStatsStoreError) {
         switch error {
         case .statsModuleDisabled, .noPermission:
-            updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: false)
+            showSiteVisitors(false)
         default:
             displaySyncingErrorNotice()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -2,14 +2,6 @@ import UIKit
 import WordPressUI
 import Yosemite
 
-// TODO: move this helper to its own file.
-extension UIStoryboard {
-    func instantiateViewController<T: NSObject>(ofClass classType: T.Type) -> T? {
-        let identifier = classType.classNameWithoutNamespaces
-        return instantiateViewController(withIdentifier: identifier) as? T
-    }
-}
-
 class DashboardStatsV3ViewController: UIViewController {
     // MARK: subviews
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -3,6 +3,8 @@ import WordPressUI
 import Yosemite
 
 class DashboardStatsV3ViewController: UIViewController {
+    var displaySyncingErrorNotice: () -> Void = {}
+
     var onPullToRefresh: () -> Void = {}
 
     // MARK: subviews
@@ -95,6 +97,8 @@ extension DashboardStatsV3ViewController: DashboardUI {
     }
 
     func reloadData(completion: @escaping () -> Void) {
+        refreshControl.beginRefreshing()
+
         let group = DispatchGroup()
 
         var reloadError: Error? = nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -3,11 +3,15 @@ import WordPressUI
 import Yosemite
 
 class DashboardStatsV3ViewController: UIViewController {
+    var onPullToRefresh: () -> Void = {}
+
     // MARK: subviews
     //
     // TODO: make refresh control work.
     var refreshControl: UIRefreshControl = {
-        return UIRefreshControl(frame: .zero)
+        let refreshControl = UIRefreshControl(frame: .zero)
+        refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
+        return refreshControl
     }()
 
     private var scrollView: UIScrollView = {
@@ -25,7 +29,7 @@ class DashboardStatsV3ViewController: UIViewController {
     private var newOrdersContainerView: UIView = {
         return UIView(frame: .zero)
     }()
-    
+
     private var newOrdersHeightConstraint: NSLayoutConstraint?
 
     // MARK: child view controllers
@@ -72,6 +76,15 @@ class DashboardStatsV3ViewController: UIViewController {
         if let containerVC = container as? NewOrdersViewController {
             newOrdersHeightConstraint?.constant = containerVC.preferredContentSize.height
         }
+    }
+}
+
+// MARK: Actions
+//
+private extension DashboardStatsV3ViewController {
+    @objc func pullToRefresh() {
+        applyHideAnimation(for: newOrdersContainerView)
+        onPullToRefresh()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -25,6 +25,7 @@ class DashboardStatsV3ViewController: UIViewController {
     private var newOrdersContainerView: UIView = {
         return UIView(frame: .zero)
     }()
+    
     private var newOrdersHeightConstraint: NSLayoutConstraint?
 
     // MARK: child view controllers

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -9,7 +9,6 @@ class DashboardStatsV3ViewController: UIViewController {
 
     // MARK: subviews
     //
-    // TODO: make refresh control work.
     var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl(frame: .zero)
         refreshControl.addTarget(self, action: #selector(pullToRefresh), for: .valueChanged)
@@ -23,10 +22,6 @@ class DashboardStatsV3ViewController: UIViewController {
     private var stackView: UIStackView = {
         return UIStackView(arrangedSubviews: [])
     }()
-
-    private var storeStatsView: UIView {
-        return storeStatsViewController.view
-    }
 
     private var newOrdersContainerView: UIView = {
         return UIView(frame: .zero)
@@ -222,6 +217,7 @@ private extension DashboardStatsV3ViewController {
 
     func configureChildViewControllerContainerViews() {
         // Store stats.
+        let storeStatsView = storeStatsViewController.view!
         NSLayoutConstraint.activate([
             storeStatsView.heightAnchor.constraint(equalToConstant: 380),
             ])

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -1,0 +1,175 @@
+import UIKit
+import WordPressUI
+import Yosemite
+
+extension UIView {
+    public func pinSubviewToAllEdges(_ subview: UIView, insets: UIEdgeInsets) {
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: subview.leadingAnchor),
+            trailingAnchor.constraint(equalTo: subview.trailingAnchor),
+            topAnchor.constraint(equalTo: subview.topAnchor),
+            bottomAnchor.constraint(equalTo: subview.bottomAnchor),
+            ])
+    }
+}
+
+extension UIStoryboard {
+    func instantiateViewController<T: NSObject>(ofClass classType: T.Type) -> T? {
+        let identifier = classType.classNameWithoutNamespaces
+        return instantiateViewController(withIdentifier: identifier) as? T
+    }
+}
+
+class DashboardStatsV3ViewController: UIViewController {
+    // MARK: subviews
+    var refreshControl: UIRefreshControl = {
+        return UIRefreshControl(frame: .zero)
+    }()
+
+    private var scrollView: UIScrollView = {
+        return UIScrollView(frame: .zero)
+    }()
+
+    private var stackView: UIStackView = {
+        return UIStackView(arrangedSubviews: [])
+    }()
+
+    private var storeStatsView: UIView {
+        return storeStatsViewController.view
+    }
+
+    // MARK: child view controllers
+    private var storeStatsViewController: StoreStatsViewController = {
+        guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: StoreStatsViewController.self) else {
+            fatalError()
+        }
+        return viewController
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        scrollView.refreshControl = refreshControl
+
+        configureContainerViews()
+        configureChildViewControllers()
+        configureChildViewControllerContainerViews()
+    }
+}
+
+extension DashboardStatsV3ViewController: DashboardUI {
+    func defaultAccountDidUpdate() {
+        storeStatsViewController.clearAllFields()
+    }
+
+    func reloadData(completion: @escaping () -> Void) {
+        let group = DispatchGroup()
+
+        var reloadError: Error? = nil
+
+        group.enter()
+        storeStatsViewController.syncAllStats() { error in
+            if let error = error {
+                reloadError = error
+            }
+            group.leave()
+        }
+
+//        group.enter()
+//        newOrdersViewController.syncNewOrders() { error in
+//            if let error = error {
+//                reloadError = error
+//            }
+//            group.leave()
+//        }
+//
+//        group.enter()
+//        topPerformersViewController.syncTopPerformers() { error in
+//            if let error = error {
+//                reloadError = error
+//            }
+//            group.leave()
+//        }
+
+        group.notify(queue: .main) { [weak self] in
+            completion()
+            self?.refreshControl.endRefreshing()
+            if let error = reloadError {
+                DDLogError("⛔️ Error loading dashboard: \(error)")
+                self?.handleSyncError(error: error)
+            } else {
+                self?.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: true)
+            }
+        }
+    }
+}
+
+private extension DashboardStatsV3ViewController {
+    func updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: Bool) {
+        storeStatsViewController.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitStats)
+    }
+
+    func handleSiteVisitStatsStoreError(error: SiteVisitStatsStoreError) {
+        switch error {
+        case .statsModuleDisabled, .noPermission:
+            updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: false)
+        default:
+            displaySyncingErrorNotice()
+        }
+    }
+
+    private func handleSyncError(error: Error) {
+        switch error {
+        case let siteVisitStatsStoreError as SiteVisitStatsStoreError:
+            handleSiteVisitStatsStoreError(error: siteVisitStatsStoreError)
+        default:
+            displaySyncingErrorNotice()
+        }
+    }
+}
+
+private extension DashboardStatsV3ViewController {
+    func configureContainerViews() {
+        view.addSubview(scrollView)
+        view.pinSubviewToAllEdges(scrollView)
+
+        scrollView.addSubview(stackView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 18),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+            ])
+    }
+
+    func configureChildViewControllerContainerViews() {
+        // Store stats.
+        let storeStatsContainerView = UIView(frame: .zero)
+        storeStatsContainerView.addSubview(storeStatsView)
+        storeStatsContainerView.pinSubviewAtCenter(storeStatsView)
+        storeStatsContainerView.translatesAutoresizingMaskIntoConstraints = false
+        storeStatsView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            storeStatsContainerView.heightAnchor.constraint(equalToConstant: 380),
+            storeStatsView.widthAnchor.constraint(equalTo: storeStatsContainerView.widthAnchor),
+            storeStatsView.heightAnchor.constraint(equalTo: storeStatsContainerView.heightAnchor)
+            ])
+
+        let arrangedSubviews = [
+            storeStatsContainerView
+            ]
+        arrangedSubviews.forEach { subview in
+            stackView.addArrangedSubview(subview)
+        }
+    }
+
+    func configureChildViewControllers() {
+        let childViewControllers = [storeStatsViewController]
+        childViewControllers.forEach { (childViewController) in
+            add(childViewController)
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
+		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
+		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
@@ -400,6 +402,8 @@
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
+		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
+		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -797,6 +801,22 @@
 				024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */,
 			);
 			path = Developer;
+			sourceTree = "<group>";
+		};
+		029D444722F13F5C00DEFA8A /* Factories */ = {
+			isa = PBXGroup;
+			children = (
+				029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */,
+			);
+			path = Factories;
+			sourceTree = "<group>";
+		};
+		029D444B22F1417400DEFA8A /* Stats v3 */ = {
+			isa = PBXGroup;
+			children = (
+				029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */,
+			);
+			path = "Stats v3";
 			sourceTree = "<group>";
 		};
 		74036CBE211B87FD00E462C2 /* MyStore */ = {
@@ -1491,6 +1511,8 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				029D444B22F1417400DEFA8A /* Stats v3 */,
+				029D444722F13F5C00DEFA8A /* Factories */,
 				74036CBE211B87FD00E462C2 /* MyStore */,
 				CE85FD5820F7A59E0080B73E /* Settings */,
 				CE85FD5220F677770080B73E /* Dashboard.storyboard */,
@@ -2052,6 +2074,7 @@
 				B57C5C9621B80E5500FF82B2 /* Dictionary+Woo.swift in Sources */,
 				CE27257F21925AE8002B22EB /* ValueOneTableViewCell.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
+				029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */,
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
@@ -2163,6 +2186,7 @@
 				CE22709F2293052700C0626C /* WebviewHelper.swift in Sources */,
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				74AFF2EA211B9B1B0038153A /* StoreStatsViewController.swift in Sources */,
+				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,


### PR DESCRIPTION
Fixes #1153 

## Changes
- Created `DashboardUI` protocol and `DashboardUIFactory` that returns the v3 UI for now
- `DashboardUI` is a view controller that contains the subviews owned by child view controllers
  - `DashboardStatsV3ViewController` is an implementation of `DashboardUI` 
  - The reasons for the factory to return a container view controller:
    - there is a mix of subviews (views owned by child view controllers and also a 18px spacer view)
    - we'd need a container for both subviews and child view controllers
    - in stats v4, the child view controller stack view doesn't have a 18px top margin anymore, and will be hard to just configure with a list of child view controllers
- Set storyboard identifier for each child view controller
- In `DashboardStatsV3ViewController`, set up the container views following the Dashboard scene in `Dashboard.storyboard`. Set up child view controllers and their views/container views. - Removed child view controller container views from `Dashboard.storyboard` and moved code for the child view controllers from `DashboardViewController` to `DashboardStatsV3ViewController`

## Testing
This PR should not change any app behavior. You can test the changes by launching different stores on iPhone and/or iPad, with rotation, pull-to-refresh and interactions with the store stats, new orders, and top performers

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
