### PR TITLE
Reviews tab mark I: Networking

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 				74AE244C2113704C00CA8C54 /* OrderStatsRemoteTests.swift */,
 				D8FBFF1B22D51C34006E3336 /* OrderStatsRemoteV4Tests.swift */,
 				74749B9422413119005C4CF2 /* ProductsRemoteTests.swift */,
+				D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */,
 				7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */,
 				743E84F9221742E300FAC9D7 /* ShipmentsRemoteTests.swift */,
 				74AB5B5021AF426D00859C12 /* SiteAPIRemoteTests.swift */,
@@ -942,7 +943,6 @@
 		B5C6FCCB20A34B5E00A4F8E4 /* Mapper */ = {
 			isa = PBXGroup;
 			children = (
-				D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */,
 				D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */,
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A46230BC838007B6E01 /* ProductReview.swift */; };
 		D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */; };
 		D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */; };
+		D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
 		D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */; };
@@ -492,6 +493,7 @@
 		D88D5A46230BC838007B6E01 /* ProductReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReview.swift; sourceTree = "<group>"; };
 		D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStatus.swift; sourceTree = "<group>"; };
 		D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewListMapper.swift; sourceTree = "<group>"; };
+		D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProductReviewsRemoteTests.swift; path = NetworkingTests/Remote/ProductReviewsRemoteTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
 		D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGranularityV4.swift; sourceTree = "<group>"; };
@@ -940,6 +942,7 @@
 		B5C6FCCB20A34B5E00A4F8E4 /* Mapper */ = {
 			isa = PBXGroup;
 			children = (
+				D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */,
 				D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */,
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
@@ -1412,6 +1415,7 @@
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,
+				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,
 				740211E121939908002248DA /* CommentRemoteTests.swift in Sources */,
 				B57B1E6A21C925280046E764 /* DotcomValidatorTests.swift in Sources */,
 				B567AF3020A0FB8F00AB6C62 /* DotcomRequestTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */; };
 		D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
+		D8C251D0230BD72700F49782 /* ProductReviewMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251CF230BD72700F49782 /* ProductReviewMapper.swift */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
 		D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */; };
 		D8FBFF0F22D3B25E006E3336 /* WooAPIVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */; };
@@ -497,6 +498,7 @@
 		D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProductReviewsRemoteTests.swift; path = NetworkingTests/Remote/ProductReviewsRemoteTests.swift; sourceTree = SOURCE_ROOT; };
 		D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewListMapperTests.swift; sourceTree = "<group>"; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
+		D8C251CF230BD72700F49782 /* ProductReviewMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewMapper.swift; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
 		D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGranularityV4.swift; sourceTree = "<group>"; };
 		D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WooAPIVersionTests.swift; path = NetworkingTests/Requests/WooAPIVersionTests.swift; sourceTree = SOURCE_ROOT; };
@@ -882,6 +884,7 @@
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
 				CE0A0F18223987DF0075ED8D /* ProductListMapper.swift */,
 				D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */,
+				D8C251CF230BD72700F49782 /* ProductReviewMapper.swift */,
 				7412A8EB21B6E286005D182A /* ReportOrderTotalsMapper.swift */,
 				743E84ED2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift */,
 				7426CA1021AF30BD004E9FFC /* SiteAPIMapper.swift */,
@@ -1259,6 +1262,7 @@
 				7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */,
 				D88D5A45230BC6F9007B6E01 /* ProductReviewsRemote.swift in Sources */,
 				B59325D4217E4206000B0E8E /* NoteBlock.swift in Sources */,
+				D8C251D0230BD72700F49782 /* ProductReviewMapper.swift in Sources */,
 				B557DA1A20979D66005962F4 /* Settings.swift in Sources */,
 				CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */,
 				74ABA1D1213F22CA00FFAD30 /* TopEarnersStatsRemote.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */; };
 		D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */; };
 		D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */; };
+		D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
 		D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */; };
