### PR TITLE
Rename Notifications to Reviews

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.5
 -----
 - bugfix: on certain devices, pulling down to refresh on Order Details screen used to result in weird UI with misplaced labels. Should be fixed in this release.
+- Enhancement: The Notifications tab has been replaced by Reviews 
 
 2.4
 -----

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -71,6 +71,12 @@ extension UIImage {
         return Gridicon.iconOfType(.cog)
     }
 
+    /// Comment Icon
+    ///
+    static var commentImage: UIImage {
+        return Gridicon.iconOfType(.comment)
+    }
+
     /// Delete Icon
     ///
     static var deleteImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Gridicons
 import Yosemite
 import WordPressUI
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -264,10 +264,10 @@ private extension MainTabBarController {
     ///
     func showDotOn(_ tab: WooTab) {
         hideDotOn(tab)
-        let dot = GreenDotView(frame: CGRect(x: DotConstants.xOffset,
-                                             y: DotConstants.yOffset,
-                                             width: DotConstants.diameter,
-                                             height: DotConstants.diameter), borderWidth: DotConstants.borderWidth)
+        let dot = PurpleDotView(frame: CGRect(x: DotConstants.xOffset,
+                                              y: DotConstants.yOffset,
+                                              width: DotConstants.diameter,
+                                              height: DotConstants.diameter), borderWidth: DotConstants.borderWidth)
         dot.tag = dotTag(for: tab)
         dot.isHidden = true
         tabBar.subviews[tab.rawValue].subviews.first?.insertSubview(dot, at: 1)
@@ -311,7 +311,7 @@ private extension MainTabBarController {
 
 // MARK: - GreenDot UIView
 //
-private class GreenDotView: UIView {
+private class PurpleDotView: UIView {
 
     private var borderWidth = CGFloat(1) // Border line width defaults to 1
 
@@ -343,7 +343,7 @@ private class GreenDotView: UIView {
         path.fill()
 
         path.lineWidth = borderWidth
-        StyleManager.wooWhite.setStroke()
+        StyleManager.wooCommerceBrandColor.setStroke()
         path.stroke()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -16,9 +16,9 @@ enum WooTab: Int {
     ///
     case orders = 1
 
-    /// Notifications Tab
+    /// Reviews Tab
     ///
-    case notifications = 2
+    case reviews = 2
 }
 
 
@@ -127,7 +127,7 @@ private extension MainTabBarController {
             WooAnalytics.shared.track(.dashboardSelected)
         case .orders:
             WooAnalytics.shared.track(.ordersSelected)
-        case .notifications:
+        case .reviews:
             WooAnalytics.shared.track(.notificationsSelected)
         }
     }
@@ -140,7 +140,7 @@ private extension MainTabBarController {
             WooAnalytics.shared.track(.dashboardReselected)
         case .orders:
             WooAnalytics.shared.track(.ordersReselected)
-        case .notifications:
+        case .reviews:
             WooAnalytics.shared.track(.notificationsReselected)
         }
     }
@@ -163,10 +163,10 @@ extension MainTabBarController {
         navigateTo(.orders)
     }
 
-    /// Switches to the Notifications tab and pops to the root view controller
+    /// Switches to the Reviews tab and pops to the root view controller
     ///
-    static func switchToNotificationsTab() {
-        navigateTo(.notifications)
+    static func switchToReviewsTab() {
+        navigateTo(.reviews)
     }
 
     /// Switches the TabBarController to the specified Tab
@@ -211,7 +211,7 @@ extension MainTabBarController {
     /// Switches to the Notifications Tab, and displays the details for the specified Notification ID.
     ///
     static func presentNotificationDetails(for noteID: Int) {
-        switchToNotificationsTab()
+        switchToReviewsTab()
 
         guard let notificationsViewController: NotificationsViewController = childViewController() else {
             return
@@ -254,11 +254,11 @@ private extension MainTabBarController {
     ///
     func badgeCountWasUpdated(newValue: Int) {
         guard newValue > 0 else {
-            hideDotOn(.notifications)
+            hideDotOn(.reviews)
             return
         }
 
-        showDotOn(.notifications)
+        showDotOn(.reviews)
     }
 
     /// Shows the dot in the specified WooTab

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -302,7 +302,7 @@ private extension MainTabBarController {
     enum DotConstants {
         static let diameter    = CGFloat(10)
         static let borderWidth = CGFloat(1)
-        static let xOffset     = CGFloat(2)
+        static let xOffset     = CGFloat(16)
         static let yOffset     = CGFloat(0)
         static let tagOffset   = 999
     }
@@ -339,11 +339,11 @@ private class PurpleDotView: UIView {
                                                y: rect.origin.y + borderWidth,
                                                width: rect.size.width - borderWidth*2,
                                                height: rect.size.height - borderWidth*2))
-        StyleManager.wooAccent.setFill()
+        StyleManager.wooCommerceBrandColor.setFill()
         path.fill()
 
         path.lineWidth = borderWidth
-        StyleManager.wooCommerceBrandColor.setStroke()
+        StyleManager.wooWhite.setStroke()
         path.stroke()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -188,7 +188,7 @@ private extension NotificationsViewController {
     /// Setup: TabBar
     ///
     func configureTabBarItem() {
-        tabBarItem.title = NSLocalizedString("Notifications", comment: "Title of the Notifications tab — plural form of Notification")
+        tabBarItem.title = NSLocalizedString("Reviews", comment: "Title of the Reviews tab — plural form of Review")
         tabBarItem.image = .bellImage
     }
 
@@ -246,16 +246,16 @@ private extension NotificationsViewController {
     func refreshTitle() {
         guard currentTypeFilter != .all else {
             navigationItem.title = NSLocalizedString(
-                "Notifications",
-                comment: "Title that appears on top of the main Notifications screen when there is no filter applied to the list (plural form of the word Notification)."
+                "Reviews",
+                comment: "Title that appears on top of the main Reviews screen when there is no filter applied to the list (plural form of the word Review)."
             )
             return
         }
 
         let title = String.localizedStringWithFormat(
             NSLocalizedString(
-                "Notifications: %@",
-                comment: "Title that appears on top of the Notifications screen when a filter is applied. It reads: Notifications: {name of filter}"
+                "Reviews: %@",
+                comment: "Title that appears on top of the Reviews screen when a filter is applied. It reads: Reviews: {name of filter}"
             ),
             currentTypeFilter.description.capitalized
         )

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -168,7 +168,7 @@ private extension NotificationsViewController {
     ///
     func configureTabBarItem() {
         tabBarItem.title = NSLocalizedString("Reviews", comment: "Title of the Reviews tab — plural form of Review")
-        tabBarItem.image = .bellImage
+        tabBarItem.image = .commentImage
     }
 
     /// Setup: Navigation

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -40,16 +40,6 @@ class NotificationsViewController: UIViewController {
                                               sortedBy: [descriptor])
     }()
 
-    private func filterPredicate() -> NSPredicate  {
-        let notDeletedPredicate = NSPredicate(format: "deleteInProgress == NO")
-        let sitePredicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
-        let typeReviewPredicate =  NSPredicate(format: "subtype == %@", Note.Subkind.storeReview.rawValue)
-
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [typeReviewPredicate,
-                                                                   sitePredicate,
-                                                                   notDeletedPredicate])
-    }
-
     /// Pull To Refresh Support.
     ///
     private lazy var refreshControl: UIRefreshControl = {
@@ -375,8 +365,20 @@ private extension NotificationsViewController {
     }
 
     func refreshResultsPredicate() {
-        resultsController.predicate = self.filterPredicate()
+        resultsController.predicate = filterPredicate()
     }
+
+    func filterPredicate() -> NSPredicate {
+        let notDeletedPredicate = NSPredicate(format: "deleteInProgress == NO")
+        let sitePredicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let typeReviewPredicate =  NSPredicate(format: "subtype == %@", Note.Subkind.storeReview.rawValue)
+
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [typeReviewPredicate,
+                                                                   sitePredicate,
+                                                                   notDeletedPredicate])
+    }
+
+
 }
 
 

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -42,6 +42,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.cogImage)
     }
 
+    func testCommentImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.commentImage)
+    }
+
     func testDeleteImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.deleteImage)
     }


### PR DESCRIPTION
Fixes #1151 

Change the Notifications Tab to Reviews.

In action:
<img src="https://user-images.githubusercontent.com/2722505/62242840-15056c80-b3aa-11e9-8b7d-56b1b854842c.png" width="350"/>

*Note* To keep the diff as small as possible, I have not renamed the NotificationsViewController. If / when we get this PR to a point where is mergeable, I would rename it too ReviewsViewController.

## Changes
- Renamed Notifications tab to Reviews.
- Removed dynamic filters from the view controller, including the right toolbar button

## Testing
- Check that the name of the Notifications tab item has changed to Reviews. 
- Check that the title of Reviews tab has changed to Reviews
- Leave a review in the store. Check that it is presented in the Reviews tab
- Check that the Reviews tab contains only reviews
- Try to display the empty state placeholder. Check that there are no other references to Notifications


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.