### PR TITLE
Core Data/Networking/Yosemite: fetch and persist `timezone` of `Site`

### DIFF
--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -64,7 +64,14 @@ public struct Site: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int, name: String, description: String, url: String, plan: String, isWooCommerceActive: Bool, isWordPressStore: Bool, timezone: String) {
+    public init(siteID: Int,
+                name: String,
+                description: String,
+                url: String,
+                plan: String,
+                isWooCommerceActive: Bool,
+                isWordPressStore: Bool,
+                timezone: String) {
         self.siteID = siteID
         self.name = name
         self.description = description

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -33,6 +33,9 @@ public struct Site: Decodable {
     ///
     public let isWordPressStore: Bool
 
+    /// Time zone identifier of the site (TZ database name).
+    ///
+    public let timezone: String
 
     /// Decodable Conformance.
     ///
@@ -47,6 +50,7 @@ public struct Site: Decodable {
         let optionsContainer = try siteContainer.nestedContainer(keyedBy: OptionKeys.self, forKey: .options)
         let isWordPressStore = try optionsContainer.decode(Bool.self, forKey: .isWordPressStore)
         let isWooCommerceActive = try optionsContainer.decode(Bool.self, forKey: .isWooCommerceActive)
+        let timezone = try optionsContainer.decode(String.self, forKey: .timezone)
 
         self.init(siteID: siteID,
                   name: name,
@@ -54,12 +58,13 @@ public struct Site: Decodable {
                   url: url,
                   plan: String(), // Not created on init. Added in supplementary API request.
                   isWooCommerceActive: isWooCommerceActive,
-                  isWordPressStore: isWordPressStore)
+                  isWordPressStore: isWordPressStore,
+                  timezone: timezone)
     }
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int, name: String, description: String, url: String, plan: String, isWooCommerceActive: Bool, isWordPressStore: Bool) {
+    public init(siteID: Int, name: String, description: String, url: String, plan: String, isWooCommerceActive: Bool, isWordPressStore: Bool, timezone: String) {
         self.siteID = siteID
         self.name = name
         self.description = description
@@ -67,6 +72,7 @@ public struct Site: Decodable {
         self.plan = plan
         self.isWordPressStore = isWordPressStore
         self.isWooCommerceActive = isWooCommerceActive
+        self.timezone = timezone
     }
 }
 
@@ -108,6 +114,7 @@ private extension Site {
     enum OptionKeys: String, CodingKey {
         case isWordPressStore = "is_wpcom_store"
         case isWooCommerceActive = "woocommerce_is_active"
+        case timezone = "timezone"
     }
 
     enum PlanKeys: String, CodingKey {

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -55,7 +55,8 @@ public class AccountRemote: Remote {
     public func loadSites(completion: @escaping ([Site]?, Error?) -> Void) {
         let path = "me/sites"
         let parameters = [
-            "fields": "ID,name,description,URL,options"
+            "fields": "ID,name,description,URL,options",
+            "options": "timezone,is_wpcom_store,woocommerce_is_active"
         ]
 
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -3,6 +3,9 @@
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
 ## Model 19 (Release 2.6.0.0)
+- @jaclync 2019-08-14
+- Add `timezone` attribute to `Site` entity
+
 - @jaclync 2019-08-06
 - Add `timeRange` attribute to `OrderStatsV4` entity
 

--- a/Storage/Storage/Model/Site+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Site+CoreDataProperties.swift
@@ -14,4 +14,5 @@ extension Site {
     @NSManaged public var plan: String?
     @NSManaged public var isWooCommerceActive: NSNumber?
     @NSManaged public var isWordPressStore: NSNumber?
+    @NSManaged public var timezone: String?
 }

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 19.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 19.xcdatamodel/contents
@@ -323,6 +323,7 @@
         <attribute name="plan" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timezone" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
@@ -387,7 +388,7 @@
         <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
         <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
         <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
-        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="150"/>
+        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="165"/>
         <element name="SiteSetting" positionX="-362.54296875" positionY="217.9921875" width="128" height="135"/>
         <element name="SiteVisitStats" positionX="134.515625" positionY="224.62109375" width="128" height="90"/>
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -16,6 +16,7 @@ extension Storage.Site: ReadOnlyConvertible {
 //        plan = site.plan // We're not assigning the plan here because it's not sent on the intial API request.
         isWooCommerceActive = NSNumber(booleanLiteral: site.isWooCommerceActive)
         isWordPressStore = NSNumber(booleanLiteral: site.isWordPressStore)
+        timezone = site.timezone
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -27,6 +28,7 @@ extension Storage.Site: ReadOnlyConvertible {
                     url: url ?? "",
                     plan: plan ?? "",
                     isWooCommerceActive: isWooCommerceActive?.boolValue ?? false,
-                    isWordPressStore: isWordPressStore?.boolValue ?? false)
+                    isWordPressStore: isWordPressStore?.boolValue ?? false,
+                    timezone: timezone ?? "")
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -345,6 +345,7 @@ private extension AccountStoreTests {
                     url: "automattic.com",
                     plan: String(),
                     isWooCommerceActive: true,
-                    isWordPressStore: false)
+                    isWordPressStore: false,
+                    timezone: "Asia/Taipei")
     }
 }


### PR DESCRIPTION
Part 1 for #1173 

## Changes
- Core Data schema update:
  - Added `timezone: String` attribute to `Site` entity
- Networking layer:
  - Specified `options` param to fetch 3 options that we need based on [API documentation](https://developer.wordpress.com/docs/api/1.1/get/me/sites/) and decoded accordingly
- Yosemite layer:
  - Updated setter and getter for `Site`

## Testing
Log out and log in to verify that site information are still fetched properly (like name, tagline, url)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