@@ -494,6 +495,7 @@
 		D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStatus.swift; sourceTree = "<group>"; };
 		D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewListMapper.swift; sourceTree = "<group>"; };
 		D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ProductReviewsRemoteTests.swift; path = NetworkingTests/Remote/ProductReviewsRemoteTests.swift; sourceTree = SOURCE_ROOT; };
+		D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewListMapperTests.swift; sourceTree = "<group>"; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
 		D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGranularityV4.swift; sourceTree = "<group>"; };
@@ -963,6 +965,7 @@
 				74A7B4BB217A807400E85A8B /* SiteSettingsMapperTests.swift */,
 				74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */,
 				74ABA1D4213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift */,
+				D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -1391,6 +1394,7 @@
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
 				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
+				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,
 				7412A8EE21B6E335005D182A /* ReportOrderMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		D8736B6022F0887900A14A29 /* OrderCountMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B5F22F0887900A14A29 /* OrderCountMapper.swift */; };
 		D8736B6222F089E200A14A29 /* orders-count.json in Resources */ = {isa = PBXBuildFile; fileRef = D8736B6122F089E200A14A29 /* orders-count.json */; };
 		D87F6151226591E10031A13B /* NullNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F6150226591E10031A13B /* NullNetwork.swift */; };
+		D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */ = {isa = PBXBuildFile; fileRef = D88D5A40230BC5DA007B6E01 /* reviews-all.json */; };
+		D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */ = {isa = PBXBuildFile; fileRef = D88D5A42230BC668007B6E01 /* reviews-single.json */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
 		D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */; };
@@ -480,6 +482,8 @@
 		D8736B5F22F0887900A14A29 /* OrderCountMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderCountMapper.swift; sourceTree = "<group>"; };
 		D8736B6122F089E200A14A29 /* orders-count.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "orders-count.json"; sourceTree = "<group>"; };
 		D87F6150226591E10031A13B /* NullNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullNetwork.swift; sourceTree = "<group>"; };
+		D88D5A40230BC5DA007B6E01 /* reviews-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reviews-all.json"; sourceTree = "<group>"; };
+		D88D5A42230BC668007B6E01 /* reviews-single.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reviews-single.json"; sourceTree = "<group>"; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
 		D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGranularityV4.swift; sourceTree = "<group>"; };
@@ -803,6 +807,8 @@
 				74749B98224135C4005C4CF2 /* product.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				7412A8EF21B6E415005D182A /* report-orders.json */,
+				D88D5A40230BC5DA007B6E01 /* reviews-all.json */,
+				D88D5A42230BC668007B6E01 /* reviews-single.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
 				74159622224D2C86003C21CF /* settings-product.json */,
@@ -1090,6 +1096,7 @@
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
+				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				740211DF2193985A002248DA /* comment-moderate-spam.json in Resources */,
 				B5147876211B9227007562E5 /* broken-orders-mark-2.json in Resources */,
 				B58D10C82114D21D00107ED4 /* generic_error.json in Resources */,
@@ -1106,6 +1113,7 @@
 				B58D10CA2114D22E00107ED4 /* new-order-note.json in Resources */,
 				B57B1E6C21C94C9F0046E764 /* timeout_error.json in Resources */,
 				B5C6FCD620A3768900A4F8E4 /* order.json in Resources */,
+				D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */,
 				74C947862193A6C70024CB60 /* comment-moderate-unapproved.json in Resources */,
 				B559EBAA20A0B5CD00836CD4 /* orders-load-all.json in Resources */,
 				74C8F06620EEB76400B6EDC9 /* order-notes.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -229,6 +229,10 @@
 		D87F6151226591E10031A13B /* NullNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F6150226591E10031A13B /* NullNetwork.swift */; };
 		D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */ = {isa = PBXBuildFile; fileRef = D88D5A40230BC5DA007B6E01 /* reviews-all.json */; };
 		D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */ = {isa = PBXBuildFile; fileRef = D88D5A42230BC668007B6E01 /* reviews-single.json */; };
