### PR TITLE
Stats v3/v4 corner cases: show/hide top banner & handle more UI state transitions with top banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -88,15 +88,13 @@ private extension DashboardUIFactory {
                 topBannerPresenter.hideTopBanner(animated: true)
             }
         case .v3ShownV4Eligible:
-            let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: .v3)
+            guard let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: .v3) as? DashboardUI & TopBannerPresenter else {
+                assertionFailure("Dashboard UI should be able to present top banner")
+                return
+            }
             onUIUpdate(updatedDashboardUI)
 
             guard previousState != currentState else {
-                return
-            }
-
-            guard let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter else {
-                assertionFailure("Dashboard UI \(updatedDashboardUI.self) should be able to present top banner")
                 return
             }
 
@@ -105,18 +103,16 @@ private extension DashboardUIFactory {
                 }, dismissHandler: { [weak self] in
                     self?.stateCoordinator.dismissV3ToV4Banner()
             })
-            topBannerPresenter.hideTopBanner(animated: false)
-            topBannerPresenter.showTopBanner(topBannerView)
+            updatedDashboardUI.hideTopBanner(animated: false)
+            updatedDashboardUI.showTopBanner(topBannerView)
         case .v4RevertedToV3:
-            let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: .v3)
+            guard let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: .v3) as? DashboardUI & TopBannerPresenter else {
+                assertionFailure("Dashboard UI should be able to present top banner")
+                return
+            }
             onUIUpdate(updatedDashboardUI)
 
             guard previousState != currentState else {
-                return
-            }
-
-            guard let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter else {
-                assertionFailure("Dashboard UI \(updatedDashboardUI.self) should be able to present top banner")
                 return
             }
 
@@ -128,8 +124,8 @@ private extension DashboardUIFactory {
             }, dismissHandler: { [weak self] in
                 self?.stateCoordinator.dismissV4ToV3Banner()
             })
