### PR TITLE
Reload the UI after the products are done downloading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.5
 -----
- 
+- bugfix: on certain devices, pulling down to refresh on Order Details screen used to result in weird UI with misplaced labels. Should be fixed in this release.
+
 2.4
 -----
 - New feature: in Order Details > Shipment Tracking, a new action is added to the "more" action menu for copying tracking number.

--- a/WooCommerce/Classes/Tools/AsyncDictionary.swift
+++ b/WooCommerce/Classes/Tools/AsyncDictionary.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// A wrapper of dictionary that can be updated asynchronously.
+///
+final class AsyncDictionary<Key, Value> where Key: Hashable {
+    private var dictionary: [Key: Value] = [:]
+    private var operationUUIDsByKey: [Key: UUID] = [:]
+
+    /// Returns value for key.
+    ///
+    func value(forKey key: Key) -> Value? {
+        return dictionary[key]
+    }
+
+    /// Calculates the value for a key asynchronously, updates the dictionary, and then calls the update callback.
+    ///
+    /// - Parameters:
+    ///   - key: key for value
+    ///   - operation: called to calculate the value for key asynchronously
+    ///   - onCompletion: called on main thread after the operation finishes. If the calculated value can be updated for
+    ///     key, the value is returned. Otherwise, if the calculated cannot be updated for the key (e.g. the dictionary
+    ///     has been cleared or a later operation has been scheduled), nil is returned
+    func calculate(forKey key: Key,
+                   operation: @escaping () -> (Value),
+                   onCompletion: @escaping (Value?) -> ()) {
+        let uuid = UUID()
+        operationUUIDsByKey[key] = uuid
+        DispatchQueue.global().async {
+            let value = operation()
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else {
+                    onCompletion(nil)
+                    return
+                }
+                guard self.operationUUIDsByKey[key] == uuid else {
+                    onCompletion(nil)
+                    return
+                }
+                self.dictionary[key] = value
+                onCompletion(value)
+            }
+        }
+    }
+
+    /// Removes all entries in the dictionary.
+    ///
+    func clear() {
+        operationUUIDsByKey.removeAll()
+        dictionary.removeAll()
+    }
+}

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -67,6 +67,7 @@ final class OrderDetailsViewModel {
     var orderNotes: [OrderNote] = [] {
         didSet {
             dataSource.orderNotes = orderNotes
+            dataSource.reloadSections()
             onUIReloadRequired?()
         }
     }
@@ -74,7 +75,11 @@ final class OrderDetailsViewModel {
     /// Closure to be executed when the UI needs to be reloaded.
     /// That could happen, for example, when new incoming data is detected
     ///
-    var onUIReloadRequired: (() -> Void)?
+    var onUIReloadRequired: (() -> Void)? {
+        didSet {
+            dataSource.onUIReloadRequired = onUIReloadRequired
+        }
+    }
 
     /// Closure to be executed when a cell triggers an action
     ///

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -105,7 +105,6 @@ final class OrderDetailsViewModel {
 extension OrderDetailsViewModel {
     func configureResultsControllers(onReload: @escaping () -> Void) {
         dataSource.configureResultsControllers(onReload: onReload)
-        //configureOrderListener()
     }
 
     func updateOrderStatus(order: Order) {
@@ -336,6 +335,7 @@ extension OrderDetailsViewModel {
                 return
             }
 
+            self.onUIReloadRequired?()
             onCompletion?(nil)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -127,7 +127,7 @@ private extension OrderDetailsViewController {
 
     private func configureViewModel() {
         viewModel.onUIReloadRequired = { [weak self] in
-            self?.reloadTableViewSectionsAndData()
+            self?.reloadTableViewDataIfPossible()
         }
 
         viewModel.configureResultsControllers { [weak self] in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -23,7 +23,9 @@
 /* Begin PBXBuildFile section */
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
+		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
+		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -395,7 +397,9 @@
 /* Begin PBXFileReference section */
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
+		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
+		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -944,6 +948,7 @@
 				CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */,
 				D8AB131D225DC25F002BB5D1 /* MockOrders.swift */,
 				024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */,
+				02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1013,6 +1018,7 @@
 				B58B4ABC2108F7F800076FDD /* Notices */,
 				B541B2182189F387008FE7C1 /* StringFormatter */,
 				CE14452C2188C0EC00A991D8 /* Zendesk */,
+				0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */,
 				74460D3F22289B7600D7316A /* Coordinator.swift */,
 				7459A6C521B0680300F83A78 /* RequirementsChecker.swift */,
 				B54FBE542111F70700390F57 /* ResultsController+UIKit.swift */,
@@ -2145,6 +2151,7 @@
 				D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */,
 				CE21B3DD20FF9BC200A259D5 /* ProductListViewController.swift in Sources */,
 				D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */,
+				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* NoteTableViewCell.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* FulfillButtonTableViewCell.swift in Sources */,
@@ -2227,6 +2234,7 @@
 				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,
 				D83F593D225B4B5000626E75 /* ManualTrackingViewControllerTests.swift in Sources */,
 				CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */,
+				02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */,
 				B555531121B57E6F00449E71 /* MockupApplicationAdapter.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/AsyncDictionaryTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/AsyncDictionaryTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import WooCommerce
+
+class AsyncDictionaryTests: XCTestCase {
+    private let asyncDictionary = AsyncDictionary<Int, String>()
+
+    func testAsyncValueCalculationAndUpdate() {
+        let key = 107
+        let value = "Woo!"
+
+        let expectationForOperation = self.expectation(description: "Wait for operation to be called not on the main thread")
+        let operation = { () -> String in
+            XCTAssertFalse(Thread.current.isMainThread)
+            expectationForOperation.fulfill()
+            return value
+        }
+        let expectationForOnCompletion = self.expectation(description: "Wait for completion callback to be called on the main thread")
+        let onCompletion = { (updatedValue: String?) in
+            XCTAssertEqual(updatedValue, value)
+            XCTAssertTrue(Thread.current.isMainThread)
+            expectationForOnCompletion.fulfill()
+        }
+        asyncDictionary.calculate(forKey: key, operation: operation, onCompletion: onCompletion)
+        waitForExpectations(timeout: 0.5, handler: nil)
+        XCTAssertEqual(asyncDictionary.value(forKey: key), value)
+    }
+
+    func testClearingDictionary() {
+        let key = 107
+        let value = "Woo!"
+
+        var isDictionaryCleared = false
+        let operation1 = { () -> String in
+            while !isDictionaryCleared {
+                continue
+            }
+            return value
+        }
+        let expectationForOnCompletion = self.expectation(description: "Wait for completion callback")
+        let onCompletion = { (updatedValue: String?) in
+            XCTAssertNil(updatedValue)
+            XCTAssertTrue(Thread.current.isMainThread)
+            expectationForOnCompletion.fulfill()
+        }
+        asyncDictionary.calculate(forKey: key, operation: operation1, onCompletion: onCompletion)
+        asyncDictionary.clear()
+        isDictionaryCleared = true
+        XCTAssertNil(asyncDictionary.value(forKey: key))
+        waitForExpectations(timeout: 0.1, handler: nil)
+        // After the async operation completes, the dictionary value should remain nil.
+        XCTAssertNil(asyncDictionary.value(forKey: key))
+    }
+
+    func testAsyncUpdatesWhereTheFirstOperationFinishesLast() {
+        let key = 107
+        let value1 = "Woah!"
+        let value2 = "Woo!"
+
+        // The first operation will finish after the second operation finishes.
+        var isValue2Updated = false
+        let operation1 = { () -> String in
+            while !isValue2Updated {
+                continue
+            }
+            return value1
+        }
+        let expectationForOnOperation1Completion = self.expectation(description: "Wait for completion callback for the first operation")
+        let onOperation1Completion = { (updatedValue: String?) in
+            XCTAssertNil(updatedValue)
+            XCTAssertTrue(Thread.current.isMainThread)
+            expectationForOnOperation1Completion.fulfill()
+        }
+        asyncDictionary.calculate(forKey: key, operation: operation1, onCompletion: onOperation1Completion)
+
+        let operation2 = { () -> String in
+            return value2
+        }
+        let onOperation2Completion = { (updatedValue: String?) in
+            XCTAssertEqual(updatedValue, value2)
+            XCTAssertTrue(Thread.current.isMainThread)
+            isValue2Updated = true
+        }
+
+        asyncDictionary.calculate(forKey: key, operation: operation2, onCompletion: onOperation2Completion)
+        waitForExpectations(timeout: 0.1, handler: nil)
+        XCTAssertEqual(asyncDictionary.value(forKey: key), value2)
+    }
+}


### PR DESCRIPTION
Fixes #1149 

During the Great Refactoring of Order Details event, I saw some commented out code but never followed up on it. My apologies 😬 

This fixes the issue where products would download in the background on an Order Details screen, but would not refresh the screen, so that the user can see the product image. I am not updating release notes because I'd like target the 2.4 build. (Targeting 2.4 means the user will never "see" the bug in the first place.)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