+		D88D5A45230BC6F9007B6E01 /* ProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A44230BC6F9007B6E01 /* ProductReviewsRemote.swift */; };
+		D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A46230BC838007B6E01 /* ProductReview.swift */; };
+		D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */; };
+		D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */; };
 		D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */ = {isa = PBXBuildFile; fileRef = D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */; };
 		D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */; };
 		D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */; };
@@ -484,6 +488,10 @@
 		D87F6150226591E10031A13B /* NullNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullNetwork.swift; sourceTree = "<group>"; };
 		D88D5A40230BC5DA007B6E01 /* reviews-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reviews-all.json"; sourceTree = "<group>"; };
 		D88D5A42230BC668007B6E01 /* reviews-single.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reviews-single.json"; sourceTree = "<group>"; };
+		D88D5A44230BC6F9007B6E01 /* ProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewsRemote.swift; sourceTree = "<group>"; };
+		D88D5A46230BC838007B6E01 /* ProductReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReview.swift; sourceTree = "<group>"; };
+		D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStatus.swift; sourceTree = "<group>"; };
+		D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewListMapper.swift; sourceTree = "<group>"; };
 		D8C11A5B22DFCF8100D4A88D /* order-stats-v4-year-alt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-stats-v4-year-alt.json"; sourceTree = "<group>"; };
 		D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderStatsRemoteV4.swift; sourceTree = "<group>"; };
 		D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGranularityV4.swift; sourceTree = "<group>"; };
@@ -699,6 +707,8 @@
 				B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */,
 				B557DA0120975500005962F4 /* OrdersRemote.swift */,
 				748D4247210F89ED00CF7D1B /* OrderStatsRemote.swift */,
+				D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */,
+				D88D5A44230BC6F9007B6E01 /* ProductReviewsRemote.swift */,
 				CE0A0F1A223989670075ED8D /* ProductsRemote.swift */,
 				7412A8E921B6E192005D182A /* ReportRemote.swift */,
 				743E84E922171C5800FAC9D7 /* ShipmentsRemote.swift */,
@@ -706,7 +716,6 @@
 				74046E1A217A684D007DD7BF /* SiteSettingsRemote.swift */,
 				74A1D26E21189EA000931DFA /* SiteVisitStatsRemote.swift */,
 				74ABA1D0213F22CA00FFAD30 /* TopEarnersStatsRemote.swift */,
-				D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -867,6 +876,7 @@
 				748D424B210FA34400CF7D1B /* OrderStatsMapper.swift */,
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
 				CE0A0F18223987DF0075ED8D /* ProductListMapper.swift */,
+				D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */,
 				7412A8EB21B6E286005D182A /* ReportOrderTotalsMapper.swift */,
 				743E84ED2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift */,
 				7426CA1021AF30BD004E9FFC /* SiteAPIMapper.swift */,
@@ -979,6 +989,8 @@
 				CE17C6B0229462C000AACE1C /* ProductStockStatus.swift */,
 				CE6BFEE92236E191005C79FB /* ProductType.swift */,
 				CE132BBB223859710029DB6C /* ProductTag.swift */,
+				D88D5A46230BC838007B6E01 /* ProductReview.swift */,
+				D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -1239,6 +1251,7 @@
 				B56C1EB620EA757B00D749F9 /* SiteListMapper.swift in Sources */,
 				B50A583921AD861700617455 /* APNSDevice.swift in Sources */,
 				7426CA0D21AF27B9004E9FFC /* SiteAPIRemote.swift in Sources */,
+				D88D5A45230BC6F9007B6E01 /* ProductReviewsRemote.swift in Sources */,
 				B59325D4217E4206000B0E8E /* NoteBlock.swift in Sources */,
 				B557DA1A20979D66005962F4 /* Settings.swift in Sources */,
 				CE132BBA223851F80029DB6C /* ProductCategory.swift in Sources */,
@@ -1248,6 +1261,7 @@
 				B59325D3217E4206000B0E8E /* NoteMedia.swift in Sources */,
 				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
+				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
 				741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,
