### PR TITLE
Dashboard/Stats v4: update site visit params

### DIFF
--- a/Networking/Networking/Remote/SiteVisitStatsRemote.swift
+++ b/Networking/Networking/Remote/SiteVisitStatsRemote.swift
@@ -15,13 +15,18 @@ public class SiteVisitStatsRemote: Remote {
     ///   - completion: Closure to be executed upon completion.
     ///
     public func loadSiteVisitorStats(for siteID: Int,
+                                     siteTimezone: TimeZone? = nil,
                                      unit: StatGranularity,
                                      latestDateToInclude: Date,
                                      quantity: Int,
                                      completion: @escaping (SiteVisitStats?, Error?) -> Void) {
         let path = "\(Constants.sitesPath)/\(siteID)/\(Constants.siteVisitStatsPath)/"
+        let dateFormatter = DateFormatter.Stats.statsDayFormatter
+        if let siteTimezone = siteTimezone {
+            dateFormatter.timeZone = siteTimezone
+        }
         let parameters = [ParameterKeys.unit: unit.rawValue,
-                          ParameterKeys.date: DateFormatter.Stats.statsDayFormatter.string(from: latestDateToInclude),
+                          ParameterKeys.date: dateFormatter.string(from: latestDateToInclude),
                           ParameterKeys.quantity: String(quantity),
                           ParameterKeys.statFields: Constants.visitorStatFieldValue]
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: path, parameters: parameters)

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -82,6 +82,13 @@ public extension StorageType {
         return firstObject(ofType: SiteVisitStats.self, matching: predicate)
     }
 
+    /// Retrieves the Stored SiteVisitStats for stats v4.
+    ///
+    func loadSiteVisitStats(granularity: String, date: String) -> SiteVisitStats? {
+        let predicate = NSPredicate(format: "granularity ==[c] %@ AND date = %@", granularity, date)
+        return firstObject(ofType: SiteVisitStats.self, matching: predicate)
+    }
+
     /// Retrieves the Stored OrderStats.
     ///
     func loadOrderStats(granularity: String) -> OrderStats? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -147,6 +147,7 @@ private extension StoreStatsAndTopPerformersViewController {
 
                 group.enter()
                 self.syncSiteVisitStats(for: siteID,
+                                        siteTimezone: siteTimezone,
                                         timeRange: vc.timeRange,
                                         latestDateToInclude: latestDateToInclude) { error in
                     if let error = error {
@@ -317,8 +318,13 @@ private extension StoreStatsAndTopPerformersViewController {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func syncSiteVisitStats(for siteID: Int, timeRange: StatsTimeRangeV4, latestDateToInclude: Date, onCompletion: ((Error?) -> Void)? = nil) {
+    func syncSiteVisitStats(for siteID: Int,
+                            siteTimezone: TimeZone,
+                            timeRange: StatsTimeRangeV4,
+                            latestDateToInclude: Date,
+                            onCompletion: ((Error?) -> Void)? = nil) {
         let action = StatsActionV4.retrieveSiteVisitStats(siteID: siteID,
+                                                          siteTimezone: siteTimezone,
                                                           timeRange: timeRange,
                                                           latestDateToInclude: latestDateToInclude) { error in
                                                             if let error = error {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -344,9 +344,11 @@ private extension StoreStatsV4PeriodViewController {
 private extension StoreStatsV4PeriodViewController {
     func updateSiteVisitStatsResultsController(currentDate: Date) -> ResultsController<StorageSiteVisitStats> {
         let storageManager = AppDelegate.shared.storageManager
+        let dateFormatter = DateFormatter.Stats.statsDayFormatter
+        dateFormatter.timeZone = siteTimezone
         let predicate = NSPredicate(format: "granularity ==[c] %@ AND date == %@",
                                     timeRange.siteVisitStatsGranularity.rawValue,
-                                    DateFormatter.Stats.statsDayFormatter.string(from: currentDate))
+                                    dateFormatter.string(from: currentDate))
         let descriptor = NSSortDescriptor(keyPath: \StorageSiteVisitStats.date, ascending: false)
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -290,7 +290,8 @@ private extension StoreStatsV4PeriodViewController {
 
     func configureNoRevenueView() {
         noRevenueView.isHidden = true
-        noRevenueLabel.text = NSLocalizedString("No revenue this period", comment: "Text displayed when no order data are available for the selected time range.")
+        noRevenueLabel.text = NSLocalizedString("No revenue this period",
+                                                comment: "Text displayed when no order data are available for the selected time range.")
         noRevenueLabel.font = StyleManager.subheadlineFont
         noRevenueLabel.textColor = StyleManager.defaultTextColor
     }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */; };
 		0232372922F7DA6E00715FAB /* StatsTimeRangeV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */; };
 		028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */; };
+		029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */; };
 		02BA23C222EEEABC009539E7 /* AvailabilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */; };
 		02BA23C422EEEB3B009539E7 /* AvailabilityAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */; };
 		02BA23C622EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */; };
@@ -145,6 +146,7 @@
 		0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+DateTests.swift"; sourceTree = "<group>"; };
 		0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeV4.swift; sourceTree = "<group>"; };
 		028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsStoreErrorTests.swift; sourceTree = "<group>"; };
+		029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeTests.swift; sourceTree = "<group>"; };
 		02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityStore.swift; sourceTree = "<group>"; };
 		02BA23C322EEEB3B009539E7 /* AvailabilityAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityAction.swift; sourceTree = "<group>"; };
 		02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV4AvailabilityStoreTests.swift; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 		0225512222FC310200D98613 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				029B00A5230D64CD00B0AE66 /* Enums */,
 				0225512322FC310E00D98613 /* Extensions */,
 			);
 			path = Model;
