### PR TITLE
Order Detail: Fix interpolated strings in NSLocalizedString

### DIFF
--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderPaymentDetailsViewModel.swift
@@ -75,10 +75,10 @@ final class OrderPaymentDetailsViewModel {
         }
 
         let datePaid = order.datePaid?.toString(dateStyle: .medium, timeStyle: .none) ?? String()
-        return NSLocalizedString(
-            "\(datePaid) via \(order.paymentMethodTitle)",
-            comment: "Payment on <date> received via (payment method title)"
-        )
+        let template = NSLocalizedString(
+            "%@ via %@",
+            comment: "Payment on <date> received via (payment method title)")
+        return String.localizedStringWithFormat(template, datePaid, order.paymentMethodTitle)
     }
 
     var couponLines: [OrderCouponLine] {


### PR DESCRIPTION
Since Interpolated strings are harder to understand by translators and they may end up translating/changing the variable name, causing a crash, I modified an `NSLocalizedString` which were using interpolated strings, introduced in this PR https://github.com/woocommerce/woocommerce-ios/pull/1211.