### PR TITLE
Fix warning in unit tests for ServiceLocator

### DIFF
--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -31,7 +31,7 @@ final class ServiceLocatorTests: XCTestCase {
     func testNoticesDefaultsToNoticePresenter() {
         let notices = ServiceLocator.noticePresenter
 
-        XCTAssertTrue(notices is NoticePresenter)
+        XCTAssertTrue((notices as Any) is NoticePresenter)
     }
 
     func testServiceLocatorProvidesPushNotificationsManager() {


### PR DESCRIPTION
Fixes #1237 

Remove a warning in a unit test 

## Changes
- Downcast the subject to Any so that the `is` check does not throw a warning

## Testing
- Run the tests, check that we only have the usual two warnings about Swift 5 conversion and the Pods project

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.