### PR TITLE
Explain a Jetpack fix that affected our login flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.6
 -----
 - bugfix: 9+ orders in the orders badge text is now easier to read
+- bugfix: Keep those sign-in bugs coming! We tracked down and fixed a `Log in with Jetpack` issue, where users with a Byte Order Mark in their `wp-config.php` file were returning error responses during API requests. These users would see their store listed in the sign-in screen, but were unable to tap the Continue button.
 
 2.5
 -----


### PR DESCRIPTION
Fixes #828. 

Jetpack pushed a fix that affects our users during the sign-in flow. This is the attempt to explain that fix to our users.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
