### PR TITLE
Documentation: Add mentions to the ServiceLocator

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -325,3 +325,15 @@ into a ReadOnly instance:
                 
         C.      "Weak Entities" are okay not to conform to this protocol. In turn, their parent (strong entities) can be observed.
 
+
+## **WooCommerce**
+
+The outer layer is where the UI and the business logic associated to it belongs to. 
+
+It is important to note that at the moment there is not a global unified architecture of this layer, but more of a micro-architecture oriented approach and the general idea that business logic should be detached from view controllers. 
+
+That being said, there are some high-level abstractions that are starting to pop up.
+
+### Global depdencies
+
+Global dependencies are provided by an implementation of the Service Locator pattern. In WooCommerce, a `ServiceLocator` is just a set of static getters to the high-level global abstractions (i.e. stats, stores manager) and set of setters that allow overriding the actual implementation of those abstractions for better testability. 

--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -83,7 +83,7 @@ The full listing:
             onCompletion?(error)
         }
 
-        StoresManager.shared.dispatch(action)
+        ServiceLocator.storesManager.dispatch(action)
     }
 ```
 


### PR DESCRIPTION
Fixes #1212 

Add a mention to the ServiceLocator. I think we are starting to reach the point where we can spin off a new document for the `WooCommerce` target, so maybe in the next update?

## Changes
- Added mentions to the ServiceLocator in Yosemite.md and Architecture.md

## Testing
- 👀  📖 

Update release notes:

- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
