### PR TITLE
Service Locator mark I. Service Locator and Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -51,7 +51,7 @@ public extension TracksProvider {
     /// When a user opts-out, wipe data
     ///
     func clearUsers() {
-        guard WooAnalytics.shared.userHasOptedIn else {
+        guard ServiceLocator.analytics.userHasOptedIn else {
             // To be safe, nil out the anonymousUserID guid so a fresh one is regenerated
             UserDefaults.standard[.defaultAnonymousID] = nil
             UserDefaults.standard[.analyticsUsername] = nil

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -1,19 +1,9 @@
 import Foundation
 import UIKit
 
-
 public class WooAnalytics {
 
     // MARK: - Properties
-
-    /// Shared Instance. In the test bundle, it'll get injected a mock provider
-    ///
-    static let shared: WooAnalytics = {
-        let isRunningTests = NSClassFromString("XCTestCase") != nil
-        // Inject a mock tracker in unit tests
-        let provider: AnalyticsProvider = isRunningTests ? MockupAnalyticsProvider() : TracksProvider()
-        return WooAnalytics(analyticsProvider: provider)
-    }()
 
     /// AnalyticsProvider: Interface to the actual analytics implementation
     ///

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-public class WooAnalytics {
+public class WooAnalytics: Analytics {
 
     // MARK: - Properties
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -228,7 +228,7 @@ private extension AppDelegate {
     /// Sets up the WordPress Authenticator.
     ///
     func setupAnalytics() {
-        WooAnalytics.shared.initialize()
+        ServiceLocator.analytics.initialize()
     }
 
     /// Sets up the WordPress Authenticator.
@@ -303,10 +303,10 @@ private extension AppDelegate {
         let versionOfLastRun = UserDefaults.standard[.versionOfLastRun] as? String
         if versionOfLastRun == nil {
             // First run after a fresh install
-            WooAnalytics.shared.track(.applicationInstalled)
+            ServiceLocator.analytics.track(.applicationInstalled)
         } else if versionOfLastRun != currentVersion {
             // App was upgraded
-            WooAnalytics.shared.track(.applicationInstalled, withProperties: ["previous_version": versionOfLastRun ?? String()])
+            ServiceLocator.analytics.track(.applicationInstalled, withProperties: ["previous_version": versionOfLastRun ?? String()])
         }
 
         UserDefaults.standard[.versionOfLastRun] = currentVersion

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -224,7 +224,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             DDLogWarn("⚠️ Could not convert WPAnalyticsStat with value: \(event.rawValue)")
             return
         }
-        WooAnalytics.shared.track(wooEvent)
+        ServiceLocator.analytics.track(wooEvent)
     }
 
     /// Tracks a given Analytics Event, with the specified properties.
@@ -234,7 +234,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             DDLogWarn("⚠️ Could not convert WPAnalyticsStat with value: \(event.rawValue)")
             return
         }
-        WooAnalytics.shared.track(wooEvent, withProperties: properties)
+        ServiceLocator.analytics.track(wooEvent, withProperties: properties)
     }
 
     /// Tracks a given Analytics Event, with the specified error.
@@ -244,6 +244,6 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             DDLogWarn("⚠️ Could not convert WPAnalyticsStat with value: \(event.rawValue)")
             return
         }
-        WooAnalytics.shared.track(wooEvent, withError: error)
+        ServiceLocator.analytics.track(wooEvent, withError: error)
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AccountHeaderView.swift
@@ -102,7 +102,7 @@ private extension AccountHeaderView {
         helpButton.setTitleColor(StyleManager.wooCommerceBrandColor, for: .normal)
         helpButton.setTitleColor(StyleManager.wooGreyMid, for: .highlighted)
         helpButton.on(.touchUpInside) { [weak self] control in
-            WooAnalytics.shared.track(.sitePickerHelpButtonTapped)
+            ServiceLocator.analytics.track(.sitePickerHelpButtonTapped)
             self?.handleHelpButtonTapped(control)
         }
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -133,8 +133,8 @@ private extension StorePickerCoordinator {
 
         // We need to call refreshUserData() here because the user selected
         // their default store and tracks should to know about it.
-        WooAnalytics.shared.refreshUserData()
-        WooAnalytics.shared.track(.sitePickerContinueTapped,
+        ServiceLocator.analytics.refreshUserData()
+        ServiceLocator.analytics.track(.sitePickerContinueTapped,
                                   withProperties: ["selected_store_id": StoresManager.shared.sessionManager.defaultStoreID ?? String()])
 
         AppDelegate.shared.authenticatorWasDismissed()

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -231,7 +231,7 @@ private extension StorePickerViewController {
 
     func refreshResults() {
         try? resultsController.performFetch()
-        WooAnalytics.shared.track(.sitePickerStoresShown, withProperties: ["num_of_stores": resultsController.numberOfObjects])
+        ServiceLocator.analytics.track(.sitePickerStoresShown, withProperties: ["num_of_stores": resultsController.numberOfObjects])
         state = StorePickerState(sites: resultsController.fetchedObjects)
     }
 

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -134,7 +134,7 @@ extension LoginPrologueViewController {
     /// Opens SafariViewController at the specified URL.
     ///
     func displaySafariViewController(at url: URL) {
-        WooAnalytics.shared.track(.loginPrologueJetpackInstructions)
+        ServiceLocator.analytics.track(.loginPrologueJetpackInstructions)
         let safariViewController = SFSafariViewController(url: url)
 
         safariViewController.modalPresentationStyle = .pageSheet
@@ -144,7 +144,7 @@ extension LoginPrologueViewController {
     /// Proceeds with the Login Flow.
     ///
     @IBAction func loginWasPressed() {
-        WooAnalytics.shared.track(.loginPrologueContinueTapped)
+        ServiceLocator.analytics.track(.loginPrologueContinueTapped)
         let loginViewController = AppDelegate.shared.authenticationManager.loginForWordPressDotCom()
 
         navigationController?.pushViewController(loginViewController, animated: true)

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -71,12 +71,12 @@ extension PushNotificationsManager {
 
             nc.requestAuthorization(queue: .main) { allowed in
                 let stat: WooAnalyticsStat = allowed ? .pushNotificationOSAlertAllowed : .pushNotificationOSAlertDenied
-                WooAnalytics.shared.track(stat)
+                ServiceLocator.analytics.track(stat)
 
                 onCompletion?(allowed)
             }
 
-            WooAnalytics.shared.track(.pushNotificationOSAlertShown)
+            ServiceLocator.analytics.track(.pushNotificationOSAlertShown)
         }
     }
 
@@ -368,7 +368,7 @@ private extension PushNotificationsManager {
         }
 
         let event: WooAnalyticsStat = (applicationState == .background) ? .pushNotificationReceived : .pushNotificationAlertPressed
-        WooAnalytics.shared.track(event, withProperties: properties)
+        ServiceLocator.analytics.track(event, withProperties: properties)
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/Analytics.swift
+++ b/WooCommerce/Classes/ServiceLocator/Analytics.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+protocol Analytics {
+    func initialize()
+    func track(_ stat: WooAnalyticsStat)
+    func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]?)
+    func track(_ stat: WooAnalyticsStat, withError error: Error)
+    func refreshUserData()
+    func setUserHasOptedOut(_ optedOut: Bool)
+    var userHasOptedIn: Bool { get set }
+    var analyticsProvider: AnalyticsProvider { get }
+}
+
+extension WooAnalytics: Analytics {}

--- a/WooCommerce/Classes/ServiceLocator/Analytics.swift
+++ b/WooCommerce/Classes/ServiceLocator/Analytics.swift
@@ -1,14 +1,49 @@
 import Foundation
 
+/// Abstracts the Analytics engine.
+///
 protocol Analytics {
+    /// Initialize the analytics engine
+    ///
     func initialize()
+
+    /// Track a spcific event without any associated properties
+    ///
+    /// - Parameter stat: the event name
+    ///
     func track(_ stat: WooAnalyticsStat)
+
+    /// Track a specific event with associated properties
+    ///
+    /// - Parameters:
+    ///   - stat: the event name
+    ///   - properties: a collection of properties related to the event
+    ///
     func track(_ stat: WooAnalyticsStat, withProperties properties: [AnyHashable: Any]?)
+
+    /// Track a specific event with an associated error (that is translated to properties)
+    ///
+    /// - Parameters:
+    ///   - stat: the event name
+    ///   - error: the error to track
+    ///
     func track(_ stat: WooAnalyticsStat, withError error: Error)
+
+    /// Refresh the tracking metadata for the currently logged-in or anonymous user.
+    /// It's good to call this function after a user logs in or out of the app.
+    ///
     func refreshUserData()
+
+    /// Sets the boolean flag to signal that the user has opted out of analytics
+    /// It will trigger a call to `refreshUserData` before starting tracking again.
+    ///
     func setUserHasOptedOut(_ optedOut: Bool)
+
+    /// Check user opt-in for analytics
+    ///
     var userHasOptedIn: Bool { get set }
+
+    /// AnalyticsProvider: Interface to the actual analytics implementation
+    ///
     var analyticsProvider: AnalyticsProvider { get }
 }
-
-extension WooAnalytics: Analytics {}

--- a/WooCommerce/Classes/ServiceLocator/Analytics.swift
+++ b/WooCommerce/Classes/ServiceLocator/Analytics.swift
@@ -7,7 +7,7 @@ protocol Analytics {
     ///
     func initialize()
 
-    /// Track a spcific event without any associated properties
+    /// Track a specific event without any associated properties
     ///
     /// - Parameter stat: the event name
     ///
@@ -37,6 +37,8 @@ protocol Analytics {
     /// Sets the boolean flag to signal that the user has opted out of analytics
     /// It will trigger a call to `refreshUserData` before starting tracking again.
     ///
+    /// - Parameters:
+    ///   - optedOut: Boolean flag. If true, we stop tracking.
     func setUserHasOptedOut(_ optedOut: Bool)
 
     /// Check user opt-in for analytics

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -7,7 +7,7 @@ final class ServiceLocator {
     private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
 
     /// Provides the access point to the analytics.
-    /// - Returns: An iumplementation of the Analytics protocol. It defaults to WooAnalytics
+    /// - Returns: An implementation of the Analytics protocol. It defaults to WooAnalytics
     static var analytics: Analytics {
         return _analytics
     }
@@ -19,6 +19,17 @@ final class ServiceLocator {
 /// The setters declared in this extension are meant to be used only from the test bundle
 extension ServiceLocator {
     static func setAnalytics(_ mock: Analytics) {
+        guard isRunningTests() else {
+            return
+        }
+
         _analytics = mock
+    }
+}
+
+
+private extension ServiceLocator {
+    static func isRunningTests() -> Bool {
+        return NSClassFromString("XCTestCase") != nil
     }
 }

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -1,0 +1,26 @@
+
+import Foundation
+
+final class ServiceLocator {
+    private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
+    //private static var _storesManager: StoresManager = DefaultStoresManager()
+
+    static var analytics: Analytics {
+        return _analytics
+    }
+
+//    static var storesManager: StoresManager {
+//        return _storesManager
+//    }
+}
+
+// Testability
+extension ServiceLocator {
+    static func setAnalytics(_ mock: Analytics) {
+        _analytics = mock
+    }
+
+//    static func setStoresManager(_ mock: StoresManager) {
+//        _storesManager = mock
+//    }
+}

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -1,26 +1,24 @@
-
 import Foundation
 
+
+/// Provides global depedencies.
+///
 final class ServiceLocator {
     private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
-    //private static var _storesManager: StoresManager = DefaultStoresManager()
 
+    /// Provides the access point to the analytics.
+    /// - Returns: An iumplementation of the Analytics protocol. It defaults to WooAnalytics
     static var analytics: Analytics {
         return _analytics
     }
-
-//    static var storesManager: StoresManager {
-//        return _storesManager
-//    }
 }
 
-// Testability
+
+// MARK: - Testability
+
+/// The setters declared in this extension are meant to be used only from the test bundle
 extension ServiceLocator {
     static func setAnalytics(_ mock: Analytics) {
         _analytics = mock
     }
-
-//    static func setStoresManager(_ mock: StoresManager) {
-//        _storesManager = mock
-//    }
 }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -110,7 +110,7 @@ class ZendeskManager: NSObject {
         safariViewController.modalPresentationStyle = .pageSheet
         controller.present(safariViewController, animated: true, completion: nil)
 
-        WooAnalytics.shared.track(.supportHelpCenterViewed)
+        ServiceLocator.analytics.track(.supportHelpCenterViewed)
     }
 
     /// Displays the Zendesk New Request view from the given controller, for users to submit new tickets.
@@ -122,7 +122,7 @@ class ZendeskManager: NSObject {
                 return
             }
 
-            WooAnalytics.shared.track(.supportNewRequestViewed)
+            ServiceLocator.analytics.track(.supportNewRequestViewed)
 
             let newRequestConfig = self.createRequest(supportSourceTag: sourceTag)
             let newRequestController = RequestUi.buildRequestUi(with: [newRequestConfig])
@@ -139,7 +139,7 @@ class ZendeskManager: NSObject {
                 return
             }
 
-            WooAnalytics.shared.track(.supportTicketListViewed)
+            ServiceLocator.analytics.track(.supportTicketListViewed)
 
             let requestConfig = self.createRequest(supportSourceTag: sourceTag)
             let requestListController = RequestUi.buildRequestList(with: [requestConfig])
@@ -159,7 +159,7 @@ class ZendeskManager: NSObject {
     /// Displays an alert allowing the user to change their Support email address.
     ///
     func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping onUserInformationCompletion) {
-        WooAnalytics.shared.track(.supportIdentityFormViewed)
+        ServiceLocator.analytics.track(.supportIdentityFormViewed)
         presentInController = controller
 
         // If the user hasn't already set a username, go ahead and ask for that too.
@@ -759,25 +759,25 @@ private extension ZendeskManager {
     @objc func zendeskNotification(_ notification: Notification) {
         switch notification.name.rawValue {
         case ZDKAPI_RequestSubmissionSuccess:
-            WooAnalytics.shared.track(.supportNewRequestCreated)
+            ServiceLocator.analytics.track(.supportNewRequestCreated)
         case ZDKAPI_RequestSubmissionError:
-            WooAnalytics.shared.track(.supportNewRequestFailed)
+            ServiceLocator.analytics.track(.supportNewRequestFailed)
         case ZDKAPI_UploadAttachmentSuccess:
-            WooAnalytics.shared.track(.supportNewRequestFileAttached)
+            ServiceLocator.analytics.track(.supportNewRequestFileAttached)
         case ZDKAPI_UploadAttachmentError:
-            WooAnalytics.shared.track(.supportNewRequestFileAttachmentFailed)
+            ServiceLocator.analytics.track(.supportNewRequestFileAttachmentFailed)
         case ZDKAPI_CommentSubmissionSuccess:
-            WooAnalytics.shared.track(.supportTicketUserReplied)
+            ServiceLocator.analytics.track(.supportTicketUserReplied)
         case ZDKAPI_CommentSubmissionError:
-            WooAnalytics.shared.track(.supportTicketUserReplyFailed)
+            ServiceLocator.analytics.track(.supportTicketUserReplyFailed)
         case ZDKAPI_RequestsError:
-            WooAnalytics.shared.track(.supportTicketListViewFailed)
+            ServiceLocator.analytics.track(.supportTicketListViewFailed)
         case ZDKAPI_CommentListSuccess:
-            WooAnalytics.shared.track(.supportTicketUserViewed)
+            ServiceLocator.analytics.track(.supportTicketUserViewed)
         case ZDKAPI_CommentListError:
-            WooAnalytics.shared.track(.supportTicketViewFailed)
+            ServiceLocator.analytics.track(.supportTicketViewFailed)
         case ZD_HC_SearchSuccess:
-            WooAnalytics.shared.track(.supportHelpCenterUserSearched)
+            ServiceLocator.analytics.track(.supportHelpCenterUserSearched)
         default:
             break
         }

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -173,7 +173,7 @@ extension OrderDetailsViewModel {
         switch dataSource.sections[indexPath.section].rows[indexPath.row] {
 
         case .addOrderNote:
-            WooAnalytics.shared.track(.orderDetailAddNoteButtonTapped)
+            ServiceLocator.analytics.track(.orderDetailAddNoteButtonTapped)
 
             let newNoteViewController = NewNoteViewController()
             newNoteViewController.viewModel = self
@@ -181,7 +181,7 @@ extension OrderDetailsViewModel {
             let navController = WooNavigationController(rootViewController: newNoteViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .trackingAdd:
-            WooAnalytics.shared.track(.orderDetailAddTrackingButtonTapped)
+            ServiceLocator.analytics.track(.orderDetailAddTrackingButtonTapped)
 
             let addTrackingViewModel = AddTrackingViewModel(order: order)
             let addTracking = ManualTrackingViewController(viewModel: addTrackingViewModel)
@@ -195,10 +195,10 @@ extension OrderDetailsViewModel {
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .details:
-            WooAnalytics.shared.track(.orderDetailProductDetailTapped)
+            ServiceLocator.analytics.track(.orderDetailProductDetailTapped)
             viewController.performSegue(withIdentifier: Constants.productDetailsSegue, sender: nil)
         case .billingEmail:
-            WooAnalytics.shared.track(.orderDetailCustomerEmailTapped)
+            ServiceLocator.analytics.track(.orderDetailCustomerEmailTapped)
             displayEmailComposerIfPossible(from: viewController)
         case .billingPhone:
             displayContactCustomerAlert(from: viewController)
@@ -236,12 +236,12 @@ private extension OrderDetailsViewModel {
                 return
             }
 
-            WooAnalytics.shared.track(.orderDetailCustomerPhoneOptionTapped)
+            ServiceLocator.analytics.track(.orderDetailCustomerPhoneOptionTapped)
             self.callCustomerIfPossible(at: phoneURL)
         }
 
         actionSheet.addDefaultActionWithTitle(ContactAction.message) { [weak self] _ in
-            WooAnalytics.shared.track(.orderDetailCustomerSMSOptionTapped)
+            ServiceLocator.analytics.track(.orderDetailCustomerSMSOptionTapped)
             self?.displayMessageComposerIfPossible(from: from)
         }
 
@@ -251,7 +251,7 @@ private extension OrderDetailsViewModel {
 
         from.present(actionSheet, animated: true)
 
-        WooAnalytics.shared.track(.orderDetailCustomerPhoneMenuTapped)
+        ServiceLocator.analytics.track(.orderDetailCustomerPhoneMenuTapped)
     }
 
     /// Attempts to perform a phone call at the specified URL
@@ -262,7 +262,7 @@ private extension OrderDetailsViewModel {
         }
 
         UIApplication.shared.open(phoneURL, options: [:], completionHandler: nil)
-        WooAnalytics.shared.track(.orderContactAction, withProperties: ["id": order.orderID,
+        ServiceLocator.analytics.track(.orderContactAction, withProperties: ["id": order.orderID,
                                                                         "status": order.statusKey,
                                                                         "type": "call"])
 
@@ -306,7 +306,7 @@ extension OrderDetailsViewModel {
                                                                             return
                                                                         }
 
-                                                                        WooAnalytics.shared.track(.orderTrackingLoaded, withProperties: ["id": orderID])
+                                                                        ServiceLocator.analytics.track(.orderTrackingLoaded, withProperties: ["id": orderID])
 
                                                                         onCompletion?(nil)
         }
@@ -325,7 +325,7 @@ extension OrderDetailsViewModel {
             }
 
             self?.orderNotes = orderNotes
-            WooAnalytics.shared.track(.orderNotesLoaded, withProperties: ["id": self?.order.orderID ?? 0])
+            ServiceLocator.analytics.track(.orderNotesLoaded, withProperties: ["id": self?.order.orderID ?? 0])
             onCompletion?(nil)
         }
 
@@ -355,7 +355,7 @@ extension OrderDetailsViewModel {
         let statusKey = order.statusKey
         let providerName = tracking.trackingProvider ?? ""
 
-        WooAnalytics.shared.track(.orderTrackingDelete, withProperties: ["id": orderID,
+        ServiceLocator.analytics.track(.orderTrackingDelete, withProperties: ["id": orderID,
                                                                          "status": statusKey,
                                                                          "carrier": providerName,
                                                                          "source": "order_detail"])
@@ -366,13 +366,13 @@ extension OrderDetailsViewModel {
                                                                     if let error = error {
                                                                         DDLogError("⛔️ Order Details - Delete Tracking: orderID \(orderID). Error: \(error)")
 
-                                                                        WooAnalytics.shared.track(.orderTrackingDeleteFailed,
+                                                                        ServiceLocator.analytics.track(.orderTrackingDeleteFailed,
                                                                                                   withError: error)
                                                                         onCompletion(error)
                                                                         return
                                                                     }
 
-                                                                    WooAnalytics.shared.track(.orderTrackingDeleteSuccess)
+                                                                    ServiceLocator.analytics.track(.orderTrackingDeleteSuccess)
                                                                     onCompletion(nil)
 
         }

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderEmailComposer.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderEmailComposer.swift
@@ -10,7 +10,7 @@ final class OrderEmailComposer: NSObject, MFMailComposeViewControllerDelegate {
         }
 
         displayEmailComposer(for: email, from: from)
-        WooAnalytics.shared.track(.orderContactAction, withProperties: ["id": order.orderID,
+        ServiceLocator.analytics.track(.orderContactAction, withProperties: ["id": order.orderID,
                                                                         "status": order.statusKey,
                                                                         "type": "email"])
     }

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderMessageComposer.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderMessageComposer.swift
@@ -12,7 +12,7 @@ final class OrderMessageComposer: NSObject, MFMessageComposeViewControllerDelega
         }
 
         displayMessageComposer(for: phoneNumber, from: from)
-        WooAnalytics.shared.track(.orderContactAction, withProperties: ["id": order.orderID,
+        ServiceLocator.analytics.track(.orderContactAction, withProperties: ["id": order.orderID,
                                                                         "status": order.statusKey,
                                                                         "type": "sms"])
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -156,12 +156,12 @@ extension DashboardViewController {
 private extension DashboardViewController {
 
     @objc func settingsTapped() {
-        WooAnalytics.shared.track(.settingsTapped)
+        ServiceLocator.analytics.track(.settingsTapped)
         performSegue(withIdentifier: Segues.settingsSegue, sender: nil)
     }
 
     func pullToRefresh() {
-        WooAnalytics.shared.track(.dashboardPulledToRefresh)
+        ServiceLocator.analytics.track(.dashboardPulledToRefresh)
         reloadData()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -117,7 +117,7 @@ private extension NewOrdersViewController {
             return
         }
 
-       WooAnalytics.shared.track(.dashboardNewOrdersButtonTapped)
+       ServiceLocator.analytics.track(.dashboardNewOrdersButtonTapped)
        MainTabBarController.presentOrders(statusFilter: pendingStatus)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -463,7 +463,7 @@ private extension PeriodDataViewController {
             isInitialLoad = false
             return
         }
-        WooAnalytics.shared.track(.dashboardMainStatsDate, withProperties: ["range": granularity.rawValue])
+        ServiceLocator.analytics.track(.dashboardMainStatsDate, withProperties: ["range": granularity.rawValue])
         isInitialLoad = false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -280,7 +280,7 @@ private extension StoreStatsViewController {
             return
         }
 
-        WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
+        ServiceLocator.analytics.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -103,7 +103,7 @@ extension TopPerformerDataViewController {
             if let error = error {
                 DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
             } else {
-                WooAnalytics.shared.track(.dashboardTopPerformersLoaded, withProperties: ["granularity": self.granularity.rawValue])
+                ServiceLocator.analytics.track(.dashboardTopPerformersLoaded, withProperties: ["granularity": self.granularity.rawValue])
             }
             onCompletion?(error)
         }
@@ -249,7 +249,7 @@ private extension TopPerformerDataViewController {
             isInitialLoad = false
             return
         }
-        WooAnalytics.shared.track(.dashboardTopPerformersDate, withProperties: ["range": granularity.rawValue])
+        ServiceLocator.analytics.track(.dashboardTopPerformersDate, withProperties: ["range": granularity.rawValue])
         isInitialLoad = false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -261,7 +261,7 @@ private extension HelpAndSupportViewController {
             self.warnDeveloperIfNeeded()
 
             // Tracking when the dialog's "OK" button is pressed, not necessarily if the value changed.
-            WooAnalytics.shared.track(.supportIdentitySet)
+            ServiceLocator.analytics.track(.supportIdentitySet)
             self.tableView.reloadData()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -269,7 +269,7 @@ private extension PrivacySettingsViewController {
         let action = AccountAction.updateAccountSettings(userID: userID, tracksOptOut: userOptedOut) { error in
 
             guard let _ = error else {
-                WooAnalytics.shared.setUserHasOptedOut(userOptedOut)
+                ServiceLocator.analytics.setUserHasOptedOut(userOptedOut)
 
                 return
             }
@@ -277,12 +277,12 @@ private extension PrivacySettingsViewController {
         StoresManager.shared.dispatch(action)
 
         // This event will only report if the user has turned tracking back on
-        WooAnalytics.shared.track(.settingsCollectInfoToggled)
+        ServiceLocator.analytics.track(.settingsCollectInfoToggled)
     }
 
     func reportCrashesWasUpdated(newValue: Bool) {
         // This event will only report if the user has Analytics currently on
-        WooAnalytics.shared.track(.settingsReportCrashesToggled)
+        ServiceLocator.analytics.track(.settingsReportCrashesToggled)
     }
 
     /// Display Automattic's Cookie Policy web page
@@ -360,13 +360,13 @@ extension PrivacySettingsViewController: UITableViewDelegate {
 
         switch sections[indexPath.section].rows[indexPath.row] {
         case .shareInfoPolicy:
-            WooAnalytics.shared.track(.settingsShareInfoLearnMoreTapped)
+            ServiceLocator.analytics.track(.settingsShareInfoLearnMoreTapped)
             presentCookiePolicyWebView()
         case .thirdPartyPolicy:
-            WooAnalytics.shared.track(.settingsThirdPartyLearnMoreTapped)
+            ServiceLocator.analytics.track(.settingsThirdPartyLearnMoreTapped)
             presentCookiePolicyWebView()
         case .privacyPolicy:
-            WooAnalytics.shared.track(.settingsPrivacyPolicyTapped)
+            ServiceLocator.analytics.track(.settingsPrivacyPolicyTapped)
             presentPrivacyPolicyWebView()
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -250,7 +250,7 @@ private extension SettingsViewController {
 private extension SettingsViewController {
 
     func logoutWasPressed() {
-        WooAnalytics.shared.track(.settingsLogoutTapped)
+        ServiceLocator.analytics.track(.settingsLogoutTapped)
         let messageUnformatted = NSLocalizedString(
             "Are you sure you want to log out of the account %@?",
             comment: "Alert message to confirm a user meant to log out."
@@ -260,12 +260,12 @@ private extension SettingsViewController {
 
         let cancelText = NSLocalizedString("Back", comment: "Alert button title - dismisses alert, which cancels the log out attempt")
         alertController.addActionWithTitle(cancelText, style: .cancel) { _ in
-            WooAnalytics.shared.track(.settingsLogoutConfirmation, withProperties: ["result": "negative"])
+            ServiceLocator.analytics.track(.settingsLogoutConfirmation, withProperties: ["result": "negative"])
         }
 
         let logoutText = NSLocalizedString("Log Out", comment: "Alert button title - confirms and logs out the user")
         alertController.addDefaultActionWithTitle(logoutText) { _ in
-            WooAnalytics.shared.track(.settingsLogoutConfirmation, withProperties: ["result": "positive"])
+            ServiceLocator.analytics.track(.settingsLogoutConfirmation, withProperties: ["result": "positive"])
             self.logOutUser()
         }
 
@@ -273,7 +273,7 @@ private extension SettingsViewController {
     }
 
     func switchStoreWasPressed() {
-        WooAnalytics.shared.track(.settingsSelectedStoreTapped)
+        ServiceLocator.analytics.track(.settingsSelectedStoreTapped)
         if let navigationController = navigationController {
             storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
             storePickerCoordinator?.start()
@@ -281,22 +281,22 @@ private extension SettingsViewController {
     }
 
     func supportWasPressed() {
-        WooAnalytics.shared.track(.settingsContactSupportTapped)
+        ServiceLocator.analytics.track(.settingsContactSupportTapped)
         performSegue(withIdentifier: Segues.helpSupportSegue, sender: nil)
     }
 
     func privacyWasPressed() {
-        WooAnalytics.shared.track(.settingsPrivacySettingsTapped)
+        ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
         performSegue(withIdentifier: Segues.privacySegue, sender: nil)
     }
 
     func aboutWasPressed() {
-        WooAnalytics.shared.track(.settingsAboutLinkTapped)
+        ServiceLocator.analytics.track(.settingsAboutLinkTapped)
         performSegue(withIdentifier: Segues.aboutSegue, sender: nil)
     }
 
     func licensesWasPressed() {
-        WooAnalytics.shared.track(.settingsLicensesLinkTapped)
+        ServiceLocator.analytics.track(.settingsLicensesLinkTapped)
         performSegue(withIdentifier: Segues.licensesSegue, sender: nil)
     }
 
@@ -318,7 +318,7 @@ private extension SettingsViewController {
     }
 
     func weAreHiringWasPressed(url: URL) {
-        WooAnalytics.shared.track(.settingsWereHiringTapped)
+        ServiceLocator.analytics.track(.settingsWereHiringTapped)
 
         WebviewHelper.launch(url, with: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -190,10 +190,10 @@ extension DashboardStatsV3ViewController: NewOrdersDelegate {
     func didUpdateNewOrdersData(hasNewOrders: Bool) {
         if hasNewOrders {
             applyUnhideAnimation(for: newOrdersContainerView)
-            WooAnalytics.shared.track(.dashboardUnfulfilledOrdersLoaded, withProperties: ["has_unfulfilled_orders": "true"])
+            ServiceLocator.analytics.track(.dashboardUnfulfilledOrdersLoaded, withProperties: ["has_unfulfilled_orders": "true"])
         } else {
             applyHideAnimation(for: newOrdersContainerView)
-            WooAnalytics.shared.track(.dashboardUnfulfilledOrdersLoaded, withProperties: ["has_unfulfilled_orders": "false"])
+            ServiceLocator.analytics.track(.dashboardUnfulfilledOrdersLoaded, withProperties: ["has_unfulfilled_orders": "false"])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -340,7 +340,7 @@ private extension StoreStatsAndTopPerformersViewController {
                                                             if let error = error {
                                                                 DDLogError("⛔️ Dashboard (Top Performers) — Error synchronizing top earner stats: \(error)")
                                                             } else {
-                                                                WooAnalytics.shared.track(.dashboardTopPerformersLoaded,
+                                                                ServiceLocator.analytics.track(.dashboardTopPerformersLoaded,
                                                                                           withProperties: [
                                                                                             "granularity": timeRange.topEarnerStatsGranularity.rawValue
                                                                     ])
@@ -392,7 +392,7 @@ private extension StoreStatsAndTopPerformersViewController {
             return
         }
 
-        WooAnalytics.shared.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
+        ServiceLocator.analytics.track(.dashboardMainStatsLoaded, withProperties: ["granularity": granularity.rawValue])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -476,7 +476,7 @@ private extension StoreStatsV4PeriodViewController {
             isInitialLoad = false
             return
         }
-        WooAnalytics.shared.track(.dashboardMainStatsDate, withProperties: ["range": granularity.rawValue])
+        ServiceLocator.analytics.track(.dashboardMainStatsDate, withProperties: ["range": granularity.rawValue])
         isInitialLoad = false
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -136,11 +136,11 @@ private extension MainTabBarController {
     func trackTabSelected(newTab: WooTab) {
         switch newTab {
         case .myStore:
-            WooAnalytics.shared.track(.dashboardSelected)
+            ServiceLocator.analytics.track(.dashboardSelected)
         case .orders:
-            WooAnalytics.shared.track(.ordersSelected)
+            ServiceLocator.analytics.track(.ordersSelected)
         case .reviews:
-            WooAnalytics.shared.track(.notificationsSelected)
+            ServiceLocator.analytics.track(.notificationsSelected)
         }
     }
 
@@ -149,11 +149,11 @@ private extension MainTabBarController {
     func trackTabReselected(tab: WooTab) {
         switch tab {
         case .myStore:
-            WooAnalytics.shared.track(.dashboardReselected)
+            ServiceLocator.analytics.track(.dashboardReselected)
         case .orders:
-            WooAnalytics.shared.track(.ordersReselected)
+            ServiceLocator.analytics.track(.ordersReselected)
         case .reviews:
-            WooAnalytics.shared.track(.notificationsReselected)
+            ServiceLocator.analytics.track(.notificationsReselected)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -142,7 +142,7 @@ private extension NotificationDetailsViewController {
     /// Refresh Control's Callback.
     ///
     @IBAction func pullToRefresh(sender: UIRefreshControl) {
-        WooAnalytics.shared.track(.notificationsListPulledToRefresh)
+        ServiceLocator.analytics.track(.notificationsListPulledToRefresh)
 
         synchronizeNotification(noteId: note.noteId) {
             sender.endRefreshing()
@@ -343,26 +343,26 @@ private extension NotificationDetailsViewController {
             let siteID = commentBlock.meta.identifier(forKey: .site) {
 
             commentCell.onSpam = { [weak self] in
-                WooAnalytics.shared.track(.notificationReviewSpamTapped)
-                WooAnalytics.shared.track(.notificationReviewAction, withProperties: ["type": CommentStatus.spam.rawValue])
+                ServiceLocator.analytics.track(.notificationReviewSpamTapped)
+                ServiceLocator.analytics.track(.notificationReviewAction, withProperties: ["type": CommentStatus.spam.rawValue])
                 self?.moderateComment(siteID: siteID, commentID: commentID, doneStatus: .spam, undoStatus: .unspam)
             }
 
             commentCell.onTrash = { [weak self] in
-                WooAnalytics.shared.track(.notificationReviewTrashTapped)
-                WooAnalytics.shared.track(.notificationReviewAction, withProperties: ["type": CommentStatus.trash.rawValue])
+                ServiceLocator.analytics.track(.notificationReviewTrashTapped)
+                ServiceLocator.analytics.track(.notificationReviewAction, withProperties: ["type": CommentStatus.trash.rawValue])
                 self?.moderateComment(siteID: siteID, commentID: commentID, doneStatus: .trash, undoStatus: .untrash)
             }
 
             commentCell.onApprove = { [weak self] in
-                WooAnalytics.shared.track(.notificationReviewApprovedTapped)
-                WooAnalytics.shared.track(.notificationReviewAction, withProperties: ["type": CommentStatus.approved.rawValue])
+                ServiceLocator.analytics.track(.notificationReviewApprovedTapped)
+                ServiceLocator.analytics.track(.notificationReviewAction, withProperties: ["type": CommentStatus.approved.rawValue])
                 self?.moderateComment(siteID: siteID, commentID: commentID, doneStatus: .approved, undoStatus: .unapproved)
             }
 
             commentCell.onUnapprove = { [weak self] in
-                WooAnalytics.shared.track(.notificationReviewApprovedTapped)
-                WooAnalytics.shared.track(.notificationReviewAction, withProperties: ["type": CommentStatus.unapproved.rawValue])
+                ServiceLocator.analytics.track(.notificationReviewApprovedTapped)
+                ServiceLocator.analytics.track(.notificationReviewAction, withProperties: ["type": CommentStatus.unapproved.rawValue])
                 self?.moderateComment(siteID: siteID, commentID: commentID, doneStatus: .unapproved, undoStatus: .approved)
             }
         }
@@ -379,12 +379,12 @@ private extension NotificationDetailsViewController {
     func moderateComment(siteID: Int, commentID: Int, doneStatus: CommentStatus, undoStatus: CommentStatus) {
         guard let undo = moderateCommentAction(siteID: siteID, commentID: commentID, status: undoStatus, onCompletion: { (error) in
             guard let error = error else {
-                WooAnalytics.shared.track(.notificationReviewActionSuccess)
+                ServiceLocator.analytics.track(.notificationReviewActionSuccess)
                 return
             }
 
             DDLogError("⛔️ Comment (UNDO) moderation failure for ID: \(commentID) attempting \(doneStatus.description) status. Error: \(error)")
-            WooAnalytics.shared.track(.notificationReviewActionFailed, withError: error)
+            ServiceLocator.analytics.track(.notificationReviewActionFailed, withError: error)
             NotificationDetailsViewController.displayModerationErrorNotice(failedStatus: undoStatus)
         }) else {
             return
@@ -392,16 +392,16 @@ private extension NotificationDetailsViewController {
 
         guard let done = moderateCommentAction(siteID: siteID, commentID: commentID, status: doneStatus, onCompletion: { (error) in
             guard let error = error else {
-                WooAnalytics.shared.track(.notificationReviewActionSuccess)
+                ServiceLocator.analytics.track(.notificationReviewActionSuccess)
                 NotificationDetailsViewController.displayModerationCompleteNotice(newStatus: doneStatus, onUndoAction: {
-                    WooAnalytics.shared.track(.notificationReviewActionUndo)
+                    ServiceLocator.analytics.track(.notificationReviewActionUndo)
                     StoresManager.shared.dispatch(undo)
                 })
                 return
             }
 
             DDLogError("⛔️ Comment moderation failure for ID: \(commentID) attempting \(doneStatus.description) status. Error: \(error)")
-            WooAnalytics.shared.track(.notificationReviewActionFailed, withError: error)
+            ServiceLocator.analytics.track(.notificationReviewActionFailed, withError: error)
             NotificationDetailsViewController.displayModerationErrorNotice(failedStatus: doneStatus)
         }) else {
             return

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -229,14 +229,14 @@ private extension NotificationsViewController {
 private extension NotificationsViewController {
 
     @IBAction func pullToRefresh(sender: UIRefreshControl) {
-        WooAnalytics.shared.track(.notificationsListPulledToRefresh)
+        ServiceLocator.analytics.track(.notificationsListPulledToRefresh)
         synchronizeNotifications {
             sender.endRefreshing()
         }
     }
 
     @IBAction func markAllAsRead() {
-        WooAnalytics.shared.track(.notificationsListReadAllTapped)
+        ServiceLocator.analytics.track(.notificationsListReadAllTapped)
         if unreadNotes.isEmpty {
             DDLogVerbose("# Every single notification is already marked as Read!")
             return
@@ -319,7 +319,7 @@ private extension NotificationsViewController {
             if let error = error {
                 DDLogError("⛔️ Error synchronizing notifications: \(error)")
             } else {
-                WooAnalytics.shared.track(.notificationListLoaded)
+                ServiceLocator.analytics.track(.notificationListLoaded)
             }
 
             self.refreshResultsPredicate()
@@ -338,7 +338,7 @@ private extension NotificationsViewController {
     func displayRatingPrompt() {
         defer {
             if let wooEvent = WooAnalyticsStat.valueOf(stat: .appReviewsRatedApp) {
-                WooAnalytics.shared.track(wooEvent)
+                ServiceLocator.analytics.track(wooEvent)
             }
         }
 
@@ -475,7 +475,7 @@ extension NotificationsViewController {
             presentNotificationDetails(for: note)
         }
 
-        WooAnalytics.shared.track(.notificationOpened, withProperties: [ "type": note.kind.rawValue,
+        ServiceLocator.analytics.track(.notificationOpened, withProperties: [ "type": note.kind.rawValue,
                                                                          "already_read": note.read ])
 
         markAsReadIfNeeded(note: note)
@@ -597,7 +597,7 @@ private extension NotificationsViewController {
                 return
             }
 
-            WooAnalytics.shared.track(.notificationShareStoreButtonTapped)
+            ServiceLocator.analytics.track(.notificationShareStoreButtonTapped)
             SharingHelper.shareURL(url: url, title: site.name, from: overlayView.actionButtonView, in: self)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -185,16 +185,16 @@ private extension FulfillViewController {
         let done = updateOrderAction(siteID: order.siteID, orderID: orderID, statusKey: doneStatus)
         let undo = updateOrderAction(siteID: order.siteID, orderID: orderID, statusKey: undoStatus)
 
-        WooAnalytics.shared.track(.orderFulfillmentCompleteButtonTapped)
-        WooAnalytics.shared.track(.orderStatusChange, withProperties: ["id": order.orderID,
+        ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
+        ServiceLocator.analytics.track(.orderStatusChange, withProperties: ["id": order.orderID,
                                                                        "from": order.statusKey,
                                                                        "to": OrderStatusEnum.completed.rawValue])
         StoresManager.shared.dispatch(done)
 
         displayOrderCompleteNotice {
-            WooAnalytics.shared.track(.orderMarkedCompleteUndoButtonTapped)
-            WooAnalytics.shared.track(.orderStatusChangeUndo, withProperties: ["id": orderID])
-            WooAnalytics.shared.track(.orderStatusChange, withProperties: ["id": orderID,
+            ServiceLocator.analytics.track(.orderMarkedCompleteUndoButtonTapped)
+            ServiceLocator.analytics.track(.orderStatusChangeUndo, withProperties: ["id": orderID])
+            ServiceLocator.analytics.track(.orderStatusChange, withProperties: ["id": orderID,
                                                                            "from": doneStatus,
                                                                            "to": undoStatus])
             StoresManager.shared.dispatch(undo)
@@ -210,11 +210,11 @@ private extension FulfillViewController {
         return OrderAction.updateOrder(siteID: siteID, orderID: orderID, statusKey: statusKey, onCompletion: { error in
             guard let error = error else {
                 NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
-                WooAnalytics.shared.track(.orderStatusChangeSuccess)
+                ServiceLocator.analytics.track(.orderStatusChangeSuccess)
                 return
             }
 
-            WooAnalytics.shared.track(.orderStatusChangeFailed, withError: error)
+            ServiceLocator.analytics.track(.orderStatusChangeFailed, withError: error)
             DDLogError("⛔️ Order Update Failure: [\(orderID).status = \(statusKey)]. Error: \(error)")
 
             self.displayErrorNotice(orderID: orderID)
@@ -432,7 +432,7 @@ extension FulfillViewController: UITableViewDelegate {
         switch sections[indexPath.section].rows[indexPath.row] {
 
         case .trackingAdd:
-            WooAnalytics.shared.track(.orderFulfillmentAddTrackingButtonTapped)
+            ServiceLocator.analytics.track(.orderFulfillmentAddTrackingButtonTapped)
 
             let viewModel = AddTrackingViewModel(order: order)
             let addTracking = ManualTrackingViewController(viewModel: viewModel)
@@ -466,7 +466,7 @@ private extension FulfillViewController {
         actionSheet.view.tintColor = StyleManager.wooCommerceBrandColor
         actionSheet.addCancelActionWithTitle(DeleteAction.cancel)
         actionSheet.addDestructiveActionWithTitle(DeleteAction.delete) { [weak self] _ in
-            WooAnalytics.shared.track(.orderFulfillmentDeleteTrackingButtonTapped)
+            ServiceLocator.analytics.track(.orderFulfillmentDeleteTrackingButtonTapped)
             self?.deleteTracking(shipmentTracking)
         }
 
@@ -489,7 +489,7 @@ private extension FulfillViewController {
         let statusKey = order.statusKey
         let providerName = tracking.trackingProvider ?? ""
 
-        WooAnalytics.shared.track(.orderTrackingDelete, withProperties: ["id": orderID,
+        ServiceLocator.analytics.track(.orderTrackingDelete, withProperties: ["id": orderID,
                                                                          "status": statusKey,
                                                                          "carrier": providerName,
                                                                          "source": "order_fulfill"])
@@ -500,13 +500,13 @@ private extension FulfillViewController {
                                                                     if let error = error {
                                                                         DDLogError("⛔️ Delete Tracking Failure: orderID \(orderID). Error: \(error)")
 
-                                                                        WooAnalytics.shared.track(.orderTrackingDeleteFailed,
+                                                                        ServiceLocator.analytics.track(.orderTrackingDeleteFailed,
                                                                                                   withError: error)
                                                                         self?.displayDeleteErrorNotice(orderID: orderID, tracking: tracking)
                                                                         return
                                                                     }
 
-                                                                    WooAnalytics.shared.track(.orderTrackingDeleteSuccess)
+                                                                    ServiceLocator.analytics.track(.orderTrackingDeleteSuccess)
                                                                     self?.syncTrackingsHiddingAddButtonIfNecessary()
         }
 
@@ -548,7 +548,7 @@ private extension FulfillViewController {
                                                                             return
                                                                         }
 
-                                                                        WooAnalytics.shared.track(.orderTrackingLoaded, withProperties: ["id": orderID])
+                                                                        ServiceLocator.analytics.track(.orderTrackingLoaded, withProperties: ["id": orderID])
 
                                                                         onCompletion?(nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -140,7 +140,7 @@ private extension ManualTrackingViewController {
     }
 
     @objc func primaryButtonTapped() {
-        WooAnalytics.shared.track(.orderShipmentTrackingAddButtonTapped)
+        ServiceLocator.analytics.track(.orderShipmentTrackingAddButtonTapped)
         viewModel.isCustom ? addCustomTracking() : addTracking()
     }
 }
@@ -398,7 +398,7 @@ private extension ManualTrackingViewController {
 //
 extension ManualTrackingViewController: ShipmentProviderListDelegate {
     func shipmentProviderList(_ list: ShipmentProvidersViewController, didSelect: Yosemite.ShipmentTrackingProvider, groupName: String) {
-        WooAnalytics.shared.track(.orderShipmentTrackingCarrierSelected,
+        ServiceLocator.analytics.track(.orderShipmentTrackingCarrierSelected,
                                   withProperties: ["option": didSelect.name])
 
         viewModel.shipmentProvider = didSelect
@@ -469,7 +469,7 @@ private extension ManualTrackingViewController {
             .yearMonthDayDateFormatter
             .string(from: viewModel.shipmentDate)
 
-        WooAnalytics.shared.track(.orderTrackingAdd, withProperties: ["id": orderID,
+        ServiceLocator.analytics.track(.orderTrackingAdd, withProperties: ["id": orderID,
                                                                       "status": statusKey,
                                                                       "carrier": providerName])
 
@@ -483,7 +483,7 @@ private extension ManualTrackingViewController {
                                                             if let error = error {
                                                                 DDLogError("⛔️ Add Tracking Failure: orderID \(orderID). Error: \(error)")
 
-                                                                WooAnalytics.shared.track(.orderTrackingAddFailed,
+                                                                ServiceLocator.analytics.track(.orderTrackingAddFailed,
                                                                                           withError: error)
 
                                                                 self?.configureForEditingTracking()
@@ -492,7 +492,7 @@ private extension ManualTrackingViewController {
                                                                 return
                                                             }
 
-                                                        WooAnalytics.shared.track(.orderTrackingAddSuccess)
+                                                        ServiceLocator.analytics.track(.orderTrackingAddSuccess)
 
                                                             self?.dismiss()
         }
@@ -517,7 +517,7 @@ private extension ManualTrackingViewController {
             .yearMonthDayDateFormatter
             .string(from: viewModel.shipmentDate)
 
-        WooAnalytics.shared.track(.orderTrackingAdd, withProperties: ["id": orderID,
+        ServiceLocator.analytics.track(.orderTrackingAdd, withProperties: ["id": orderID,
                                                                       "status": statusKey,
                                                                       "carrier": providerName])
 
@@ -530,7 +530,7 @@ private extension ManualTrackingViewController {
                                                         if let error = error {
                                                             DDLogError("⛔️ Add Tracking Failure: orderID \(orderID). Error: \(error)")
 
-                                                            WooAnalytics.shared.track(.orderTrackingAddFailed,
+                                                            ServiceLocator.analytics.track(.orderTrackingAddFailed,
                                                                                       withError: error)
 
                                                             self?.configureForEditingTracking()
@@ -539,7 +539,7 @@ private extension ManualTrackingViewController {
                                                             return
                                                         }
 
-                                                        WooAnalytics.shared.track(.orderTrackingAddSuccess)
+                                                        ServiceLocator.analytics.track(.orderTrackingAddSuccess)
 
                                                         self?.dismiss()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -51,8 +51,8 @@ class NewNoteViewController: UIViewController {
     @objc func addButtonTapped() {
         configureForCommittingNote()
 
-        WooAnalytics.shared.track(.orderNoteAddButtonTapped)
-        WooAnalytics.shared.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.order.orderID,
+        ServiceLocator.analytics.track(.orderNoteAddButtonTapped)
+        ServiceLocator.analytics.track(.orderNoteAdd, withProperties: ["parent_id": viewModel.order.orderID,
                                                                   "status": viewModel.order.statusKey,
                                                                   "type": isCustomerNote ? "customer" : "private"])
 
@@ -62,13 +62,13 @@ class NewNoteViewController: UIViewController {
                                                   note: noteText) { [weak self] (orderNote, error) in
             if let error = error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
-                WooAnalytics.shared.track(.orderNoteAddFailed, withError: error)
+                ServiceLocator.analytics.track(.orderNoteAddFailed, withError: error)
 
                 self?.displayErrorNotice()
                 self?.configureForEditingNote()
                 return
             }
-            WooAnalytics.shared.track(.orderNoteAddSuccess)
+            ServiceLocator.analytics.track(.orderNoteAddSuccess)
             self?.dismiss(animated: true, completion: nil)
         }
 
@@ -176,7 +176,7 @@ private extension NewNoteViewController {
             )
 
             let stateValue = newValue ? "on" : "off"
-            WooAnalytics.shared.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
+            ServiceLocator.analytics.track(.orderNoteEmailCustomerToggled, withProperties: ["state": stateValue])
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -204,7 +204,7 @@ private extension OrderDetailsViewController {
 extension OrderDetailsViewController {
 
     @objc func pullToRefresh() {
-        WooAnalytics.shared.track(.orderDetailPulledToRefresh)
+        ServiceLocator.analytics.track(.orderDetailPulledToRefresh)
         let group = DispatchGroup()
 
         group.enter()
@@ -284,9 +284,9 @@ private extension OrderDetailsViewController {
     func toggleBillingFooter() {
         displaysBillingDetails = !displaysBillingDetails
         if displaysBillingDetails {
-            WooAnalytics.shared.track(.orderDetailShowBillingTapped)
+            ServiceLocator.analytics.track(.orderDetailShowBillingTapped)
         } else {
-            WooAnalytics.shared.track(.orderDetailHideBillingTapped)
+            ServiceLocator.analytics.track(.orderDetailHideBillingTapped)
         }
     }
 
@@ -307,7 +307,7 @@ private extension OrderDetailsViewController {
     }
 
     func fulfillWasPressed() {
-        WooAnalytics.shared.track(.orderDetailFulfillButtonTapped)
+        ServiceLocator.analytics.track(.orderDetailFulfillButtonTapped)
         let fulfillViewController = FulfillViewController(order: viewModel.order, products: viewModel.products)
         navigationController?.pushViewController(fulfillViewController, animated: true)
     }
@@ -326,7 +326,7 @@ private extension OrderDetailsViewController {
             return
         }
 
-        WooAnalytics.shared.track(.orderDetailTrackPackageButtonTapped)
+        ServiceLocator.analytics.track(.orderDetailTrackPackageButtonTapped)
         displayWebView(url: url)
     }
 
@@ -441,7 +441,7 @@ private extension OrderDetailsViewController {
         }
 
         actionSheet.addDestructiveActionWithTitle(TrackingAction.deleteTracking) { [weak self] _ in
-            WooAnalytics.shared.track(.orderDetailTrackingDeleteButtonTapped)
+            ServiceLocator.analytics.track(.orderDetailTrackingDeleteButtonTapped)
             self?.deleteTracking(tracking)
         }
 
@@ -458,7 +458,7 @@ private extension OrderDetailsViewController {
 //
 private extension OrderDetailsViewController {
     private func displayOrderStatusList() {
-        WooAnalytics.shared.track(.orderDetailOrderStatusEditButtonTapped,
+        ServiceLocator.analytics.track(.orderDetailOrderStatusEditButtonTapped,
                                   withProperties: ["status": viewModel.order.statusKey])
         let statusList = OrderStatusListViewController(order: viewModel.order)
         let navigationController = UINavigationController(rootViewController: statusList)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
@@ -297,7 +297,7 @@ private extension OrderSearchViewController {
 
         transitionToSyncingState()
         StoresManager.shared.dispatch(action)
-        WooAnalytics.shared.track(.ordersListFilterOrSearch, withProperties: ["filter": "", "search": "\(keyword)"])
+        ServiceLocator.analytics.track(.ordersListFilterOrSearch, withProperties: ["filter": "", "search": "\(keyword)"])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
@@ -171,14 +171,14 @@ private extension OrderStatusListViewController {
         let undo = updateOrderAction(siteID: order.siteID, orderID: orderID, statusKey: undoStatus)
 
         StoresManager.shared.dispatch(done)
-        WooAnalytics.shared.track(.orderStatusChange,
+        ServiceLocator.analytics.track(.orderStatusChange,
                                   withProperties: ["id": orderID,
                                                    "from": undoStatus,
                                                    "to": newStatus])
 
         displayOrderUpdatedNotice {
             StoresManager.shared.dispatch(undo)
-            WooAnalytics.shared.track(.orderStatusChange,
+            ServiceLocator.analytics.track(.orderStatusChange,
                                       withProperties: ["id": orderID,
                                                        "from": newStatus,
                                                        "to": undoStatus])
@@ -191,11 +191,11 @@ private extension OrderStatusListViewController {
         return OrderAction.updateOrder(siteID: siteID, orderID: orderID, statusKey: statusKey, onCompletion: { error in
             guard let error = error else {
                 NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
-                WooAnalytics.shared.track(.orderStatusChangeSuccess)
+                ServiceLocator.analytics.track(.orderStatusChangeSuccess)
                 return
             }
 
-            WooAnalytics.shared.track(.orderStatusChangeFailed, withError: error)
+            ServiceLocator.analytics.track(.orderStatusChangeFailed, withError: error)
             DDLogError("⛔️ Order Update Failure: [\(orderID).status = \(statusKey)]. Error: \(error)")
 
             self.displayErrorNotice(orderID: orderID)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -328,7 +328,7 @@ extension OrdersViewController {
             return
         }
 
-        WooAnalytics.shared.track(.ordersListSearchTapped)
+        ServiceLocator.analytics.track(.ordersListSearchTapped)
         let searchViewController = OrderSearchViewController(storeID: storeID)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 
@@ -336,7 +336,7 @@ extension OrdersViewController {
     }
 
     @IBAction func displayFiltersAlert() {
-        WooAnalytics.shared.track(.ordersListFilterTapped)
+        ServiceLocator.analytics.track(.ordersListFilterTapped)
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = StyleManager.wooCommerceBrandColor
 
@@ -359,7 +359,7 @@ extension OrdersViewController {
     }
 
     @IBAction func pullToRefresh(sender: UIRefreshControl) {
-        WooAnalytics.shared.track(.ordersListPulledToRefresh)
+        ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         syncOrderStatus()
         syncingCoordinator.synchronizeFirstPage {
             sender.endRefreshing()
@@ -373,9 +373,9 @@ extension OrdersViewController {
 private extension OrdersViewController {
 
     func didChangeFilter(newFilter: OrderStatus?) {
-        WooAnalytics.shared.track(.filterOrdersOptionSelected,
+        ServiceLocator.analytics.track(.filterOrdersOptionSelected,
                                   withProperties: ["status": newFilter?.slug ?? String()])
-        WooAnalytics.shared.track(.ordersListFilterOrSearch,
+        ServiceLocator.analytics.track(.ordersListFilterOrSearch,
                                   withProperties: ["filter": newFilter?.slug ?? String(),
                                                    "search": ""])
         // Display the Filter in the Title
@@ -450,7 +450,7 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
                 DDLogError("⛔️ Error synchronizing orders: \(error)")
                 self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
             } else {
-                WooAnalytics.shared.track(.ordersListLoaded, withProperties: ["status": self.statusFilter?.slug ?? String()])
+                ServiceLocator.analytics.track(.ordersListLoaded, withProperties: ["status": self.statusFilter?.slug ?? String()])
             }
 
             self.transitionToResultsUpdatedState()
@@ -566,7 +566,7 @@ private extension OrdersViewController {
                 return
             }
 
-            WooAnalytics.shared.track(.orderShareStoreButtonTapped)
+            ServiceLocator.analytics.track(.orderShareStoreButtonTapped)
             SharingHelper.shareURL(url: url, title: site.name, from: overlayView.actionButtonView, in: self)
         }
 
@@ -602,7 +602,7 @@ private extension OrdersViewController {
     func displayRatingPrompt() {
         defer {
             if let wooEvent = WooAnalyticsStat.valueOf(stat: .appReviewsRatedApp) {
-                WooAnalytics.shared.track(wooEvent)
+                ServiceLocator.analytics.track(wooEvent)
             }
         }
 
@@ -719,7 +719,7 @@ extension OrdersViewController {
             return
         }
 
-        WooAnalytics.shared.track(.orderOpen, withProperties: ["id": viewModel.order.orderID,
+        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": viewModel.order.orderID,
                                                                "status": viewModel.order.statusKey])
         singleOrderViewController.viewModel = viewModel
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -87,7 +87,7 @@ private extension ShipmentProvidersViewController {
                                                                                     if let error = error {
                                                                                         self?.presentNotice(error)
                                                                                     }
-                                                                                    WooAnalytics.shared.track(.orderTrackingProvidersLoaded)
+                                                                                    ServiceLocator.analytics.track(.orderTrackingProvidersLoaded)
                                                                                     self?.footerSpinnerView.stopAnimating()
         }
 
@@ -335,7 +335,7 @@ private extension ShipmentProvidersViewController {
     }
 
     func addCustomProvider() {
-        WooAnalytics.shared.track(.orderShipmentTrackingCustomProviderSelected)
+        ServiceLocator.analytics.track(.orderShipmentTrackingCustomProviderSelected)
 
         let initialCustomProviderName = searchController.searchBar.text
         let addCustomTrackingViewModel = AddCustomTrackingViewModel(order: viewModel.order,

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -96,7 +96,7 @@ private extension AuthenticatedState {
     /// Executed whenever a DotcomError is received (ApplicationLayer). This allows us to have a *Master* error handling flow!
     ///
     func tunnelTimeoutWasReceived(note: Notification) {
-        WooAnalytics.shared.track(.jetpackTunnelTimeout)
+        ServiceLocator.analytics.track(.jetpackTunnelTimeout)
     }
 }
 

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -133,7 +133,7 @@ class StoresManager {
     /// Prepares for changing the selected store and remains Authenticated.
     ///
     func removeDefaultStore() {
-        WooAnalytics.shared.refreshUserData()
+        ServiceLocator.analytics.refreshUserData()
         ZendeskManager.shared.reset()
         AppDelegate.shared.pushNotesManager.unregisterForRemoteNotifications()
         AppDelegate.shared.pushNotesManager.resetBadgeCount()
@@ -146,7 +146,7 @@ class StoresManager {
         state = DeauthenticatedState()
 
         sessionManager.reset()
-        WooAnalytics.shared.refreshUserData()
+        ServiceLocator.analytics.refreshUserData()
         ZendeskManager.shared.reset()
         AppDelegate.shared.storageManager.reset()
 
@@ -200,7 +200,7 @@ private extension StoresManager {
         let action = AccountAction.synchronizeAccount { [weak self] (account, error) in
             if let `self` = self, let account = account, self.isAuthenticated {
                 self.sessionManager.defaultAccount = account
-                WooAnalytics.shared.refreshUserData()
+                ServiceLocator.analytics.refreshUserData()
             }
 
             onCompletion(error)
@@ -222,7 +222,7 @@ private extension StoresManager {
                 let accountSettings = accountSettings,
                 self.isAuthenticated {
                 // Save the user's preference
-                WooAnalytics.shared.setUserHasOptedOut(accountSettings.tracksOptOut)
+                ServiceLocator.analytics.setUserHasOptedOut(accountSettings.tracksOptOut)
             }
 
             onCompletion(error)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -328,7 +328,6 @@
 		D8149F542251CFE60006A245 /* EditableOrderTrackingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D8149F522251CFE50006A245 /* EditableOrderTrackingTableViewCell.xib */; };
 		D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8149F552251EE300006A245 /* UITextField+Helpers.swift */; };
 		D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */; };
-		D8174F0B22EB62B60024E762 /* MockupAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */; };
 		D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817585D22BB5E8700289CFE /* OrderEmailComposer.swift */; };
 		D817586022BB614A00289CFE /* OrderMessageComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817585F22BB614A00289CFE /* OrderMessageComposer.swift */; };
 		D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817586122BB64C300289CFE /* OrderDetailsNotices.swift */; };
@@ -365,6 +364,7 @@
 		D8736B5722EF53A100A14A29 /* OrdersBadgeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5622EF53A100A14A29 /* OrdersBadgeController.swift */; };
 		D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */; };
 		D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */; };
+		D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -910,6 +910,7 @@
 		746791642108D853007CF1DC /* Mockups */ = {
 			isa = PBXGroup;
 			children = (
+				746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */,
 				B555531021B57E6F00449E71 /* MockupApplicationAdapter.swift */,
 				B53A569C21123EEB000776C9 /* MockupStorage.swift */,
 				B53A56A12112470C000776C9 /* MockupStorage+Sample.swift */,
@@ -924,7 +925,6 @@
 		747AA0872107CE270047A89B /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
-				746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */,
 				CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */,
 				74213449210A323C00C13890 /* WooAnalyticsStat.swift */,
 				747AA0882107CEC60047A89B /* AnalyticsProvider.swift */,
@@ -2099,7 +2099,6 @@
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
-				D8174F0B22EB62B60024E762 /* MockupAnalyticsProvider.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
@@ -2351,6 +2350,7 @@
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
+				D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */; };
 		D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */; };
 		D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */; };
+		D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -786,6 +787,7 @@
 		D8736B5622EF53A100A14A29 /* OrdersBadgeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersBadgeController.swift; sourceTree = "<group>"; };
 		D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
+		D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocatorTests.swift; sourceTree = "<group>"; };
 		D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditableOrderTrackingTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/EditableOrderTrackingTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
@@ -992,6 +994,7 @@
 		B53A569521123D27000776C9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */,
 				D8736B5022EB69E300A14A29 /* OrderDetailsViewModelTests.swift */,
 				D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */,
 				D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */,
@@ -2317,6 +2320,7 @@
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,
 				B5980A6721AC91AA00EBF596 /* BundleWooTests.swift in Sources */,
+				D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */,
 				CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */,
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -373,6 +373,8 @@
 		D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */; };
 		D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
+		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
+		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
 		D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F82AC422AF903700B67E4B /* IconsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -792,6 +794,8 @@
 		D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderPaymentDetailsViewModelTests.swift; path = WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
+		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
+		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		D8F82AC422AF903700B67E4B /* IconsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = IconsTests.swift; path = WooCommerceTests/Extensions/IconsTests.swift; sourceTree = SOURCE_ROOT; };
 		D8FBFF1622D4CC2F006E3336 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; name = docs; path = ../docs; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1159,6 +1163,7 @@
 		B56DB3F12049C0B800D4AA8E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				D8D15F81230A178100D48B3F /* ServiceLocator */,
 				747AA0872107CE270047A89B /* Analytics */,
 				B55D4C0420B6026700D7A50F /* Authentication */,
 				CE1CCB4C20572444000EE3AC /* Extensions */,
@@ -1695,6 +1700,15 @@
 			path = OrderDetailsViewModel;
 			sourceTree = "<group>";
 		};
+		D8D15F81230A178100D48B3F /* ServiceLocator */ = {
+			isa = PBXGroup;
+			children = (
+				D8D15F82230A17A000D48B3F /* ServiceLocator.swift */,
+				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
+			);
+			path = ServiceLocator;
+			sourceTree = "<group>";
+		};
 		F4B77A83B2A3D94EA331691B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -2127,6 +2141,7 @@
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
+				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
 				D843D5D322485009001BFA55 /* ShipmentProvidersViewController.swift in Sources */,
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
@@ -2252,6 +2267,7 @@
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,
+				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B57B678E21078C5400AF8905 /* OrderItemViewModel.swift in Sources */,
 				D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockupAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupAnalyticsProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import WooCommerce
 
 public class MockupAnalyticsProvider: AnalyticsProvider {
     var receivedEvents = [String]()

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import WooCommerce
+
+final class ServiceLocatorTests: XCTestCase {
+
+    func testServiceLocatorProvidesAnalytics() {
+        XCTAssertNotNil(ServiceLocator.analytics)
+    }
+
+    func testAnalyticsDefaultsToWooAnalytics() {
+        let analytics = ServiceLocator.analytics
+
+        XCTAssertTrue(analytics is WooAnalytics)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -9,6 +9,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
     override func setUp() {
         order = MockOrders().sampleOrder()
         viewModel = OrderDetailsViewModel(order: order)
+        let analytics = WooAnalytics(analyticsProvider: MockupAnalyticsProvider())
+        ServiceLocator.setAnalytics(analytics)
         super.setUp()
     }
 
@@ -29,7 +31,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         viewModel.deleteTracking(mockShipmentTracking) { _ in }
 
-        let analytics = WooAnalytics.shared.analyticsProvider as! MockupAnalyticsProvider
+        let analytics = ServiceLocator.analytics.analyticsProvider as! MockupAnalyticsProvider
         let receivedEvents = analytics.receivedEvents
 
         XCTAssert(receivedEvents.contains(WooAnalyticsStat.orderTrackingDelete.rawValue))


### PR DESCRIPTION
Fixes #1197 

As discussed in p99K0U-1BK-p2 we are going to start fetching the global dependencies from a [Service Locator](https://en.wikipedia.org/wiki/Service_locator_pattern). 

The refactoring will be split in several PRs., this is the first one. The scope for this first PR is:
- [ ] Add the Service Locator
- [ ] Provide access to WooAnalytics through the service locator. WooAnalytics is not a singleton anymore
- [ ] Integrate the change in call sites to WooAnalytics

## Changes
- Add Service Locator and tests
- Add an interface to abstract WooAnalytics, called Analytics
- Move `MockupAnalyticsProvider` from the main target back to the testing target, undoing the change in PR #1130 

## Testing
- Checkout the branch, build the project and run the tests.
- Make sure that tests pass
- Make sure that Tracks events are still being submitted. It wouldn't hurt to check in the actual Tracks that the events are being received. 