@@ -322,6 +325,14 @@
 			isa = PBXGroup;
 			children = (
 				0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
+		029B00A5230D64CD00B0AE66 /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -888,6 +899,7 @@
 			files = (
 				7495C5292114979D00CDD33B /* StatsStoreTests.swift in Sources */,
 				7499A9ED2220527500D8FDFA /* ShipmentStoreTests.swift in Sources */,
+				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockupAcount.swift in Sources */,
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -21,6 +21,7 @@ public enum StatsActionV4: Action {
     /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
     ///
     case retrieveSiteVisitStats(siteID: Int,
+        siteTimezone: TimeZone,
         timeRange: StatsTimeRangeV4,
         latestDateToInclude: Date,
         onCompletion: (Error?) -> Void)

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -30,14 +30,10 @@ extension StatsTimeRangeV4 {
     /// Represents the period unit of the site visit stats given a time range.
     public var siteVisitStatsGranularity: StatGranularity {
         switch self {
-        case .today:
+        case .today, .thisWeek, .thisMonth:
             return .day
-        case .thisWeek:
-            return .week
-        case .thisMonth:
-            return .month
         case .thisYear:
-            return .year
+            return .month
         }
     }
 
@@ -52,6 +48,24 @@ extension StatsTimeRangeV4 {
             return .month
         case .thisYear:
             return .year
+        }
+    }
+
+    /// The number of intervals for site visit stats to fetch given a time range.
+    /// The interval unit is in `siteVisitStatsGranularity`.
+    func siteVisitStatsQuantity(date: Date, siteTimezone: TimeZone) -> Int {
+        switch self {
+        case .today:
+            return 1
+        case .thisWeek:
+            return 7
+        case .thisMonth:
+            var calendar = Calendar.current
+            calendar.timeZone = siteTimezone
+            let daysThisMonth = calendar.range(of: .day, in: .month, for: date)
+            return daysThisMonth?.count ?? 0
+        case .thisYear:
+            return 12
         }
     }
 }

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Yosemite
+
+class StatsTimeRangeTests: XCTestCase {
+
+    func testVisitStatsQuantityOnFebInLeapYear() {
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let date = Date(timeIntervalSince1970: 1580516969)
+        let timezone = TimeZone(identifier: "GMT")!
+        let quantity = StatsTimeRangeV4.thisMonth.siteVisitStatsQuantity(date: date,
+                                                                         siteTimezone: timezone)
+        XCTAssertEqual(quantity, 29)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -119,6 +119,7 @@ final class StatsStoreV4Tests: XCTestCase {
 
         let action = StatsActionV4
             .retrieveSiteVisitStats(siteID: sampleSiteID,
+                                    siteTimezone: .current,
                                     timeRange: .thisWeek,
                                     latestDateToInclude: date(with: "2018-08-06T17:06:55")) { (error) in
                                         XCTAssertNil(error)
@@ -148,6 +149,7 @@ final class StatsStoreV4Tests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "site-visits-alt")
         let action = StatsActionV4
             .retrieveSiteVisitStats(siteID: sampleSiteID,
+                                    siteTimezone: .current,
                                     timeRange: .thisYear,
                                     latestDateToInclude: date(with: "2018-08-06T17:06:55")) { (error) in
                                         XCTAssertNil(error)
@@ -171,6 +173,7 @@ final class StatsStoreV4Tests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/visits/", filename: "generic_error")
         let action = StatsActionV4.retrieveSiteVisitStats(siteID: sampleSiteID,
+                                                          siteTimezone: .current,
                                                           timeRange: .thisYear,
                                                           latestDateToInclude: date(with: "2018-08-06T17:06:55")) { (error) in
                                                             XCTAssertNotNil(error)
@@ -188,6 +191,7 @@ final class StatsStoreV4Tests: XCTestCase {
         let statsStore = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let action = StatsActionV4.retrieveSiteVisitStats(siteID: sampleSiteID,
+                                                          siteTimezone: .current,
                                                           timeRange: .thisYear,
                                                           latestDateToInclude: date(with: "2018-08-06T17:06:55")) { (error) in
                                                             XCTAssertNotNil(error)


### PR DESCRIPTION
Part 1 for #1106 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

## Changes
- Updated site visit stats granularity and added quantity for `StatsTimeRangeV4` based on the first task in https://github.com/woocommerce/woocommerce-ios/issues/1106#issuecomment-523384351
- In `StatsActionV4` and `StatsStoreV4`, added `siteTimezone` parameter when retrieving site visit stats
  - Now that there are multiple time ranges with the same site visit stats granularity, `date` field is used along with `granularity` to identity a `SiteVisitStats` for stats v4
- In `StoreStatsAndTopPerformersViewController`, passed site time zone to `StatsActionV4`
- In `SiteVisitStatsRemote`, added an optional `siteTimezone: TimeZone` to allow `date` param to be in a certain time zone

## Testing
Prerequisite: the site has WC admin plugin activated
- Go to "my store" tab
- Observe the "Visitors" stats in each time range --> it should be a number (not "-") after data are loaded