### PR TITLE
Products no longer load images, no matter how long you wait

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - bugfix: 9+ orders in the orders badge text is now easier to read
 - bugfix: Keep those sign-in bugs coming! We tracked down and fixed a `Log in with Jetpack` issue, where users with a Byte Order Mark in their `wp-config.php` file were returning error responses during API requests. These users would see their store listed in the sign-in screen, but were unable to tap the Continue button.
 - bugfix: prevents a potential edge case where the login screen could be dismissed in a future version of iOS.
+- bugfix: While tuning up the behind-the-scenes for Order Detail screens, we accidentally lost the ability to automatically download any missing product images. Product image downloads restored!
 
 2.5
 -----

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -76,7 +76,7 @@ private extension ProductStore {
     /// Synchronizes the Products found in a specified Order.
     ///
     func requestMissingProducts(for order: Order, onCompletion: @escaping (Error?) -> Void) {
-        let itemIDs = order.items.map { $0.itemID }
+        let itemIDs = order.items.map { $0.productID }
         let productIDs = itemIDs.uniqued()  // removes duplicate product IDs
 
         let storage = storageManager.viewStorage


### PR DESCRIPTION
Fixes #1149 

This PR is a bug fix for product images in the Order Details page. They were no longer downloading, no matter how long you waited on them. The only way to force a product image to display on the Order Details screen was to tap on the product row, wait for the image to download, then dismiss the product details page.

## To test
1. Find an order number that has a photo for the product. Example: I used Order No. 3059 in Julia's store.
2. Navigate to Order List and choose the order.
3. If you are on a fast internet connection, do not wait more than 30 seconds for the image to load. (Slow connections are estimated to time out within 2 minutes).
4. See the image appear in place.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
