### PR TITLE
Order Details: Updated Order Notes

### DIFF
--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -131,6 +131,7 @@ extension OrderDetailsViewModel {
             CustomerNoteTableViewCell.self,
             CustomerInfoTableViewCell.self,
             WooBasicTableViewCell.self,
+            OrderNoteHeaderTableViewCell.self,
             OrderNoteTableViewCell.self,
             PaymentTableViewCell.self,
             ProductDetailsTableViewCell.self,

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteHeaderTableViewCell.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+
+// MARK: - OrderNoteHeaderTableViewCell
+//
+class OrderNoteHeaderTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var dateLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureLabels()
+    }
+
+    /// Date of Creation: To be displayed in the cell
+    ///
+    var dateCreated: String? {
+        get {
+            return dateLabel.text
+        }
+        set {
+            dateLabel.text = newValue
+        }
+    }
+
+}
+
+// MARK: - Private Methods
+//
+private extension OrderNoteHeaderTableViewCell {
+
+    /// Setup: Labels
+    ///
+    func configureLabels() {
+        dateLabel.applyHeadlineStyle()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteHeaderTableViewCell.swift
@@ -3,7 +3,7 @@ import UIKit
 
 // MARK: - OrderNoteHeaderTableViewCell
 //
-class OrderNoteHeaderTableViewCell: UITableViewCell {
+final class OrderNoteHeaderTableViewCell: UITableViewCell {
 
     @IBOutlet weak var dateLabel: UILabel!
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteHeaderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteHeaderTableViewCell.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="54" id="KGk-i7-Jjw" customClass="OrderNoteHeaderTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="54"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="53.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dTE-qH-9vS">
+                        <rect key="frame" x="16" y="16.5" width="296" height="20.5"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="dTE-qH-9vS" secondAttribute="trailing" constant="8" id="2uv-7m-x6k"/>
+                    <constraint firstItem="dTE-qH-9vS" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16.5" id="Knk-L2-Sdr"/>
+                    <constraint firstItem="dTE-qH-9vS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Z64-WB-jYO"/>
+                    <constraint firstAttribute="bottom" secondItem="dTE-qH-9vS" secondAttribute="bottom" constant="16.5" id="gx3-1Z-Lb7"/>
+                    <constraint firstItem="dTE-qH-9vS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="oml-U7-DuX"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="dateLabel" destination="dTE-qH-9vS" id="qCX-ST-do6"/>
+            </connections>
+            <point key="canvasLocation" x="79.710144927536234" y="35.491071428571423"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
@@ -12,10 +12,6 @@ class OrderNoteTableViewCell: UITableViewCell {
 
     /// Top Right Label
     ///
-    @IBOutlet private var dateLabel: UILabel!
-
-    /// Secondary Top Label
-    ///
     @IBOutlet private var statusLabel: UILabel!
 
     /// Bottom Label
@@ -30,29 +26,6 @@ class OrderNoteTableViewCell: UITableViewCell {
 
         configureLabels()
         configureIconButton()
-    }
-
-
-    /// Date of Creation: To be displayed at the top of the cell
-    ///
-    var dateCreated: String? {
-        get {
-            return dateLabel.text
-        }
-        set {
-            dateLabel.text = newValue
-        }
-    }
-
-    /// Note's Payload
-    ///
-    var contents: String? {
-        get {
-            return noteLabel.text
-        }
-        set {
-            noteLabel.text = newValue
-        }
     }
 
     /// Indicates if the note is visible to the Customer (or it's set to private!)
@@ -70,6 +43,29 @@ class OrderNoteTableViewCell: UITableViewCell {
             noteTypeWasUpdated()
         }
     }
+
+    var author: String? {
+        didSet {
+            noteTypeWasUpdated()
+        }
+    }
+
+    var dateCreated: String? {
+        didSet {
+            noteTypeWasUpdated()
+        }
+    }
+
+    /// Note's Payload
+    ///
+    var contents: String? {
+        get {
+            return noteLabel.text
+        }
+        set {
+            noteLabel.text = newValue
+        }
+    }
 }
 
 
@@ -80,25 +76,26 @@ private extension OrderNoteTableViewCell {
     /// Updates the Status Label + Icon's Color
     ///
     func noteTypeWasUpdated() {
+        let theAuthor = author ?? ""
+        let dateOfCreation = dateCreated ?? ""
         if isCustomerNote {
             iconButton.backgroundColor = StyleManager.statusPrimaryBoldColor
-            statusLabel.text = NSLocalizedString("Note to customer", comment: "Labels an order note to let user know it's visible to the customer")
+            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (To Customer)", comment: "Labels an order note to let user know it's visible to the customer")
         } else if isSystemAuthor {
             iconButton.backgroundColor = StyleManager.wooCommerceBrandColor
-            statusLabel.text = NSLocalizedString("System status", comment: "Labels an order note to let user know it's a system status message")
+            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (System)", comment: "Labels an order note to let user know it's a system status message")
         } else {
             iconButton.backgroundColor = StyleManager.wooGreyMid
-            statusLabel.text = NSLocalizedString("Private note", comment: "Labels an order note to let the user know it's private and not seen by the customer")
+            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (Private)", comment: "Labels an order note to let the user know it's private and not seen by the customer")
         }
     }
 
     /// Setup: Labels
     ///
     func configureLabels() {
-        dateLabel.applyBodyStyle()
-        noteLabel.applyBodyStyle()
         statusLabel.applyBodyStyle()
         statusLabel.textColor = StyleManager.wooGreyMid
+        noteLabel.applyBodyStyle()
     }
 
     /// Setup: Icon Button

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
@@ -80,16 +80,22 @@ private extension OrderNoteTableViewCell {
         let dateOfCreation = dateCreated ?? ""
         if isCustomerNote {
             iconButton.backgroundColor = StyleManager.statusPrimaryBoldColor
-            let localizationComment = "Labels an order note to let user know it's visible to the customer. Reads like 05:30 PM - username (To Customer)"
-            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (To Customer)", comment: localizationComment)
+            let template =
+                NSLocalizedString("%@ - %@ (To Customer)",
+                                  comment: "Labels an order note. The user know it's visible to the customer. Reads like 05:30 PM - username (To Customer)")
+            statusLabel.text = String.localizedStringWithFormat(template, dateOfCreation, theAuthor)
         } else if isSystemAuthor {
             iconButton.backgroundColor = StyleManager.wooCommerceBrandColor
-            let localizationComment = "Labels an order note to let user know it's a system status message. Reads like 05:30 PM - username (System)"
-            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (System)", comment: localizationComment)
+            let template =
+                NSLocalizedString("%@ - %@ (System)",
+                                  comment: "Labels an order note. The user know it's a system status message. Reads like 05:30 PM - username (System)")
+            statusLabel.text = String.localizedStringWithFormat(template, dateOfCreation, theAuthor)
         } else {
             iconButton.backgroundColor = StyleManager.wooGreyMid
-            let localizationComment = "Labels an order note to let the user know it's not visible to the customer. Reads like 05:30 PM - username (Private)"
-            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (Private)", comment: localizationComment)
+            let template =
+                NSLocalizedString("%@ - %@ (Private)",
+                                  comment: "Labels an order note. The user know it's not visible to the customer. Reads like 05:30 PM - username (Private)")
+            statusLabel.text = String.localizedStringWithFormat(template, dateOfCreation, theAuthor)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
@@ -80,13 +80,16 @@ private extension OrderNoteTableViewCell {
         let dateOfCreation = dateCreated ?? ""
         if isCustomerNote {
             iconButton.backgroundColor = StyleManager.statusPrimaryBoldColor
-            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (To Customer)", comment: "Labels an order note to let user know it's visible to the customer")
+            let localizationComment = "Labels an order note to let user know it's visible to the customer. Reads like 05:30 PM - username (To Customer)"
+            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (To Customer)", comment: localizationComment)
         } else if isSystemAuthor {
             iconButton.backgroundColor = StyleManager.wooCommerceBrandColor
-            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (System)", comment: "Labels an order note to let user know it's a system status message")
+            let localizationComment = "Labels an order note to let user know it's a system status message. Reads like 05:30 PM - username (System)"
+            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (System)", comment: localizationComment)
         } else {
             iconButton.backgroundColor = StyleManager.wooGreyMid
-            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (Private)", comment: "Labels an order note to let the user know it's private and not seen by the customer")
+            let localizationComment = "Labels an order note to let the user know it's not visible to the customer. Reads like 05:30 PM - username (Private)"
+            statusLabel.text = NSLocalizedString("\(dateOfCreation) - \(theAuthor) (Private)", comment: localizationComment)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.xib
@@ -31,20 +31,14 @@
                         </constraints>
                         <inset key="imageEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
                     </button>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fyu-0I-8Fk">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h9D-sT-W5S">
                         <rect key="frame" x="54" y="19" width="250" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h9D-sT-W5S">
-                        <rect key="frame" x="54" y="43.5" width="250" height="20.5"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7py-ye-y1B">
-                        <rect key="frame" x="54" y="68" width="250" height="20.5"/>
+                        <rect key="frame" x="54" y="43.5" width="250" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -52,29 +46,23 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailingMargin" secondItem="h9D-sT-W5S" secondAttribute="trailing" id="10O-OD-hx6"/>
-                    <constraint firstItem="h9D-sT-W5S" firstAttribute="top" secondItem="fyu-0I-8Fk" secondAttribute="bottom" priority="750" constant="4" id="36q-mx-OTD"/>
                     <constraint firstItem="7py-ye-y1B" firstAttribute="top" secondItem="h9D-sT-W5S" secondAttribute="bottom" constant="4" id="MrP-2V-xgC"/>
                     <constraint firstItem="YMK-WG-vE9" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Qsi-AX-gpI"/>
                     <constraint firstAttribute="trailing" secondItem="7py-ye-y1B" secondAttribute="trailing" constant="16" id="TJ8-k4-vEO"/>
-                    <constraint firstItem="fyu-0I-8Fk" firstAttribute="leading" secondItem="YMK-WG-vE9" secondAttribute="trailing" constant="14" id="YGa-PW-eLs">
-                        <variation key="heightClass=regular-widthClass=compact" constant="12"/>
-                    </constraint>
-                    <constraint firstItem="h9D-sT-W5S" firstAttribute="leading" secondItem="fyu-0I-8Fk" secondAttribute="leading" id="cFC-lm-Oef"/>
+                    <constraint firstItem="h9D-sT-W5S" firstAttribute="top" secondItem="YMK-WG-vE9" secondAttribute="top" id="cvF-lP-ns4"/>
                     <constraint firstItem="YMK-WG-vE9" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="8" id="dQ0-UK-1FW"/>
-                    <constraint firstItem="fyu-0I-8Fk" firstAttribute="top" secondItem="YMK-WG-vE9" secondAttribute="top" id="fam-32-ROy"/>
+                    <constraint firstItem="h9D-sT-W5S" firstAttribute="leading" secondItem="YMK-WG-vE9" secondAttribute="trailing" constant="12" id="g4p-lY-o8h"/>
                     <constraint firstAttribute="bottomMargin" secondItem="7py-ye-y1B" secondAttribute="bottom" priority="250" constant="8" id="r4x-c9-yPW"/>
-                    <constraint firstItem="fyu-0I-8Fk" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="uD0-6h-0tL"/>
                     <constraint firstItem="7py-ye-y1B" firstAttribute="leading" secondItem="h9D-sT-W5S" secondAttribute="leading" id="vTe-SY-gaS"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="dateLabel" destination="fyu-0I-8Fk" id="NXx-gP-jfl"/>
                 <outlet property="iconButton" destination="YMK-WG-vE9" id="B9f-Mv-uD8"/>
                 <outlet property="noteLabel" destination="7py-ye-y1B" id="KnD-L8-UjD"/>
                 <outlet property="statusLabel" destination="h9D-sT-W5S" id="T4j-Su-yEa"/>
             </connections>
-            <point key="canvasLocation" x="34" y="101.5"/>
+            <point key="canvasLocation" x="33.600000000000001" y="100.74962518740631"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
 		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
+		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
+		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -410,6 +412,8 @@
 		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
+		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
+		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -1617,6 +1621,8 @@
 				CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */,
 				B557DA1320979904005962F4 /* CustomerNoteTableViewCell.swift */,
 				B557DA1420979904005962F4 /* CustomerNoteTableViewCell.xib */,
+				45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */,
+				45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */,
 				CE1EC8EF20B8A408009762BF /* OrderNoteTableViewCell.swift */,
 				CE1EC8EE20B8A408009762BF /* OrderNoteTableViewCell.xib */,
 				CE1EC8C320B46819009762BF /* PaymentTableViewCell.swift */,
@@ -1810,6 +1816,7 @@
 				B5A8F8AF20B88DCC00D211DE /* LoginPrologueViewController.xib in Resources */,
 				74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */,
 				B5F571B021BF149D0010D1B8 /* o.caf in Resources */,
+				45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */,
 				B5D1AFC820BC7B9600DB0E8C /* StorePickerViewController.xib in Resources */,
 				CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */,
 				B57C744320F54F1C00EEFC87 /* AccountHeaderView.xib in Resources */,
@@ -2049,6 +2056,7 @@
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
 				CE263DE6206ACD220015A693 /* NotificationsViewController.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
+				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				D8174F0B22EB62B60024E762 /* MockupAnalyticsProvider.swift in Sources */,


### PR DESCRIPTION
This PR is related to this issue: Closes https://github.com/woocommerce/woocommerce-ios/issues/1092

Implemented the new design for order notes in Order Details, following the Refunds i3 designs.

## Changes
- Edited `OrderDetailsDataSource` to manage the new Order Note Section which contains all the notes grouped under a certain date (day granularity).
- Edited `OrderDetailsViewModel` to register the new cell `OrderNoteHeaderTableViewCell`
- New `OrderNoteHeaderTableViewCell` for showing the date section of Order Notes.
- Edited `OrderNoteTableViewCell` to match the new design.

## Testing

- Look at the code
- Run the app, and open an order detail which contains order notes.
- Run WooCommerceTests

## Screenshots

| Order 165             |  Order 215 |
:-------------------------:|:-------------------------:
![Newnote 1](https://user-images.githubusercontent.com/495617/63530576-058bc600-c507-11e9-986f-e4e818fa2721.png) | ![Newnote 2](https://user-images.githubusercontent.com/495617/63530583-09b7e380-c507-11e9-95ca-a341c723548e.png)
