### PR TITLE
Service Locator mark II. Stores

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -55,7 +55,7 @@ public extension TracksProvider {
             // To be safe, nil out the anonymousUserID guid so a fresh one is regenerated
             UserDefaults.standard[.defaultAnonymousID] = nil
             UserDefaults.standard[.analyticsUsername] = nil
-            tracksService.switchToAnonymousUser(withAnonymousID: StoresManager.shared.sessionManager.anonymousUserID)
+            tracksService.switchToAnonymousUser(withAnonymousID: ServiceLocator.stores.sessionManager.anonymousUserID)
             return
         }
 
@@ -69,7 +69,7 @@ public extension TracksProvider {
 private extension TracksProvider {
     func switchTracksUsersIfNeeded() {
         let currentAnalyticsUsername = UserDefaults.standard[.analyticsUsername] as? String ?? ""
-        if StoresManager.shared.isAuthenticated, let account = StoresManager.shared.sessionManager.defaultAccount {
+        if ServiceLocator.stores.isAuthenticated, let account = ServiceLocator.stores.sessionManager.defaultAccount {
             if currentAnalyticsUsername.isEmpty {
                 // No previous username logged
                 UserDefaults.standard[.analyticsUsername] = account.username
@@ -79,12 +79,12 @@ private extension TracksProvider {
                 tracksService.switchToAuthenticatedUser(withUsername: account.username, userID: String(account.userID), skipAliasEventCreation: true)
             } else {
                 // Username changed for some reason - switch back to anonymous first
-                tracksService.switchToAnonymousUser(withAnonymousID: StoresManager.shared.sessionManager.anonymousUserID)
+                tracksService.switchToAnonymousUser(withAnonymousID: ServiceLocator.stores.sessionManager.anonymousUserID)
                 tracksService.switchToAuthenticatedUser(withUsername: account.username, userID: String(account.userID), skipAliasEventCreation: false)
             }
         } else {
             UserDefaults.standard[.analyticsUsername] = nil
-            tracksService.switchToAnonymousUser(withAnonymousID: StoresManager.shared.sessionManager.anonymousUserID)
+            tracksService.switchToAnonymousUser(withAnonymousID: ServiceLocator.stores.sessionManager.anonymousUserID)
         }
     }
 

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -186,12 +186,12 @@ private extension WooAnalytics {
     /// This function appends any additional properties to the provided properties dict if needed.
     ///
     func updatePropertiesIfNeeded(for stat: WooAnalyticsStat, properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
-        guard stat.shouldSendSiteProperties, StoresManager.shared.isAuthenticated else {
+        guard stat.shouldSendSiteProperties, ServiceLocator.stores.isAuthenticated else {
             return properties
         }
 
         var updatedProperties = properties ?? [:]
-        let site = StoresManager.shared.sessionManager.defaultSite
+        let site = ServiceLocator.stores.sessionManager.defaultSite
         updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
         updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressStore
         return updatedProperties

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -102,7 +102,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        guard let defaultStoreID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
 
@@ -266,7 +266,7 @@ private extension AppDelegate {
     /// Push Notifications: Authorization + Registration!
     ///
     func setupPushNotificationsManagerIfPossible() {
-        guard StoresManager.shared.isAuthenticated, StoresManager.shared.needsDefaultStore == false else {
+        guard ServiceLocator.stores.isAuthenticated, ServiceLocator.stores.needsDefaultStore == false else {
             return
         }
 
@@ -321,7 +321,7 @@ extension AppDelegate {
     /// Whenever there is no default WordPress.com Account, let's display the Authentication UI.
     ///
     func displayAuthenticatorIfNeeded() {
-        guard StoresManager.shared.isAuthenticated == false else {
+        guard ServiceLocator.stores.isAuthenticated == false else {
             return
         }
 
@@ -341,7 +341,7 @@ extension AppDelegate {
     /// Whenever the app is authenticated but there is no Default StoreID: Let's display the Store Picker.
     ///
     func displayStorePickerIfNeeded() {
-        guard StoresManager.shared.isAuthenticated, StoresManager.shared.needsDefaultStore else {
+        guard ServiceLocator.stores.isAuthenticated, ServiceLocator.stores.needsDefaultStore else {
             return
         }
         guard let tabBar = AppDelegate.shared.tabBarController,
@@ -358,11 +358,11 @@ extension AppDelegate {
     /// Whenever we're in an Authenticated state, let's Sync all of the WC-Y entities.
     ///
     func synchronizeEntitiesIfPossible() {
-        guard StoresManager.shared.isAuthenticated else {
+        guard ServiceLocator.stores.isAuthenticated else {
             return
         }
 
-        StoresManager.shared.synchronizeEntities()
+        ServiceLocator.stores.synchronizeEntities(onCompletion: nil)
     }
 
     /// Runs whenever the Authentication Flow is completed successfully.

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -203,18 +203,18 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             fatalError("Self Hosted sites are not supported. Please review the Authenticator settings!")
         }
 
-        StoresManager.shared.authenticate(credentials: .init(authToken: wpcom.authToken))
+        ServiceLocator.stores.authenticate(credentials: .init(authToken: wpcom.authToken))
         let action = AccountAction.synchronizeAccount { (account, error) in
             if let account = account {
                 let credentials = Credentials(username: account.username, authToken: wpcom.authToken, siteAddress: wpcom.siteURL)
-                StoresManager.shared
+                ServiceLocator.stores
                     .authenticate(credentials: credentials)
                     .synchronizeEntities(onCompletion: onCompletion)
             } else {
-                StoresManager.shared.synchronizeEntities(onCompletion: onCompletion)
+                ServiceLocator.stores.synchronizeEntities(onCompletion: onCompletion)
             }
         }
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Tracks a given Analytics Event.

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -46,7 +46,7 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
             onCompletion()
             return
         }
-        guard storeID != StoresManager.shared.sessionManager.defaultStoreID else {
+        guard storeID != ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion()
             return
         }
@@ -55,7 +55,7 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
     }
 
     func didSelectStore(with storeID: Int) {
-        guard storeID != StoresManager.shared.sessionManager.defaultStoreID else {
+        guard storeID != ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
 
@@ -84,7 +84,7 @@ private extension StorePickerCoordinator {
         guard selectedConfiguration == .switchingStores else {
             return
         }
-        guard let newStoreName = StoresManager.shared.sessionManager.defaultSite?.name else {
+        guard let newStoreName = ServiceLocator.stores.sessionManager.defaultSite?.name else {
             return
         }
 
@@ -97,7 +97,7 @@ private extension StorePickerCoordinator {
     }
 
     func logOutOfCurrentStore(onCompletion: @escaping () -> Void) {
-        StoresManager.shared.removeDefaultStore()
+        ServiceLocator.stores.removeDefaultStore()
 
         // Note: We are not deleting products here because products from multiple sites
         // can exist in Storage simultaneously. Eventually we should make orders and stats
@@ -109,19 +109,19 @@ private extension StorePickerCoordinator {
         let statsAction = StatsAction.resetStoredStats {
             group.leave()
         }
-        StoresManager.shared.dispatch(statsAction)
+        ServiceLocator.stores.dispatch(statsAction)
 
         group.enter()
         let statsV4Action = StatsActionV4.resetStoredStats {
             group.leave()
         }
-        StoresManager.shared.dispatch(statsV4Action)
+        ServiceLocator.stores.dispatch(statsV4Action)
 
         group.enter()
         let orderAction = OrderAction.resetStoredOrders {
             group.leave()
         }
-        StoresManager.shared.dispatch(orderAction)
+        ServiceLocator.stores.dispatch(orderAction)
 
         group.notify(queue: .main) {
             onCompletion()
@@ -129,13 +129,13 @@ private extension StorePickerCoordinator {
     }
 
     func finalizeStoreSelection(_ storeID: Int) {
-        StoresManager.shared.updateDefaultStore(storeID: storeID)
+        ServiceLocator.stores.updateDefaultStore(storeID: storeID)
 
         // We need to call refreshUserData() here because the user selected
         // their default store and tracks should to know about it.
         ServiceLocator.analytics.refreshUserData()
         ServiceLocator.analytics.track(.sitePickerContinueTapped,
-                                  withProperties: ["selected_store_id": StoresManager.shared.sessionManager.defaultStoreID ?? String()])
+                                  withProperties: ["selected_store_id": ServiceLocator.stores.sessionManager.defaultStoreID ?? String()])
 
         AppDelegate.shared.authenticatorWasDismissed()
         if selectedConfiguration == .login {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -196,7 +196,7 @@ private extension StorePickerViewController {
     }
 
     func setupAccountHeader() {
-        guard let defaultAccount = StoresManager.shared.sessionManager.defaultAccount else {
+        guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
             return
         }
 
@@ -262,7 +262,7 @@ extension StorePickerViewController {
     /// Runs whenever the application is about to terminate.
     ///
     @objc func applicationTerminating() {
-        guard StoresManager.shared.isAuthenticated else {
+        guard ServiceLocator.stores.isAuthenticated else {
             return
         }
 
@@ -270,7 +270,7 @@ extension StorePickerViewController {
         // was never selected so force the user to go through the auth flow again.
         //
         // For more deets, see: https://github.com/woocommerce/woocommerce-ios/issues/466
-        StoresManager.shared.deauthenticate()
+        ServiceLocator.stores.deauthenticate()
     }
 }
 
@@ -290,14 +290,14 @@ private extension StorePickerViewController {
         }
 
         // If a site address was passed in credentials, select it
-        if let siteAddress = StoresManager.shared.sessionManager.defaultCredentials?.siteAddress,
+        if let siteAddress = ServiceLocator.stores.sessionManager.defaultCredentials?.siteAddress,
             let site = sites.filter({ $0.url == siteAddress }).first {
             currentlySelectedSite = site
             return
         }
 
         // If there is a defaultSite already set, select it
-        if let site = StoresManager.shared.sessionManager.defaultSite {
+        if let site = ServiceLocator.stores.sessionManager.defaultSite {
             currentlySelectedSite = site
             return
         }
@@ -362,11 +362,11 @@ private extension StorePickerViewController {
     /// Re-initializes the Login Flow, forcing a logout. This may be required if the WordPress.com Account has no Stores available.
     ///
     func restartAuthentication() {
-        guard StoresManager.shared.needsDefaultStore, let navigationController = navigationController else {
+        guard ServiceLocator.stores.needsDefaultStore, let navigationController = navigationController else {
             return
         }
 
-        StoresManager.shared.deauthenticate()
+        ServiceLocator.stores.deauthenticate()
 
         let loginViewController = AppDelegate.shared.authenticationManager.loginForWordPressDotCom()
         navigationController.setViewControllers([loginViewController], animated: true)

--- a/WooCommerce/Classes/Notifications/PushNotificationsConfiguration.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsConfiguration.swift
@@ -21,7 +21,7 @@ struct PushNotificationsConfiguration {
 
     /// Reference to the StoresManager that should receive any Yosemite Actions.
     ///
-    var storesManager: StoresManager {
+    var storesManager: Stores {
         return storesManagerClosure()
     }
 
@@ -47,7 +47,7 @@ struct PushNotificationsConfiguration {
 
     /// StoresManager Closure: Returns a reference to StoresManager
     ///
-    private let storesManagerClosure: () -> StoresManager
+    private let storesManagerClosure: () -> Stores
 
     /// SupportManagerAdapter Closure: Returns a reference to the SupportManagerAdapter
     ///
@@ -64,7 +64,7 @@ struct PushNotificationsConfiguration {
     ///
     init(application: @autoclosure @escaping () -> ApplicationAdapter,
          defaults: @autoclosure @escaping () -> UserDefaults,
-         storesManager: @autoclosure @escaping () -> StoresManager,
+         storesManager: @autoclosure @escaping () -> Stores,
          supportManager: @autoclosure @escaping () -> SupportManagerAdapter,
          userNotificationsCenter: @autoclosure @escaping () -> UserNotificationsCenterAdapter) {
 
@@ -86,7 +86,7 @@ extension PushNotificationsConfiguration {
     static var `default`: PushNotificationsConfiguration {
         return PushNotificationsConfiguration(application: UIApplication.shared,
                                               defaults: .standard,
-                                              storesManager: .shared,
+                                              storesManager: ServiceLocator.stores,
                                               supportManager: ZendeskManager.shared,
                                               userNotificationsCenter: UNUserNotificationCenter.current())
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsConfiguration.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsConfiguration.swift
@@ -21,7 +21,7 @@ struct PushNotificationsConfiguration {
 
     /// Reference to the StoresManager that should receive any Yosemite Actions.
     ///
-    var storesManager: Stores {
+    var storesManager: StoresManager {
         return storesManagerClosure()
     }
 
@@ -47,7 +47,7 @@ struct PushNotificationsConfiguration {
 
     /// StoresManager Closure: Returns a reference to StoresManager
     ///
-    private let storesManagerClosure: () -> Stores
+    private let storesManagerClosure: () -> StoresManager
 
     /// SupportManagerAdapter Closure: Returns a reference to the SupportManagerAdapter
     ///
@@ -64,7 +64,7 @@ struct PushNotificationsConfiguration {
     ///
     init(application: @autoclosure @escaping () -> ApplicationAdapter,
          defaults: @autoclosure @escaping () -> UserDefaults,
-         storesManager: @autoclosure @escaping () -> Stores,
+         storesManager: @autoclosure @escaping () -> StoresManager,
          supportManager: @autoclosure @escaping () -> SupportManagerAdapter,
          userNotificationsCenter: @autoclosure @escaping () -> UserNotificationsCenterAdapter) {
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 final class ServiceLocator {
     private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
-    private static var _stores: Stores = StoresManager(sessionManager: .standard)
+    private static var _stores: StoresManager = DefaultStoresManager(sessionManager: .standard)
 
     /// Provides the access point to the analytics.
     /// - Returns: An implementation of the Analytics protocol. It defaults to WooAnalytics
@@ -15,7 +15,7 @@ final class ServiceLocator {
 
     /// Provides the access point to the stores.
     /// - Returns: An implementation of the Stores protocol. It defaults to StoresManager
-    static var stores: Stores {
+    static var stores: StoresManager {
         return _stores
     }
 }
@@ -33,7 +33,7 @@ extension ServiceLocator {
         _analytics = mock
     }
 
-    static func setStores(_ mock: Stores) {
+    static func setStores(_ mock: StoresManager) {
         guard isRunningTests() else {
             return
         }

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -5,11 +5,18 @@ import Foundation
 ///
 final class ServiceLocator {
     private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
+    private static var _stores: Stores = StoresManager(sessionManager: .standard)
 
     /// Provides the access point to the analytics.
     /// - Returns: An iumplementation of the Analytics protocol. It defaults to WooAnalytics
     static var analytics: Analytics {
         return _analytics
+    }
+
+    /// Provides the access point to the stores.
+    /// - Returns: An iumplementation of the Stores protocol. It defaults to StoresManager
+    static var stores: Stores {
+        return _stores
     }
 }
 
@@ -20,5 +27,9 @@ final class ServiceLocator {
 extension ServiceLocator {
     static func setAnalytics(_ mock: Analytics) {
         _analytics = mock
+    }
+
+    static func setStores(_ mock: Stores) {
+        _stores = mock
     }
 }

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -14,7 +14,7 @@ final class ServiceLocator {
     }
 
     /// Provides the access point to the stores.
-    /// - Returns: An iumplementation of the Stores protocol. It defaults to StoresManager
+    /// - Returns: An implementation of the Stores protocol. It defaults to StoresManager
     static var stores: Stores {
         return _stores
     }
@@ -34,6 +34,10 @@ extension ServiceLocator {
     }
 
     static func setStores(_ mock: Stores) {
+        guard isRunningTests() else {
+            return
+        }
+
         _stores = mock
     }
 }

--- a/WooCommerce/Classes/ServiceLocator/Stores.swift
+++ b/WooCommerce/Classes/ServiceLocator/Stores.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Yosemite
+
+/// Abstreacts the Stores coordination
+///
+protocol Stores {
+
+    /// Forwards the Action to the current State.
+    ///
+    func dispatch(_ action: Action)
+
+    /// Forwards the Actions to the current State.
+    ///
+    func dispatch(_ actions: [Action])
+
+    /// Prepares for changing the selected store and remains Authenticated.
+    ///
+    func removeDefaultStore()
+
+    /// Switches the internal state to Authenticated.
+    ///
+    @discardableResult
+    func authenticate(credentials: Credentials) -> Stores
+
+    /// Switches the state to a Deauthenticated one.
+    ///
+    @discardableResult
+    func deauthenticate() -> Stores
+
+    /// Synchronizes all of the Session's Entities.
+    ///
+    @discardableResult
+    func synchronizeEntities(onCompletion: (() -> Void)?) -> Stores
+
+    /// Updates the Default Store as specified.
+    ///
+    func updateDefaultStore(storeID: Int)
+
+    /// Indicates if the StoresManager is currently authenticated, or not.
+    ///
+    var isAuthenticated: Bool { get }
+
+    /// Indicates if we need a Default StoreID, or there's one already set.
+    ///
+    var needsDefaultStore: Bool { get }
+
+    /// SessionManager: Persistent Storage for Session-Y Properties.
+    /// This property is thread safe
+    var sessionManager: SessionManager { get }
+}

--- a/WooCommerce/Classes/ServiceLocator/Stores.swift
+++ b/WooCommerce/Classes/ServiceLocator/Stores.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Yosemite
 
-/// Abstreacts the Stores coordination
+/// Abstracts the Stores coordination
 ///
 protocol Stores {
 

--- a/WooCommerce/Classes/ServiceLocator/StoresManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/StoresManager.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// Abstracts the Stores coordination
 ///
-protocol Stores {
+protocol StoresManager {
 
     /// Forwards the Action to the current State.
     ///
@@ -20,17 +20,17 @@ protocol Stores {
     /// Switches the internal state to Authenticated.
     ///
     @discardableResult
-    func authenticate(credentials: Credentials) -> Stores
+    func authenticate(credentials: Credentials) -> StoresManager
 
     /// Switches the state to a Deauthenticated one.
     ///
     @discardableResult
-    func deauthenticate() -> Stores
+    func deauthenticate() -> StoresManager
 
     /// Synchronizes all of the Session's Entities.
     ///
     @discardableResult
-    func synchronizeEntities(onCompletion: (() -> Void)?) -> Stores
+    func synchronizeEntities(onCompletion: (() -> Void)?) -> StoresManager
 
     /// Updates the Default Store as specified.
     ///

--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -522,7 +522,7 @@ extension CurrencySettings {
     }
 
     private func refreshResultsPredicate() {
-        let sitePredicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let settingTypePredicate = NSPredicate(format: "settingGroupKey ==[c] %@", SiteSettingGroup.general.rawValue)
         resultsController.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sitePredicate, settingTypePredicate])
         try? resultsController.performFetch()

--- a/WooCommerce/Classes/Tools/Logging/CrashLogging.swift
+++ b/WooCommerce/Classes/Tools/Logging/CrashLogging.swift
@@ -16,7 +16,7 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
 
     var currentUser: TracksUser? {
 
-        guard let account = StoresManager.shared.sessionManager.defaultAccount else {
+        guard let account = ServiceLocator.stores.sessionManager.defaultAccount else {
             return nil
         }
 

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -43,10 +43,10 @@ class RequirementsChecker {
     ///       the WC version alert will *not* be displayed.
     ///
     static func checkMinimumWooVersionForDefaultStore() {
-        guard StoresManager.shared.isAuthenticated else {
+        guard ServiceLocator.stores.isAuthenticated else {
             return
         }
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID, siteID != 0 else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID, siteID != 0 else {
             DDLogWarn("⚠️ Cannot check WC version on default store — default siteID is nil or 0.")
             return
         }
@@ -70,7 +70,7 @@ class RequirementsChecker {
     ///
     static func checkMinimumWooVersion(for siteID: Int, onCompletion: ((_ result: RequirementCheckResult, _ error: Error?) -> Void)? = nil) {
         let action = retrieveSiteAPIAction(siteID: siteID, onCompletion: onCompletion)
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/Tools/SiteCountry.swift
+++ b/WooCommerce/Classes/Tools/SiteCountry.swift
@@ -6,7 +6,7 @@ final class SiteCountry {
     ///
     private lazy var resultsController: ResultsController<StorageSiteSetting> = {
         let storageManager = AppDelegate.shared.storageManager
-        let sitePredicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let settingCountryPredicate = NSPredicate(format: "settingID ==[c] %@", Constants.countryKey)
 
         let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sitePredicate, settingCountryPredicate])

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -189,7 +189,7 @@ class ZendeskManager: NSObject {
     ///
     func getTags(supportSourceTag: String?) -> [String] {
         var tags = [Constants.platformTag, Constants.sdkTag, Constants.jetpackTag]
-        guard let site = StoresManager.shared.sessionManager.defaultSite else {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return tags
         }
 
@@ -387,10 +387,10 @@ private extension ZendeskManager {
     }
 
     func getUserInformationIfAvailable() {
-        userEmail = StoresManager.shared.sessionManager.defaultAccount?.email
-        userName = StoresManager.shared.sessionManager.defaultAccount?.username
+        userEmail = ServiceLocator.stores.sessionManager.defaultAccount?.email
+        userName = ServiceLocator.stores.sessionManager.defaultAccount?.username
 
-        if let displayName = StoresManager.shared.sessionManager.defaultAccount?.displayName,
+        if let displayName = ServiceLocator.stores.sessionManager.defaultAccount?.displayName,
             !displayName.isEmpty {
             userName = displayName
         }
@@ -554,7 +554,7 @@ private extension ZendeskManager {
     }
 
     func getCurrentSiteDescription() -> String {
-        guard let site = StoresManager.shared.sessionManager.defaultSite else {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
             return String()
         }
 

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -37,7 +37,7 @@ private extension MainTabViewModel {
     }
 
     @objc func requestBadgeCount() {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             DDLogError("# Error: Cannot fetch order count")
             return
         }
@@ -50,7 +50,7 @@ private extension MainTabViewModel {
             self?.processBadgeCount(orderCount)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func processBadgeCount(_ orderCount: OrderCount?) {

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -165,7 +165,7 @@ private extension AddTrackingViewModel {
             DDLogError("⛔️ Save selected Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func loadSelectedShipmentProvider() {
@@ -181,7 +181,7 @@ private extension AddTrackingViewModel {
             DDLogError("⛔️ Read selected Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -278,7 +278,7 @@ private extension AddCustomTrackingViewModel {
             DDLogError("⛔️ Save selected Custom Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func loadSelectedCustomShipmentProvider() {
@@ -294,6 +294,6 @@ private extension AddCustomTrackingViewModel {
             DDLogError("⛔️ Read selected Custom Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsResultsControllers.swift
@@ -21,7 +21,7 @@ final class OrderDetailsResultsControllers {
     ///
     private lazy var productResultsController: ResultsController<StorageProduct> = {
         let storageManager = AppDelegate.shared.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -31,7 +31,7 @@ final class OrderDetailsResultsControllers {
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = AppDelegate.shared.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -292,7 +292,7 @@ extension OrderDetailsViewModel {
             onCompletion?(order, nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncTracking(onCompletion: ((Error?) -> Void)? = nil) {
@@ -311,7 +311,7 @@ extension OrderDetailsViewModel {
                                                                         onCompletion?(nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncNotes(onCompletion: ((Error?) -> ())? = nil) {
@@ -329,7 +329,7 @@ extension OrderDetailsViewModel {
             onCompletion?(nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
@@ -344,7 +344,7 @@ extension OrderDetailsViewModel {
             onCompletion?(nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func deleteTracking(_ tracking: ShipmentTracking, onCompletion: @escaping (Error?) -> Void) {
@@ -377,7 +377,7 @@ extension OrderDetailsViewModel {
 
         }
 
-        StoresManager.shared.dispatch(deleteTrackingAction)
+        ServiceLocator.stores.dispatch(deleteTrackingAction)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -69,7 +69,7 @@ final class ProductDetailsViewModel {
     private lazy var resultsController: ResultsController<StorageSiteSetting> = {
         let storageManager = AppDelegate.shared.storageManager
 
-        let sitePredicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let settingTypePredicate = NSPredicate(format: "settingGroupKey ==[c] %@", SiteSettingGroup.product.rawValue)
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sitePredicate, settingTypePredicate])
 
@@ -745,7 +745,7 @@ extension ProductDetailsViewModel {
             onCompletion?(nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -309,7 +309,7 @@ extension ShippingProvidersViewModel {
 private enum ResultsControllerConstants {
     static let predicateForAllProviders =
         NSPredicate(format: "siteID == %lld",
-                    StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+                    ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
     static let groupNameKeyPath =
         #keyPath(StorageShipmentTrackingProvider.group.name)
     static let providerNameKeyPath = #keyPath(StorageShipmentTrackingProvider.name)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -58,7 +58,7 @@ private extension DashboardViewController {
             "My store",
             comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
         )
-        title = StoresManager.shared.sessionManager.defaultSite?.name ?? myStore
+        title = ServiceLocator.stores.sessionManager.defaultSite?.name ?? myStore
         tabBarItem.title = myStore
     }
 
@@ -133,7 +133,7 @@ extension DashboardViewController {
     /// Runs whenever the default Account is updated.
     ///
     @objc func defaultAccountWasUpdated() {
-        guard isViewLoaded, StoresManager.shared.isAuthenticated == false else {
+        guard isViewLoaded, ServiceLocator.stores.isAuthenticated == false else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/NewOrdersViewController.swift
@@ -62,7 +62,7 @@ class NewOrdersViewController: UIViewController {
 extension NewOrdersViewController {
 
     func syncNewOrders(onCompletion: ((Error?) -> Void)? = nil) {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion?(nil)
             return
         }
@@ -76,7 +76,7 @@ extension NewOrdersViewController {
             onCompletion?(error)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/StoreStatsViewController.swift
@@ -222,7 +222,7 @@ private extension StoreStatsViewController {
 private extension StoreStatsViewController {
 
     func syncVisitorStats(for granularity: StatGranularity, onCompletion: ((Error?) -> Void)? = nil) {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion?(nil)
             return
         }
@@ -236,11 +236,11 @@ private extension StoreStatsViewController {
             }
             onCompletion?(error)
         }
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncOrderStats(for granularity: StatGranularity, onCompletion: ((Error?) -> Void)? = nil) {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion?(nil)
             return
         }
@@ -254,7 +254,7 @@ private extension StoreStatsViewController {
             }
             onCompletion?(error)
         }
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -276,7 +276,7 @@ private extension StoreStatsViewController {
     }
 
     func trackStatsLoaded(for granularity: StatGranularity) {
-        guard StoresManager.shared.isAuthenticated else {
+        guard ServiceLocator.stores.isAuthenticated else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -87,7 +87,7 @@ class TopPerformerDataViewController: UIViewController {
 extension TopPerformerDataViewController {
 
     func syncTopPerformers(onCompletion: ((Error?) -> Void)? = nil) {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion?(nil)
             return
         }
@@ -108,7 +108,7 @@ extension TopPerformerDataViewController {
             onCompletion?(error)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Renders Placeholder Content.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -23,7 +23,7 @@ class HelpAndSupportViewController: UIViewController {
         }
 
         // If no preferred ZD email exists, try the account email
-        if let mainEmail = StoresManager.shared.sessionManager.defaultAccount?.email {
+        if let mainEmail = ServiceLocator.stores.sessionManager.defaultAccount?.email {
             return mainEmail
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -69,7 +69,7 @@ class PrivacySettingsViewController: UIViewController {
 private extension PrivacySettingsViewController {
 
     func loadAccountSettings(completion: (()-> Void)? = nil) {
-        guard let defaultAccount = StoresManager.shared.sessionManager.defaultAccount else {
+        guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
             return
         }
 
@@ -87,7 +87,7 @@ private extension PrivacySettingsViewController {
             completion?()
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -260,7 +260,7 @@ private extension PrivacySettingsViewController {
     func collectInfoWasUpdated(newValue: Bool) {
         let userOptedOut = !newValue
 
-        guard let defaultAccount = StoresManager.shared.sessionManager.defaultAccount else {
+        guard let defaultAccount = ServiceLocator.stores.sessionManager.defaultAccount else {
             return
         }
 
@@ -274,7 +274,7 @@ private extension PrivacySettingsViewController {
                 return
             }
         }
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
 
         // This event will only report if the user has turned tracking back on
         ServiceLocator.analytics.track(.settingsCollectInfoToggled)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -21,13 +21,13 @@ class SettingsViewController: UIViewController {
     /// Main Account's displayName
     ///
     private var accountName: String {
-        return StoresManager.shared.sessionManager.defaultAccount?.displayName ?? String()
+        return ServiceLocator.stores.sessionManager.defaultAccount?.displayName ?? String()
     }
 
     /// Main Site's URL
     ///
     private var siteUrl: String {
-        let urlAsString = StoresManager.shared.sessionManager.defaultSite?.url as NSString?
+        let urlAsString = ServiceLocator.stores.sessionManager.defaultSite?.url as NSString?
         return urlAsString?.hostname() ?? String()
     }
 
@@ -313,7 +313,7 @@ private extension SettingsViewController {
     }
 
     func logOutUser() {
-        StoresManager.shared.deauthenticate()
+        ServiceLocator.stores.deauthenticate()
         navigationController?.popToRootViewController(animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -103,7 +103,7 @@ private extension StoreStatsAndTopPerformersViewController {
 
         ensureGhostContentIsDisplayed()
 
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
 
@@ -174,7 +174,7 @@ private extension StoreStatsAndTopPerformersViewController {
                 }
             }
         }
-        StoresManager.shared.dispatch(loadSiteAction)
+        ServiceLocator.stores.dispatch(loadSiteAction)
     }
 
     func showSpinner(shouldShowSpinner: Bool) {
@@ -317,7 +317,7 @@ private extension StoreStatsAndTopPerformersViewController {
                                                     onCompletion?(error)
         })
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncSiteVisitStats(for siteID: Int, timeRange: StatsTimeRangeV4, latestDateToInclude: Date, onCompletion: ((Error?) -> Void)? = nil) {
@@ -330,7 +330,7 @@ private extension StoreStatsAndTopPerformersViewController {
                                                             onCompletion?(error)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncTopEarnersStats(for siteID: Int, timeRange: StatsTimeRangeV4, latestDateToInclude: Date, onCompletion: ((Error?) -> Void)? = nil) {
@@ -348,7 +348,7 @@ private extension StoreStatsAndTopPerformersViewController {
                                                             onCompletion?(error)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -388,7 +388,7 @@ private extension StoreStatsAndTopPerformersViewController {
 //
 private extension StoreStatsAndTopPerformersViewController {
     func trackStatsLoaded(for granularity: StatsGranularityV4) {
-        guard StoresManager.shared.isAuthenticated else {
+        guard ServiceLocator.stores.isAuthenticated else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -160,7 +160,7 @@ private extension NotificationDetailsViewController {
             onCompletion()
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -395,7 +395,7 @@ private extension NotificationDetailsViewController {
                 ServiceLocator.analytics.track(.notificationReviewActionSuccess)
                 NotificationDetailsViewController.displayModerationCompleteNotice(newStatus: doneStatus, onUndoAction: {
                     ServiceLocator.analytics.track(.notificationReviewActionUndo)
-                    StoresManager.shared.dispatch(undo)
+                    ServiceLocator.stores.dispatch(undo)
                 })
                 return
             }
@@ -407,7 +407,7 @@ private extension NotificationDetailsViewController {
             return
         }
 
-        StoresManager.shared.dispatch(done)
+        ServiceLocator.stores.dispatch(done)
         navigationController?.popViewController(animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -276,7 +276,7 @@ private extension NotificationsViewController {
             }
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Marks a specific Notification as read.
@@ -291,7 +291,7 @@ private extension NotificationsViewController {
                 DDLogError("⛔️ Error marking single notification as read: \(error)")
             }
         }
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Marks the specified collection of Notifications as Read.
@@ -309,7 +309,7 @@ private extension NotificationsViewController {
             self?.updateMarkAllReadButtonState()
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Synchronizes the Notifications associated to the active WordPress.com account.
@@ -328,7 +328,7 @@ private extension NotificationsViewController {
         }
 
         transitionToSyncingState()
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -370,7 +370,7 @@ private extension NotificationsViewController {
 
     func filterPredicate() -> NSPredicate {
         let notDeletedPredicate = NSPredicate(format: "deleteInProgress == NO")
-        let sitePredicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let typeReviewPredicate =  NSPredicate(format: "subtype == %@", Note.Subkind.storeReview.rawValue)
 
         return NSCompoundPredicate(andPredicateWithSubpredicates: [typeReviewPredicate,
@@ -590,7 +590,7 @@ private extension NotificationsViewController {
             guard let `self` = self else {
                 return
             }
-            guard let site = StoresManager.shared.sessionManager.defaultSite else {
+            guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
                 return
             }
             guard let url = URL(string: site.url) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -189,7 +189,7 @@ private extension FulfillViewController {
         ServiceLocator.analytics.track(.orderStatusChange, withProperties: ["id": order.orderID,
                                                                        "from": order.statusKey,
                                                                        "to": OrderStatusEnum.completed.rawValue])
-        StoresManager.shared.dispatch(done)
+        ServiceLocator.stores.dispatch(done)
 
         displayOrderCompleteNotice {
             ServiceLocator.analytics.track(.orderMarkedCompleteUndoButtonTapped)
@@ -197,7 +197,7 @@ private extension FulfillViewController {
             ServiceLocator.analytics.track(.orderStatusChange, withProperties: ["id": orderID,
                                                                            "from": doneStatus,
                                                                            "to": undoStatus])
-            StoresManager.shared.dispatch(undo)
+            ServiceLocator.stores.dispatch(undo)
         }
 
         AppRatingManager.shared.incrementSignificantEvent()
@@ -510,7 +510,7 @@ private extension FulfillViewController {
                                                                     self?.syncTrackingsHiddingAddButtonIfNecessary()
         }
 
-        StoresManager.shared.dispatch(deleteTrackingAction)
+        ServiceLocator.stores.dispatch(deleteTrackingAction)
     }
 
     /// Displays the `Unable to delete tracking` Notice.
@@ -553,7 +553,7 @@ private extension FulfillViewController {
                                                                         onCompletion?(nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func configureTrackingResultsController() {

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -497,7 +497,7 @@ private extension ManualTrackingViewController {
                                                             self?.dismiss()
         }
 
-        StoresManager.shared.dispatch(addTrackingAction)
+        ServiceLocator.stores.dispatch(addTrackingAction)
     }
 
     func addCustomTracking() {
@@ -544,7 +544,7 @@ private extension ManualTrackingViewController {
                                                         self?.dismiss()
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
 
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -72,7 +72,7 @@ class NewNoteViewController: UIViewController {
             self?.dismiss(animated: true, completion: nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderLoaderViewController.swift
@@ -95,7 +95,7 @@ private extension OrderLoaderViewController {
         }
 
         state = .loading
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
@@ -41,7 +41,7 @@ class OrderSearchViewController: UIViewController {
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = AppDelegate.shared.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -296,7 +296,7 @@ private extension OrderSearchViewController {
         }
 
         transitionToSyncingState()
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
         ServiceLocator.analytics.track(.ordersListFilterOrSearch, withProperties: ["filter": "", "search": "\(keyword)"])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
@@ -10,7 +10,7 @@ final class OrderStatusListViewController: UIViewController {
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = AppDelegate.shared.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -170,14 +170,14 @@ private extension OrderStatusListViewController {
         let done = updateOrderAction(siteID: order.siteID, orderID: orderID, statusKey: newStatus)
         let undo = updateOrderAction(siteID: order.siteID, orderID: orderID, statusKey: undoStatus)
 
-        StoresManager.shared.dispatch(done)
+        ServiceLocator.stores.dispatch(done)
         ServiceLocator.analytics.track(.orderStatusChange,
                                   withProperties: ["id": orderID,
                                                    "from": undoStatus,
                                                    "to": newStatus])
 
         displayOrderUpdatedNotice {
-            StoresManager.shared.dispatch(undo)
+            ServiceLocator.stores.dispatch(undo)
             ServiceLocator.analytics.track(.orderStatusChange,
                                       withProperties: ["id": orderID,
                                                        "from": newStatus,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -199,12 +199,12 @@ private extension OrdersViewController {
         // this will also fire upon logging out, when the account
         // is set to nil. So let's protect against multi-threaded
         // access attempts if the account is indeed nil.
-        guard StoresManager.shared.isAuthenticated,
-            StoresManager.shared.needsDefaultStore == false else {
+        guard ServiceLocator.stores.isAuthenticated,
+            ServiceLocator.stores.needsDefaultStore == false else {
                 return
         }
 
-        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", StoresManager.shared.sessionManager.defaultStoreID ?? Int.min)
+        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
     }
 
     /// Setup: Navigation Item
@@ -324,7 +324,7 @@ extension OrdersViewController {
 extension OrdersViewController {
 
     @IBAction func displaySearchOrders() {
-        guard let storeID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let storeID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
 
@@ -401,7 +401,7 @@ private extension OrdersViewController {
         }
 
         let action = OrderAction.resetStoredOrders(onCompletion: onCompletion)
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     /// Reset the current status filter if needed (e.g. when changing stores and the currently
@@ -431,7 +431,7 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
     /// Synchronizes the Orders for the Default Store (if any).
     ///
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)? = nil) {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion?(false)
             return
         }
@@ -457,11 +457,11 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
             onCompletion?(error == nil)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     func syncOrderStatus(onCompletion: ((Error?) -> Void)? = nil) {
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             onCompletion?(nil)
             return
         }
@@ -477,7 +477,7 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
             onCompletion?(error)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 }
 
@@ -559,7 +559,7 @@ private extension OrdersViewController {
             guard let `self` = self else {
                 return
             }
-            guard let site = StoresManager.shared.sessionManager.defaultSite else {
+            guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
                 return
             }
             guard let url = URL(string: site.url) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -76,7 +76,7 @@ private extension ShipmentProvidersViewController {
     ///
     func fetchGroups() {
         footerSpinnerView.startAnimating()
-        guard let siteID = StoresManager.shared.sessionManager.defaultStoreID else {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
 
@@ -91,7 +91,7 @@ private extension ShipmentProvidersViewController {
                                                                                     self?.footerSpinnerView.stopAnimating()
         }
 
-        StoresManager.shared.dispatch(loadGroupsAction)
+        ServiceLocator.stores.dispatch(loadGroupsAction)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -118,7 +118,7 @@ private extension ProductLoaderViewController {
         }
 
         state = .loading
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.stores.dispatch(action)
     }
 
     @objc func dismissButtonTapped() {

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -104,6 +104,6 @@ private extension AuthenticatedState {
 private extension AuthenticatedState {
     func resetServices() {
         let resetStoredProviders = AppSettingsAction.resetStoredProviders(onCompletion: nil)
-        StoresManager.shared.dispatch(resetStoredProviders)
+        ServiceLocator.stores.dispatch(resetStoredProviders)
     }
 }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -3,9 +3,9 @@ import Yosemite
 
 
 
-// MARK: - StoresManager
+// MARK: - DefaultStoresManager
 //
-class StoresManager: Stores {
+class DefaultStoresManager: StoresManager {
 
     private let sessionManagerLockQueue = DispatchQueue(label: "StoresManager.sessionManagerLockQueue")
 
@@ -86,7 +86,7 @@ class StoresManager: Stores {
     /// Switches the internal state to Authenticated.
     ///
     @discardableResult
-    func authenticate(credentials: Credentials) -> Stores {
+    func authenticate(credentials: Credentials) -> StoresManager {
         state = AuthenticatedState(credentials: credentials)
         sessionManager.defaultCredentials = credentials
 
@@ -96,7 +96,7 @@ class StoresManager: Stores {
     /// Synchronizes all of the Session's Entities.
     ///
     @discardableResult
-    func synchronizeEntities(onCompletion: (() -> Void)? = nil) -> Stores {
+    func synchronizeEntities(onCompletion: (() -> Void)? = nil) -> StoresManager {
         let group = DispatchGroup()
 
         group.enter()
@@ -138,7 +138,7 @@ class StoresManager: Stores {
     /// Switches the state to a Deauthenticated one.
     ///
     @discardableResult
-    func deauthenticate() -> Stores {
+    func deauthenticate() -> StoresManager {
         state = DeauthenticatedState()
 
         sessionManager.reset()
@@ -164,7 +164,7 @@ class StoresManager: Stores {
 
 // MARK: - Private Methods
 //
-private extension StoresManager {
+private extension DefaultStoresManager {
 
     /// Loads the Default Account into the current Session, if possible.
     ///

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -5,11 +5,7 @@ import Yosemite
 
 // MARK: - StoresManager
 //
-class StoresManager: Stores {
-
-//    /// Shared Instance
-//    ///
-//    static var shared = StoresManager(sessionManager: .standard)
+final class StoresManager: Stores {
 
     private let sessionManagerLockQueue = DispatchQueue(label: "StoresManager.sessionManagerLockQueue")
 

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -5,11 +5,11 @@ import Yosemite
 
 // MARK: - StoresManager
 //
-class StoresManager {
+class StoresManager: Stores {
 
-    /// Shared Instance
-    ///
-    static var shared = StoresManager(sessionManager: .standard)
+//    /// Shared Instance
+//    ///
+//    static var shared = StoresManager(sessionManager: .standard)
 
     private let sessionManagerLockQueue = DispatchQueue(label: "StoresManager.sessionManagerLockQueue")
 
@@ -90,7 +90,7 @@ class StoresManager {
     /// Switches the internal state to Authenticated.
     ///
     @discardableResult
-    func authenticate(credentials: Credentials) -> StoresManager {
+    func authenticate(credentials: Credentials) -> Stores {
         state = AuthenticatedState(credentials: credentials)
         sessionManager.defaultCredentials = credentials
 
@@ -100,7 +100,7 @@ class StoresManager {
     /// Synchronizes all of the Session's Entities.
     ///
     @discardableResult
-    func synchronizeEntities(onCompletion: (() -> Void)? = nil) -> StoresManager {
+    func synchronizeEntities(onCompletion: (() -> Void)? = nil) -> Stores {
         let group = DispatchGroup()
 
         group.enter()
@@ -142,7 +142,7 @@ class StoresManager {
     /// Switches the state to a Deauthenticated one.
     ///
     @discardableResult
-    func deauthenticate() -> StoresManager {
+    func deauthenticate() -> Stores {
         state = DeauthenticatedState()
 
         sessionManager.reset()

--- a/WooCommerce/Classes/Yosemite/StoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/StoresManager.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 // MARK: - StoresManager
 //
-final class StoresManager: Stores {
+class StoresManager: Stores {
 
     private let sessionManagerLockQueue = DispatchQueue(label: "StoresManager.sessionManagerLockQueue")
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */; };
 		D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */; };
 		D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */; };
+		D88D5A3F230B676D007B6E01 /* Stores.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A3E230B676D007B6E01 /* Stores.swift */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -788,6 +789,7 @@
 		D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocatorTests.swift; sourceTree = "<group>"; };
+		D88D5A3E230B676D007B6E01 /* Stores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stores.swift; sourceTree = "<group>"; };
 		D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditableOrderTrackingTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/EditableOrderTrackingTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
@@ -1708,6 +1710,7 @@
 			children = (
 				D8D15F82230A17A000D48B3F /* ServiceLocator.swift */,
 				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
+				D88D5A3E230B676D007B6E01 /* Stores.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2197,6 +2200,7 @@
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,
+				D88D5A3F230B676D007B6E01 /* Stores.swift in Sources */,
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 		B53B3F37219C75AC00DF1EB6 /* OrderLoaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B3F36219C75AC00DF1EB6 /* OrderLoaderViewController.swift */; };
 		B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B3F38219C817800DF1EB6 /* UIStoryboard+Woo.swift */; };
 		B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B898820D450AF00EDB467 /* SessionManagerTests.swift */; };
-		B53B898D20D462A000EDB467 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B898C20D462A000EDB467 /* StoresManager.swift */; };
+		B53B898D20D462A000EDB467 /* DefaultStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B898C20D462A000EDB467 /* DefaultStoresManager.swift */; };
 		B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541B2122189E7FD008FE7C1 /* ScannerWooTests.swift */; };
 		B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541B2142189EEA1008FE7C1 /* Scanner+Helpers.swift */; };
 		B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541B2162189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift */; };
@@ -367,7 +367,6 @@
 		D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */; };
 		D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746791652108D87B007CF1DC /* MockupAnalyticsProvider.swift */; };
 		D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */; };
-		D88D5A3F230B676D007B6E01 /* Stores.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A3E230B676D007B6E01 /* Stores.swift */; };
 		D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */; };
 		D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */; };
 		D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AB131D225DC25F002BB5D1 /* MockOrders.swift */; };
@@ -375,6 +374,7 @@
 		D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */; };
 		D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */; };
 		D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */; };
+		D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D1230CA90200F49782 /* StoresManager.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
 		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
@@ -516,7 +516,7 @@
 		B53B3F36219C75AC00DF1EB6 /* OrderLoaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderLoaderViewController.swift; sourceTree = "<group>"; };
 		B53B3F38219C817800DF1EB6 /* UIStoryboard+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Woo.swift"; sourceTree = "<group>"; };
 		B53B898820D450AF00EDB467 /* SessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
-		B53B898C20D462A000EDB467 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
+		B53B898C20D462A000EDB467 /* DefaultStoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultStoresManager.swift; sourceTree = "<group>"; };
 		B541B2122189E7FD008FE7C1 /* ScannerWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScannerWooTests.swift; sourceTree = "<group>"; };
 		B541B2142189EEA1008FE7C1 /* Scanner+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Scanner+Helpers.swift"; sourceTree = "<group>"; };
 		B541B2162189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Helpers.swift"; sourceTree = "<group>"; };
@@ -791,7 +791,6 @@
 		D8736B5922F07D7100A14A29 /* MainTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModel.swift; sourceTree = "<group>"; };
 		D8736B7422F1FE1600A14A29 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocatorTests.swift; sourceTree = "<group>"; };
-		D88D5A3E230B676D007B6E01 /* Stores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stores.swift; sourceTree = "<group>"; };
 		D89E0C30226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EditableOrderTrackingTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/EditableOrderTrackingTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddManualCustomTrackingViewModelTests.swift; path = WooCommerceTests/Model/AddManualCustomTrackingViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8AB131D225DC25F002BB5D1 /* MockOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrders.swift; sourceTree = "<group>"; };
@@ -799,6 +798,7 @@
 		D8C11A5D22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderPaymentDetailsViewModel.swift; sourceTree = "<group>"; };
 		D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderPaymentDetailsViewModelTests.swift; path = WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
+		D8C251D1230CA90200F49782 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
@@ -1040,7 +1040,7 @@
 		B53B898B20D4627A00EDB467 /* Yosemite */ = {
 			isa = PBXGroup;
 			children = (
-				B53B898C20D462A000EDB467 /* StoresManager.swift */,
+				B53B898C20D462A000EDB467 /* DefaultStoresManager.swift */,
 				B5DBF3CA20E149CC00B53AED /* AuthenticatedState.swift */,
 				B5DBF3C420E148E000B53AED /* DeauthenticatedState.swift */,
 			);
@@ -1711,9 +1711,9 @@
 		D8D15F81230A178100D48B3F /* ServiceLocator */ = {
 			isa = PBXGroup;
 			children = (
+				D8C251D1230CA90200F49782 /* StoresManager.swift */,
 				D8D15F82230A17A000D48B3F /* ServiceLocator.swift */,
 				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
-				D88D5A3E230B676D007B6E01 /* Stores.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2111,6 +2111,7 @@
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
+				D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */,
 				B50911312049E27A007D25DC /* OrdersViewController.swift in Sources */,
 				B5A8F8AD20B88D9900D211DE /* LoginPrologueViewController.swift in Sources */,
 				B5D1AFC620BC7B7300DB0E8C /* StorePickerViewController.swift in Sources */,
@@ -2204,7 +2205,6 @@
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,
-				D88D5A3F230B676D007B6E01 /* Stores.swift in Sources */,
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,
@@ -2294,7 +2294,7 @@
 				B53B3F37219C75AC00DF1EB6 /* OrderLoaderViewController.swift in Sources */,
 				CE1D5A59228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
-				B53B898D20D462A000EDB467 /* StoresManager.swift in Sources */,
+				B53B898D20D462A000EDB467 /* DefaultStoresManager.swift in Sources */,
 				B5D1AFC020BC67C200DB0E8C /* WooConstants.swift in Sources */,
 				93FA787421CD7E9E00B663E5 /* CurrencySettings.swift in Sources */,
 				74EC34A5225FE21F004BBC2E /* ProductLoaderViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockupStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupStoresManager.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 /// MockupStoresManager: MockupStoresManager Mockup!
 ///
-class MockupStoresManager: StoresManager {
+class MockupStoresManager: DefaultStoresManager {
 
     /// Contains all of the dispatched Actions
     ///

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -12,4 +12,14 @@ final class ServiceLocatorTests: XCTestCase {
 
         XCTAssertTrue(analytics is WooAnalytics)
     }
+
+    func testServiceLocatorProvidesStores() {
+        XCTAssertNotNil(ServiceLocator.stores)
+    }
+
+    func testAnalyticsDefaultsToStoresManager() {
+        let stores = ServiceLocator.stores
+
+        XCTAssertTrue(stores is StoresManager)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -20,6 +20,6 @@ final class ServiceLocatorTests: XCTestCase {
     func testStoresDefaultsToStoresManager() {
         let stores = ServiceLocator.stores
 
-        XCTAssertTrue(stores is StoresManager)
+        XCTAssertTrue(stores is DefaultStoresManager)
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -17,7 +17,7 @@ final class ServiceLocatorTests: XCTestCase {
         XCTAssertNotNil(ServiceLocator.stores)
     }
 
-    func testAnalyticsDefaultsToStoresManager() {
+    func testStoresDefaultsToStoresManager() {
         let stores = ServiceLocator.stores
 
         XCTAssertTrue(stores is StoresManager)

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -19,7 +19,7 @@ class StoresManagerTests: XCTestCase {
     /// Verifies that the Initial State is Deauthenticated, whenever there are no Default Credentials.
     ///
     func testInitialStateIsDeauthenticatedAssumingCredentialsWereMissing() {
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         XCTAssertFalse(manager.isAuthenticated)
     }
 
@@ -30,7 +30,7 @@ class StoresManagerTests: XCTestCase {
         var session = SessionManager.testingInstance
         session.defaultCredentials = SessionSettings.credentials
 
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         XCTAssertTrue(manager.isAuthenticated)
     }
 
@@ -38,7 +38,7 @@ class StoresManagerTests: XCTestCase {
     /// Verifies that `authenticate(username: authToken:)` effectively switches the Manager to an Authenticated State.
     ///
     func testAuthenticateEffectivelyTogglesStoreManagerToAuthenticatedState() {
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         manager.authenticate(credentials: SessionSettings.credentials)
 
         XCTAssertTrue(manager.isAuthenticated)
@@ -48,7 +48,7 @@ class StoresManagerTests: XCTestCase {
     /// Verifies that `deauthenticate` effectively switches the Manager to a Deauthenticated State.
     ///
     func testDeauthenticateEffectivelyTogglesStoreManagerToDeauthenticatedState() {
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         manager.authenticate(credentials: SessionSettings.credentials)
         manager.deauthenticate()
 
@@ -59,7 +59,7 @@ class StoresManagerTests: XCTestCase {
     /// Verifies that `authenticate(username: authToken:)` persists the Credentials in the Keychain Storage.
     ///
     func testAuthenticatePersistsDefaultCredentialsInKeychain() {
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         manager.authenticate(credentials: SessionSettings.credentials)
 
         let session = SessionManager.testingInstance
@@ -69,7 +69,7 @@ class StoresManagerTests: XCTestCase {
     /// Verifies the user remains authenticated after site switching
     ///
     func testRemoveDefaultStoreLeavesUserAuthenticated() {
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         manager.authenticate(credentials: SessionSettings.credentials)
         manager.removeDefaultStore()
 
@@ -79,7 +79,7 @@ class StoresManagerTests: XCTestCase {
     /// Verify the session manager resets properties after site switching
     ///
     func testRemoveDefaultStoreDeletesSessionManagerDefaultsExceptCredentials() {
-        let manager = StoresManager.testingInstance
+        let manager = DefaultStoresManager.testingInstance
         manager.authenticate(credentials: SessionSettings.credentials)
 
         let session = SessionManager.testingInstance
@@ -95,11 +95,11 @@ class StoresManagerTests: XCTestCase {
 
 // MARK: - StoresManager: Testing Methods
 //
-extension StoresManager {
+extension DefaultStoresManager {
 
     /// Returns a StoresManager instance with testing Keychain/UserDefaults
     ///
-    static var testingInstance: StoresManager {
-        return StoresManager(sessionManager: .testingInstance)
+    static var testingInstance: DefaultStoresManager {
+        return DefaultStoresManager(sessionManager: .testingInstance)
     }
 }


### PR DESCRIPTION
Fixes #1199 

⚠️  This PR depends on #1198 . The base branch would need to be updated after #1198 is merged ⚠️ 

as mentioned in p99K0U-1BK-p2, we are going to abstract the global dependencies behind a Service Locator.

The scope for this PR is:
- [ ] Provide access to StoresManager through the service locator. StoresManager is not a singleton anymore
- [ ] Integrate the change in call sites to StoresManager

**Note:** 
I don't like the naming I have used in this PR. I think the protocol should be named `StoresManager` instead of `Stores` and the default implementation should be `DefaultStoresManager` instead of just `StoresManager`. But, I didn't want to submit any changes to the `StoresManager` class that made review more difficult. If/when this gets approved we can rename both the interface and the class before merging.

## Changes
- Added a `Stores` protocol (see 🆙 for more context about the name)
- Added a property to the ServiceLocator to provide a reference to the Stores protocol, initialised with StoresManager
- Update all the call sites

## Testing
- Build and run the tests. In theory, because the `StoresManager.shared` method was removed from the app, if the code builds, we should be good to go. But...
- Play around with the app. it should be possible to log in and out of it.