@@ -1272,6 +1286,7 @@
 				D8736B6022F0887900A14A29 /* OrderCountMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,
+				D88D5A4B230BCF0A007B6E01 /* ProductReviewListMapper.swift in Sources */,
 				93D8BBFB226BBC5100AD2EB3 /* AccountSettings.swift in Sources */,
 				B53EF53821813806003E146F /* DotcomError.swift in Sources */,
 				D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */,
@@ -1336,6 +1351,7 @@
 				CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */,
 				B557DA0420975500005962F4 /* OrdersRemote.swift in Sources */,
 				B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */,
+				D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */,
 				B557DA0F20975E07005962F4 /* DotcomRequest.swift in Sources */,
 				740211E321939C84002248DA /* CommentResultMapper.swift in Sources */,
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductReviewListMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewListMapper.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Mapper: Product Reviews List
+///
+struct ProductReviewListMapper: Mapper {
+    /// Site Identifier associated to the product reviews that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
+    ///
+    let siteID: Int
+
+    /// (Attempts) to convert a dictionary into [Product].
+    ///
+    func map(response: Data) throws -> [ProductReview] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductReviewListEnvelope.self, from: response).products
+    }
+}
+
+
+/// ProductReviewListEnvelope Disposable Entity:
+/// `Load All Products Reviews` endpoint returns the updated products document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductReviewListEnvelope: Decodable {
+    let products: [ProductReview]
+
+    private enum CodingKeys: String, CodingKey {
+        case products = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ProductReviewListMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewListMapper.swift
@@ -18,7 +18,7 @@ struct ProductReviewListMapper: Mapper {
             .siteID: siteID
         ]
 
-        return try decoder.decode(ProductReviewListEnvelope.self, from: response).products
+        return try decoder.decode(ProductReviewListEnvelope.self, from: response).productReviews
     }
 }
 
@@ -28,9 +28,9 @@ struct ProductReviewListMapper: Mapper {
 /// This entity allows us to do parse all the things with JSONDecoder.
 ///
 private struct ProductReviewListEnvelope: Decodable {
-    let products: [ProductReview]
+    let productReviews: [ProductReview]
 
     private enum CodingKeys: String, CodingKey {
-        case products = "data"
+        case productReviews = "data"
     }
 }

--- a/Networking/Networking/Mapper/ProductReviewMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewMapper.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+
+/// Mapper: ProductReview
+///
+struct ProductReviewMapper: Mapper {
+
+    /// Site Identifier associated to the product review that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
+    ///
+    let siteID: Int
+
+
+    /// (Attempts) to convert a dictionary into ProductReview.
+    ///
+    func map(response: Data) throws -> ProductReview {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductReviewEnvelope.self, from: response).productReview
+    }
+}
+
+
+/// ProductReviewEnvelope Disposable Entity
+///
+/// `Load Product Review` endpoint returns the requested product document in the `data` key. This entity
+/// allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductReviewEnvelope: Decodable {
+    let productReview: ProductReview
+
+    private enum CodingKeys: String, CodingKey {
+        case productReview = "data"
+    }
+}
+

