### PR TITLE
Reviews tab mark III: Yosemite

### DIFF
--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -25,16 +25,16 @@ public struct ProductReview: Decodable {
 
     /// ProductReview struct initializer.
     ///
-    init(siteID: Int,
-         reviewID: Int,
-         productID: Int,
-         dateCreated: Date,
-         statusKey: String,
-         reviewer: String,
-         reviewerEmail: String,
-         review: String,
-         rating: Int,
-         verified: Bool) {
+    public init(siteID: Int,
+                reviewID: Int,
+                productID: Int,
+                dateCreated: Date,
+                statusKey: String,
+                reviewer: String,
+                reviewerEmail: String,
+                review: String,
+                rating: Int,
+                verified: Bool) {
         self.siteID = siteID
         self.reviewID = reviewID
         self.productID = productID

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -98,6 +98,17 @@ private extension ProductReview {
 }
 
 
+// MARK: - Equatable Conformance
+//
+extension ProductReview: Equatable {
+    public static func == (lhs: ProductReview, rhs: ProductReview) -> Bool {
+        return lhs.siteID == rhs.siteID &&
+            lhs.reviewID == rhs.reviewID &&
+            lhs.productID == rhs.productID
+    }
+}
+
+
 // MARK: - Decoding Errors
 //
 enum ProductReviewDecodingError: Error {

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -273,7 +273,7 @@ public extension StorageType {
 
     /// Retrieves a stored ProductReview for the provided siteID and reviewID.
     ///
-    func loadProduct(siteID: Int, reviewID: Int) -> ProductReview? {
+    func loadProductReview(siteID: Int, reviewID: Int) -> ProductReview? {
         let predicate = NSPredicate(format: "siteID = %ld AND reviewID = %ld", siteID, reviewID)
         return firstObject(ofType: ProductReview.self, matching: predicate)
     }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		D831E2E2230E3513000037D0 /* ProductReviewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E1230E3513000037D0 /* ProductReviewStore.swift */; };
 		D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E3230E3524000037D0 /* ProductReviewAction.swift */; };
 		D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E5230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift */; };
+		D831E2E8230E74EF000037D0 /* ProductReviewStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E7230E74EF000037D0 /* ProductReviewStoreTests.swift */; };
 		D8736B6D22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */; };
 		D8736B6F22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */; };
 		D8736B7322F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */; };
@@ -261,6 +262,7 @@
 		D831E2E1230E3513000037D0 /* ProductReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStore.swift; sourceTree = "<group>"; };
 		D831E2E3230E3524000037D0 /* ProductReviewAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewAction.swift; sourceTree = "<group>"; };
 		D831E2E5230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductReview+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		D831E2E7230E74EF000037D0 /* ProductReviewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStoreTests.swift; sourceTree = "<group>"; };
 		D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCountItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyType.swift"; sourceTree = "<group>"; };
@@ -458,6 +460,7 @@
 				7499936720EFC0ED00CF01CD /* OrderNoteStoreTests.swift */,
 				7455262F22305F88003F8932 /* OrderStatusStoreTests.swift */,
 				744914F6224AD2AF00546DE4 /* ProductStoreTests.swift */,
+				D831E2E7230E74EF000037D0 /* ProductReviewStoreTests.swift */,
 				7492FAE0217FB87100ED2C69 /* SettingStoreTests.swift */,
 				7499A9EC2220527500D8FDFA /* ShipmentStoreTests.swift */,
 				7495C5282114979D00CDD33B /* StatsStoreTests.swift */,
@@ -913,6 +916,7 @@
 				B5C9DE252087FF20006B910A /* MockupProcessor.swift in Sources */,
 				D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */,
 				B54EAF2121188C470029C35E /* EntityListenerTests.swift in Sources */,
+				D831E2E8230E74EF000037D0 /* ProductReviewStoreTests.swift in Sources */,
 				741F34842195F752005F5BD9 /* CommentStoreTests.swift in Sources */,
 				B5C9DE282087FF20006B910A /* MockupSite.swift in Sources */,
 				B5BC736820D1AA8F00B5B6FA /* AccountStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		D80F758C223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */; };
 		D831E2E2230E3513000037D0 /* ProductReviewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E1230E3513000037D0 /* ProductReviewStore.swift */; };
 		D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E3230E3524000037D0 /* ProductReviewAction.swift */; };
+		D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E5230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift */; };
 		D8736B6D22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */; };
 		D8736B6F22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */; };
 		D8736B7322F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */; };
