### PR TITLE
Reviews tab mark II: Storage

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		D821645C2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82164582239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataProperties.swift */; };
 		D821645D2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82164592239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift */; };
 		D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821645A2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift */; };
+		D8550D02230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8550D00230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift */; };
+		D8550D03230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8550D01230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift */; };
 		D8736B6822F0AC9000A14A29 /* OrderCountItem+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6422F0AC9000A14A29 /* OrderCountItem+CoreDataClass.swift */; };
 		D8736B6922F0AC9000A14A29 /* OrderCountItem+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6522F0AC9000A14A29 /* OrderCountItem+CoreDataProperties.swift */; };
 		D8736B6A22F0AC9000A14A29 /* OrderCount+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6622F0AC9000A14A29 /* OrderCount+CoreDataClass.swift */; };
@@ -95,8 +97,6 @@
 		D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61542265AA900031A13B /* PListFileStorage.swift */; };
 		D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61562265AD980031A13B /* FileStorageTests.swift */; };
 		D87F615C2265AF190031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615B2265AF190031A13B /* shipment-provider.plist */; };
-		D8C251D6230D183200F49782 /* ProductReview+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D4230D183100F49782 /* ProductReview+CoreDataClass.swift */; };
-		D8C251D7230D183200F49782 /* ProductReview+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D5230D183100F49782 /* ProductReview+CoreDataProperties.swift */; };
 		D8FBFF5522D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
 		D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
 		D8FBFF5722D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5122D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
@@ -218,6 +218,8 @@
 		D82164592239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProviderGroup+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D821645A2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProviderGroup+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		D82A61EF2239EB9900335D40 /* Model 12.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 12.xcdatamodel"; sourceTree = "<group>"; };
+		D8550D00230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductReview+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		D8550D01230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductReview+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D8736B6322F0AB4E00A14A29 /* Model 18.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 18.xcdatamodel"; sourceTree = "<group>"; };
 		D8736B6422F0AC9000A14A29 /* OrderCountItem+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCountItem+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D8736B6522F0AC9000A14A29 /* OrderCountItem+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCountItem+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -228,8 +230,6 @@
 		D87F61542265AA900031A13B /* PListFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PListFileStorage.swift; sourceTree = "<group>"; };
 		D87F61562265AD980031A13B /* FileStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorageTests.swift; path = StorageTests/Tools/FileStorageTests.swift; sourceTree = SOURCE_ROOT; };
 		D87F615B2265AF190031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
-		D8C251D4230D183100F49782 /* ProductReview+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductReview+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataClass.swift"; sourceTree = "<absolute>"; };
-		D8C251D5230D183100F49782 /* ProductReview+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductReview+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
 		D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 17.xcdatamodel"; sourceTree = "<group>"; };
 		D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -452,8 +452,6 @@
 				747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */,
 				7474538F2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift */,
 				747453902242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift */,
-				D8C251D4230D183100F49782 /* ProductReview+CoreDataClass.swift */,
-				D8C251D5230D183100F49782 /* ProductReview+CoreDataProperties.swift */,
 				747453932242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift */,
 				747453942242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift */,
 				747453972242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift */,
@@ -464,6 +462,8 @@
 				CE43A8FC229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift */,
 				747453912242C85E00E0B5EE /* ProductImage+CoreDataClass.swift */,
 				747453922242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift */,
+				D8550D01230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift */,
+				D8550D00230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift */,
 				747453992242C85E00E0B5EE /* ProductTag+CoreDataClass.swift */,
 				7474539A2242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift */,
 				7499FA42221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift */,
@@ -686,6 +686,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5B914C520EFF03500F2F832 /* Site+CoreDataClass.swift in Sources */,
+				D8550D03230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift in Sources */,
 				74938EC9216FA9B200540BA1 /* OrderStatsItem+CoreDataProperties.swift in Sources */,
 				747453A02242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift in Sources */,
 				B54CA5BB20A4BD2800F38CD1 /* NSManagedObject+Object.swift in Sources */,
