### PR TITLE
Stats/Yosemite: fetch site visit stats for Stats v4 time ranges

### DIFF
--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -17,4 +17,11 @@ public enum StatsActionV4: Action {
         latestDateToInclude: Date,
         quantity: Int,
         onCompletion: (Error?) -> Void)
+
+    /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
+    ///
+    case retrieveSiteVisitStats(siteID: Int,
+        timeRange: StatsTimeRangeV4,
+        latestDateToInclude: Date,
+        onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -13,6 +13,7 @@ public enum StatsTimeRangeV4: String {
 }
 
 extension StatsTimeRangeV4 {
+    /// Represents the period unit of the store stats using Stats v4 API given a time range.
     public var intervalGranularity: StatsGranularityV4 {
         switch self {
         case .today:
@@ -23,6 +24,20 @@ extension StatsTimeRangeV4 {
             return .daily
         case .thisYear:
             return .monthly
+        }
+    }
+
+    /// Represents the period unit of the site visit stats given a time range.
+    public var siteVisitStatsUnitGranularity: StatGranularity {
+        switch self {
+        case .today:
+            return .day
+        case .thisWeek:
+            return .week
+        case .thisMonth:
+            return .month
+        case .thisYear:
+            return .year
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -112,7 +112,7 @@ private extension StatsStore {
                                     latestDateToInclude: latestDateToInclude,
                                     quantity: quantity) { [weak self] (siteVisitStats, error) in
             guard let siteVisitStats = siteVisitStats else {
-                onCompletion(error.flatMap({ SiteVisitStatsStoreError(error: $0) }))
+                onCompletion(error.map({ SiteVisitStatsStoreError(error: $0) }))
                 return
             }
 

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -116,7 +116,6 @@ private extension StatsStore {
                 return
             }
 
-
             self?.upsertStoredSiteVisitStats(readOnlyStats: siteVisitStats)
             onCompletion(nil)
         }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -108,7 +108,7 @@ public extension StatsStoreV4 {
                                             onCompletion(error.map({ SiteVisitStatsStoreError(error: $0) }))
                                             return
                                         }
-                                        
+
                                         self?.upsertStoredSiteVisitStats(readOnlyStats: siteVisitStats)
                                         onCompletion(nil)
         }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -108,8 +108,7 @@ public extension StatsStoreV4 {
                                             onCompletion(error.flatMap({ SiteVisitStatsStoreError(error: $0) }))
                                             return
                                         }
-
-
+                                        
                                         self?.upsertStoredSiteVisitStats(readOnlyStats: siteVisitStats)
                                         onCompletion(nil)
         }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -105,7 +105,7 @@ public extension StatsStoreV4 {
                                     latestDateToInclude: latestDateToInclude,
                                     quantity: 1) { [weak self] (siteVisitStats, error) in
                                         guard let siteVisitStats = siteVisitStats else {
-                                            onCompletion(error.flatMap({ SiteVisitStatsStoreError(error: $0) }))
+                                            onCompletion(error.map({ SiteVisitStatsStoreError(error: $0) }))
                                             return
                                         }
                                         


### PR DESCRIPTION
Fixes #1165

Based on https://github.com/woocommerce/woocommerce-ios/pull/1163

- [x] ⚠️  update PR base to `develop` before merging!

## Changes
- Added a case in `StatsActionV4` to fetch site visit stats for Stats v4 UI use cases with time range
- Added the same implementation in `StatsStoreV4` and in tests for site visit stats as in v3 (current prod)

## Testing
CI, as there are no direct app-level changes

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