@@ -259,6 +260,7 @@
 		D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProvider+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D831E2E1230E3513000037D0 /* ProductReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStore.swift; sourceTree = "<group>"; };
 		D831E2E3230E3524000037D0 /* ProductReviewAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewAction.swift; sourceTree = "<group>"; };
+		D831E2E5230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductReview+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCountItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyType.swift"; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				74937507224985BB007D85D1 /* ProductDimensions+ReadOnlyConvertible.swift */,
 				CE43A90122A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift */,
 				7493750D224988DE007D85D1 /* ProductImage+ReadOnlyConvertible.swift */,
+				D831E2E5230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift */,
 				7493751122498B2C007D85D1 /* ProductTag+ReadOnlyConvertible.swift */,
 				74D42DBB221C983F00B4977D /* ShipmentTracking+ReadOnlyConvertible.swift */,
 				D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */,
@@ -843,6 +846,7 @@
 				74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */,
 				749375002249605E007D85D1 /* ProductAction.swift in Sources */,
 				D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */,
+				D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */,
 				74937508224985BB007D85D1 /* ProductDimensions+ReadOnlyConvertible.swift in Sources */,
 				B53D89E520E6C22B00F90866 /* Model.swift in Sources */,
 				933A27352222352500C2143A /* Logging.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -114,6 +114,8 @@
 		CE5F9A7A22B2D455001755E8 /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */; };
 		D80F758A223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F7589223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift */; };
 		D80F758C223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */; };
+		D831E2E2230E3513000037D0 /* ProductReviewStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E1230E3513000037D0 /* ProductReviewStore.swift */; };
+		D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D831E2E3230E3524000037D0 /* ProductReviewAction.swift */; };
 		D8736B6D22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */; };
 		D8736B6F22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */; };
 		D8736B7322F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */; };
@@ -255,6 +257,8 @@
 		CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
 		D80F7589223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D80F758B223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShipmentTrackingProvider+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		D831E2E1230E3513000037D0 /* ProductReviewStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewStore.swift; sourceTree = "<group>"; };
+		D831E2E3230E3524000037D0 /* ProductReviewAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewAction.swift; sourceTree = "<group>"; };
 		D8736B6C22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B6E22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCountItem+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		D8736B7222F1F41B00A14A29 /* OrderCount+ReadOnlyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCount+ReadOnlyType.swift"; sourceTree = "<group>"; };
@@ -427,6 +431,7 @@
 				74A7688B20D45EBA00F9D437 /* OrderStore.swift */,
 				7499936520EFBC7200CF01CD /* OrderNoteStore.swift */,
 				CE3B7AD62225ECA90050FE4B /* OrderStatusStore.swift */,
+				D831E2E1230E3513000037D0 /* ProductReviewStore.swift */,
 				749374FD2249601F007D85D1 /* ProductStore.swift */,
 				7492FADC217FAF5C00ED2C69 /* SettingStore.swift */,
 				74D7FFF9221F01E90008CC0E /* ShipmentStore.swift */,
@@ -582,6 +587,7 @@
 				7499936320EFBC1A00CF01CD /* OrderNoteAction.swift */,
 				CE3B7AD42225EBF10050FE4B /* OrderStatusAction.swift */,
 				749374FF2249605E007D85D1 /* ProductAction.swift */,
+				D831E2E3230E3524000037D0 /* ProductReviewAction.swift */,
 				7492FADE217FB11D00ED2C69 /* SettingAction.swift */,
 				74643EE0221F567E00EDC51A /* ShipmentAction.swift */,
 				74A18C57211382A000DCF8A8 /* StatsAction.swift */,
@@ -811,6 +817,7 @@
 				7471401321877A8B009A11CC /* NotificationStore.swift in Sources */,
 				74D42DBA221C978D00B4977D /* ShipmentTracking+ReadOnlyType.swift in Sources */,
 				B5DC3CB120D1B8720063AC41 /* AccountAction.swift in Sources */,
+				D831E2E2230E3513000037D0 /* ProductReviewStore.swift in Sources */,
 				B5BC736520D1A98500B5B6FA /* AccountStore.swift in Sources */,
 				7493751022498AB1007D85D1 /* ProductDefaultAttribute+ReadOnlyConvertible.swift in Sources */,
 				7492FAD9217FAD1000ED2C69 /* SiteSetting+ReadOnlyConvertible.swift in Sources */,
@@ -835,6 +842,7 @@
 				B5B5C797208E49B600642956 /* Action+Internal.swift in Sources */,
 				74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */,
 				749375002249605E007D85D1 /* ProductAction.swift in Sources */,
