### PR TITLE
Update release-toolkit to 0.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,18 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: b07b78c3d5a5ea47fd48f7ae54e866f6985795e7
-  tag: 0.2.3
+  revision: b57127b313fd06519cbebfd4a3f6784eec1ef5fc
+  tag: 0.7.1
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.2.3)
-      diffy
-      git
-      nokogiri
-      octokit
+    fastlane-plugin-wpmreleasetoolkit (0.7.1)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint
+      nokogiri (>= 1.10.4)
+      octokit (~> 4.13)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -154,6 +159,9 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
+    jsonlint (0.3.0)
+      oj (~> 3)
+      optimist (~> 3)
     jwt (2.1.0)
     memoist (0.16.0)
     mime-types (3.2.2)
@@ -170,19 +178,29 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    oj (3.9.0)
+    optimist (3.0.0)
+    options (2.3.2)
     os (1.0.1)
+    parallel (1.17.0)
     plist (3.5.0)
+    progress_bar (1.3.0)
+      highline (>= 1.6, < 3)
+      options (~> 2.3.0)
     public_suffix (2.0.5)
     rake (12.3.3)
+    rake-compiler (1.0.7)
+      rake
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
+    rmagick (3.2.0)
     rouge (2.0.7)
     ruby-macho (1.4.0)
     rubyzip (1.2.2)
@@ -237,6 +255,7 @@ DEPENDENCIES
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   rake!
+  rmagick (~> 3.2.0)
   xcpretty-travis-formatter!
 
 BUNDLED WITH

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -2,5 +2,9 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.2.3'
+group :screenshots, optional: true do
+  gem 'rmagick', '~> 3.2.0'
+end
+
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', :tag => '0.7.1'
 gem 'fastlane-plugin-sentry'


### PR DESCRIPTION

This PR updates `release-toolkit` to `0.7.1` to get rid of the security alert related to `Nokogiri`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
