### PR TITLE
Clear background color of view grouping product name and price

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.xib
@@ -45,7 +45,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="pPE-SE-pY7" secondAttribute="trailing" id="0CJ-5r-B3p"/>
                                     <constraint firstItem="14R-zK-tgC" firstAttribute="leading" secondItem="HX7-V5-bhX" secondAttribute="leading" id="BTS-zX-yTf"/>


### PR DESCRIPTION
Fixes #1125 

I am not sure why this bug is not visible when running on iOS 12, but it only manifests itself on iOS 13

This is how the Order Details screen looks after applying the fix. To the left, iOS 12, to the right, iOS 13

<img src="https://user-images.githubusercontent.com/2722505/63242543-4b882600-c28a-11e9-8cc9-5b875d8697d1.jpg" width="350"/>


## Changes
- Set the background colour of the view that groups title and price to `.clear`

## Testing
- Build and run. 
- Check that the selected state of the Products section in the Order Details screen looks like it should.
- Ideally, test on iOS 13 as well. 