+				D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */,
 				74937508224985BB007D85D1 /* ProductDimensions+ReadOnlyConvertible.swift in Sources */,
 				B53D89E520E6C22B00F90866 /* Model.swift in Sources */,
 				933A27352222352500C2143A /* Logging.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductReviewAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductReviewAction.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Yosemite/Yosemite/Actions/ProductReviewAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductReviewAction.swift
@@ -1,1 +1,20 @@
 import Foundation
+import Networking
+
+
+/// ProductReviewAction: Defines all of the Actions supported by the ProductReviewStore.
+///
+public enum ProductReviewAction: Action {
+
+    /// Synchronizes the ProductReviews matching the specified criteria.
+    ///
+    case synchronizeProductReviews(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+
+    /// Retrieves the specified ProductReview.
+    ///
+    case retrieveProductReview(siteID: Int, reviewID: Int, onCompletion: (ProductReview?, Error?) -> Void)
+
+    /// Deletes all of the cached product reviews.
+    ///
+    case resetStoredProductReviews(onCompletion: () -> Void)
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -32,6 +32,7 @@ public typealias OrderStatsV4Interval = Networking.OrderStatsV4Interval
 public typealias OrderStatsV4Totals = Networking.OrderStatsV4Totals
 public typealias OrderStatus = Networking.OrderStatus
 public typealias Product = Networking.Product
+public typealias ProductReview = Networking.ProductReview
 public typealias ProductStatus = Networking.ProductStatus
 public typealias ProductStockStatus = Networking.ProductStockStatus
 public typealias ProductType = Networking.ProductType

--- a/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Storage
+
+
+// MARK: - Storage.ProductReview: ReadOnlyConvertible
+//
+extension Storage.ProductReview: ReadOnlyConvertible {
+
+    /// Updates the Storage.ProductReview with the ReadOnly.
+    ///
+    public func update(with review: Yosemite.ProductReview) {
+        siteID          = Int64(review.siteID)
+        reviewID        = Int64(review.reviewID)
+        productID       = Int64(review.productID)
+        dateCreated     = review.dateCreated
+        statusKey       = review.statusKey
+        reviewer        = review.reviewer
+        reviewerEmail   = review.reviewerEmail
+        self.review     = review.review
+        rating          = Int64(review.rating)
+        verified        = review.verified
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.ProductReview {
+        return ProductReview(siteID: Int(siteID),
+                             reviewID: Int(reviewID),
+                             productID: Int(productID),
+                             dateCreated: dateCreated ?? Date(),
+                             statusKey: statusKey ?? "",
+                             reviewer: reviewer ?? "" ,
+                             reviewerEmail: reviewerEmail ?? "",
+                             review: review ?? "",
+                             rating: Int(rating),
+                             verified: verified)
+    }
+}

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -57,7 +57,7 @@ private extension ProductReviewStore {
     func synchronizeProductReviews(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductReviewsRemote(network: network)
 
-        remote.loadAllProductReviews(for: siteID) { [weak self] (productReviews, error) in
+        remote.loadAllProductReviews(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (productReviews, error) in
             guard let productReviews = productReviews else {
                 onCompletion(error)
                 return

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -132,7 +132,7 @@ private extension ProductReviewStore {
             let storageProductReview = storage.loadProductReview(siteID: readOnlyProductReview.siteID, reviewID: readOnlyProductReview.productID) ??
                 storage.insertNewObject(ofType: Storage.ProductReview.self)
 
-            //storageProduct.update(with: readOnlyProductReview)
+            storageProductReview.update(with: readOnlyProductReview)
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -120,7 +120,10 @@ private extension ProductReviewStore {
             DispatchQueue.main.async(execute: onCompletion)
         }
     }
+}
 
+
+extension ProductReviewStore {
     /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities into the Storage Layer.
     ///
     /// - Parameters:
@@ -129,11 +132,10 @@ private extension ProductReviewStore {
     ///
     func upsertStoredProductReviews(readOnlyProductReviews: [Networking.ProductReview], in storage: StorageType) {
         for readOnlyProductReview in readOnlyProductReviews {
-            let storageProductReview = storage.loadProductReview(siteID: readOnlyProductReview.siteID, reviewID: readOnlyProductReview.productID) ??
+            let storageProductReview = storage.loadProductReview(siteID: readOnlyProductReview.siteID, reviewID: readOnlyProductReview.reviewID) ??
                 storage.insertNewObject(ofType: Storage.ProductReview.self)
 
             storageProductReview.update(with: readOnlyProductReview)
         }
     }
 }
-

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -14,7 +14,7 @@ public final class ProductReviewStore: Store {
     /// Registers for supported Actions.
     ///
     override public func registerSupportedActions(in dispatcher: Dispatcher) {
-        dispatcher.register(processor: self, for: ProductAction.self)
+        dispatcher.register(processor: self, for: ProductReviewAction.self)
     }
 
     /// Receives and executes Actions.

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -1,1 +1,139 @@
 import Foundation
+import Networking
+import Storage
+
+
+// MARK: - ProductReviewStore
+//
+public final class ProductReviewStore: Store {
+
+    private lazy var sharedDerivedStorage: StorageType = {
+        return storageManager.newDerivedStorage()
+    }()
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: ProductAction.self)
+    }
+
+    /// Receives and executes Actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? ProductReviewAction else {
+            assertionFailure("ProductReviewStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .resetStoredProductReviews(let onCompletion):
+            resetStoredProductReviews(onCompletion: onCompletion)
+        case .synchronizeProductReviews(let siteID, let pageNumber, let pageSize, let onCompletion):
+            synchronizeProductReviews(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .retrieveProductReview(let siteID, let reviewID, let onCompletion):
+            retrieveProductReview(siteID: siteID, reviewID: reviewID, onCompletion: onCompletion)
+        }
+    }
+}
+
+
+// MARK: - Services!
+//
+private extension ProductReviewStore {
+
+    /// Deletes all of the Stored ProductReviews.
+    ///
+    func resetStoredProductReviews(onCompletion: () -> Void) {
+        let storage = storageManager.viewStorage
+        storage.deleteAllObjects(ofType: Storage.ProductReview.self)
+        storage.saveIfNeeded()
+        DDLogDebug("Product Reviews deleted")
+
+        onCompletion()
+    }
+
+    /// Synchronizes the product reviews associated with a given Site ID (if any!).
+    ///
+    func synchronizeProductReviews(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+        let remote = ProductReviewsRemote(network: network)
+
+        remote.loadAllProductReviews(for: siteID) { [weak self] (productReviews, error) in
+            guard let productReviews = productReviews else {
+                onCompletion(error)
+                return
+            }
+
+            self?.upsertStoredProductReviewsInBackground(readOnlyProductReviews: productReviews) {
+                onCompletion(nil)
+            }
+        }
+    }
+
+    /// Retrieves the product review associated with a given siteID + reviewID (if any!).
+    ///
+    func retrieveProductReview(siteID: Int, reviewID: Int, onCompletion: @escaping (Networking.ProductReview?, Error?) -> Void) {
+        let remote = ProductReviewsRemote(network: network)
+
+        remote.loadProductReview(for: siteID, reviewID: reviewID) { [weak self] (productReview, error) in
+            guard let productReview = productReview else {
+                if case NetworkError.notFound? = error {
+                    self?.deleteStoredProductReview(siteID: siteID, reviewID: reviewID)
+                }
+                onCompletion(nil, error)
+                return
+            }
+
+            self?.upsertStoredProductReviewsInBackground(readOnlyProductReviews: [productReview]) {
+                onCompletion(productReview, nil)
+            }
+        }
+    }
+}
+
+
+// MARK: - Storage: ProductReview
+//
+private extension ProductReviewStore {
+
+    /// Deletes any Storage.ProductReview with the specified `siteID` and `reviewID`
+    ///
+    func deleteStoredProductReview(siteID: Int, reviewID: Int) {
+        let storage = storageManager.viewStorage
+        guard let productReview = storage.loadProductReview(siteID: siteID, reviewID: reviewID) else {
+            return
+        }
+
+        storage.deleteObject(productReview)
+        storage.saveIfNeeded()
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities *in a background thread*. onCompletion will be called
+    /// on the main thread!
+    ///
+    func upsertStoredProductReviewsInBackground(readOnlyProductReviews: [Networking.ProductReview], onCompletion: @escaping () -> Void) {
+        let derivedStorage = sharedDerivedStorage
+        derivedStorage.perform {
+            self.upsertStoredProductReviews(readOnlyProductReviews: readOnlyProductReviews, in: derivedStorage)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+
+    /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities into the Storage Layer.
+    ///
+    /// - Parameters:
+    ///     - readOnlyProductReviews: Remote ProductReviews to be persisted.
+    ///     - storage: Where we should save all the things!
+    ///
+    func upsertStoredProductReviews(readOnlyProductReviews: [Networking.ProductReview], in storage: StorageType) {
+        for readOnlyProductReview in readOnlyProductReviews {
+            let storageProductReview = storage.loadProductReview(siteID: readOnlyProductReview.siteID, reviewID: readOnlyProductReview.productID) ??
+                storage.insertNewObject(ofType: Storage.ProductReview.self)
+
+            //storageProduct.update(with: readOnlyProductReview)
+        }
+    }
+}
+

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -7,5 +7,86 @@ import XCTest
 /// ProductReviewStore Unit Tests
 ///
 final class ProductReviewStoreTests: XCTestCase {
-    
+
+    /// Mockup Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mockup Storage: InMemory
+    ///
+    private var storageManager: MockupStorageManager!
+
+    /// Mockup Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockupNetwork!
+
+    /// Convenience Property: Returns the StorageType associated with the main thread.
+    ///
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+
+    /// Testing SiteID
+    ///
+    private let sampleSiteID = 123
+
+    /// Testing ReviewID
+    ///
+    private let sampleReviewID = 173
+
+    /// Testing ProductID
+    ///
+    private let sampleProductID = 282
+
+    /// Testing Page Number
+    ///
+    private let defaultPageNumber = 1
+
+    /// Testing Page Size
+    ///
+    private let defaultPageSize = 75
+
+    // MARK: - Overridden Methods
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockupStorageManager()
+        network = MockupNetwork()
+    }
+
+    override func tearDown() {
+        dispatcher = nil
+        storageManager = nil
+        network = nil
+
+        super.tearDown()
+    }
+
+
+    // MARK: - ProductReviewAction.synchronizeProductReviews
+
+    /// Verifies that ProductReviewAction.synchronizeProductReviews effectively persists any retrieved product reviews.
+    ///
+    func testRetrieveProductReviewsEffectivelyPersistsRetrievedProductReviews() {
+        let expectation = self.expectation(description: "Retrieve product review list")
+        let productReviewStore = ProductReviewStore(dispatcher: dispatcher,
+                                                    storageManager: storageManager,
+                                                    network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductReview.self), 0)
+
+        let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID,
+                                                                   pageNumber: defaultPageNumber,
+                                                                   pageSize: defaultPageSize) { error in
+                                                                    XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductReview.self), 2)
+                                                                    XCTAssertNil(error)
+
+                                                                    expectation.fulfill()
+        }
+
+        productReviewStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -116,6 +116,37 @@ final class ProductReviewStoreTests: XCTestCase {
         productReviewStore.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    /// Verifies that ProductReviewAction.synchronizeProductReviews returns an error whenever there is an error response from the backend.
+    ///
+    func testRetrieveProductReviewsReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve product reviews error response")
+        let productReviewStore = ProductReviewStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "generic_error")
+        let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        productReviewStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that ProductReviewAction.synchronizeProductReviews returns an error whenever there is no backend response.
+    ///
+    func testRetrieveProductReviewsReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve product reviews empty response")
+        let productReviewStore = ProductReviewStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let action = ProductReviewAction.synchronizeProductReviews(siteID: sampleSiteID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        productReviewStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }
 
 

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Yosemite
+@testable import Networking
+@testable import Storage
+
+
+/// ProductReviewStore Unit Tests
+///
+final class ProductReviewStoreTests: XCTestCase {
+    
+}

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -156,7 +156,7 @@ final class ProductReviewStoreTests: XCTestCase {
 
     /// Verifies that `ProductReviewAction.retrieveProductReview` returns the expected `ProductReview`.
     ///
-    func testRetrieveSingleProductreviewReturnsExpectedFields() {
+    func testRetrieveSingleProductReviewReturnsExpectedFields() {
         let expectation = self.expectation(description: "Retrieve single product review")
         let remoteProductReview = sampleProductReview()
 
@@ -166,6 +166,36 @@ final class ProductReviewStoreTests: XCTestCase {
             XCTAssertNotNil(productReview)
             XCTAssertEqual(productReview, remoteProductReview)
 
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductReviewAction.retrieveProductReview` returns an error whenever there is an error response from the backend.
+    ///
+    func testRetrieveSingleProductReviewReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve single product review error response")
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews/173", filename: "generic_error")
+        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (product, error) in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductReviewAction.retrieveProductReview` returns an error whenever there is no backend response.
+    ///
+    func testRetrieveSingleProductReviewReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve single product review empty response")
+
+        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (product, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(product)
             expectation.fulfill()
         }
 


### PR DESCRIPTION
Fixes #1204 

⚠️ The base branch needs to be changed to develop before merging ⚠️ 

This PR adds support for Product Reviews to Yosemite

## Changes
- Add `ProductReviewAction` and `ProductReviewStore` with unit tests
- Small updates to model objects in the Storage and Networking layer.

## Testing
- 👀  at the code
- check tests are ✅ 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.