@@ -754,15 +755,14 @@
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,
 				7499FA44221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift in Sources */,
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
-				D8C251D7230D183200F49782 /* ProductReview+CoreDataProperties.swift in Sources */,
 				D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,
+				D8550D02230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
-				D8C251D6230D183200F49782 /* ProductReview+CoreDataClass.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,
 				CE43A8FE229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift in Sources */,
 				747453A22242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61542265AA900031A13B /* PListFileStorage.swift */; };
 		D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87F61562265AD980031A13B /* FileStorageTests.swift */; };
 		D87F615C2265AF190031A13B /* shipment-provider.plist in Resources */ = {isa = PBXBuildFile; fileRef = D87F615B2265AF190031A13B /* shipment-provider.plist */; };
+		D8C251D6230D183200F49782 /* ProductReview+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D4230D183100F49782 /* ProductReview+CoreDataClass.swift */; };
+		D8C251D7230D183200F49782 /* ProductReview+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D5230D183100F49782 /* ProductReview+CoreDataProperties.swift */; };
 		D8FBFF5522D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */; };
 		D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */; };
 		D8FBFF5722D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBFF5122D66A06006E3336 /* OrderStatsV4Totals+CoreDataClass.swift */; };
@@ -226,6 +228,8 @@
 		D87F61542265AA900031A13B /* PListFileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PListFileStorage.swift; sourceTree = "<group>"; };
 		D87F61562265AD980031A13B /* FileStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FileStorageTests.swift; path = StorageTests/Tools/FileStorageTests.swift; sourceTree = SOURCE_ROOT; };
 		D87F615B2265AF190031A13B /* shipment-provider.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "shipment-provider.plist"; sourceTree = "<group>"; };
+		D8C251D4230D183100F49782 /* ProductReview+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductReview+CoreDataClass.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataClass.swift"; sourceTree = "<absolute>"; };
+		D8C251D5230D183100F49782 /* ProductReview+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductReview+CoreDataProperties.swift"; path = "/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
 		D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 17.xcdatamodel"; sourceTree = "<group>"; };
 		D8FBFF4F22D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataClass.swift"; sourceTree = "<group>"; };
 		D8FBFF5022D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -448,6 +452,8 @@
 				747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */,
 				7474538F2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift */,
 				747453902242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift */,
+				D8C251D4230D183100F49782 /* ProductReview+CoreDataClass.swift */,
+				D8C251D5230D183100F49782 /* ProductReview+CoreDataProperties.swift */,
 				747453932242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift */,
 				747453942242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift */,
 				747453972242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift */,
@@ -748,6 +754,7 @@
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,
 				7499FA44221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift in Sources */,
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
+				D8C251D7230D183200F49782 /* ProductReview+CoreDataProperties.swift in Sources */,
 				D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
@@ -755,6 +762,7 @@
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
+				D8C251D6230D183200F49782 /* ProductReview+CoreDataClass.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,
 				CE43A8FE229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift in Sources */,
 				747453A22242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -3,6 +3,9 @@
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
 ## Model 19 (Release 2.6.0.0)
+- @ctarda 2019-08-21
+- Add `ProductReview` entity
+
 - @jaclync 2019-08-14
 - Add `timezone` attribute to `Site` entity
 
@@ -13,6 +16,7 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 - @ctarda 2019-07-30
     - Add `OrderCount` entity
     - Add `OrderCountItem` entity
+
 ## Model 17 (Release 2.3.0.0)
 - @ctarda 2019-07-10
     - Add `OrderStatsV4` entity

