### PR TITLE
Set LoginPrologue's presentation style to fullscreen to prevent it from being dismissed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.6
 -----
 - bugfix: 9+ orders in the orders badge text is now easier to read
+- bugfix: prevents a potential edge case where the login screen could be dismissed in a future version of iOS.
 
 2.5
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -56,6 +56,7 @@ class AuthenticationManager {
     func displayAuthentication(from presenter: UIViewController) {
         let prologueViewController = LoginPrologueViewController()
         let navigationController = LoginNavigationController(rootViewController: prologueViewController)
+        navigationController.modalPresentationStyle = .fullScreen
 
         presenter.present(navigationController, animated: true, completion: nil)
     }


### PR DESCRIPTION
Fixes #1123 

First, the issue: on iOS 13 it is possible to dismiss the LoginPrologueViewController by swiping down.

**The issue**
<img src="https://user-images.githubusercontent.com/2722505/63236339-e9222c00-c26f-11e9-9d1a-481a259c3c04.gif" width="350"/>

**Before and after on iOS 12**
<img src="https://user-images.githubusercontent.com/2722505/63236427-34d4d580-c270-11e9-94df-117ac4a2b75d.jpg" width=""/>

**Before and after on iOS 13**
<img src="https://user-images.githubusercontent.com/2722505/63236437-3acab680-c270-11e9-9e6f-ac2c55607d12.jpg" width=""/>

## Changes
As suggested by @jaclync , updating the modal presentation style to fullscreen seems to be enough.

## Testing
Testing is a bit tricky. We'd need to run the code on iOS 13, so I'd suggest:
- Installing Xcode 11 beta 5
- Checking out the branch `try/xcode11-login`
- Build and run with Xcode 11
- Log out and check that it is not possible to dismiss the LoginPrologue
- Another build and run with Xcode 10 wouldn't hurt.

I cherry-picked the commit `e66ef8c` in `try/Xcode-login` to the current PR

If you know of a simpler way to run the code on iOS, please let me know!