### PR TITLE
A unit test fails on first run

### DIFF
--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -252,7 +252,12 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
         self.order = order
         self.providerName = initialName
 
-        loadSelectedCustomShipmentProvider()
+        // if we don't have a provider name, try to load a previous one
+        guard let providerName = self.providerName,
+            !providerName.isEmpty else {
+                loadSelectedCustomShipmentProvider()
+                return
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1115 

A unit test was failing, testInitialisingWithProviderNameReturnsName(). It would return "A name" instead of expected "Hogsmeade". This was happening because in the initializer, the param name was assigned to the property, but then the next step is attempting to load a previous shipping provider name and the previous tracking link. Because the other unit tests have already run, a previous shipping provider does exist, with the name "A name". So the new provider name is overwritten with the old one.

**To Test**
Steps to reproduce the behavior:
1. Clean the project. Switch to a different branch, any PR review branch (that's not this one) should do
2. Run the unit tests
3. During this first run, the unit test fails
4. Run that unit test a second time. The unit test passes

To see the fix:
1. Clean the project. Switch to this branch
2. Run the unit tests
3. The unit test should pass during the first run

**Screenshots**
<img width="1267" alt="Screen Shot 2019-07-18 at 11 12 08 AM" src="https://user-images.githubusercontent.com/1062444/61473896-0bf9b180-a94d-11e9-8a83-1df73846677e.png">

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
