### PR TITLE
Stats v4 UI: show no revenue message for the time range

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OrderStatsV4Interval+Chart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OrderStatsV4Interval+Chart.swift
@@ -1,0 +1,8 @@
+import Yosemite
+
+extension OrderStatsV4Interval {
+    /// Value of the revenue during a stats interval.
+    var revenueValue: Decimal {
+        return subtotals.grossRevenue
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -561,6 +561,13 @@ private extension StoreStatsV4PeriodViewController {
             barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
         }
         updateChartAccessibilityValues()
+
+        updateUI(hasRevenue: hasRevenue())
+    }
+
+    func hasRevenue() -> Bool {
+        let totalRevenue = orderStatsIntervals.map({ $0.revenueValue }).reduce(0, +)
+        return totalRevenue > 0
     }
 
     func reloadLastUpdatedField() {
@@ -581,8 +588,8 @@ private extension StoreStatsV4PeriodViewController {
         var dataEntries: [BarChartDataEntry] = []
         let currencyCode = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode)
         orderStatsIntervals.forEach { (item) in
-            let entry = BarChartDataEntry(x: Double(barCount), y: (item.subtotals.grossRevenue as NSDecimalNumber).doubleValue)
-            let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String("\(item.subtotals.grossRevenue)"),
+            let entry = BarChartDataEntry(x: Double(barCount), y: (item.revenueValue as NSDecimalNumber).doubleValue)
+            let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String("\(item.revenueValue)"),
                                                                                 with: currencyCode,
                                                                                 roundSmallNumbers: false) ?? String()
             entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -54,6 +54,8 @@ class StoreStatsV4PeriodViewController: UIViewController {
     @IBOutlet private weak var yAxisAccessibilityView: UIView!
     @IBOutlet private weak var xAxisAccessibilityView: UIView!
     @IBOutlet private weak var chartAccessibilityView: UIView!
+    @IBOutlet private weak var noRevenueView: UIView!
+    @IBOutlet private weak var noRevenueLabel: UILabel!
 
     private var lastUpdatedDate: Date?
     private var yAxisMinimum: String = Constants.chartYAxisMinimum.humanReadableString()
@@ -133,6 +135,7 @@ class StoreStatsV4PeriodViewController: UIViewController {
         super.viewDidLoad()
         configureView()
         configureBarChart()
+        configureNoRevenueView()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -270,6 +273,13 @@ private extension StoreStatsV4PeriodViewController {
         )
     }
 
+    func configureNoRevenueView() {
+        noRevenueView.isHidden = true
+        noRevenueLabel.text = NSLocalizedString("No revenue this period", comment: "Text displayed when no order data are available for the selected time range.")
+        noRevenueLabel.font = StyleManager.subheadlineFont
+        noRevenueLabel.textColor = StyleManager.defaultTextColor
+    }
+
     func configureBarChart() {
         barChartView.chartDescription?.enabled = false
         barChartView.dragEnabled = false
@@ -324,6 +334,21 @@ private extension StoreStatsV4PeriodViewController {
                                     DateFormatter.Stats.statsDayFormatter.string(from: currentDate))
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteVisitStats.date, ascending: false)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }
+
+    func updateUI(hasRevenue: Bool) {
+        noRevenueView.isHidden = hasRevenue
+        updateBarChartAxisUI(hasRevenue: hasRevenue)
+    }
+
+    func updateBarChartAxisUI(hasRevenue: Bool) {
+        let labelTextColor = hasRevenue ? StyleManager.wooSecondary: StyleManager.wooGreyMid
+
+        let xAxis = barChartView.xAxis
+        xAxis.labelTextColor = labelTextColor
+
+        let yAxis = barChartView.leftAxis
+        yAxis.labelTextColor = labelTextColor
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -16,6 +16,8 @@
                 <outlet property="borderView" destination="IHi-Ph-CQQ" id="bgg-u3-bda"/>
                 <outlet property="chartAccessibilityView" destination="NEo-bw-gS4" id="Ep1-tI-L3J"/>
                 <outlet property="lastUpdated" destination="0Wi-nd-Ucs" id="XPO-tH-TLR"/>
+                <outlet property="noRevenueLabel" destination="5uh-zy-gDZ" id="ZRx-lP-Af2"/>
+                <outlet property="noRevenueView" destination="fg2-ey-bVn" id="LBf-aq-yXB"/>
                 <outlet property="ordersData" destination="6HA-Qe-PkT" id="zOF-dV-3LN"/>
                 <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
                 <outlet property="revenueData" destination="ukd-qU-WVq" id="ydx-PH-lcl"/>
@@ -194,6 +196,24 @@
                                                 <accessibilityTraits key="traits" notEnabled="YES"/>
                                             </accessibility>
                                         </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
+                                            <rect key="frame" x="152.5" y="235.5" width="42" height="38.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uh-zy-gDZ">
+                                                    <rect key="frame" x="0.0" y="9" width="42" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="5uh-zy-gDZ" secondAttribute="trailing" id="kKN-cg-YhY"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="top" secondItem="fg2-ey-bVn" secondAttribute="top" constant="9" id="od2-Oi-xwq"/>
+                                                <constraint firstAttribute="bottom" secondItem="5uh-zy-gDZ" secondAttribute="bottom" constant="9" id="uQ7-1p-B6d"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="leading" secondItem="fg2-ey-bVn" secondAttribute="leading" id="ylg-AY-x2q"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
@@ -201,10 +221,12 @@
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
                                         <constraint firstItem="NEo-bw-gS4" firstAttribute="leading" secondItem="yvj-Kj-G3f" secondAttribute="trailing" constant="8" id="EcA-ZK-LGL"/>
                                         <constraint firstAttribute="trailing" secondItem="TTF-Fx-NHe" secondAttribute="trailing" id="JA8-YG-kdu"/>
+                                        <constraint firstItem="fg2-ey-bVn" firstAttribute="centerY" secondItem="zPE-Y0-ax8" secondAttribute="centerY" id="KX8-lm-OjL"/>
                                         <constraint firstItem="yvj-Kj-G3f" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="TcO-x3-t7A"/>
                                         <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="yvj-Kj-G3f" secondAttribute="bottom" id="X68-Fa-xY5"/>
                                         <constraint firstItem="NEo-bw-gS4" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="Xsc-Oa-g5y"/>
                                         <constraint firstItem="yvj-Kj-G3f" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="aCl-eO-awT"/>
+                                        <constraint firstItem="fg2-ey-bVn" firstAttribute="centerX" secondItem="zPE-Y0-ax8" secondAttribute="centerX" id="beQ-H2-7xo"/>
                                         <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="NEo-bw-gS4" secondAttribute="bottom" id="mFp-ya-fbL"/>
                                         <constraint firstAttribute="bottom" secondItem="TTF-Fx-NHe" secondAttribute="bottom" id="prr-z8-NDw"/>
                                         <constraint firstAttribute="trailing" secondItem="NEo-bw-gS4" secondAttribute="trailing" id="y4j-07-4hx"/>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
+		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -425,6 +426,7 @@
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
+		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -836,6 +838,7 @@
 				028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */,
 				028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */,
 				0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */,
+				02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -2097,6 +2100,7 @@
 				D843D5CB22437E59001BFA55 /* TitleAndEditableValueTableViewCell.swift in Sources */,
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
+				02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */,
 				748C7782211E294000814F2C /* Double+Woo.swift in Sources */,
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,


### PR DESCRIPTION
Fixes #1154 

## Changes
- Added a view and a label subview to `StoreStatsV4PeriodViewController.xib` for UI shown when there is no revenue for the time range
- Configured the no revenue container view and label, and updated their visibility and chart axis UI when no revenue for the time range
- Unified the interval revenue value with `revenueValue: Decimal` that is drawn on the chart
  - I accidentally used `subtotals.netRevenue` for one of the revenue values, so I thought this might help

## Testing
Prerequisite: the site/store has WC admin extension activated, and has no revenue for today and some revenue for the rest of the week or month or year
- Build from Xcode with a store that has WC admin
- In "My store", check the chart in "today" tab --> there should be a "No revenue this period" message and the chart axis labels should be greyed out

## Example screenshots

no revenue | non-zero revenue
-- | --
<img width="432" alt="Screen Shot 2019-08-16 at 2 55 05 PM" src="https://user-images.githubusercontent.com/1945542/63149349-711cf180-c036-11e9-9c51-1dc48e1f6a16.png"> | <img width="432" alt="Screen Shot 2019-08-16 at 2 55 11 PM" src="https://user-images.githubusercontent.com/1945542/63149350-711cf180-c036-11e9-826c-c63f87dc19be.png">


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