-            topBannerPresenter.hideTopBanner(animated: false)
-            topBannerPresenter.showTopBanner(topBannerView)
+            updatedDashboardUI.hideTopBanner(animated: false)
+            updatedDashboardUI.showTopBanner(topBannerView)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -22,23 +22,24 @@ protocol DashboardUI: UIViewController {
 
 final class DashboardUIFactory {
     private let siteID: Int
-    private var stateCoordinator: StatsVersionStateCoordinator?
+    private let stateCoordinator: StatsVersionStateCoordinator
 
     private var lastStatsVersion: StatsVersion?
     private var lastDashboardUI: DashboardUI?
 
     init(siteID: Int) {
         self.siteID = siteID
+        self.stateCoordinator = StatsVersionStateCoordinator(siteID: siteID)
     }
 
     func reloadDashboardUI(isFeatureFlagOn: Bool,
                            onUIUpdate: @escaping (_ dashboardUI: DashboardUI) -> Void) {
         if isFeatureFlagOn {
-            let stateCoordinator = StatsVersionStateCoordinator(siteID: siteID,
-                                                                onStateChange: { [weak self] state in
-                                                                    self?.onStatsVersionStateChange(state: state, onUIUpdate: onUIUpdate)
-            })
-            self.stateCoordinator = stateCoordinator
+            stateCoordinator.onStateChange = { [weak self] (previousState, currentState) in
+                self?.onStatsVersionStateChange(previousState: previousState,
+                                                currentState: currentState,
+                                                onUIUpdate: onUIUpdate)
+            }
             stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         } else {
             onUIUpdate(dashboardUI(siteID: siteID, statsVersion: .v3))
@@ -75,16 +76,60 @@ final class DashboardUIFactory {
 }
 
 private extension DashboardUIFactory {
-    func onStatsVersionStateChange(state: StatsVersionState, onUIUpdate: @escaping (_ dashboardUI: DashboardUI) -> Void) {
-        switch state {
+    func onStatsVersionStateChange(previousState: StatsVersionState?,
+                                   currentState: StatsVersionState,
+                                   onUIUpdate: @escaping (_ dashboardUI: DashboardUI) -> Void) {
+        switch currentState {
         case .initial(let statsVersion), .eligible(let statsVersion):
-            onUIUpdate(dashboardUI(siteID: siteID, statsVersion: statsVersion))
+            let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: statsVersion)
+            onUIUpdate(updatedDashboardUI)
+
+            if let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter {
+                topBannerPresenter.hideTopBanner(animated: true)
+            }
         case .v3ShownV4Eligible:
-            // TODO-1232: handle v3 --> v4 upgrading: shows top banner to announce stats v4 feature for user to opt in.
-            onUIUpdate(dashboardUI(siteID: siteID, statsVersion: .v4))
+            let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: .v3)
+            onUIUpdate(updatedDashboardUI)
+
+            guard previousState != currentState else {
+                return
+            }
+
+            guard let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter else {
+                assertionFailure("Dashboard UI \(updatedDashboardUI.self) should be able to present top banner")
+                return
+            }
+
+            let topBannerView = DashboardTopBannerFactory.v3ToV4BannerView(actionHandler: { [weak self] in
+                self?.stateCoordinator.statsV4ButtonPressed()
+                }, dismissHandler: { [weak self] in
+                    self?.stateCoordinator.dismissV3ToV4Banner()
+            })
+            topBannerPresenter.hideTopBanner(animated: false)
+            topBannerPresenter.showTopBanner(topBannerView)
         case .v4RevertedToV3:
-            // TODO-1232: handle v4 --> v3 downgrading: reverts dashboard UI to v3 and shows top banner with explanations.
-            onUIUpdate(dashboardUI(siteID: siteID, statsVersion: .v3))
+            let updatedDashboardUI = dashboardUI(siteID: siteID, statsVersion: .v3)
+            onUIUpdate(updatedDashboardUI)
+
+            guard previousState != currentState else {
+                return
+            }
+            
+            guard let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter else {
+                assertionFailure("Dashboard UI \(updatedDashboardUI.self) should be able to present top banner")
+                return
+            }
+
+            let topBannerView = DashboardTopBannerFactory.v4ToV3BannerView(actionHandler: {
+                guard let url = URL(string: "https://wordpress.org/plugins/woocommerce-admin/") else {
+                    return
+                }
+                WebviewHelper.launch(url, with: updatedDashboardUI)
+            }, dismissHandler: { [weak self] in
+                self?.stateCoordinator.dismissV4ToV3Banner()
+            })
+            topBannerPresenter.hideTopBanner(animated: false)
+            topBannerPresenter.showTopBanner(topBannerView)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -114,7 +114,7 @@ private extension DashboardUIFactory {
             guard previousState != currentState else {
                 return
             }
-            
+
             guard let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter else {
                 assertionFailure("Dashboard UI \(updatedDashboardUI.self) should be able to present top banner")
                 return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -7,6 +7,10 @@ class DashboardStatsV3ViewController: UIViewController {
 
     var onPullToRefresh: () -> Void = {}
 
+    /// MARK: TopBannerPresenter
+
+    private(set) var topBannerView: UIView?
+
     // MARK: subviews
     //
     private var refreshControl: UIRefreshControl = {
@@ -135,6 +139,42 @@ extension DashboardStatsV3ViewController: DashboardUI {
     }
 }
 
+extension DashboardStatsV3ViewController: TopBannerPresenter {
+    func showTopBanner(_ topBannerView: UIView) {
+        self.topBannerView = topBannerView
+
+        topBannerView.isHidden = true
+        stackView.insertArrangedSubview(topBannerView, at: 0)
+        UIView.animate(withDuration: 0.1) {
+            topBannerView.isHidden = false
+        }
+    }
+
+    func hideTopBanner(animated: Bool) {
+        guard let banner = topBannerView else {
+            return
+        }
+        guard animated else {
+            removeTopBanner(banner)
+            return
+        }
+        UIView.animate(withDuration: 0.1,
+                       animations: {
+                        banner.isHidden = true
+        }, completion: { [weak self] isCompleted in
+            guard isCompleted else {
+                return
+            }
+            self?.removeTopBanner(banner)
+        })
+    }
+
+    func removeTopBanner(_ topBanner: UIView) {
+        topBanner.removeFromSuperview()
+        topBannerView = nil
+    }
+}
+
 private extension DashboardStatsV3ViewController {
     func showSiteVisitors(_ shouldShowSiteVisitors: Bool) {
         storeStatsViewController.updateSiteVisitStatsVisibility(shouldShowSiteVisitStats: shouldShowSiteVisitors)
@@ -206,16 +246,19 @@ private extension DashboardStatsV3ViewController {
         scrollView.addSubview(stackView)
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.pinSubviewToAllEdges(stackView)
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 18),
-            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
             ])
     }
 
     func configureChildViewControllerContainerViews() {
+        // Top spacer view.
+        let topSpacerView = UIView(frame: .zero)
+        NSLayoutConstraint.activate([
+            topSpacerView.heightAnchor.constraint(equalToConstant: 18),
+            ])
+
         // Store stats.
         let storeStatsView = storeStatsViewController.view!
         NSLayoutConstraint.activate([
@@ -254,6 +297,7 @@ private extension DashboardStatsV3ViewController {
         }
 
         let arrangedSubviews = [
+            topSpacerView,
             storeStatsView,
             spacerView,
             newOrdersContainerView,

--- a/WooCommerce/WooCommerceTests/Mockups/MockupStatsVersionStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupStatsVersionStoresManager.swift
@@ -12,7 +12,7 @@ class MockupStatsVersionStoresManager: DefaultStoresManager {
 
     /// Set by setter `AppSettingsAction`.
     ///
-    private var statsVersionLastShown: StatsVersion?
+    var statsVersionLastShown: StatsVersion?
 
     init(initialStatsVersionLastShown: StatsVersion? = nil, sessionManager: SessionManager) {
         self.statsVersionLastShown = initialStatsVersionLastShown

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -37,7 +37,9 @@ final class DashboardUIFactoryTests: XCTestCase {
         dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
 
         var dashboardUITypes: [UIViewController.Type] = []
-        let expectedDashboardUITypes: [UIViewController.Type] = [DashboardStatsV3ViewController.self, StoreStatsAndTopPerformersViewController.self]
+        let expectedDashboardUITypes: [UIViewController.Type] = [DashboardStatsV3ViewController.self,
+                                                                 // After reload, UI is reverted to v3
+                                                                 DashboardStatsV3ViewController.self]
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -127,4 +127,47 @@ final class DashboardUIFactoryTests: XCTestCase {
         }
         waitForExpectations(timeout: 0.1, handler: nil)
     }
+
+    /// Stats v4 --> v3 --> v4
+    func testWhenV4IsUnavailableAndThenAvailableWhileStatsV4IsLastShown() {
+        mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
+                                                            sessionManager: SessionManager.testingInstance)
+        mockStoresManager.isStatsV4Available = false
+        ServiceLocator.setStores(mockStoresManager)
+
+        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
+
+        var dashboardUIArray: [DashboardUI] = []
+        let expectation = self.expectation(description: "Wait for the stats v4")
+        expectation.expectedFulfillmentCount = 1
+
+        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { [weak self] dashboardUI in
+            dashboardUIArray.append(dashboardUI)
+            // The first updated view controller is v4, and the second view controller is reverted back to v3.
+            if dashboardUIArray.count >= 2 {
+                XCTAssertTrue(dashboardUIArray[0] is StoreStatsAndTopPerformersViewController)
+                XCTAssertTrue(dashboardUIArray[1] is DashboardStatsV3ViewController)
+
+                guard let self = self else {
+                    XCTFail()
+                    return
+                }
+                // Stats v4 now becomes available
+                self.mockStoresManager.isStatsV4Available = true
+                dashboardUIArray = []
+
+                self.dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { dashboardUI in
+                    dashboardUIArray.append(dashboardUI)
+
+                    // The first view controller is v4 -> v3 UI, and the second view controller is v3 -> v4 UI.
+                    if dashboardUIArray.count >= 2 {
+                        XCTAssertTrue(dashboardUIArray[0] is DashboardStatsV3ViewController)
+                        XCTAssertTrue(dashboardUIArray[1] is DashboardStatsV3ViewController)
+                        expectation.fulfill()
+                    }
+                }
+            }
+        }
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsVersionStateCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsVersionStateCoordinatorTests.swift
@@ -21,13 +21,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         waitForExpectations(timeout: 0.1, handler: nil)
     }
@@ -42,13 +43,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         waitForExpectations(timeout: 0.1, handler: nil)
     }
@@ -65,13 +67,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         waitForExpectations(timeout: 0.1, handler: nil)
     }
@@ -88,13 +91,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         waitForExpectations(timeout: 0.1, handler: nil)
     }
@@ -111,13 +115,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         waitForExpectations(timeout: 0.1, handler: nil)
     }
@@ -134,13 +139,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
         waitForExpectations(timeout: 0.1, handler: nil)
     }
@@ -157,13 +163,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
 
         // Dismiss v3 to v4 banner.
@@ -184,13 +191,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
 
         // Upgrade to v4 from banner.
@@ -211,13 +219,14 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 1
 
         var states: [StatsVersionState] = []
-        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134, onStateChange: { state in
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
             states.append(state)
             if states.count >= expectedStates.count {
                 XCTAssertEqual(states, expectedStates)
                 expectation.fulfill()
             }
-        })
+        }
         stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
 
         // Dismiss v4 to v3 banner.
@@ -225,5 +234,131 @@ final class StatsVersionStateCoordinatorTests: XCTestCase {
 
         waitForExpectations(timeout: 0.1, handler: nil)
     }
-    
+
+    /// Reloads (V3 --> v4), v4 remains available, then reloads again
+    func testUpgradeFromV3ToV4ThenReload() {
+        mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v3,
+                                                            sessionManager: SessionManager.testingInstance)
+        mockStoresManager.isStatsV4Available = true
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectedStates: [StatsVersionState] = [
+            // First reload
+            .initial(statsVersion: .v3), .v3ShownV4Eligible,
+            // Second reload
+            .v3ShownV4Eligible]
+        let expectation = self.expectation(description: "Wait for states to match")
+        expectation.expectedFulfillmentCount = 1
+
+        var states: [StatsVersionState] = []
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
+            states.append(state)
+            if states.count >= expectedStates.count {
+                XCTAssertEqual(states, expectedStates)
+                expectation.fulfill()
+            }
+        }
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    /// Reloads (V3 --> v4), v4 becomes unavailable, then reloads again
+    func testUpgradeFromV3ToV4ThenV4IsUnavailableThenReload() {
+        mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v3,
+                                                            sessionManager: SessionManager.testingInstance)
+        mockStoresManager.isStatsV4Available = true
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectedStates: [StatsVersionState] = [
+            // First reload
+            .initial(statsVersion: .v3), .v3ShownV4Eligible,
+            // Second reload
+            .v3ShownV4Eligible, .v4RevertedToV3]
+        let expectation = self.expectation(description: "Wait for states to match")
+        expectation.expectedFulfillmentCount = 1
+
+        var states: [StatsVersionState] = []
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
+            states.append(state)
+            if states.count >= expectedStates.count {
+                XCTAssertEqual(states, expectedStates)
+                expectation.fulfill()
+            }
+        }
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        mockStoresManager.isStatsV4Available = false
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    // Reloads (V4 --> v3), v4 remains unavailable, then reloads again
+    func testWhenV4IsUnavailableWhileStatsV4IsLastShownThenReload() {
+        mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
+                                                            sessionManager: SessionManager.testingInstance)
+        mockStoresManager.isStatsV4Available = false
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectedStates: [StatsVersionState] = [
+            // First reload
+            .initial(statsVersion: .v4), .v4RevertedToV3,
+            // Second reload
+            .v4RevertedToV3]
+        let expectation = self.expectation(description: "Wait for states to match")
+        expectation.expectedFulfillmentCount = 1
+
+        var states: [StatsVersionState] = []
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
+            states.append(state)
+            if states.count >= expectedStates.count {
+                XCTAssertEqual(states, expectedStates)
+                expectation.fulfill()
+            }
+        }
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        mockStoresManager.statsVersionLastShown = .v3
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    // Reloads (V4 --> v3), v4 becomes available, then reloads again
+    func testWhenV4IsUnavailableWhileStatsV4IsLastShownThenV4IsAvailableThenReload() {
+        mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
+                                                            sessionManager: SessionManager.testingInstance)
+        mockStoresManager.isStatsV4Available = false
+        ServiceLocator.setStores(mockStoresManager)
+
+        let expectedStates: [StatsVersionState] = [
+            // First reload
+            .initial(statsVersion: .v4), .v4RevertedToV3,
+            // Second reload
+            .v4RevertedToV3, .v3ShownV4Eligible]
+        let expectation = self.expectation(description: "Wait for states to match")
+        expectation.expectedFulfillmentCount = 1
+
+        var states: [StatsVersionState] = []
+        let stateCoordinator = StatsVersionStateCoordinator(siteID: 134)
+        stateCoordinator.onStateChange = { _, state in
+            states.append(state)
+            if states.count >= expectedStates.count {
+                XCTAssertEqual(states, expectedStates)
+                expectation.fulfill()
+            }
+        }
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        mockStoresManager.statsVersionLastShown = .v3
+        mockStoresManager.isStatsV4Available = true
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
 }


### PR DESCRIPTION
Task 2.1, 2.2, 3.1., 3.2 for #1232 
- [x] ⚠️Update PR base to `develop` before merging as it originally depends on https://github.com/woocommerce/woocommerce-ios/pull/1245 ⚠️ 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Updated `StatsVersionStateCoordinator`:
  - Updated state change callback with both the previous and current UI states
  - Handled more UI state transitions from last shown and eligible stats version with test cases
- Updated `DashboardUIFactory`:
  - Now `StatsVersionStateCoordinator` has the same lifecycle as `DashboardUIFactory` so that all UI state transitions can be recorded between reloads
  - Showed/hid top banner in certain state transitions
- Updated `DashboardStatsV3ViewController` to implement `TopBannerPresenter`

## Testing
Prerequisite: the site has WC admin installed
- On web, **deactivate** the WC admin plugin in `/wp-admin/plugins.php`
- Build the app with the PR branch
- When the app launches --> the dashboard should **show the v3 UI (`days/weeks/months/years` tabs)** (if the app previously showed v4, you'd see a top banner but there's a separate testing step later to trigger this banner UI)
- Pull down to refresh at least once --> there should be no UI changes
- On web, **activate** the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh  --> the dashboard should **show a top banner about the new stats while the dashboard still shows stats v3 UI**
- Pull down to refresh at least once --> there should be no UI changes
- Tap on "Try It Now" on the top banner --> the dashboard should **update to show stats v4 UI**
- Pull down to refresh at least once --> there should be no UI changes
- On web, **deactivate** the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh  --> the dashboard should **update to show stats v3 UI with a top banner about the new stats becoming unavailable**
- Pull down to refresh at least once --> there should be no UI changes
- Tap on "Learn More" on the top banner --> the website about WC admin should be shown
- Close the website
- Tap on "X" on the top banner --> the top banner should be gone
- Feel free to test from v3 -> v4 again, and tap on "X" on the top banner --> the top banner should be gone