### PR TITLE
 Global dependencies. Service Locator and AppDelegate

### DIFF
--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -2,12 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataClass.swift">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataProperties.swift">
-   </FileRef>
-   <FileRef
       location = "group:WooCommerce/WooCommerce.xcodeproj">
    </FileRef>
    <FileRef

--- a/WooCommerce.xcworkspace/contents.xcworkspacedata
+++ b/WooCommerce.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataClass.swift">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/ctarda/Development/woocommerce-ios/Storage/Storage/Model/ProductReview+CoreDataProperties.swift">
+   </FileRef>
+   <FileRef
       location = "group:WooCommerce/WooCommerce.xcodeproj">
    </FileRef>
    <FileRef

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -27,10 +27,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     let authenticationManager = AuthenticationManager()
 
-    /// Push Notifications Manager
-    ///
-    let pushNotesManager = PushNotificationsManager()
-
     /// CoreData Stack
     ///
     let storageManager = CoreDataManager(name: WooConstants.databaseStackName)
@@ -102,17 +98,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return
         }
 
-        pushNotesManager.registerDeviceToken(with: deviceToken, defaultStoreID: defaultStoreID)
+        ServiceLocator.pushNotesManager.registerDeviceToken(with: deviceToken, defaultStoreID: defaultStoreID)
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        pushNotesManager.registrationDidFail(with: error)
+        ServiceLocator.pushNotesManager.registrationDidFail(with: error)
     }
 
     func application(_ application: UIApplication,
                      didReceiveRemoteNotification userInfo: [AnyHashable: Any],
                      fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        pushNotesManager.handleNotification(userInfo, completionHandler: completionHandler)
+        ServiceLocator.pushNotesManager.handleNotification(userInfo, completionHandler: completionHandler)
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -27,10 +27,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     let authenticationManager = AuthenticationManager()
 
-    /// In-App Notifications Presenter
-    ///
-    let noticePresenter = NoticePresenter()
-
     /// Push Notifications Manager
     ///
     let pushNotesManager = PushNotificationsManager()
@@ -260,6 +256,7 @@ private extension AppDelegate {
     /// Setup: Notice Presenter
     ///
     func setupNoticePresenter() {
+        var noticePresenter = ServiceLocator.noticePresenter
         noticePresenter.presentingViewController = window?.rootViewController
     }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -23,10 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     var window: UIWindow?
 
-    /// CoreData Stack
-    ///
-    let storageManager = CoreDataManager(name: WooConstants.databaseStackName)
-
     /// Cocoalumberjack DDLog
     /// The type definition is needed because DDFilelogger doesn't have a nullability specifier (but is still a non-optional).
     ///

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -23,11 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     var window: UIWindow?
 
-    /// Cocoalumberjack DDLog
-    /// The type definition is needed because DDFilelogger doesn't have a nullability specifier (but is still a non-optional).
-    ///
-    let fileLogger: DDFileLogger = DDFileLogger()
-
     /// Tab Bar Controller
     ///
     var tabBarController: MainTabBarController? {
@@ -224,11 +219,15 @@ private extension AppDelegate {
     /// Sets up CocoaLumberjack logging.
     ///
     func setupCocoaLumberjack() {
+        var fileLogger = ServiceLocator.fileLogger
         fileLogger.rollingFrequency = TimeInterval(60*60*24)  // 24 hours
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7
 
+        guard let logger = fileLogger as? DDFileLogger else {
+            return
+        }
         DDLog.add(DDOSLogger.sharedInstance)
-        DDLog.add(fileLogger)
+        DDLog.add(logger)
     }
 
     /// Sets up the current Log Leve.

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -23,10 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     var window: UIWindow?
 
-    /// WordPressAuthenticator Wrapper
-    ///
-    let authenticationManager = AuthenticationManager()
-
     /// CoreData Stack
     ///
     let storageManager = CoreDataManager(name: WooConstants.databaseStackName)
@@ -90,7 +86,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             fatalError()
         }
 
-        return authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
+        return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -226,7 +222,7 @@ private extension AppDelegate {
     /// Sets up the WordPress Authenticator.
     ///
     func setupAuthenticationManager() {
-        authenticationManager.initialize()
+        ServiceLocator.authenticationManager.initialize()
     }
 
     /// Sets up CocoaLumberjack logging.
@@ -328,7 +324,7 @@ extension AppDelegate {
             fatalError()
         }
 
-        authenticationManager.displayAuthentication(from: rootViewController)
+        ServiceLocator.authenticationManager.displayAuthentication(from: rootViewController)
     }
 
     /// Whenever the app is authenticated but there is no Default StoreID: Let's display the Store Picker.

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -6,7 +6,7 @@ import Yosemite
 
 /// Encapsulates all of the interactions with the WordPress Authenticator
 ///
-class AuthenticationManager {
+class AuthenticationManager: Authentication {
 
     /// Store Picker Coordinator
     ///

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -93,7 +93,7 @@ private extension StorePickerCoordinator {
                 + "Reads like: Switched to {store name}. You will only receive notifications from this store.")
         let notice = Notice(title: message, feedbackType: .success)
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     func logOutOfCurrentStore(onCompletion: @escaping () -> Void) {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -204,7 +204,7 @@ private extension StorePickerViewController {
         accountHeaderView.fullname = defaultAccount.displayName
         accountHeaderView.downloadGravatar(with: defaultAccount.email)
         accountHeaderView.isHelpButtonEnabled = configuration == .login
-        accountHeaderView.onHelpRequested = { AppDelegate.shared.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin) }
+        accountHeaderView.onHelpRequested = { ServiceLocator.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin) }
     }
 
     func setupNavigation() {
@@ -368,7 +368,7 @@ private extension StorePickerViewController {
 
         ServiceLocator.stores.deauthenticate()
 
-        let loginViewController = AppDelegate.shared.authenticationManager.loginForWordPressDotCom()
+        let loginViewController = ServiceLocator.authenticationManager.loginForWordPressDotCom()
         navigationController.setViewControllers([loginViewController], animated: true)
     }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -111,8 +111,8 @@ class StorePickerViewController: UIViewController {
 
     /// Site Picker's dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
-    private lazy var noticePresenter: NoticePresenter = {
-        let noticePresenter = NoticePresenter()
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         return noticePresenter
     }()

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -120,7 +120,7 @@ class StorePickerViewController: UIViewController {
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
     private let resultsController: ResultsController<StorageSite> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "isWooCommerceActive == YES")
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -109,7 +109,7 @@ class StorePickerViewController: UIViewController {
         return AccountHeaderView.instantiateFromNib()
     }()
 
-    /// Site Picker's dedicated NoticePresenter (use this here instead of AppDelegate.shared.noticePresenter)
+    /// Site Picker's dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
     private lazy var noticePresenter: NoticePresenter = {
         let noticePresenter = NoticePresenter()

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -145,7 +145,7 @@ extension LoginPrologueViewController {
     ///
     @IBAction func loginWasPressed() {
         ServiceLocator.analytics.track(.loginPrologueContinueTapped)
-        let loginViewController = AppDelegate.shared.authenticationManager.loginForWordPressDotCom()
+        let loginViewController = ServiceLocator.authenticationManager.loginForWordPressDotCom()
 
         navigationController?.pushViewController(loginViewController, animated: true)
         navigationController?.setNavigationBarHidden(false, animated: true)

--- a/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
+++ b/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
@@ -42,6 +42,6 @@ extension UIApplication: ApplicationAdapter {
     ///
     func presentInAppNotification(message: String) {
         let notice = Notice(title: message, message: nil, feedbackType: .success)
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -7,7 +7,7 @@ import Yosemite
 
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
 ///
-class PushNotificationsManager {
+class PushNotificationsManager: PushNotesManager {
 
     /// PushNotifications Configuration
     ///

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -1,0 +1,28 @@
+import Foundation
+import UIKit
+import WordPressAuthenticator
+
+/// Abstracts the Authentication engine.
+///
+protocol Authentication {
+
+    /// Returns a LoginViewController preinitialized for WordPress.com
+    ///
+    func loginForWordPressDotCom() -> UIViewController
+
+    /// Presents the Support Interface from a given ViewController, with a specified SourceTag.
+    ///
+    func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag)
+
+    /// Handles an Authentication URL Callback. Returns *true* on success.
+    ///
+    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool
+
+    /// Displays the Login Flow using the specified UIViewController as presenter.
+    ///
+    func displayAuthentication(from presenter: UIViewController)
+
+    /// Initializes the WordPress Authenticator.
+    ///
+    func initialize()
+}

--- a/WooCommerce/Classes/ServiceLocator/Logs.swift
+++ b/WooCommerce/Classes/ServiceLocator/Logs.swift
@@ -1,0 +1,11 @@
+import Foundation
+import CocoaLumberjack
+
+/// Abstracts the Login engine.
+///
+protocol Logs {
+    var logFileManager: DDLogFileManager { get }
+    var rollingFrequency: TimeInterval { get set }
+}
+
+extension DDFileLogger: Logs { }

--- a/WooCommerce/Classes/ServiceLocator/NoticePresenter.swift
+++ b/WooCommerce/Classes/ServiceLocator/NoticePresenter.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressUI
 
 /// Abstracts the In-App Notifications Presenter
-protocol Notices {
+protocol NoticePresenter {
 
     /// Enqueues the specified Notice for display.
     ///

--- a/WooCommerce/Classes/ServiceLocator/Notices.swift
+++ b/WooCommerce/Classes/ServiceLocator/Notices.swift
@@ -1,0 +1,14 @@
+import Foundation
+import WordPressUI
+
+/// Abstracts the In-App Notifications Presenter
+protocol Notices {
+    
+    /// Enqueues the specified Notice for display.
+    ///
+    func enqueue(notice: Notice)
+
+    /// UIViewController to be used as Notice(s) Presenter
+    ///
+    var presentingViewController: UIViewController? { get set }
+}

--- a/WooCommerce/Classes/ServiceLocator/Notices.swift
+++ b/WooCommerce/Classes/ServiceLocator/Notices.swift
@@ -3,7 +3,7 @@ import WordPressUI
 
 /// Abstracts the In-App Notifications Presenter
 protocol Notices {
-    
+
     /// Enqueues the specified Notice for display.
     ///
     func enqueue(notice: Notice)

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -1,0 +1,32 @@
+import Foundation
+import UIKit
+
+protocol PushNotesManager {
+
+    /// Resets the Badge Count.
+    ///
+    func resetBadgeCount()
+
+    /// Unregisters the Application from WordPress.com Push Notifications Service.
+    ///
+    func unregisterForRemoteNotifications()
+
+    /// Handles Push Notifications Registration Errors. This method unregisters the current device from the WordPress.com
+    /// Push Service.
+    ///
+    /// - Parameter error: Error received after attempting to register for Push Notifications.
+    ///
+    func registrationDidFail(with error: Error)
+
+    /// Registers the Device Token agains WordPress.com backend, if there's a default account.
+    ///
+    /// - Parameters:
+    ///     - tokenData: APNS's Token Data
+    ///     - defaultStoreID: Default WooCommerce Store ID
+    ///
+    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int)
+
+    /// Handles a Remote Push Notifican Payload. On completion the `completionHandler` will be executed.
+    ///
+    func handleNotification(_ userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void)
+}

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -26,9 +26,8 @@ final class ServiceLocator {
     private static var _storageManager = CoreDataManager(name: WooConstants.databaseStackName)
 
     /// Cocoalumberjack DDLog
-    /// The type definition is needed because DDFilelogger doesn't have a nullability specifier (but is still a non-optional).
     ///
-    private static var _fileLogger: DDFileLogger = DDFileLogger()
+    private static var _fileLogger: Logs = DDFileLogger()
 
     /// Provides the access point to the analytics.
     /// - Returns: An implementation of the Analytics protocol. It defaults to WooAnalytics
@@ -66,6 +65,12 @@ final class ServiceLocator {
     /// of the CoreDataManager should be subclasses
     static var storageManager: CoreDataManager {
         return _storageManager
+    }
+
+    /// Provides the access point to the FileLogger.
+    /// - Returns: An implementation of the Logs protocol. It defaults to DDFileLogger
+    static var fileLogger: Logs {
+        return _fileLogger
     }
 }
 
@@ -120,6 +125,14 @@ extension ServiceLocator {
         }
 
         _storageManager = mock
+    }
+
+    static func setFileLogger(_ mock: Logs) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _fileLogger = mock
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -6,7 +6,15 @@ import Storage
 /// Provides global depedencies.
 ///
 final class ServiceLocator {
+
+    // MARK: - Private properties
+
+    /// WooAnalytics Wrapper
+    ///
     private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
+
+    /// StoresManager
+    ///
     private static var _stores: StoresManager = DefaultStoresManager(sessionManager: .standard)
 
     /// WordPressAuthenticator Wrapper
@@ -28,6 +36,9 @@ final class ServiceLocator {
     /// Cocoalumberjack DDLog
     ///
     private static var _fileLogger: Logs = DDFileLogger()
+
+
+    // MARK: - Getters
 
     /// Provides the access point to the analytics.
     /// - Returns: An implementation of the Analytics protocol. It defaults to WooAnalytics

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -53,6 +53,12 @@ final class ServiceLocator {
     static var pushNotesManager: PushNotesManager {
         return _pushNotesManager
     }
+
+    /// Provides the access point to the AuthenticationManager.
+    /// - Returns: An implementation of the AuthenticationManager protocol. It defaults to DefaultAuthenticationManager
+    static var authenticationManager: Authentication {
+        return _authenticationManager
+    }
 }
 
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -23,7 +23,7 @@ final class ServiceLocator {
 
     /// In-App Notifications Presenter
     ///
-    private static var _noticePresenter: Notices = NoticePresenter()
+    private static var _noticePresenter: NoticePresenter = DefaultNoticePresenter()
 
     /// Push Notifications Manager
     ///
@@ -54,7 +54,7 @@ final class ServiceLocator {
 
     /// Provides the access point to the NoticePresenter.
     /// - Returns: An implementation of the NoticePresenter protocol. It defaults to DefaultNoticePresenter
-    static var noticePresenter: Notices {
+    static var noticePresenter: NoticePresenter {
         return _noticePresenter
     }
 
@@ -106,7 +106,7 @@ extension ServiceLocator {
         _stores = mock
     }
 
-    static func setNoticePresenter(_ mock: Notices) {
+    static func setNoticePresenter(_ mock: NoticePresenter) {
         guard isRunningTests() else {
             return
         }

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CocoaLumberjack
+import Storage
 
 
 /// Provides global depedencies.
@@ -6,6 +8,27 @@ import Foundation
 final class ServiceLocator {
     private static var _analytics: Analytics = WooAnalytics(analyticsProvider: TracksProvider())
     private static var _stores: StoresManager = DefaultStoresManager(sessionManager: .standard)
+
+    /// WordPressAuthenticator Wrapper
+    ///
+    private static var _authenticationManager = AuthenticationManager()
+
+    /// In-App Notifications Presenter
+    ///
+    private static var _noticePresenter = NoticePresenter()
+
+    /// Push Notifications Manager
+    ///
+    private static var _pushNotesManager = PushNotificationsManager()
+
+    /// CoreData Stack
+    ///
+    private static var _storageManager = CoreDataManager(name: WooConstants.databaseStackName)
+
+    /// Cocoalumberjack DDLog
+    /// The type definition is needed because DDFilelogger doesn't have a nullability specifier (but is still a non-optional).
+    ///
+    private static var _fileLogger: DDFileLogger = DDFileLogger()
 
     /// Provides the access point to the analytics.
     /// - Returns: An implementation of the Analytics protocol. It defaults to WooAnalytics

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -11,15 +11,15 @@ final class ServiceLocator {
 
     /// WordPressAuthenticator Wrapper
     ///
-    private static var _authenticationManager = AuthenticationManager()
+    private static var _authenticationManager: Authentication = AuthenticationManager()
 
     /// In-App Notifications Presenter
     ///
-    private static var _noticePresenter = NoticePresenter()
+    private static var _noticePresenter: Notices = NoticePresenter()
 
     /// Push Notifications Manager
     ///
-    private static var _pushNotesManager = PushNotificationsManager()
+    private static var _pushNotesManager: PushNotesManager = PushNotificationsManager()
 
     /// CoreData Stack
     ///
@@ -59,6 +59,14 @@ final class ServiceLocator {
     static var authenticationManager: Authentication {
         return _authenticationManager
     }
+
+    /// Provides the access point to the StorageManager.
+    /// - Returns: An instance of CoreDataManager. Notice how we break the pattern we
+    /// use in all other properties provided by the ServiceLocator. Mocked implementations
+    /// of the CoreDataManager should be subclasses
+    static var storageManager: CoreDataManager {
+        return _storageManager
+    }
 }
 
 
@@ -80,6 +88,38 @@ extension ServiceLocator {
         }
 
         _stores = mock
+    }
+
+    static func setNoticePresenter(_ mock: Notices) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _noticePresenter = mock
+    }
+
+    static func setPushNotesManager(_ mock: PushNotesManager) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _pushNotesManager = mock
+    }
+
+    static func setAuthenticationManager(_ mock: Authentication) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _authenticationManager = mock
+    }
+
+    static func setStorageManager(_ mock: CoreDataManager) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _storageManager = mock
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -41,6 +41,10 @@ final class ServiceLocator {
     static var stores: StoresManager {
         return _stores
     }
+
+    static var noticePresenter: Notices {
+        return _noticePresenter
+    }
 }
 
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -37,13 +37,21 @@ final class ServiceLocator {
     }
 
     /// Provides the access point to the stores.
-    /// - Returns: An implementation of the Stores protocol. It defaults to StoresManager
+    /// - Returns: An implementation of the StoresManager protocol. It defaults to DefaultStoresManager
     static var stores: StoresManager {
         return _stores
     }
 
+    /// Provides the access point to the NoticePresenter.
+    /// - Returns: An implementation of the NoticePresenter protocol. It defaults to DefaultNoticePresenter
     static var noticePresenter: Notices {
         return _noticePresenter
+    }
+
+    /// Provides the access point to the PushNotesManager.
+    /// - Returns: An implementation of the PushNotesManager protocol. It defaults to PushNotificationsManager
+    static var pushNotesManager: PushNotesManager {
+        return _pushNotesManager
     }
 }
 

--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -101,7 +101,7 @@ public class CurrencySettings {
     /// ResultsController: Whenever settings change, I will change. We both change. The world changes.
     ///
     private lazy var resultsController: ResultsController<StorageSiteSetting> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteSetting.siteID, ascending: false)
         return ResultsController<StorageSiteSetting>(storageManager: storageManager, sortedBy: [descriptor])
     }()

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -6,7 +6,7 @@ import WordPressUI
 
 /// NoticePresenter: Coordinates Notice rendering, in both, FG and BG execution modes.
 ///
-class NoticePresenter: Notices {
+class DefaultNoticePresenter: NoticePresenter {
 
     /// UIKit Feedback Gen!
     ///
@@ -36,7 +36,7 @@ class NoticePresenter: Notices {
 
 // MARK: - Private Methods
 //
-private extension NoticePresenter {
+private extension DefaultNoticePresenter {
 
     func presentNextNoticeIfPossible() {
         guard noticeOnScreen == nil, let next = notices.popFirst() else {

--- a/WooCommerce/Classes/Tools/Notices/NoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticePresenter.swift
@@ -6,7 +6,7 @@ import WordPressUI
 
 /// NoticePresenter: Coordinates Notice rendering, in both, FG and BG execution modes.
 ///
-class NoticePresenter {
+class NoticePresenter: Notices {
 
     /// UIKit Feedback Gen!
     ///

--- a/WooCommerce/Classes/Tools/SiteCountry.swift
+++ b/WooCommerce/Classes/Tools/SiteCountry.swift
@@ -5,7 +5,7 @@ final class SiteCountry {
     /// ResultsController. Fetches the store country from SiteSetting
     ///
     private lazy var resultsController: ResultsController<StorageSiteSetting> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let settingCountryPredicate = NSPredicate(format: "settingID ==[c] %@", Constants.countryKey)
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -544,7 +544,7 @@ private extension ZendeskManager {
 
     func getLogFile() -> String {
 
-        guard let logFileInformation = AppDelegate.shared.fileLogger.logFileManager.sortedLogFileInfos.first,
+        guard let logFileInformation = ServiceLocator.fileLogger.logFileManager.sortedLogFileInfos.first,
             let logData = try? Data(contentsOf: URL(fileURLWithPath: logFileInformation.filePath)),
             let logText = String(data: logData, encoding: .utf8) else {
                 return ""

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsNotices.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsNotices.swift
@@ -14,7 +14,7 @@ final class OrderDetailsNotices {
         )
 
         let notice = Notice(title: message, feedbackType: .error)
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the `Unable to delete tracking` Notice.
@@ -32,6 +32,6 @@ final class OrderDetailsNotices {
                                 onAction()
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsResultsControllers.swift
@@ -8,7 +8,7 @@ final class OrderDetailsResultsControllers {
 
     // Shipment Tracking ResultsController.
     private lazy var trackingResultsController: ResultsController<StorageShipmentTracking> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld",
                                     self.order.siteID,
                                     self.order.orderID)
@@ -20,7 +20,7 @@ final class OrderDetailsResultsControllers {
     /// Product ResultsController.
     ///
     private lazy var productResultsController: ResultsController<StorageProduct> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
@@ -30,7 +30,7 @@ final class OrderDetailsResultsControllers {
     /// Status Results Controller.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -60,14 +60,14 @@ final class ProductDetailsViewModel {
     /// EntityListener: Update / Deletion Notifications.
     ///
     private lazy var entityListener: EntityListener<Product> = {
-        return EntityListener(storageManager: AppDelegate.shared.storageManager,
+        return EntityListener(storageManager: ServiceLocator.storageManager,
                               readOnlyEntity: product)
     }()
 
     /// ResultsController for `WC > Settings > Products > General` from the site.
     ///
     private lazy var resultsController: ResultsController<StorageSiteSetting> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
 
         let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let settingTypePredicate = NSPredicate(format: "settingGroupKey ==[c] %@", SiteSettingGroup.product.rawValue)

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -53,7 +53,7 @@ final class ShippingProvidersViewModel {
     /// ResultsController to fetch the list of shipment providers,
     /// excluding the store country
     private lazy var providersExcludingStoreCountry: ResultsController<StorageShipmentTrackingProvider> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let groupNameKeyPath = ResultsControllerConstants.groupNameKeyPath
         let providerNameKeyPath = ResultsControllerConstants.providerNameKeyPath
         let excludingStoreCountry = predicateExcludingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
@@ -72,7 +72,7 @@ final class ShippingProvidersViewModel {
     /// Results controller, to fetch the list of shipment providers
     /// correspoding to the store country
     private lazy var providersForStoreCountry: ResultsController<StorageShipmentTrackingProvider> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let groupNameKeyPath = ResultsControllerConstants.groupNameKeyPath
         let providerNameKeyPath = ResultsControllerConstants.providerNameKeyPath
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -188,7 +188,7 @@ private extension DashboardViewController {
             self?.reloadData()
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -46,7 +46,7 @@ class PeriodDataViewController: UIViewController {
     /// SiteVisitStats ResultsController: Loads site visit stats from the Storage Layer
     ///
     private lazy var siteStatsResultsController: ResultsController<StorageSiteVisitStats> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "granularity ==[c] %@", granularity.rawValue)
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteVisitStats.date, ascending: false)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -56,7 +56,7 @@ class PeriodDataViewController: UIViewController {
     /// OrderStats ResultsController: Loads order stats from the Storage Layer
     ///
     private lazy var orderStatsResultsController: ResultsController<StorageOrderStats> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "granularity ==[c] %@", granularity.rawValue)
         let descriptor = NSSortDescriptor(keyPath: \StorageOrderStats.date, ascending: false)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -20,7 +20,7 @@ class TopPerformerDataViewController: UIViewController {
     /// ResultsController: Loads TopEarnerStats for the current granularity from the Storage Layer
     ///
     private lazy var resultsController: ResultsController<StorageTopEarnerStats> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let formattedDateString = StatsStore.buildDateString(from: Date(), with: granularity)
         let predicate = NSPredicate(format: "granularity = %@ AND date = %@", granularity.rawValue, formattedDateString)
         let descriptor = NSSortDescriptor(key: "date", ascending: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -16,7 +16,7 @@ class ApplicationLogViewController: UIViewController {
 
     /// Access the shared DDFileLogger
     ///
-    let fileLogger = AppDelegate.shared.fileLogger
+    let fileLogger = ServiceLocator.fileLogger
 
     /// List of log files
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -34,7 +34,7 @@ class SettingsViewController: UIViewController {
     /// ResultsController: Loads Sites from the Storage Layer.
     ///
     private let resultsController: ResultsController<StorageSite> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "isWooCommerceActive == YES")
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -83,7 +83,7 @@ class StoreStatsV4PeriodViewController: UIViewController {
     /// OrderStats ResultsController: Loads order stats from the Storage Layer
     ///
     private lazy var orderStatsResultsController: ResultsController<StorageOrderStatsV4> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "timeRange ==[c] %@", timeRange.rawValue)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [])
     }()
@@ -343,7 +343,7 @@ private extension StoreStatsV4PeriodViewController {
 // MARK: - Internal Updates
 private extension StoreStatsV4PeriodViewController {
     func updateSiteVisitStatsResultsController(currentDate: Date) -> ResultsController<StorageSiteVisitStats> {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "granularity ==[c] %@ AND date == %@",
                                     timeRange.siteVisitStatsGranularity.rawValue,
                                     DateFormatter.Stats.statsDayFormatter.string(from: currentDate))

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -16,7 +16,7 @@ class NotificationDetailsViewController: UIViewController {
     /// EntityListener: Update / Deletion Notifications.
     ///
     private lazy var entityListener: EntityListener<Note> = {
-        return EntityListener(storageManager: AppDelegate.shared.storageManager, readOnlyEntity: note)
+        return EntityListener(storageManager: ServiceLocator.storageManager, readOnlyEntity: note)
     }()
 
     /// Pull To Refresh Support.

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationDetailsViewController.swift
@@ -175,7 +175,7 @@ private extension NotificationDetailsViewController {
         let title = NSLocalizedString("The notification has been removed", comment: "Displayed whenever a Notification that was onscreen got deleted.")
         let notice = Notice(title: title, feedbackType: .error)
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the Error Notice.
@@ -190,7 +190,7 @@ private extension NotificationDetailsViewController {
         )
         let notice = Notice(title: message, feedbackType: .error)
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the `Comment moderated` Notice. Whenever the `Undo` button gets pressed, we'll execute the `onUndoAction` closure.
@@ -210,7 +210,7 @@ private extension NotificationDetailsViewController {
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
         let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle, actionHandler: onUndoAction)
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -737,7 +737,7 @@ private extension NotificationsViewController {
         markAsReadCount += 1
         let message = NSLocalizedString("All notifications marked as read", comment: "Mark all notifications as read notice")
         let notice = Notice(title: message, feedbackType: .success)
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -31,7 +31,7 @@ class NotificationsViewController: UIViewController {
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Notes in sync.
     ///
     private lazy var resultsController: ResultsController<StorageNote> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageNote.timestamp, ascending: false)
 
         return ResultsController<StorageNote>(storageManager: storageManager,

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -254,7 +254,7 @@ private extension NotificationsViewController {
     /// Nukes the BadgeCount
     ///
     func resetApplicationBadge() {
-        AppDelegate.shared.pushNotesManager.resetBadgeCount()
+        ServiceLocator.pushNotesManager.resetBadgeCount()
     }
 
     /// Update the last seen time for notifications

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -35,7 +35,7 @@ final class FulfillViewController: UIViewController {
     /// ResultsController fetching ShipemntTracking data
     ///
     private lazy var trackingResultsController: ResultsController<StorageShipmentTracking> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld",
                                     self.order.siteID,
                                     self.order.orderID)

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -228,7 +228,7 @@ private extension FulfillViewController {
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
         let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle, actionHandler: onUndoAction)
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the `Unable to Fulfill Order` Notice.
@@ -243,7 +243,7 @@ private extension FulfillViewController {
             self?.fulfillWasPressed()
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the product detail screen for the provided ProductID
@@ -528,7 +528,7 @@ private extension FulfillViewController {
                                 self?.deleteTracking(tracking)
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -18,8 +18,8 @@ final class ManualTrackingViewController: UIViewController {
 
     /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
-    private lazy var noticePresenter: NoticePresenter = {
-        let noticePresenter = NoticePresenter()
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         return noticePresenter
     }()

--- a/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ManualTrackingViewController.swift
@@ -16,7 +16,7 @@ final class ManualTrackingViewController: UIViewController {
         return self.viewModel.sections
     }()
 
-    /// Dedicated NoticePresenter (use this here instead of AppDelegate.shared.noticePresenter)
+    /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
     private lazy var noticePresenter: NoticePresenter = {
         let noticePresenter = NoticePresenter()

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -18,8 +18,8 @@ class NewNoteViewController: UIViewController {
 
     /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
-    private lazy var noticePresenter: NoticePresenter = {
-        let noticePresenter = NoticePresenter()
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         return noticePresenter
     }()

--- a/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/NewNoteViewController.swift
@@ -16,7 +16,7 @@ class NewNoteViewController: UIViewController {
 
     private var noteText: String = ""
 
-    /// Dedicated NoticePresenter (use this here instead of AppDelegate.shared.noticePresenter)
+    /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
     private lazy var noticePresenter: NoticePresenter = {
         let noticePresenter = NoticePresenter()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderDetailsViewController.swift
@@ -33,7 +33,7 @@ final class OrderDetailsViewController: UIViewController {
     /// EntityListener: Update / Deletion Notifications.
     ///
     private lazy var entityListener: EntityListener<Order> = {
-        return EntityListener(storageManager: AppDelegate.shared.storageManager, readOnlyEntity: viewModel.order)
+        return EntityListener(storageManager: ServiceLocator.storageManager, readOnlyEntity: viewModel.order)
     }()
 
     /// Order to be rendered!

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderLoaderViewController.swift
@@ -32,7 +32,7 @@ class OrderLoaderViewController: UIViewController {
     /// ResultsController: Handles all things order status
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderSearchViewController.swift
@@ -31,7 +31,7 @@ class OrderSearchViewController: UIViewController {
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Orders in sync.
     ///
     private lazy var resultsController: ResultsController<StorageOrder> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
 
         return ResultsController<StorageOrder>(storageManager: storageManager, sortedBy: [descriptor])
@@ -40,7 +40,7 @@ class OrderSearchViewController: UIViewController {
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) OrderStatuses in sync.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
@@ -253,7 +253,7 @@ extension OrderStatusListViewController {
         let actionTitle = NSLocalizedString("Undo", comment: "Undo Action")
         let notice = Notice(title: message, feedbackType: .success, actionTitle: actionTitle, actionHandler: onUndoAction)
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the `Unable to Change Status of Order` Notice.
@@ -268,6 +268,6 @@ extension OrderStatusListViewController {
             self?.applyButtonTapped()
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderStatusListViewController.swift
@@ -9,7 +9,7 @@ final class OrderStatusListViewController: UIViewController {
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) OrderStatuses in sync.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -29,7 +29,7 @@ class OrdersViewController: UIViewController {
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Orders in sync.
     ///
     private lazy var resultsController: ResultsController<StorageOrder> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
 
         return ResultsController<StorageOrder>(storageManager: storageManager, sectionNameKeyPath: "normalizedAgeAsString", sortedBy: [descriptor])
@@ -38,7 +38,7 @@ class OrdersViewController: UIViewController {
     /// ResultsController: Handles all things order status
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, sortedBy: [descriptor])

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -545,7 +545,7 @@ private extension OrdersViewController {
             self?.sync(pageNumber: pageNumber, pageSize: pageSize)
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays the Empty State Overlay.

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -22,7 +22,7 @@ final class ShipmentProvidersViewController: UIViewController {
         return returnValue
     }()
 
-    /// Dedicated NoticePresenter (use this here instead of AppDelegate.shared.noticePresenter)
+    /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
     private lazy var noticePresenter: NoticePresenter = {
         let noticePresenter = NoticePresenter()

--- a/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ShipmentProvidersViewController.swift
@@ -24,8 +24,8 @@ final class ShipmentProvidersViewController: UIViewController {
 
     /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
-    private lazy var noticePresenter: NoticePresenter = {
-        let noticePresenter = NoticePresenter()
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
         noticePresenter.presentingViewController = self
         return noticePresenter
     }()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -180,7 +180,7 @@ private extension ProductDetailsViewController {
         ), viewModel.productID)
 
         let notice = Notice(title: message, feedbackType: .error)
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 
     /// Displays a notice indicating that an error occurred while sync'ing.
@@ -196,7 +196,7 @@ private extension ProductDetailsViewController {
             self?.pullToRefresh()
         }
 
-        AppDelegate.shared.noticePresenter.enqueue(notice: notice)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -59,7 +59,7 @@ class AuthenticatedState: StoresManagerState {
     /// Executed before the current state is deactivated.
     ///
     func willLeave() {
-        let pushNotesManager = AppDelegate.shared.pushNotesManager
+        let pushNotesManager = ServiceLocator.pushNotesManager
 
         pushNotesManager.unregisterForRemoteNotifications()
         pushNotesManager.resetBadgeCount()

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -25,7 +25,7 @@ class AuthenticatedState: StoresManagerState {
     /// Designated Initializer
     ///
     init(credentials: Credentials) {
-        let storageManager = AppDelegate.shared.storageManager
+        let storageManager = ServiceLocator.storageManager
         let network = AlamofireNetwork(credentials: credentials)
 
         services = [

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -131,8 +131,8 @@ class DefaultStoresManager: StoresManager {
     func removeDefaultStore() {
         ServiceLocator.analytics.refreshUserData()
         ZendeskManager.shared.reset()
-        AppDelegate.shared.pushNotesManager.unregisterForRemoteNotifications()
-        AppDelegate.shared.pushNotesManager.resetBadgeCount()
+        ServiceLocator.pushNotesManager.unregisterForRemoteNotifications()
+        ServiceLocator.pushNotesManager.resetBadgeCount()
     }
 
     /// Switches the state to a Deauthenticated one.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -144,7 +144,7 @@ class DefaultStoresManager: StoresManager {
         sessionManager.reset()
         ServiceLocator.analytics.refreshUserData()
         ZendeskManager.shared.reset()
-        AppDelegate.shared.storageManager.reset()
+        ServiceLocator.storageManager.reset()
 
         NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */; };
 		D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */; };
 		D831E2DC230E0558000037D0 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2DB230E0558000037D0 /* Authentication.swift */; };
+		D831E2E0230E0BA7000037D0 /* Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2DF230E0BA7000037D0 /* Logs.swift */; };
 		D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */; };
 		D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */; };
 		D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F592E225B269C00626E75 /* DatePickerTableViewCell.swift */; };
@@ -778,6 +779,7 @@
 		D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Appearance.swift"; sourceTree = "<group>"; };
 		D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmptyListMessageWithActionTests.swift; path = WooCommerceTests/ViewRelated/EmptyListMessageWithActionTests.swift; sourceTree = SOURCE_ROOT; };
 		D831E2DB230E0558000037D0 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
+		D831E2DF230E0BA7000037D0 /* Logs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logs.swift; sourceTree = "<group>"; };
 		D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderTrackingTableViewCell.xib; sourceTree = "<group>"; };
 		D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderTrackingTableViewCell.swift; sourceTree = "<group>"; };
 		D83F592E225B269C00626E75 /* DatePickerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerTableViewCell.swift; sourceTree = "<group>"; };
@@ -1746,6 +1748,7 @@
 				D8C251D8230D256F00F49782 /* Notices.swift */,
 				D8C251DA230D288A00F49782 /* PushNotesManager.swift */,
 				D831E2DB230E0558000037D0 /* Authentication.swift */,
+				D831E2DF230E0BA7000037D0 /* Logs.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2254,6 +2257,7 @@
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,
 				CE583A072107849F00D73C1C /* SwitchTableViewCell.swift in Sources */,
 				D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */,
+				D831E2E0230E0BA7000037D0 /* Logs.swift in Sources */,
 				02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */,
 				D81D9228222E7F0800FFA585 /* OrderStatusListViewController.swift in Sources */,
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 		B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B582F95820FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift */; };
 		B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B586906521A5F4B1001F1EFC /* UINavigationController+Woo.swift */; };
 		B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58B4AAF2108F01400076FDD /* NoticeView.swift */; };
-		B58B4AB32108F01700076FDD /* NoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58B4AB02108F01600076FDD /* NoticePresenter.swift */; };
+		B58B4AB32108F01700076FDD /* DefaultNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58B4AB02108F01600076FDD /* DefaultNoticePresenter.swift */; };
 		B58B4AB62108F11C00076FDD /* Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58B4AB52108F11C00076FDD /* Notice.swift */; };
 		B58B4AB82108F14700076FDD /* NoticeNotificationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58B4AB72108F14700076FDD /* NoticeNotificationInfo.swift */; };
 		B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58B4ABF2108FF6100076FDD /* Array+Helpers.swift */; };
@@ -382,7 +382,7 @@
 		D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */; };
 		D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */; };
 		D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D1230CA90200F49782 /* StoresManager.swift */; };
-		D8C251D9230D256F00F49782 /* Notices.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D8230D256F00F49782 /* Notices.swift */; };
+		D8C251D9230D256F00F49782 /* NoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D8230D256F00F49782 /* NoticePresenter.swift */; };
 		D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251DA230D288A00F49782 /* PushNotesManager.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
@@ -616,7 +616,7 @@
 		B582F95820FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewHeaderFooterView+Helpers.swift"; sourceTree = "<group>"; };
 		B586906521A5F4B1001F1EFC /* UINavigationController+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Woo.swift"; sourceTree = "<group>"; };
 		B58B4AAF2108F01400076FDD /* NoticeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
-		B58B4AB02108F01600076FDD /* NoticePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoticePresenter.swift; sourceTree = "<group>"; };
+		B58B4AB02108F01600076FDD /* DefaultNoticePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultNoticePresenter.swift; sourceTree = "<group>"; };
 		B58B4AB52108F11C00076FDD /* Notice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notice.swift; sourceTree = "<group>"; };
 		B58B4AB72108F14700076FDD /* NoticeNotificationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeNotificationInfo.swift; sourceTree = "<group>"; };
 		B58B4ABF2108FF6100076FDD /* Array+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
@@ -815,7 +815,7 @@
 		D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderPaymentDetailsViewModelTests.swift; path = WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C251D1230CA90200F49782 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
-		D8C251D8230D256F00F49782 /* Notices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notices.swift; sourceTree = "<group>"; };
+		D8C251D8230D256F00F49782 /* NoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticePresenter.swift; sourceTree = "<group>"; };
 		D8C251DA230D288A00F49782 /* PushNotesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotesManager.swift; sourceTree = "<group>"; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
@@ -1293,7 +1293,7 @@
 			children = (
 				B58B4AB52108F11C00076FDD /* Notice.swift */,
 				B58B4AB72108F14700076FDD /* NoticeNotificationInfo.swift */,
-				B58B4AB02108F01600076FDD /* NoticePresenter.swift */,
+				B58B4AB02108F01600076FDD /* DefaultNoticePresenter.swift */,
 				B58B4AAF2108F01400076FDD /* NoticeView.swift */,
 			);
 			path = Notices;
@@ -1745,7 +1745,7 @@
 				D8C251D1230CA90200F49782 /* StoresManager.swift */,
 				D8D15F82230A17A000D48B3F /* ServiceLocator.swift */,
 				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
-				D8C251D8230D256F00F49782 /* Notices.swift */,
+				D8C251D8230D256F00F49782 /* NoticePresenter.swift */,
 				D8C251DA230D288A00F49782 /* PushNotesManager.swift */,
 				D831E2DB230E0558000037D0 /* Authentication.swift */,
 				D831E2DF230E0BA7000037D0 /* Logs.swift */,
@@ -2144,7 +2144,7 @@
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
-				D8C251D9230D256F00F49782 /* Notices.swift in Sources */,
+				D8C251D9230D256F00F49782 /* NoticePresenter.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
 				D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */,
@@ -2174,7 +2174,7 @@
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
 				D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */,
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
-				B58B4AB32108F01700076FDD /* NoticePresenter.swift in Sources */,
+				B58B4AB32108F01700076FDD /* DefaultNoticePresenter.swift in Sources */,
 				CE21B3D720FE669A00A259D5 /* BasicTableViewCell.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 		D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */; };
 		D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D1230CA90200F49782 /* StoresManager.swift */; };
 		D8C251D9230D256F00F49782 /* Notices.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D8230D256F00F49782 /* Notices.swift */; };
+		D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251DA230D288A00F49782 /* PushNotesManager.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
 		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
@@ -811,6 +812,7 @@
 		D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C251D1230CA90200F49782 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
 		D8C251D8230D256F00F49782 /* Notices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notices.swift; sourceTree = "<group>"; };
+		D8C251DA230D288A00F49782 /* PushNotesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotesManager.swift; sourceTree = "<group>"; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
@@ -1740,6 +1742,7 @@
 				D8D15F82230A17A000D48B3F /* ServiceLocator.swift */,
 				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
 				D8C251D8230D256F00F49782 /* Notices.swift */,
+				D8C251DA230D288A00F49782 /* PushNotesManager.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2231,6 +2234,7 @@
 				02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */,
 				B557DA1520979904005962F4 /* CustomerNoteTableViewCell.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
+				D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */; };
 		D8C11A6222E24C4A00D4A88D /* PaymentTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */; };
 		D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D1230CA90200F49782 /* StoresManager.swift */; };
+		D8C251D9230D256F00F49782 /* Notices.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C251D8230D256F00F49782 /* Notices.swift */; };
 		D8C62471227AE0030011A7D6 /* SiteCountry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C62470227AE0030011A7D6 /* SiteCountry.swift */; };
 		D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F82230A17A000D48B3F /* ServiceLocator.swift */; };
 		D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D15F84230A18AB00D48B3F /* Analytics.swift */; };
@@ -809,6 +810,7 @@
 		D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OrderPaymentDetailsViewModelTests.swift; path = WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C11A6122E24C4A00D4A88D /* PaymentTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentTableViewCellTests.swift; path = WooCommerceTests/ViewRelated/PaymentTableViewCellTests.swift; sourceTree = SOURCE_ROOT; };
 		D8C251D1230CA90200F49782 /* StoresManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoresManager.swift; sourceTree = "<group>"; };
+		D8C251D8230D256F00F49782 /* Notices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notices.swift; sourceTree = "<group>"; };
 		D8C62470227AE0030011A7D6 /* SiteCountry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCountry.swift; sourceTree = "<group>"; };
 		D8D15F82230A17A000D48B3F /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		D8D15F84230A18AB00D48B3F /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
@@ -1737,6 +1739,7 @@
 				D8C251D1230CA90200F49782 /* StoresManager.swift */,
 				D8D15F82230A17A000D48B3F /* ServiceLocator.swift */,
 				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
+				D8C251D8230D256F00F49782 /* Notices.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2132,6 +2135,7 @@
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
+				D8C251D9230D256F00F49782 /* Notices.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
 				D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81F2D36225F0D160084BF9C /* EmptyListMessageWithActionView.swift */; };
 		D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */; };
 		D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */; };
+		D831E2DC230E0558000037D0 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2DB230E0558000037D0 /* Authentication.swift */; };
 		D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */; };
 		D83C12A022250BF0004CA04C /* OrderTrackingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */; };
 		D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F592E225B269C00626E75 /* DatePickerTableViewCell.swift */; };
@@ -776,6 +777,7 @@
 		D81F2D36225F0D160084BF9C /* EmptyListMessageWithActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyListMessageWithActionView.swift; sourceTree = "<group>"; };
 		D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISearchBar+Appearance.swift"; sourceTree = "<group>"; };
 		D82DFB4B225F303200EFE2CB /* EmptyListMessageWithActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EmptyListMessageWithActionTests.swift; path = WooCommerceTests/ViewRelated/EmptyListMessageWithActionTests.swift; sourceTree = SOURCE_ROOT; };
+		D831E2DB230E0558000037D0 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		D83C129D22250BEF004CA04C /* OrderTrackingTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OrderTrackingTableViewCell.xib; sourceTree = "<group>"; };
 		D83C129E22250BEF004CA04C /* OrderTrackingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderTrackingTableViewCell.swift; sourceTree = "<group>"; };
 		D83F592E225B269C00626E75 /* DatePickerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerTableViewCell.swift; sourceTree = "<group>"; };
@@ -1743,6 +1745,7 @@
 				D8D15F84230A18AB00D48B3F /* Analytics.swift */,
 				D8C251D8230D256F00F49782 /* Notices.swift */,
 				D8C251DA230D288A00F49782 /* PushNotesManager.swift */,
+				D831E2DB230E0558000037D0 /* Authentication.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2188,6 +2191,7 @@
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				748C7780211E18A600814F2C /* OrderStats+Woo.swift in Sources */,
+				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */,
 				CE4DA5C621DD755E00074607 /* CurrencyFormatter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+@testable import CocoaLumberjack
 
 final class ServiceLocatorTests: XCTestCase {
 
@@ -21,5 +22,49 @@ final class ServiceLocatorTests: XCTestCase {
         let stores = ServiceLocator.stores
 
         XCTAssertTrue(stores is DefaultStoresManager)
+    }
+
+    func testServiceLocatorProvidesNotices() {
+        XCTAssertNotNil(ServiceLocator.noticePresenter)
+    }
+
+    func testNoticesDefaultsToNoticePresenter() {
+        let notices = ServiceLocator.noticePresenter
+
+        XCTAssertTrue(notices is NoticePresenter)
+    }
+
+    func testServiceLocatorProvidesPushNotificationsManager() {
+        XCTAssertNotNil(ServiceLocator.pushNotesManager)
+    }
+
+    func testPushNotesManagerDefaultsToPushNotificationsManager() {
+        let pushNotes = ServiceLocator.pushNotesManager
+
+        XCTAssertTrue(pushNotes is PushNotificationsManager)
+    }
+
+    func testServiceLocatorProvidesAuthenticationManager() {
+        XCTAssertNotNil(ServiceLocator.authenticationManager)
+    }
+
+    func testAutenticationManagerDefaultsAuthenticationManager() {
+        let authentication = ServiceLocator.authenticationManager
+
+        XCTAssertTrue(authentication is AuthenticationManager)
+    }
+
+    func testServiceLocatorProvidesStorageManager() {
+        XCTAssertNotNil(ServiceLocator.storageManager)
+    }
+
+    func testServiceLocatorProvidesLogger() {
+        XCTAssertNotNil(ServiceLocator.fileLogger)
+    }
+
+    func testFileLoggerDefaultsToDDFileLogger() {
+        let fileLogger = ServiceLocator.fileLogger
+
+        XCTAssertTrue(fileLogger is DDFileLogger)
     }
 }


### PR DESCRIPTION
Fixes #1214 

This PR is about extracting some of the global dependencies that are accessible via the AppDelegate, and move them to the ServiceLocator.

The dependencies removed from the AppDelegate are:
- AuthenticationManager
- NoticesPresenter
- PushNotificationsManager
- CoreDataManager
- DDFIleLogger

The dependencies that remain in the AppDelegate are 
- tabBarController
- one call to `displayAuthenticator()`

I have tried not to rename any of the pre-existing classes, to make the diff more or less manageable. The headerdoc in the ServiceLocator reflect the names I would like to use but not the current names. My intention is that if / when this gets ready to merge, rename a few pairs class / protocol accordingly. (i.e. `Notices` >> `NoticePresenter` and `NoticePresenter` >> `DefaultNoticePresenter`)

## Changes
- Added properties to the ServiceLocator, and removed them from the AppDelegate
- Added tests to the ServiceLocatorTests

## Testing
- Build and run. 
- Run the tests.
- 👀  at the code. Did I introduce any leak / reference cycle?

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