--- a/Networking/Networking/Mapper/ProductReviewMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewMapper.swift
@@ -29,7 +29,7 @@ struct ProductReviewMapper: Mapper {
 /// ProductReviewEnvelope Disposable Entity
 ///
 /// `Load Product Review` endpoint returns the requested product document in the `data` key. This entity
-/// allows us to do parse all the things with JSONDecoder.
+/// allows us to parse all the things with JSONDecoder.
 ///
 private struct ProductReviewEnvelope: Decodable {
     let productReview: ProductReview

--- a/Networking/Networking/Mapper/ProductReviewMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewMapper.swift
@@ -38,4 +38,3 @@ private struct ProductReviewEnvelope: Decodable {
         case productReview = "data"
     }
 }
-

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Represents a ProductReview Entity.
+///
+public struct ProductReview: Decodable {
+    public let siteID: Int
+    public let reviewID: Int
+    public let productID: Int
+
+    public let dateCreated: Date        // gmt
+
+    public let statusKey: String
+
+    public let reviewer: String
+    public let reviewerEmail: String
+
+    public let review: String
+    public let rating: Int
+
+    public let verified: Bool
+
+    public var status: ProductReviewStatus {
+        return ProductReviewStatus(rawValue: statusKey)
+    }
+
+    /// ProductReview struct initializer.
+    ///
+    init(siteID: Int,
+         reviewID: Int,
+         productID: Int,
+         dateCreated: Date,
+         statusKey: String,
+         reviewer: String,
+         reviewerEmail: String,
+         review: String,
+         rating: Int,
+         verified: Bool) {
+        self.siteID = siteID
+        self.reviewID = reviewID
+        self.productID = productID
+        self.dateCreated = dateCreated
+        self.statusKey = statusKey
+        self.reviewer = reviewer
+        self.reviewerEmail = reviewerEmail
+        self.review = review
+        self.rating = rating
+        self.verified = verified
+    }
+
+    /// The public initializer for ProductReview.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+            throw ProductReviewDecodingError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let reviewID = try container.decode(Int.self, forKey: .reviewID)
+        let productID = try container.decode(Int.self, forKey: .productID)
+        let dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? Date()
+        let statusKey = try container.decode(String.self, forKey: .status)
+        let reviewer = try container.decode(String.self, forKey: .reviewer)
+        let reviewerEmail = try container.decode(String.self, forKey: .reviewerEmail)
+        let review = try container.decode(String.self, forKey: .review)
+        let rating = try container.decode(Int.self, forKey: .rating)
+        let verified = try container.decode(Bool.self, forKey: .verified)
+
+        self.init(siteID: siteID,
+                  reviewID: reviewID,
+                  productID: productID,
+                  dateCreated: dateCreated,
+                  statusKey: statusKey,
+                  reviewer: reviewer,
+                  reviewerEmail: reviewerEmail,
+                  review: review,
+                  rating: rating,
+                  verified: verified)
+    }
+}
+
+
+/// Defines all of the ProductReview CodingKeys
+///
+private extension ProductReview {
+
+    enum CodingKeys: String, CodingKey {
+        case reviewID       = "id"
+        case productID      = "product_id"
+        case dateCreated    = "date_created_gmt"
+        case status         = "status"
+        case reviewer       = "reviewer"
+        case reviewerEmail  = "reviewer_email"
+        case review         = "review"
+        case rating         = "rating"
+        case verified       = "verified"
+    }
+}
+
+
+// MARK: - Decoding Errors
+//
+enum ProductReviewDecodingError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Model/Product/ProductReviewStatus.swift
+++ b/Networking/Networking/Model/Product/ProductReviewStatus.swift
@@ -1,0 +1,81 @@
+/// Represents a ProductReviewStatus Entity.
+///
+public enum ProductReviewStatus: Decodable, Hashable {
+    case approved
+    case hold
+    case spam
+    case unspam
+    case trash
+    case untrash
+}
+
+
+/// RawRepresentable Conformance
+///
+extension ProductReviewStatus: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.approved:
+            self = .approved
+        case Keys.hold:
+            self = .hold
+        case Keys.spam:
+            self = .spam
+        case Keys.unspam:
+            self = .unspam
+        case Keys.trash:
+            self = .trash
+        case Keys.untrash:
+            self = .untrash
+        default:
+            self = .hold
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .approved: return Keys.approved
+        case .hold:     return Keys.hold
+        case .spam:     return Keys.spam
+        case .unspam:   return Keys.unspam
+        case .trash:    return Keys.trash
+        case .untrash:  return Keys.untrash
+        }
+    }
+
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .approved:
+            return NSLocalizedString("Approved", comment: "Display label for the review's approved status")
+        case .hold:
+            return NSLocalizedString("On hold", comment: "Display label for the review's hold status")
+        case .spam:
+            return NSLocalizedString("Spam", comment: "Display label for the review's spam status")
+        case .unspam:
+            return NSLocalizedString("Unspam", comment: "Display label for the review's unspam status")
+        case .trash:
+            return NSLocalizedString("Trash", comment: "Display label for the review's trash status")
+        case .untrash:
+            return NSLocalizedString("Untrash", comment: "Display label for the review's untrash status")
+        }
+    }
+}
+
+
+/// Enum containing the 'Known' ProductReviewStatus Keys
+///
+private enum Keys {
+    static let approved = "approved"
+    static let hold     = "hold"
+    static let spam     = "spam"
+    static let unspam   = "unspam"
+    static let trash    = "trash"
+    static let untrash  = "untrash"
+}

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -49,6 +49,23 @@ public final class ProductReviewsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Updates the status of a specific `ProductReview`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the ProductReview.
+    ///     - reviewID: Identifier of the ProductReview.
+    ///     - statusKey: The new status
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProductReviewStatus(for siteID: Int, reviewID: Int, statusKey: String, completion: @escaping (ProductReview?, Error?) -> Void) {
+        let path = "\(Path.reviews)/\(reviewID)"
+        let parameters = [ParameterKey.status: statusKey]
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .put, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductReviewMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -70,5 +87,6 @@ public extension ProductReviewsRemote {
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
         static let include: String    = "include"
+        static let status: String     = "status"
     }
 }

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Product reviews: Remote Endpoints
+///
+public final class ProductReviewsRemote: Remote {
+
+    // MARK: - Product Reviews
+
+    /// Retrieves all of the `ProductReview` available. We rely on the endpoint
+    /// defaults for `sorting` and `orderby`: `date_gmt` and `asc`
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote products.
+    ///     - context: view or edit. Scope under which the request is made;
+    ///                determines fields present in response. Default is view.
+    ///     - pageNumber: Number of page that should be retrieved.
+    ///     - pageSize: Number of Orders to be retrieved per page.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadAllProductReviews(for siteID: Int,
+                                context: String? = nil,
+                                pageNumber: Int = Default.pageNumber,
+                                pageSize: Int = Default.pageSize,
+                                completion: @escaping ([ProductReview]?, Error?) -> Void) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.contextKey: context ?? Default.context
+        ]
+
+        let path = Path.reviews
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductReviewListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+
+// MARK: - Constants
+//
+public extension ProductReviewsRemote {
+    enum Default {
+        public static let pageSize: Int   = 25
+        public static let pageNumber: Int = 1
+        public static let context: String = "view"
+    }
+
+    private enum Path {
+        static let reviews   = "products/reviews"
+    }
+
+    private enum ParameterKey {
+        static let page: String       = "page"
+        static let perPage: String    = "per_page"
+        static let contextKey: String = "context"
+        static let include: String    = "include"
+    }
+}

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -34,6 +34,21 @@ public final class ProductReviewsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Retrieves a specific `ProductReview`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the ProductReview.
+    ///     - reviewID: Identifier of the ProductReview.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadProductReview(for siteID: Int, reviewID: Int, completion: @escaping (ProductReview?, Error?) -> Void) {
+        let path = "\(Path.reviews)/\(reviewID)"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = ProductReviewMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 

