### PR TITLE
Update Zendesk SDK to version 3.0.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack/Swift', '~> 3.5'
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.3.0'
-  pod 'ZendeskSDK', '~> 3.0'
+  pod 'ZendeskSDK', '3.0.1'
 
   # Unit Tests
   # ==========

--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack/Swift', '~> 3.5'
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.3.0'
-  pod 'ZendeskSDK', '~> 2.3.1'
+  pod 'ZendeskSDK', '~> 3.0'
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,13 +66,13 @@ PODS:
   - WordPressUI (1.3.5-beta.1)
   - wpxmlrpc (0.8.4)
   - XLPagerTabStrip (9.0.0)
-  - ZendeskSDK (2.3.1):
-    - ZendeskSDK/Providers (= 2.3.1)
-    - ZendeskSDK/UI (= 2.3.1)
-  - ZendeskSDK/Core (2.3.1)
-  - ZendeskSDK/Providers (2.3.1):
+  - ZendeskSDK (3.0.1):
+    - ZendeskSDK/Providers (= 3.0.1)
+    - ZendeskSDK/UI (= 3.0.1)
+  - ZendeskSDK/Core (3.0.1)
+  - ZendeskSDK/Providers (3.0.1):
     - ZendeskSDK/Core
-  - ZendeskSDK/UI (2.3.1):
+  - ZendeskSDK/UI (3.0.1):
     - ZendeskSDK/Core
     - ZendeskSDK/Providers
 
@@ -88,7 +88,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.2)
   - WordPressUI (~> 1.3.5-beta)
   - XLPagerTabStrip (~> 9.0)
-  - ZendeskSDK (~> 2.3.1)
+  - ZendeskSDK (~> 3.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -143,8 +143,8 @@ SPEC CHECKSUMS:
   WordPressUI: 32cdbb68f0a214c2172ee7cb368a5d76a49cfbb9
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
-  ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
+  ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
 
-PODFILE CHECKSUM: 9a0c6c80d9160ea05c1f9ee8ab3311ad3ef3ab61
+PODFILE CHECKSUM: 8fde8953db7f6af77f9c1baef5c170eadc8da2be
 
 COCOAPODS: 1.6.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -88,7 +88,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.2)
   - WordPressUI (~> 1.3.5-beta)
   - XLPagerTabStrip (~> 9.0)
-  - ZendeskSDK (~> 3.0)
+  - ZendeskSDK (= 3.0.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -145,6 +145,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
 
-PODFILE CHECKSUM: 8fde8953db7f6af77f9c1baef5c170eadc8da2be
+PODFILE CHECKSUM: f1b65f7e75f282a478f02948a7190e8824a54e8b
 
 COCOAPODS: 1.6.2

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ZendeskSDK
 import ZendeskCoreSDK
+import CommonUISDK // Zendesk UI SDK
 import WordPressShared
 import CoreTelephony
 import SafariServices
@@ -84,9 +85,11 @@ class ZendeskManager: NSObject {
             return
         }
 
-        Zendesk.initialize(appId: ApiCredentials.zendeskAppId, clientId: ApiCredentials.zendeskClientId, zendeskUrl: ApiCredentials.zendeskUrl)
-        Support.initialize(withZendesk: Zendesk.instance)
-        Theme.currentTheme.primaryColor = StyleManager.wooCommerceBrandColor
+        Zendesk.initialize(appId: ApiCredentials.zendeskAppId,
+                           clientId: ApiCredentials.zendeskClientId,
+                           zendeskUrl: ApiCredentials.zendeskUrl)
+        SupportUI.initialize(withZendesk: Zendesk.instance)
+        CommonTheme.currentTheme.primaryColor = StyleManager.wooCommerceBrandColor
 
         haveUserIdentity = getUserProfile()
         zendeskEnabled = true

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1985,7 +1985,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/XLPagerTabStrip/XLPagerTabStrip.bundle",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskSDKStrings.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -1998,7 +1997,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/XLPagerTabStrip.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ZendeskSDKStrings.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2054,9 +2052,10 @@
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskCoreSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskProviderSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/ZendeskCoreSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/ZendeskProviderSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/ZendeskSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/CommonUISDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -2066,6 +2065,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskCoreSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskProviderSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonUISDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
This is Zendesk update part 1 of 2. I propose merging Part 1 into develop, [just like WordPress did](https://github.com/wordpress-mobile/WordPress-iOS/pull/12264). Part 2 ([Zendesk SDK v 3.0.1 Swift 5.1 beta 5 compatible build](https://developer.zendesk.com/embeddables/docs/ios_support_sdk/release_notes#3.0.1-swift-5.1-beta-5-compatible-build)) would live in a feature branch and have a Draft PR.

This PR updates Zendesk to the latest stable version, 3.0.1, and migrates the code. The new CommonUISDK is used for setting our purple nav bar color in the Create Ticket view controller and a class name changed (from Support to SupportUI). 

I updated the pod file to point to any 3.x updates

## Questions

Should we only allow it to make updates on 3.0.x? (I have trust issues with Zendesk)

## To test

Zendesk UI code changed. Testing can be limited to checking out the UI.

Fast instructions
- run the App to make sure everything works as before
- try to make some tests with Help & Support

Detailed Instructions
1. Check out this branch
2. Go to the command line and cd into your woocommerce-ios directory. Execute `bundle exec pod install` to install ZendeskSDK 3.0.1
3. Try and create a new Zendesk ticket in any number of ways: while logged out, while logged in, while on a simulator, while on a device, with your work email (should fail) and with an alternative email. 
4. If you're using a device, try attaching and sending a file.
5. Send yourself a reply (or ask me and I'll send you one). Check that the ticket appears under My Tickets for that specific device or simulator. Check that the reply comes through on that specific device or simulator. (Current open tickets made on a different device will not show up on the different device).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
