### PR TITLE
try/zendesk beta 5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -26,7 +26,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
   #pod 'WordPressAuthenticator', '~> 1.4.0'
-  pod 'WordPressAuthenticator', :path => '~/Development/WordPressAuthenticator-iOS'
+ # pod 'WordPressAuthenticator', :path => '~/Development/WordPressAuthenticator-iOS'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
   pod 'WordPressShared', '~> 1.8'

--- a/Podfile
+++ b/Podfile
@@ -44,7 +44,7 @@ target 'WooCommerce' do
   pod 'CocoaLumberjack/Swift', '~> 3.5'
   pod 'XLPagerTabStrip', '~> 9.0'
   pod 'Charts', '~> 3.2'
-  #pod 'ZendeskSDK', '~> 2.3.1'
+  pod 'ZendeskSDK', :git => 'https://github.com/zendesk/zendesk_sdk_ios.git', :branch => '3.0.1-swift5.1-beta5'
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,34 +12,20 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
   - Gridicons (0.18)
-  - lottie-ios (2.5.2)
-  - NSObject-SafeExpectations (0.0.3)
-  - "NSURL+IDN (0.3)"
-  - SVProgressHUD (2.2.5)
-  - UIDeviceIdentifier (1.1.4)
-  - WordPressAuthenticator (1.5.2):
-    - Alamofire (= 4.7.3)
-    - CocoaLumberjack (~> 3.5)
-    - Gridicons (~> 0.15)
-    - lottie-ios (= 2.5.2)
-    - "NSURL+IDN (= 0.3)"
-    - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.1)
-    - WordPressShared (~> 1.8)
-    - WordPressUI (~> 1.3)
-  - WordPressKit (4.1.2):
-    - Alamofire (~> 4.7.3)
-    - CocoaLumberjack (~> 3.4)
-    - NSObject-SafeExpectations (= 0.0.3)
-    - UIDeviceIdentifier (~> 1.1.4)
-    - WordPressShared (~> 1.8.0)
-    - wpxmlrpc (= 0.8.4)
   - WordPressShared (1.8.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.1)
-  - wpxmlrpc (0.8.4)
   - XLPagerTabStrip (9.0.0)
+  - ZendeskSDK (3.0.1):
+    - ZendeskSDK/Providers (= 3.0.1)
+    - ZendeskSDK/UI (= 3.0.1)
+  - ZendeskSDK/Core (3.0.1)
+  - ZendeskSDK/Providers (3.0.1):
+    - ZendeskSDK/Core
+  - ZendeskSDK/UI (3.0.1):
+    - ZendeskSDK/Core
+    - ZendeskSDK/Providers
 
 DEPENDENCIES:
   - Alamofire (~> 4.7)
@@ -47,10 +33,10 @@ DEPENDENCIES:
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 0.18)
-  - WordPressAuthenticator (from `~/Development/WordPressAuthenticator-iOS`)
   - WordPressShared (~> 1.8)
   - WordPressUI (~> 1.3)
   - XLPagerTabStrip (~> 9.0)
+  - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios.git`, branch `3.0.1-swift5.1-beta5`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -59,20 +45,19 @@ SPEC REPOS:
     - CocoaLumberjack
     - FormatterKit
     - Gridicons
-    - lottie-ios
-    - NSObject-SafeExpectations
-    - "NSURL+IDN"
-    - SVProgressHUD
-    - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - WordPressUI
-    - wpxmlrpc
     - XLPagerTabStrip
 
 EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :path: "~/Development/WordPressAuthenticator-iOS"
+  ZendeskSDK:
+    :branch: 3.0.1-swift5.1-beta5
+    :git: https://github.com/zendesk/zendesk_sdk_ios.git
+
+CHECKOUT OPTIONS:
+  ZendeskSDK:
+    :commit: 648eebcd02b7bf22396744e845306c9d83414ee1
+    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 SPEC CHECKSUMS:
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
@@ -80,18 +65,11 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
-  lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
-  NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
-  "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
-  SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressAuthenticator: 08a644cf0190e6146cc7d96bee89983d85ce4f1a
-  WordPressKit: 09a28afc17dc63d35b6bd76c69fa94a7049183eb
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
   WordPressUI: 1639ca5d83740926df1e9ec6db1814deb86ffa5c
-  wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
+  ZendeskSDK: ce880e75f12ae5dacaa3658f49e545f3c8471030
 
-PODFILE CHECKSUM: 620dde76a83d413f8de1fb0128c0ff75c74e0452
+PODFILE CHECKSUM: 1c558a16862d762d301dc34810f30a65f40408df
 
 COCOAPODS: 1.6.1

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1596,7 +1596,6 @@
 				B56DB3C42049BFAA00D4AA8E /* Resources */,
 				B5650B1020A4CD7F009702D0 /* Embed Frameworks */,
 				B7A94351C1ADC31EA528B895 /* [CP] Embed Pods Frameworks */,
-				20B459508F75052BDBC0902F /* [CP] Copy Pods Resources */,
 				93BCF01B20DC21EF00EBF7A1 /* Fabric / Crashlytics */,
 			);
 			buildRules = (
@@ -1798,24 +1797,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		20B459508F75052BDBC0902F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressAuthenticator/WordPressAuthenticator.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressAuthenticator.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WooCommerce/Pods-WooCommerce-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		91990E72B3E1D58AC13D7628 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1881,16 +1862,13 @@
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Gridicons/Gridicons.framework",
-				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
-				"${BUILT_PRODUCTS_DIR}/NSURL+IDN/NSURL_IDN.framework",
-				"${BUILT_PRODUCTS_DIR}/SVProgressHUD/SVProgressHUD.framework",
-				"${BUILT_PRODUCTS_DIR}/UIDeviceIdentifier/UIDeviceIdentifier.framework",
-				"${BUILT_PRODUCTS_DIR}/WordPressKit/WordPressKit.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressUI/WordPressUI.framework",
 				"${BUILT_PRODUCTS_DIR}/XLPagerTabStrip/XLPagerTabStrip.framework",
-				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
-				"${BUILT_PRODUCTS_DIR}/wpxmlrpc/wpxmlrpc.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/ZendeskCoreSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/ZendeskProviderSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/ZendeskSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/CommonUISDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -1899,16 +1877,13 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Gridicons.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSURL_IDN.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SVProgressHUD.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UIDeviceIdentifier.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressShared.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressUI.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XLPagerTabStrip.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Lottie.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/wpxmlrpc.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskCoreSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskProviderSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonUISDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
This PR was branched from `xcode11`. In it, I commented out the locally referenced Authenticator pod, pointed to [Zendesk's latest build](https://developer.zendesk.com/embeddables/docs/ios_support_sdk/release_notes#release-notes) that's compatible with Swift 5.1 and Xcode 11 beta 5.

This branch won't build for me unless the Authenticator pod is updated to point to a remote git branch or the Authenticator code is commented out. I'm not sure who has the local Auth build, but uncommenting the line in the podfile will fix it for you.

## To test
1. Have Xcode 11 beta 5 installed, open the project
2. In terminal, `bundle exec pod install` to install Zendesk's update (and uninstall some pods)
3. Build the app. No code changes are made in this pod update, so running the app it isn't required.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
