### PR TITLE
Stats v4 UI: add date bar to the top of the charts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -12,6 +12,12 @@ class DashboardViewController: UIViewController {
 
     private var dashboardUI: DashboardUI!
 
+    // MARK: Subviews
+
+    private lazy var containerView: UIView = {
+        return UIView(frame: .zero)
+    }()
+
     // MARK: View Lifecycle
 
     deinit {
@@ -36,6 +42,11 @@ class DashboardViewController: UIViewController {
         // Reset title to prevent it from being empty right after login
         configureTitle()
         reloadData()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        dashboardUI.view.frame = containerView.bounds
     }
 }
 
@@ -95,15 +106,19 @@ private extension DashboardViewController {
     }
 
     func configureDashboardUI() {
+        // A container view is added to respond to safe area insets from the view controller.
+        // This is needed when the child view controller's view has to use a frame-based layout
+        // (e.g. when the child view controller is a `ButtonBarPagerTabStripViewController` subclass).
+        view.addSubview(containerView)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(containerView)
+
         dashboardUI = DashboardUIFactory.dashboardUI()
-        add(dashboardUI)
         let contentView = dashboardUI.view!
-        NSLayoutConstraint.activate([
-            contentView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            contentView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            ])
+        addChild(dashboardUI)
+        containerView.addSubview(contentView)
+        dashboardUI.didMove(toParent: self)
+
         dashboardUI.onPullToRefresh = { [weak self] in
             self?.pullToRefresh()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OrderStatsV4Interval+Chart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/OrderStatsV4Interval+Chart.swift
@@ -1,0 +1,8 @@
+import Yosemite
+
+extension OrderStatsV4Interval {
+    /// Value of the revenue during a stats interval.
+    var revenueValue: Decimal {
+        return subtotals.grossRevenue
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
@@ -1,0 +1,79 @@
+import UIKit
+import Yosemite
+
+private extension StatsTimeRangeV4 {
+    func timeRangeText(startDate: Date, endDate: Date, timezone: TimeZone) -> String {
+        let dateFormatter = timeRangeDateFormatter(timezone: timezone)
+        switch self {
+        case .today, .thisMonth, .thisYear:
+            return dateFormatter.string(from: startDate)
+        case .thisWeek:
+            let startDateString = dateFormatter.string(from: startDate)
+            let endDateString = dateFormatter.string(from: endDate)
+            return String.localizedStringWithFormat(NSLocalizedString("%1$@-%2$@", comment: "Displays a date range for a stats interval"), startDateString, endDateString)
+        }
+    }
+
+    func timeRangeDateFormatter(timezone: TimeZone) -> DateFormatter {
+        let dateFormatter: DateFormatter
+        switch intervalGranularity {
+        case .hourly:
+            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
+        case .daily:
+            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
+        case .weekly:
+            dateFormatter = DateFormatter.Charts.chartAxisMonthFormatter
+        case .monthly:
+            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
+        default:
+            fatalError("This case is not supported: \(intervalGranularity.rawValue)")
+        }
+        dateFormatter.timeZone = timezone
+        return dateFormatter
+    }
+}
+
+/// Contains a label that displays the time range - a date, date range for a week, month, or year.
+class StatsTimeRangeBarView: UIView {
+    // MARK: Subviews
+    private let label = UILabel(frame: .zero)
+
+    init() {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        configureLabel()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        configureLabel()
+    }
+
+    /// Updates the label with start/end dates, time range type, and site time zone.
+    func updateDates(startDate: Date,
+                     endDate: Date,
+                     timeRange: StatsTimeRangeV4,
+                     timezone: TimeZone) {
+        label.text = timeRange.timeRangeText(startDate: startDate,
+                                             endDate: endDate,
+                                             timezone: timezone)
+    }
+}
+
+private extension StatsTimeRangeBarView {
+    func configureLabel() {
+        addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        pinSubviewToAllEdges(label, insets: Constants.labelInsets)
+
+        label.font = StyleManager.subheadlineBoldFont
+        label.textColor = StyleManager.defaultTextColor
+    }
+}
+
+private extension StatsTimeRangeBarView {
+    enum Constants {
+        static let labelInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
@@ -29,7 +29,7 @@ private extension StatsTimeRangeBarView {
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         pinSubviewToAllEdges(label, insets: Constants.labelInsets)
 
-        label.font = StyleManager.subheadlineBoldFont
+        label.font = StyleManager.headlineSemiBold
         label.textColor = StyleManager.defaultTextColor
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
@@ -1,37 +1,4 @@
 import UIKit
-import Yosemite
-
-private extension StatsTimeRangeV4 {
-    func timeRangeText(startDate: Date, endDate: Date, timezone: TimeZone) -> String {
-        let dateFormatter = timeRangeDateFormatter(timezone: timezone)
-        switch self {
-        case .today, .thisMonth, .thisYear:
-            return dateFormatter.string(from: startDate)
-        case .thisWeek:
-            let startDateString = dateFormatter.string(from: startDate)
-            let endDateString = dateFormatter.string(from: endDate)
-            return String.localizedStringWithFormat(NSLocalizedString("%1$@-%2$@", comment: "Displays a date range for a stats interval"), startDateString, endDateString)
-        }
-    }
-
-    func timeRangeDateFormatter(timezone: TimeZone) -> DateFormatter {
-        let dateFormatter: DateFormatter
-        switch intervalGranularity {
-        case .hourly:
-            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .daily:
-            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .weekly:
-            dateFormatter = DateFormatter.Charts.chartAxisMonthFormatter
-        case .monthly:
-            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
-        default:
-            fatalError("This case is not supported: \(intervalGranularity.rawValue)")
-        }
-        dateFormatter.timeZone = timezone
-        return dateFormatter
-    }
-}
 
 /// Contains a label that displays the time range - a date, date range for a week, month, or year.
 class StatsTimeRangeBarView: UIView {
@@ -50,13 +17,8 @@ class StatsTimeRangeBarView: UIView {
     }
 
     /// Updates the label with start/end dates, time range type, and site time zone.
-    func updateDates(startDate: Date,
-                     endDate: Date,
-                     timeRange: StatsTimeRangeV4,
-                     timezone: TimeZone) {
-        label.text = timeRange.timeRangeText(startDate: startDate,
-                                             endDate: endDate,
-                                             timezone: timezone)
+    func updateUI(viewModel: StatsTimeRangeBarViewModel) {
+        label.text = viewModel.timeRangeText
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -1,0 +1,47 @@
+import Yosemite
+
+private extension StatsTimeRangeV4 {
+    func timeRangeText(startDate: Date, endDate: Date, timezone: TimeZone) -> String {
+        let dateFormatter = timeRangeDateFormatter(timezone: timezone)
+        switch self {
+        case .today, .thisMonth, .thisYear:
+            return dateFormatter.string(from: startDate)
+        case .thisWeek:
+            let startDateString = dateFormatter.string(from: startDate)
+            let endDateString = dateFormatter.string(from: endDate)
+            return String.localizedStringWithFormat(NSLocalizedString("%1$@-%2$@", comment: "Displays a date range for a stats interval"), startDateString, endDateString)
+        }
+    }
+
+    func timeRangeDateFormatter(timezone: TimeZone) -> DateFormatter {
+        let dateFormatter: DateFormatter
+        switch self {
+        case .today:
+            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
+        case .thisWeek:
+            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
+        case .thisMonth:
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("MMMM")
+            dateFormatter = formatter
+        case .thisYear:
+            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
+        }
+        dateFormatter.timeZone = timezone
+        return dateFormatter
+    }
+}
+
+/// View model for `StatsTimeRangeBarView`.
+struct StatsTimeRangeBarViewModel {
+    let timeRangeText: String
+
+    init(startDate: Date,
+         endDate: Date,
+         timeRange: StatsTimeRangeV4,
+         timezone: TimeZone) {
+        timeRangeText = timeRange.timeRangeText(startDate: startDate,
+                                                endDate: endDate,
+                                                timezone: timezone)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -18,7 +18,9 @@ private extension StatsTimeRangeV4 {
         let dateFormatter: DateFormatter
         switch self {
         case .today:
-            dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
+            let formatter = DateFormatter()
+            formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
+            dateFormatter = formatter
         case .thisWeek:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
         case .thisMonth:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -9,7 +9,8 @@ private extension StatsTimeRangeV4 {
         case .thisWeek:
             let startDateString = dateFormatter.string(from: startDate)
             let endDateString = dateFormatter.string(from: endDate)
-            return String.localizedStringWithFormat(NSLocalizedString("%1$@-%2$@", comment: "Displays a date range for a stats interval"), startDateString, endDateString)
+            let format = NSLocalizedString("%1$@-%2$@", comment: "Displays a date range for a stats interval")
+            return String.localizedStringWithFormat(format, startDateString, endDateString)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -251,6 +251,9 @@ private extension StoreStatsAndTopPerformersViewController {
     func configureView() {
         view.backgroundColor = StyleManager.tableViewBackgroundColor
         configureButtonBarBottomBorder()
+
+        // Disables any content inset adjustment since `XLPagerTabStrip` doesn't seem to support safe area insets.
+        containerView.contentInsetAdjustmentBehavior = .never
     }
 
     func configurePeriodViewControllers() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -45,12 +45,6 @@ class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripViewContro
         ensureGhostContentIsAnimated()
     }
 
-    /// Note: Overrides this function to always trigger `updateContent()` to ensure the child view controller fills the container width.
-    /// This is probably only an issue when not using `ButtonBarPagerTabStripViewController` with Storyboard.
-    override func updateIfNeeded() {
-        updateContent()
-    }
-
     // MARK: - RTL support
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -561,6 +561,13 @@ private extension StoreStatsV4PeriodViewController {
             barChartView.animate(yAxisDuration: Constants.chartAnimationDuration)
         }
         updateChartAccessibilityValues()
+
+        updateUI(hasRevenue: hasRevenue())
+    }
+
+    func hasRevenue() -> Bool {
+        let totalRevenue = orderStatsIntervals.map({ $0.revenueValue }).reduce(0, +)
+        return totalRevenue > 0
     }
 
     func reloadLastUpdatedField() {
@@ -581,8 +588,8 @@ private extension StoreStatsV4PeriodViewController {
         var dataEntries: [BarChartDataEntry] = []
         let currencyCode = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode)
         orderStatsIntervals.forEach { (item) in
-            let entry = BarChartDataEntry(x: Double(barCount), y: (item.subtotals.grossRevenue as NSDecimalNumber).doubleValue)
-            let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String("\(item.subtotals.grossRevenue)"),
+            let entry = BarChartDataEntry(x: Double(barCount), y: (item.revenueValue as NSDecimalNumber).doubleValue)
+            let formattedAmount = CurrencyFormatter().formatHumanReadableAmount(String("\(item.revenueValue)"),
                                                                                 with: currencyCode,
                                                                                 roundSmallNumbers: false) ?? String()
             entry.accessibilityValue = "\(formattedChartMarkerPeriodString(for: item)): \(formattedAmount)"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -54,6 +54,8 @@ class StoreStatsV4PeriodViewController: UIViewController {
     @IBOutlet private weak var yAxisAccessibilityView: UIView!
     @IBOutlet private weak var xAxisAccessibilityView: UIView!
     @IBOutlet private weak var chartAccessibilityView: UIView!
+    @IBOutlet private weak var noRevenueView: UIView!
+    @IBOutlet private weak var noRevenueLabel: UILabel!
 
     private var lastUpdatedDate: Date?
     private var yAxisMinimum: String = Constants.chartYAxisMinimum.humanReadableString()
@@ -133,6 +135,7 @@ class StoreStatsV4PeriodViewController: UIViewController {
         super.viewDidLoad()
         configureView()
         configureBarChart()
+        configureNoRevenueView()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -270,6 +273,13 @@ private extension StoreStatsV4PeriodViewController {
         )
     }
 
+    func configureNoRevenueView() {
+        noRevenueView.isHidden = true
+        noRevenueLabel.text = NSLocalizedString("No revenue this period", comment: "Text displayed when no order data are available for the selected time range.")
+        noRevenueLabel.font = StyleManager.subheadlineFont
+        noRevenueLabel.textColor = StyleManager.defaultTextColor
+    }
+
     func configureBarChart() {
         barChartView.chartDescription?.enabled = false
         barChartView.dragEnabled = false
@@ -324,6 +334,21 @@ private extension StoreStatsV4PeriodViewController {
                                     DateFormatter.Stats.statsDayFormatter.string(from: currentDate))
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteVisitStats.date, ascending: false)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }
+
+    func updateUI(hasRevenue: Bool) {
+        noRevenueView.isHidden = hasRevenue
+        updateBarChartAxisUI(hasRevenue: hasRevenue)
+    }
+
+    func updateBarChartAxisUI(hasRevenue: Bool) {
+        let labelTextColor = hasRevenue ? StyleManager.wooSecondary: StyleManager.wooGreyMid
+
+        let xAxis = barChartView.xAxis
+        xAxis.labelTextColor = labelTextColor
+
+        let yAxis = barChartView.leftAxis
+        yAxis.labelTextColor = labelTextColor
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -56,6 +56,8 @@ class StoreStatsV4PeriodViewController: UIViewController {
     @IBOutlet private weak var chartAccessibilityView: UIView!
     @IBOutlet private weak var noRevenueView: UIView!
     @IBOutlet private weak var noRevenueLabel: UILabel!
+    @IBOutlet private weak var timeRangeBarView: StatsTimeRangeBarView!
+    @IBOutlet private weak var timeRangeBarBottomBorderView: UIView!
 
     private var lastUpdatedDate: Date?
     private var yAxisMinimum: String = Constants.chartYAxisMinimum.humanReadableString()
@@ -232,6 +234,9 @@ private extension StoreStatsV4PeriodViewController {
     func configureView() {
         view.backgroundColor = StyleManager.wooWhite
         borderView.backgroundColor = StyleManager.wooGreyBorder
+
+        // Time range bar bottom border view
+        timeRangeBarBottomBorderView.backgroundColor = StyleManager.wooGreyBorder
 
         // Titles
         visitorsTitle.text = NSLocalizedString("Visitors", comment: "Visitors stat label on dashboard - should be plural.")
@@ -482,6 +487,15 @@ private extension StoreStatsV4PeriodViewController {
         orderStatsIntervals = orderStats?.intervals.sorted(by: { (lhs, rhs) -> Bool in
             return lhs.dateStart() < rhs.dateStart()
         }) ?? []
+        if let startDate = orderStatsIntervals.first?.dateStart(),
+            let endDate = orderStatsIntervals.last?.dateStart() {
+            let timeRangeBarViewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                                   endDate: endDate,
+                                                                   timeRange: timeRange,
+                                                                   timezone: siteTimezone)
+            timeRangeBarView.updateUI(viewModel: timeRangeBarViewModel)
+        }
+
         if !orderStatsIntervals.isEmpty {
             lastUpdatedDate = Date()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -16,6 +16,8 @@
                 <outlet property="borderView" destination="IHi-Ph-CQQ" id="bgg-u3-bda"/>
                 <outlet property="chartAccessibilityView" destination="NEo-bw-gS4" id="Ep1-tI-L3J"/>
                 <outlet property="lastUpdated" destination="0Wi-nd-Ucs" id="XPO-tH-TLR"/>
+                <outlet property="noRevenueLabel" destination="5uh-zy-gDZ" id="ZRx-lP-Af2"/>
+                <outlet property="noRevenueView" destination="fg2-ey-bVn" id="LBf-aq-yXB"/>
                 <outlet property="ordersData" destination="6HA-Qe-PkT" id="zOF-dV-3LN"/>
                 <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
                 <outlet property="revenueData" destination="ukd-qU-WVq" id="ydx-PH-lcl"/>
@@ -194,6 +196,24 @@
                                                 <accessibilityTraits key="traits" notEnabled="YES"/>
                                             </accessibility>
                                         </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
+                                            <rect key="frame" x="152.5" y="235.5" width="42" height="38.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uh-zy-gDZ">
+                                                    <rect key="frame" x="0.0" y="9" width="42" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="5uh-zy-gDZ" secondAttribute="trailing" id="kKN-cg-YhY"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="top" secondItem="fg2-ey-bVn" secondAttribute="top" constant="9" id="od2-Oi-xwq"/>
+                                                <constraint firstAttribute="bottom" secondItem="5uh-zy-gDZ" secondAttribute="bottom" constant="9" id="uQ7-1p-B6d"/>
+                                                <constraint firstItem="5uh-zy-gDZ" firstAttribute="leading" secondItem="fg2-ey-bVn" secondAttribute="leading" id="ylg-AY-x2q"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
@@ -201,10 +221,12 @@
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="175" id="7hy-0X-Qlw"/>
                                         <constraint firstItem="NEo-bw-gS4" firstAttribute="leading" secondItem="yvj-Kj-G3f" secondAttribute="trailing" constant="8" id="EcA-ZK-LGL"/>
                                         <constraint firstAttribute="trailing" secondItem="TTF-Fx-NHe" secondAttribute="trailing" id="JA8-YG-kdu"/>
+                                        <constraint firstItem="fg2-ey-bVn" firstAttribute="centerY" secondItem="zPE-Y0-ax8" secondAttribute="centerY" id="KX8-lm-OjL"/>
                                         <constraint firstItem="yvj-Kj-G3f" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="TcO-x3-t7A"/>
                                         <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="yvj-Kj-G3f" secondAttribute="bottom" id="X68-Fa-xY5"/>
                                         <constraint firstItem="NEo-bw-gS4" firstAttribute="top" secondItem="zPE-Y0-ax8" secondAttribute="top" constant="8" id="Xsc-Oa-g5y"/>
                                         <constraint firstItem="yvj-Kj-G3f" firstAttribute="leading" secondItem="zPE-Y0-ax8" secondAttribute="leading" id="aCl-eO-awT"/>
+                                        <constraint firstItem="fg2-ey-bVn" firstAttribute="centerX" secondItem="zPE-Y0-ax8" secondAttribute="centerX" id="beQ-H2-7xo"/>
                                         <constraint firstItem="TTF-Fx-NHe" firstAttribute="top" secondItem="NEo-bw-gS4" secondAttribute="bottom" id="mFp-ya-fbL"/>
                                         <constraint firstAttribute="bottom" secondItem="TTF-Fx-NHe" secondAttribute="bottom" id="prr-z8-NDw"/>
                                         <constraint firstAttribute="trailing" secondItem="NEo-bw-gS4" secondAttribute="trailing" id="y4j-07-4hx"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -44,7 +44,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="375" height="4.5"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="height" priority="250" constant="20" id="Hdx-tY-N2P"/>
+                                <constraint firstAttribute="height" priority="250" constant="20" placeholder="YES" id="Hdx-tY-N2P"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XXt-Kt-RL6" userLabel="Border view">

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -22,6 +22,8 @@
                 <outlet property="ordersTitle" destination="vlW-do-oXj" id="zdd-DS-zvJ"/>
                 <outlet property="revenueData" destination="ukd-qU-WVq" id="ydx-PH-lcl"/>
                 <outlet property="revenueTitle" destination="Sam-pk-BxI" id="HI1-z6-dRL"/>
+                <outlet property="timeRangeBarBottomBorderView" destination="XXt-Kt-RL6" id="oeb-lG-wY3"/>
+                <outlet property="timeRangeBarView" destination="8nR-qE-vPw" id="vbk-sJ-3jq"/>
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
                 <outlet property="visitorsData" destination="SZF-f7-8Va" id="ZY0-s6-PDq"/>
                 <outlet property="visitorsStackView" destination="e8D-G2-abm" id="4R3-bN-edz"/>
@@ -38,8 +40,19 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0he-5g-kXa">
                     <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="87.5"/>
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8nR-qE-vPw" customClass="StatsTimeRangeBarView" customModule="WooCommerce" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XXt-Kt-RL6" userLabel="Border view">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="VSv-HK-GcX"/>
+                            </constraints>
+                        </view>
+                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
+                            <rect key="frame" x="0.0" y="1" width="375" height="87.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="e8D-G2-abm">
                                     <rect key="frame" x="0.0" y="0.0" width="125.5" height="87.5"/>
@@ -137,8 +150,8 @@
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YbU-E4-fLs">
-                            <rect key="frame" x="0.0" y="87.5" width="375" height="1"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YbU-E4-fLs">
+                            <rect key="frame" x="0.0" y="88.5" width="375" height="1"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ird-S1-Bnw">
                                     <rect key="frame" x="0.0" y="0.0" width="14" height="1"/>
@@ -165,38 +178,38 @@
                                 </view>
                             </subviews>
                         </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
-                            <rect key="frame" x="0.0" y="88.5" width="375" height="509"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
+                            <rect key="frame" x="0.0" y="89.5" width="375" height="509"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
                                     <rect key="frame" x="0.0" y="0.0" width="14" height="509"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
                                     <rect key="frame" x="14" y="0.0" width="347" height="509"/>
                                     <subviews>
-                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
                                             <rect key="frame" x="0.0" y="8" width="32" height="485"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="32" id="sUS-FA-4ab"/>
                                             </constraints>
                                         </view>
-                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
                                             <rect key="frame" x="0.0" y="493" width="347" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="feO-ed-bxp"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
+                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
                                             <rect key="frame" x="40" y="8" width="307" height="485"/>
                                             <accessibility key="accessibilityConfiguration">
                                                 <accessibilityTraits key="traits" notEnabled="YES"/>
                                             </accessibility>
                                         </view>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
+                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fg2-ey-bVn" userLabel="Empty data view">
                                             <rect key="frame" x="152.5" y="235.5" width="42" height="38.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uh-zy-gDZ">
@@ -232,7 +245,7 @@
                                         <constraint firstAttribute="trailing" secondItem="NEo-bw-gS4" secondAttribute="trailing" id="y4j-07-4hx"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
                                     <rect key="frame" x="361" y="0.0" width="14" height="509"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
@@ -242,7 +255,7 @@
                             </subviews>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Wi-nd-Ucs">
-                            <rect key="frame" x="0.0" y="597.5" width="375" height="49.5"/>
+                            <rect key="frame" x="0.0" y="598.5" width="375" height="48.5"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="sz5-Uv-FMw" userLabel="height = 44"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -40,19 +40,22 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0he-5g-kXa">
                     <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <subviews>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8nR-qE-vPw" customClass="StatsTimeRangeBarView" customModule="WooCommerce" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8nR-qE-vPw" customClass="StatsTimeRangeBarView" customModule="WooCommerce" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="4.5"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" priority="250" constant="20" id="Hdx-tY-N2P"/>
+                            </constraints>
                         </view>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XXt-Kt-RL6" userLabel="Border view">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XXt-Kt-RL6" userLabel="Border view">
+                            <rect key="frame" x="0.0" y="4.5" width="375" height="1"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="VSv-HK-GcX"/>
                             </constraints>
                         </view>
-                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
-                            <rect key="frame" x="0.0" y="1" width="375" height="87.5"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
+                            <rect key="frame" x="0.0" y="5.5" width="375" height="87.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="e8D-G2-abm">
                                     <rect key="frame" x="0.0" y="0.0" width="125.5" height="87.5"/>
@@ -150,8 +153,8 @@
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YbU-E4-fLs">
-                            <rect key="frame" x="0.0" y="88.5" width="375" height="1"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YbU-E4-fLs">
+                            <rect key="frame" x="0.0" y="93" width="375" height="1"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ird-S1-Bnw">
                                     <rect key="frame" x="0.0" y="0.0" width="14" height="1"/>
@@ -178,32 +181,32 @@
                                 </view>
                             </subviews>
                         </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
-                            <rect key="frame" x="0.0" y="89.5" width="375" height="509"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
+                            <rect key="frame" x="0.0" y="94" width="375" height="509"/>
                             <subviews>
-                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
                                     <rect key="frame" x="0.0" y="0.0" width="14" height="509"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="BarChartView" customModule="Charts">
                                     <rect key="frame" x="14" y="0.0" width="347" height="509"/>
                                     <subviews>
-                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">
                                             <rect key="frame" x="0.0" y="8" width="32" height="485"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="32" id="sUS-FA-4ab"/>
                                             </constraints>
                                         </view>
-                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
+                                        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TTF-Fx-NHe">
                                             <rect key="frame" x="0.0" y="493" width="347" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="feO-ed-bxp"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NEo-bw-gS4">
                                             <rect key="frame" x="40" y="8" width="307" height="485"/>
                                             <accessibility key="accessibilityConfiguration">
                                                 <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -245,7 +248,7 @@
                                         <constraint firstAttribute="trailing" secondItem="NEo-bw-gS4" secondAttribute="trailing" id="y4j-07-4hx"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aWR-1n-XPz">
                                     <rect key="frame" x="361" y="0.0" width="14" height="509"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
@@ -255,7 +258,7 @@
                             </subviews>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Wi-nd-Ucs">
-                            <rect key="frame" x="0.0" y="598.5" width="375" height="48.5"/>
+                            <rect key="frame" x="0.0" y="603" width="375" height="44"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="sz5-Uv-FMw" userLabel="height = 44"/>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
+		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -427,6 +428,7 @@
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
+		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -839,6 +841,7 @@
 				028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */,
 				0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */,
 				02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */,
+				02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -2157,6 +2160,7 @@
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
 				D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */,
 				B5F8B7E02194759100DAB7E2 /* NotificationDetailsViewController.swift in Sources */,
+				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				B560D6862195BCA90027BB7E /* NoteDetailsHeaderTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
+		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -429,6 +430,7 @@
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
+		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -842,6 +844,7 @@
 				0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */,
 				02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */,
 				02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */,
+				02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -2237,6 +2240,7 @@
 				74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
+				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				D817586022BB614A00289CFE /* OrderMessageComposer.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
+		02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -431,6 +432,7 @@
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
+		02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModelTests.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -863,6 +865,14 @@
 				029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */,
 			);
 			path = "Stats v3";
+			sourceTree = "<group>";
+		};
+		02E4FD7F2306AA770049610C /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */,
+			);
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		74036CBE211B87FD00E462C2 /* MyStore */ = {
@@ -1683,6 +1693,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				02E4FD7F2306AA770049610C /* Dashboard */,
 				D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
@@ -2352,6 +2363,7 @@
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
+				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
+		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -425,6 +426,7 @@
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
+		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -836,6 +838,7 @@
 				028BAC4422F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib */,
 				028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */,
 				0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */,
+				02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -2097,6 +2100,7 @@
 				D843D5CB22437E59001BFA55 /* TitleAndEditableValueTableViewCell.swift in Sources */,
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
+				02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */,
 				748C7782211E294000814F2C /* Double+Woo.swift in Sources */,
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import WooCommerce
+
+class StatsTimeRangeBarViewModelTests: XCTestCase {
+
+    func testTodayText() {
+        // GMT: Thursday, August 15, 2019 6:14:35 PM
+        let startDate = Date(timeIntervalSince1970: 1565892875)
+        // GMT: Friday, August 16, 2019 2:14:35 AM
+        let endDate = Date(timeIntervalSince1970: 1565921675)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .today,
+                                                   timezone: timezone)
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func testThisWeekText() {
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .thisWeek,
+                                                   timezone: timezone)
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.timeZone = timezone
+        let expectedText = String.localizedStringWithFormat(NSLocalizedString("%1$@-%2$@", comment: "Displays a date range for a stats interval"),
+                                                            formatter.string(from: startDate),
+                                                            formatter.string(from: endDate))
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func testThisMonthText() {
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .thisMonth,
+                                                   timezone: timezone)
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMMM")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func testThisYearText() {
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .thisYear,
+                                                   timezone: timezone)
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("yyyy")
+        formatter.timeZone = timezone
+        let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -14,7 +14,7 @@ class StatsTimeRangeBarViewModelTests: XCTestCase {
                                                    timeRange: .today,
                                                    timezone: timezone)
         let formatter = DateFormatter()
-        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
         formatter.timeZone = timezone
         let expectedText = formatter.string(from: startDate)
         XCTAssertEqual(viewModel.timeRangeText, expectedText)


### PR DESCRIPTION
Fixes #1107  
Based on https://github.com/woocommerce/woocommerce-ios/pull/1188 since both branches have diffs on the same xib

- [x] ⚠️ update PR base to `develop` before merging ⚠️

## Changes
- Created `StatsTimeRangeBarView` that contains a label and updates its label text based on view model
- Created `StatsTimeRangeBarViewModel` that sets its `timeRangeText` based on start/end dates, site time zone, and stats time range
  - with basic unit tests (had to do manual date formatter for localization)
- Added `StatsTimeRangeBarView` view and a border view to the vertical stack view in `StoreStatsV4PeriodViewController.xib`. Configured the border view, and updated the `StatsTimeRangeBarView` when it's ready to load order data

## Testing
Prerequisite: the site/store has WC admin extension activated
- Build from Xcode with a store that has WC admin
- In "My store", check the charts in all tabs --> the text under the time range tab should correspond to "today"/"this week"/"this month"/"this year" as in the design

## Example screenshots

today | this week | this month | this year
--- | --- | --- | ---
![Simulator Screen Shot - iPhone 5s - 2019-08-19 at 10 52 43](https://user-images.githubusercontent.com/1945542/63236242-9183c080-c26f-11e9-8716-e97ea3ab5728.png) | ![Simulator Screen Shot - iPhone 5s - 2019-08-19 at 10 52 45](https://user-images.githubusercontent.com/1945542/63236243-9183c080-c26f-11e9-8e6d-e6c9b0417a48.png) | ![Simulator Screen Shot - iPhone 5s - 2019-08-19 at 10 52 47](https://user-images.githubusercontent.com/1945542/63236244-9183c080-c26f-11e9-92c9-74be77d67468.png) | ![Simulator Screen Shot - iPhone 5s - 2019-08-19 at 10 52 59](https://user-images.githubusercontent.com/1945542/63236246-921c5700-c26f-11e9-8e06-41815c91ffb9.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
