### PR TITLE
Fix build when running on devices

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -257,8 +257,9 @@ private extension AppDelegate {
         #if targetEnvironment(simulator)
             DDLogVerbose("👀 Push Notifications are not supported in the Simulator!")
         #else
+            let pushNotesManager = ServiceLocator.pushNotesManager
             pushNotesManager.registerForRemoteNotifications()
-            pushNotesManager.ensureAuthorizationIsRequested()
+            pushNotesManager.ensureAuthorizationIsRequested(onCompletion: nil)
         #endif
     }
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -7,9 +7,19 @@ protocol PushNotesManager {
     ///
     func resetBadgeCount()
 
+    /// Registers the Application for Remote Notifgications.
+    ///
+    func registerForRemoteNotifications()
+
     /// Unregisters the Application from WordPress.com Push Notifications Service.
     ///
     func unregisterForRemoteNotifications()
+
+    /// Requests Authorization to receive Push Notifications, *only* when the current Status is not determined.
+    ///
+    /// - Parameter onCompletion: Closure to be executed on completion. Receives a Boolean indicating if we've got Push Permission.
+    ///
+    func ensureAuthorizationIsRequested(onCompletion: ((Bool) -> Void)?)
 
     /// Handles Push Notifications Registration Errors. This method unregisters the current device from the WordPress.com
     /// Push Service.


### PR DESCRIPTION
Fix #1228 

@jaclync  noticed that due to the conditional compilation of a reference to the pushNotesManager in the AppDelegate, the code would not compile to run on device, and would potentially crash


## Changes
- Added two methods to the PushNotesManager protocol
- Consume the instance of PushNotesManager returned from the ServiceLocator when `targetEnvironment(simulator)` is false

## Testing
- Build directly on device. Make sure the codebase builds
- Run the tests

Update release notes:

- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.