### PR TITLE
Reset stored products when logging out of current store

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -123,6 +123,12 @@ private extension StorePickerCoordinator {
         }
         ServiceLocator.stores.dispatch(orderAction)
 
+        group.enter()
+        let productAction = ProductAction.resetStoredProducts {
+            group.leave()
+        }
+        ServiceLocator.stores.dispatch(productAction)
+
         group.notify(queue: .main) {
             onCompletion()
         }


### PR DESCRIPTION
Fixes #1248 

I am not sure this is really a bug, or if it was left on purpose, but it seems like we clear the CoreData store of all cached content when we log out of a store, so it seems like the Products might have gone unnoticed. 

@mindgraffiti You are the one that knows the product expected behaviour best, so we should wait for your input on this one.

## Changes
- Dispatch the `ProductAction.resetStoredProducts` when logging out of the current store.

## Testing
- I can not think of a better way to test this that checking out the branch, adding a breakpoint to `StorePickerCoordinator` in line 127 (`let productAction = ProductAction.resetStoredProducts {`) and then switch stores and check if the breakpoint gets hit

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.