--- a/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Networking
+
+
+final class ProductReviewListMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID = 33334444
+
+    /// Verifies that all of the ProductReview Fields are parsed correctly.
+    ///
+    func testProductReviewFieldsAreProperlyParsed() {
+        let productReviews = mapLoadAllProductReviewsResponse()
+        XCTAssertEqual(productReviews.count, 2)
+
+        let firstProductReview = productReviews[0]
+
+        XCTAssertEqual(firstProductReview.siteID, dummySiteID)
+        XCTAssertEqual(firstProductReview.reviewID, 173)
+        XCTAssertEqual(firstProductReview.productID, 32)
+
+        let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-08-20T06:06:29")
+        XCTAssertEqual(firstProductReview.dateCreated, dateCreated)
+
+        XCTAssertEqual(firstProductReview.status, ProductReviewStatus.approved)
+
+        XCTAssertEqual(firstProductReview.reviewer, "somereviewer")
+        XCTAssertEqual(firstProductReview.reviewerEmail, "somewhere@intheinternet.com")
+        XCTAssertEqual(firstProductReview.review, "<p>The fancy chair gets only three stars</p>\n")
+        XCTAssertEqual(firstProductReview.rating, 3)
+
+        XCTAssertFalse(firstProductReview.verified)
+    }
+}
+
+
+/// Private Methods.
+///
+private extension ProductReviewListMapperTests {
+
+    /// Returns the ProducReviewtListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductReviews(from filename: String) -> [ProductReview] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try! ProductReviewListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductListMapper output upon receiving `reviews-all`
+    ///
+    func mapLoadAllProductReviewsResponse() -> [ProductReview] {
+        return mapProductReviews(from: "reviews-all")
+    }
+}

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductReviewsRemoteTests
+///
+final class ProductReviewsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockupNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID = 1234
+
+    /// Dummy Product ID
+    ///
+    let sampleProductID = 282
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - Load all product reviews tests
+
+    /// Verifies that loadAllProductReviews properly parses the `reviews-all` sample response.
+    ///
+
+    func testLoadAllProductReviewsProperlyReturnsParsedProductReviews() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Product Reviews")
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-all")
+
+        remote.loadAllProductReviews(for: sampleSiteID) { reviews, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(reviews)
+            XCTAssertEqual(reviews?.count, 2)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -66,7 +66,7 @@ final class ProductReviewsRemoteTests: XCTestCase {
     ///
     func testLoadProductReviewProperlyReturnsParsedProductReviews() {
         let remote = ProductReviewsRemote(network: network)
-        let expectation = self.expectation(description: "Load Single Product Reviews")
+        let expectation = self.expectation(description: "Load Single Product Review")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews/\(sampleReviewID)", filename: "reviews-single")
 
@@ -89,6 +89,48 @@ final class ProductReviewsRemoteTests: XCTestCase {
             XCTAssertNil(review)
             XCTAssertNotNil(error)
             expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+
+    // MARK: - Update single product review tests
+
+    /// Verifies that updateProductReview properly parses the `reviews-single` sample response.
+    ///
+    func testUpdateProductReviewProperlyReturnsParsedProductReviews() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Update Product Review status")
+
+        let newStatusKey = "hold"
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews/\(sampleReviewID)", filename: "reviews-single")
+        remote.updateProductReviewStatus(for: sampleSiteID,
+                                         reviewID: sampleReviewID,
+                                         statusKey: newStatusKey) { review, error in
+                                            XCTAssertNil(error)
+                                            XCTAssertNotNil(review)
+                                            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that updateProductReview properly relays Networking Layer errors.
+    ///
+    func testUpdateProductReviewProperlyRelaysNetwokingErrors() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Update a single Product Review returns error")
+
+        let newStatusKey = "hold"
+
+        remote.updateProductReviewStatus(for: sampleSiteID,
+                                         reviewID: sampleReviewID,
+                                         statusKey: newStatusKey) { review, error in
+                                            XCTAssertNil(review)
+                                            XCTAssertNotNil(error)
+                                            expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -16,7 +16,7 @@ final class ProductReviewsRemoteTests: XCTestCase {
 
     /// Dummy Product ID
     ///
-    let sampleProductID = 282
+    let sampleReviewID = 173
 
     /// Repeat always!
     ///
@@ -28,7 +28,6 @@ final class ProductReviewsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllProductReviews properly parses the `reviews-all` sample response.
     ///
-
     func testLoadAllProductReviewsProperlyReturnsParsedProductReviews() {
         let remote = ProductReviewsRemote(network: network)
         let expectation = self.expectation(description: "Load All Product Reviews")
@@ -60,4 +59,38 @@ final class ProductReviewsRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+
+    // MARK: - Load single product review tests
+
+    /// Verifies that loadProductReview properly parses the `reviews-single` sample response.
+    ///
+    func testLoadProductReviewProperlyReturnsParsedProductReviews() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Load Single Product Reviews")
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews/\(sampleReviewID)", filename: "reviews-single")
+
+        remote.loadProductReview(for: sampleSiteID, reviewID: sampleReviewID) { review, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(review)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that loadProductReview properly relays Networking Layer errors.
+    ///
+    func testLoadProductReviewProperlyRelaysNetwokingErrors() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Load a single Product Review returns error")
+
+        remote.loadProductReview(for: sampleSiteID, reviewID: sampleReviewID) { review, error in
+            XCTAssertNil(review)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -44,4 +44,20 @@ final class ProductReviewsRemoteTests: XCTestCase {
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    /// Verifies that loadAllProductReviews properly relays Networking Layer errors.
+    ///
+    func testLoadAllProductReviewsProperlyRelaysNetwokingErrors() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Product Reviews returns error")
+
+        remote.loadAllProductReviews(for: sampleSiteID) { reviews, error in
+            XCTAssertNil(reviews)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
 }

--- a/Networking/NetworkingTests/Responses/reviews-all.json
+++ b/Networking/NetworkingTests/Responses/reviews-all.json
@@ -1,0 +1,78 @@
+{
+    "data": [
+        {
+            "id": 173,
+            "date_created": "2019-08-20T06:06:29",
+            "date_created_gmt": "2019-08-20T06:06:29",
+            "product_id": 32,
+            "status": "approved",
+            "reviewer": "somereviewer",
+            "reviewer_email": "somewhere@intheinternet.com",
+            "review": "<p>The fancy chair gets only three stars</p>\n",
+            "rating": 3,
+            "verified": false,
+            "reviewer_avatar_urls": {
+                "24": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=24&d=mm&r=g",
+                "48": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=48&d=mm&r=g",
+                "96": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=96&d=mm&r=g"
+            },
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/173"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/32"
+                    }
+                ],
+                "reviewer": [
+                    {
+                        "embeddable": true,
+                        "href": "http://store.ctarda.com/wp-json/wp/v2/users/1"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 169,
+            "date_created": "2019-08-20T06:02:21",
+            "date_created_gmt": "2019-08-20T06:02:21",
+            "product_id": 11,
+            "status": "approved",
+            "reviewer": "Software Engineer",
+            "reviewer_email": "somewhereelse@theinternet.com",
+            "review": "<p>A glowing review with a five star rating for the Colourful dress</p>\n",
+            "rating": 5,
+            "verified": false,
+            "reviewer_avatar_urls": {
+                "24": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=24&d=mm&r=g",
+                "48": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=48&d=mm&r=g",
+                "96": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=96&d=mm&r=g"
+            },
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/169"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/11"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/reviews-single.json
+++ b/Networking/NetworkingTests/Responses/reviews-single.json
@@ -1,0 +1,42 @@
+{
+    "data": {
+        "id": 173,
+        "date_created": "2019-08-20T06:06:29",
+        "date_created_gmt": "2019-08-20T06:06:29",
+        "product_id": 32,
+        "status": "approved",
+        "reviewer": "somereviewer",
+        "reviewer_email": "somewhere@intheinternet.com",
+        "review": "<p>The fancy chair gets only three stars</p>\n",
+        "rating": 3,
+        "verified": false,
+        "reviewer_avatar_urls": {
+            "24": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=24&d=mm&r=g",
+            "48": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=48&d=mm&r=g",
+            "96": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=96&d=mm&r=g"
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/173"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                }
+            ],
+            "up": [
+                {
+                    "href": "http://store.ctarda.com/wp-json/wc/v3/products/32"
+                }
+            ],
+            "reviewer": [
+                {
+                    "embeddable": true,
+                    "href": "http://store.ctarda.com/wp-json/wp/v2/users/1"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1202 

## Scope
- [ ] Add a ProducReviewsRemote to integrate with the reviews endpoint (`/wp-json/wc/v3/products/reviews`)
- [ ] Model objects, parsers and unit tests 

I have implemented support for loading all reviews, a single review, and for updating the status of a single review

## Changes
- Added a new remote (`ProductReviewsRemote`)
- Added model objects (`ProductReview` and `ProductReviewStatus`)
- Added new mappers (`ProductReviewMapper` and `ProductReviewListMapper`)
- Added tests for all of them 😄 (including mocks)

## Testing
- 👀  on the code
- ✅  unit tests