--- a/Storage/Storage/Model/ProductReview+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductReview+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(ProductReview)
+public class ProductReview: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductReview+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductReview+CoreDataProperties.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreData
+
+
+extension ProductReview {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductReview> {
+        return NSFetchRequest<ProductReview>(entityName: "ProductReview")
+    }
+
+    @NSManaged public var dateCreated: NSDate?
+    @NSManaged public var productID: Int64
+    @NSManaged public var rating: Int64
+    @NSManaged public var review: String?
+    @NSManaged public var reviewer: String?
+    @NSManaged public var reviewerEmail: String?
+    @NSManaged public var reviewID: Int64
+    @NSManaged public var siteID: Int64
+    @NSManaged public var statusKey: String?
+    @NSManaged public var verified: Bool
+
+}

--- a/Storage/Storage/Model/ProductReview+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductReview+CoreDataProperties.swift
@@ -8,7 +8,7 @@ extension ProductReview {
         return NSFetchRequest<ProductReview>(entityName: "ProductReview")
     }
 
-    @NSManaged public var dateCreated: NSDate?
+    @NSManaged public var dateCreated: Date?
     @NSManaged public var productID: Int64
     @NSManaged public var rating: Int64
     @NSManaged public var review: String?

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 19.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 19.xcdatamodel/contents
@@ -290,7 +290,7 @@
         <attribute name="src" attributeType="String" syncable="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product" syncable="YES"/>
     </entity>
-    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES" codeGenerationType="class">
+    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
         <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
@@ -396,6 +396,7 @@
         <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
         <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="105"/>
         <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductReview" positionX="-693" positionY="36" width="128" height="195"/>
         <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
         <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
         <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
@@ -406,6 +407,5 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
-        <element name="ProductReview" positionX="-693" positionY="36" width="128" height="195"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 19.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 19.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18F132" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
@@ -290,6 +290,18 @@
         <attribute name="src" attributeType="String" syncable="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product" syncable="YES"/>
     </entity>
+    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES" codeGenerationType="class">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="review" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="reviewer" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="reviewerEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="reviewID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="verified" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
     <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
         <attribute name="slug" attributeType="String" syncable="YES"/>
@@ -394,5 +406,6 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+        <element name="ProductReview" positionX="-693" positionY="36" width="128" height="195"/>
     </elements>
 </model>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -262,4 +262,19 @@ public extension StorageType {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND tagID = %ld", siteID, productID, tagID)
         return firstObject(ofType: ProductTag.self, matching: predicate)
     }
+
+    /// Retrieves all of the stored ProductReviews for the provided siteID. Sorted by dateCreated, descending
+    ///
+    func loadProductReviews(siteID: Int) -> [ProductReview]? {
+        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \ProductReview.dateCreated, ascending: false)
+        return allObjects(ofType: ProductReview.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Retrieves a stored ProductReview for the provided siteID and reviewID.
+    ///
+    func loadProduct(siteID: Int, reviewID: Int) -> ProductReview? {
+        let predicate = NSPredicate(format: "siteID = %ld AND reviewID = %ld", siteID, reviewID)
+        return firstObject(ofType: ProductReview.self, matching: predicate)
+    }
 }

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -2,12 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataClass.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataProperties.swift">
-   </FileRef>
-   <FileRef
       location = "group:WooCommerce/WooCommerce.xcodeproj">
    </FileRef>
    <FileRef

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataClass.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataProperties.swift">
+   </FileRef>
+   <FileRef
       location = "group:WooCommerce/WooCommerce.xcodeproj">
    </FileRef>
    <FileRef


### PR DESCRIPTION
Fixes #1203 

I didn't add a new model version and added the new entity to model 19, as 2.5 is running model 18. I am not sure that's the right thing to do, though, so I'm happy to add a new model version if that's better.

## Changes
- Added the ProductReview entity to the Model 19
- Generated coredata extensions 
- Added convenience methods to fetch `ProductReview` from coredata store

## Testing
Because I didn't add a new model version, it might be necessary to checkout and run first a version of the app with Model 18. I tested with release/2.5
- Checkout and run release/2.5
- Checkout, build and run this branch. 👀  at the code.
- Check that there are no migration warnings or errors in the console
- Check that I didn't introduce any warnings (apparently I tend to do that when generating coredata extensions)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.