### PR TITLE
Stats v3/v4 corner cases: app settings for 1) eligible 2) user preferred stats version and 3) banner visibility

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */; };
 		02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64162313C26400284168 /* StatsVersionBySite.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
 		68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */; };
@@ -119,6 +120,7 @@
 
 /* Begin PBXFileReference section */
 		02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 19.xcdatamodel"; sourceTree = "<group>"; };
+		02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBannerVisibility.swift; sourceTree = "<group>"; };
 		02DA64162313C26400284168 /* StatsVersionBySite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBySite.swift; sourceTree = "<group>"; };
 		02DA64182313C2AA00284168 /* StatsVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersion.swift; sourceTree = "<group>"; };
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -300,6 +302,7 @@
 				746A9D20214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift */,
 				02DA64162313C26400284168 /* StatsVersionBySite.swift */,
 				02DA64182313C2AA00284168 /* StatsVersion.swift */,
+				02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -758,6 +761,7 @@
 				B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */,
 				937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */,
 				B52B0F7B20AA28A800477698 /* Object.swift in Sources */,
+				02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */,
 				7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */,
 				746A9D23214078080013F6FF /* TopEarnerStatsItem+CoreDataClass.swift in Sources */,
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/StatsVersionBannerVisibility.swift
+++ b/Storage/Storage/Model/StatsVersionBannerVisibility.swift
@@ -1,0 +1,19 @@
+/// A wrapper of a dictionary from stats version banner type to whether the banner should be shown.
+/// These entities will be serialised to a plist file
+///
+public struct StatsVersionBannerVisibility: Codable, Equatable {
+    /// The type of banner regarding stats version
+    ///
+    /// - v3ToV4: banner shown when stats v4 is available while v3 is last shown
+    /// - v4ToV3: banner shown when stats v4 is unavailable anymore and is reverted back to v3
+    public enum StatsVersionBanner: String, Codable {
+        case v3ToV4
+        case v4ToV3
+    }
+
+    public let visibilityByBanner: [StatsVersionBanner: Bool]
+
+    public init(visibilityByBanner: [StatsVersionBanner: Bool]) {
+        self.visibilityByBanner = visibilityByBanner
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
@@ -107,14 +107,14 @@ final class StatsVersionStateCoordinator {
             switch initialStatsVersion {
             case .v3:
                 // V3 to V4
-                let visibilityAction = AppSettingsAction.loadStatsV3ToV4BannerVisibility { shouldShowBanner in
+                let visibilityAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v3ToV4) { shouldShowBanner in
                     let nextState: StatsVersionState = shouldShowBanner ? .v3ShownV4Eligible: currentState
                     onNextState(nextState)
                 }
                 ServiceLocator.stores.dispatch(visibilityAction)
             case .v4:
                 // V4 to V3
-                let visibilityAction = AppSettingsAction.loadStatsV4ToV3BannerVisibility { shouldShowBanner in
+                let visibilityAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v4ToV3) { shouldShowBanner in
                     let nextState: StatsVersionState = shouldShowBanner ? .v4RevertedToV3: .eligible(statsVersion: eligibleStatsVersion)
                     onNextState(nextState)
                 }
@@ -152,7 +152,7 @@ final class StatsVersionStateCoordinator {
 
 extension StatsVersionStateCoordinator: StatsV3ToV4BannerActionHandler {
     func dismissV3ToV4Banner() {
-        let visibilityAction = AppSettingsAction.setStatsV3ToV4BannerVisibility(shouldShowBanner: false)
+        let visibilityAction = AppSettingsAction.setStatsVersionBannerVisibility(banner: .v3ToV4, shouldShowBanner: false)
         ServiceLocator.stores.dispatch(visibilityAction)
         state = .eligible(statsVersion: .v3)
     }
@@ -164,7 +164,7 @@ extension StatsVersionStateCoordinator: StatsV3ToV4BannerActionHandler {
 
 extension StatsVersionStateCoordinator: StatsV4ToV3BannerActionHandler {
     func dismissV4ToV3Banner() {
-        let visibilityAction = AppSettingsAction.setStatsV4ToV3BannerVisibility(shouldShowBanner: false)
+        let visibilityAction = AppSettingsAction.setStatsVersionBannerVisibility(banner: .v4ToV3, shouldShowBanner: false)
         ServiceLocator.stores.dispatch(visibilityAction)
         state = .eligible(statsVersion: .v3)
     }

--- a/WooCommerce/WooCommerceTests/Mockups/MockupStatsVersionStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupStatsVersionStoresManager.swift
@@ -51,10 +51,20 @@ class MockupStatsVersionStoresManager: DefaultStoresManager {
         switch action {
         case .loadInitialStatsVersionToShow(_, let onCompletion):
             onCompletion(statsVersionLastShown)
-        case .loadStatsV3ToV4BannerVisibility(let onCompletion):
-            onCompletion(shouldShowV3ToV4Banner)
-        case .loadStatsV4ToV3BannerVisibility(let onCompletion):
-            onCompletion(shouldShowV4ToV3Banner)
+        case .loadStatsVersionBannerVisibility(let banner, let onCompletion):
+            switch banner {
+            case .v3ToV4:
+                onCompletion(shouldShowV3ToV4Banner)
+            case .v4ToV3:
+                onCompletion(shouldShowV4ToV3Banner)
+            }
+        case .setStatsVersionBannerVisibility(let banner, let shouldShowBanner):
+            switch banner {
+            case .v3ToV4:
+                shouldShowV3ToV4Banner = shouldShowBanner
+            case .v4ToV3:
+                shouldShowV4ToV3Banner = shouldShowBanner
+            }
         case .setStatsVersionLastShown(_, let statsVersion):
             statsVersionLastShown = statsVersion
         default:

--- a/WooCommerce/WooCommerceTests/Mockups/MockupStatsVersionStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupStatsVersionStoresManager.swift
@@ -10,6 +10,14 @@ class MockupStatsVersionStoresManager: DefaultStoresManager {
     ///
     var isStatsV4Available = false
 
+    /// Indicates whether the v3 to v4 banner should be shown.
+    ///
+    var shouldShowV3ToV4Banner: Bool = true
+
+    /// Indicates whether the v4 to v3 banner should be shown.
+    ///
+    var shouldShowV4ToV3Banner: Bool = true
+
     /// Set by setter `AppSettingsAction`.
     ///
     var statsVersionLastShown: StatsVersion?
@@ -41,8 +49,12 @@ class MockupStatsVersionStoresManager: DefaultStoresManager {
 
     private func onAppSettingsAction(action: AppSettingsAction) {
         switch action {
-        case .loadStatsVersionLastShown(_, let onCompletion):
+        case .loadInitialStatsVersionToShow(_, let onCompletion):
             onCompletion(statsVersionLastShown)
+        case .loadStatsV3ToV4BannerVisibility(let onCompletion):
+            onCompletion(shouldShowV3ToV4Banner)
+        case .loadStatsV4ToV3BannerVisibility(let onCompletion):
+            onCompletion(shouldShowV4ToV3Banner)
         case .setStatsVersionLastShown(_, let statsVersion):
             statsVersionLastShown = statsVersion
         default:

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -38,41 +38,33 @@ public enum AppSettingsAction: Action {
     case loadInitialStatsVersionToShow(siteID: Int,
         onCompletion: (StatsVersion?) -> Void)
 
-    /// Loads whether stats v3 to v4 banner should be shown
+    /// Loads whether a stats verion banner should be shown
     ///
-    case loadStatsV3ToV4BannerVisibility(onCompletion: (Bool) -> Void)
-
-    /// Loads whether stats v4 to v3 banner should be shown
-    ///
-    case loadStatsV4ToV3BannerVisibility(onCompletion: (Bool) -> Void)
+    case loadStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner, onCompletion: (Bool) -> Void)
 
     /// Loads the eligible stats version given the latest app settings associated with the `siteID`
     ///
     case loadStatsVersionEligible(siteID: Int,
         onCompletion: (StatsVersion?) -> Void)
 
-    /// Sets the last shown stats version associated with the `siteID`
+    /// Sets whether a stats version banner should be shown
     ///
-    case setStatsVersionLastShown(siteID: Int,
-        statsVersion: StatsVersion)
-    
+    case setStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner, shouldShowBanner: Bool)
+
     /// Sets the latest highest eligible stats version associated with the `siteID`
     ///
     case setStatsVersionEligible(siteID: Int,
+        statsVersion: StatsVersion)
+
+    /// Sets the last shown stats version associated with the `siteID`
+    ///
+    case setStatsVersionLastShown(siteID: Int,
         statsVersion: StatsVersion)
     
     /// Sets the user preferred stats version associated with the `siteID`
     ///
     case setStatsVersionPreference(siteID: Int,
         statsVersion: StatsVersion)
-    
-    /// Sets whether stats v3 to v4 banner should be shown
-    ///
-    case setStatsV3ToV4BannerVisibility(shouldShowBanner: Bool)
-    
-    /// Sets whether stats v4 to v3 banner should be shown
-    ///
-    case setStatsV4ToV3BannerVisibility(shouldShowBanner: Bool)
 
     /// Clears all the states related to stats version
     ///

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -60,7 +60,7 @@ public enum AppSettingsAction: Action {
     ///
     case setStatsVersionLastShown(siteID: Int,
         statsVersion: StatsVersion)
-    
+
     /// Sets the user preferred stats version associated with the `siteID`
     ///
     case setStatsVersionPreference(siteID: Int,

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -33,15 +33,46 @@ public enum AppSettingsAction: Action {
 
     // MARK: - Stats version
 
+    /// Loads the stats version to be shown given the latest app settings associated with the `siteID`
+    ///
+    case loadInitialStatsVersionToShow(siteID: Int,
+        onCompletion: (StatsVersion?) -> Void)
+
+    /// Loads whether stats v3 to v4 banner should be shown
+    ///
+    case loadStatsV3ToV4BannerVisibility(onCompletion: (Bool) -> Void)
+
+    /// Loads whether stats v4 to v3 banner should be shown
+    ///
+    case loadStatsV4ToV3BannerVisibility(onCompletion: (Bool) -> Void)
+
+    /// Loads the eligible stats version given the latest app settings associated with the `siteID`
+    ///
+    case loadStatsVersionEligible(siteID: Int,
+        onCompletion: (StatsVersion?) -> Void)
+
     /// Sets the last shown stats version associated with the `siteID`
     ///
     case setStatsVersionLastShown(siteID: Int,
         statsVersion: StatsVersion)
-
-    /// Loads the stored last shown stats version associated with the `siteID`
+    
+    /// Sets the latest highest eligible stats version associated with the `siteID`
     ///
-    case loadStatsVersionLastShown(siteID: Int,
-        onCompletion: (StatsVersion?) -> Void)
+    case setStatsVersionEligible(siteID: Int,
+        statsVersion: StatsVersion)
+    
+    /// Sets the user preferred stats version associated with the `siteID`
+    ///
+    case setStatsVersionPreference(siteID: Int,
+        statsVersion: StatsVersion)
+    
+    /// Sets whether stats v3 to v4 banner should be shown
+    ///
+    case setStatsV3ToV4BannerVisibility(shouldShowBanner: Bool)
+    
+    /// Sets whether stats v4 to v3 banner should be shown
+    ///
+    case setStatsV4ToV3BannerVisibility(shouldShowBanner: Bool)
 
     /// Clears all the states related to stats version
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -285,7 +285,7 @@ private extension AppSettingsStore {
                                  statsVersion: StatsVersion) {
         set(statsVersion: statsVersion, for: siteID, to: statsVersionEligibleURL, onCompletion: { error in
             if let error = error {
-                DDLogError("⛔️ Saving the last shown stats version failed: siteID \(siteID). Error: \(error)")
+                DDLogError("⛔️ Saving the eligible stats version to \(statsVersion) failed: siteID \(siteID). Error: \(error)")
             }
         })
     }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -102,14 +102,10 @@ public class AppSettingsStore: Store {
             setStatsVersionLastShownOrFromUserPreference(siteID: siteID, statsVersion: statsVersion)
         case .loadInitialStatsVersionToShow(let siteID, let onCompletion):
             loadInitialStatsVersionToShow(siteID: siteID, onCompletion: onCompletion)
-        case .loadStatsV3ToV4BannerVisibility(let onCompletion):
-            loadStatsV3ToV4BannerVisibility(onCompletion: onCompletion)
-        case .setStatsV3ToV4BannerVisibility(let shouldShowBanner):
-            setStatsVersionBannerVisibility(banner: .v3ToV4, shouldShowBanner: shouldShowBanner)
-        case .loadStatsV4ToV3BannerVisibility(let onCompletion):
-            loadStatsV4ToV3BannerVisibility(onCompletion: onCompletion)
-        case .setStatsV4ToV3BannerVisibility(let shouldShowBanner):
-            setStatsVersionBannerVisibility(banner: .v4ToV3, shouldShowBanner: shouldShowBanner)
+        case .loadStatsVersionBannerVisibility(let banner, let onCompletion):
+            loadStatsVersionBannerVisibility(banner: banner, onCompletion: onCompletion)
+        case .setStatsVersionBannerVisibility(let banner, let shouldShowBanner):
+            setStatsVersionBannerVisibility(banner: banner, shouldShowBanner: shouldShowBanner)
         case .resetStatsVersionStates:
             resetStatsVersionStates()
         }
@@ -325,18 +321,10 @@ private extension AppSettingsStore {
         write(StatsVersionBySite(statsVersionBySite: statsVersionBySite), to: fileURL, onCompletion: onCompletion)
     }
 
-    func loadStatsV3ToV4BannerVisibility(onCompletion: (Bool) -> Void) {
+    func loadStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner,
+                                         onCompletion: (Bool) -> Void) {
         guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL),
-            let shouldShowBanner = existingData.visibilityByBanner[.v3ToV4] else {
-                onCompletion(true)
-                return
-        }
-        onCompletion(shouldShowBanner)
-    }
-
-    func loadStatsV4ToV3BannerVisibility(onCompletion: (Bool) -> Void) {
-        guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL),
-            let shouldShowBanner = existingData.visibilityByBanner[.v4ToV3] else {
+            let shouldShowBanner = existingData.visibilityByBanner[banner] else {
                 onCompletion(true)
                 return
         }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -37,6 +37,20 @@ public class AppSettingsStore: Store {
         return documents!.appendingPathComponent(Constants.customShipmentProvidersFileName)
     }()
 
+    /// URL to the plist file that we use to determine the visibility for stats version banner.
+    ///
+    private lazy var statsVersionBannerVisibilityURL: URL = {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        return documents!.appendingPathComponent(Constants.statsVersionBannerVisibilityFileName)
+    }()
+
+    /// URL to the plist file that we use to store the eligible stats version.
+    ///
+    private lazy var statsVersionEligibleURL: URL = {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        return documents!.appendingPathComponent(Constants.statsVersionEligibleFileName)
+    }()
+
     /// URL to the plist file that we use to store the stats version displayed on Dashboard UI.
     ///
     private lazy var statsVersionLastShownURL: URL = {
@@ -80,10 +94,22 @@ public class AppSettingsStore: Store {
                                         onCompletion: onCompletion)
         case .resetStoredProviders(let onCompletion):
             resetStoredProviders(onCompletion: onCompletion)
-        case .setStatsVersionLastShown(let siteID, let statsVersion):
-            setStatsVersionLastShown(siteID: siteID, statsVersion: statsVersion)
-        case .loadStatsVersionLastShown(let siteID, let onCompletion):
-            loadStatsVersionLastShown(siteID: siteID, onCompletion: onCompletion)
+        case .loadStatsVersionEligible(let siteID, let onCompletion):
+            loadStatsVersionEligible(siteID: siteID, onCompletion: onCompletion)
+        case .setStatsVersionEligible(let siteID, let statsVersion):
+            setStatsVersionEligible(siteID: siteID, statsVersion: statsVersion)
+        case .setStatsVersionLastShown(let siteID, let statsVersion), .setStatsVersionPreference(let siteID, let statsVersion):
+            setStatsVersionLastShownOrFromUserPreference(siteID: siteID, statsVersion: statsVersion)
+        case .loadInitialStatsVersionToShow(let siteID, let onCompletion):
+            loadInitialStatsVersionToShow(siteID: siteID, onCompletion: onCompletion)
+        case .loadStatsV3ToV4BannerVisibility(let onCompletion):
+            loadStatsV3ToV4BannerVisibility(onCompletion: onCompletion)
+        case .setStatsV3ToV4BannerVisibility(let shouldShowBanner):
+            setStatsVersionBannerVisibility(banner: .v3ToV4, shouldShowBanner: shouldShowBanner)
+        case .loadStatsV4ToV3BannerVisibility(let onCompletion):
+            loadStatsV4ToV3BannerVisibility(onCompletion: onCompletion)
+        case .setStatsV4ToV3BannerVisibility(let shouldShowBanner):
+            setStatsVersionBannerVisibility(banner: .v4ToV3, shouldShowBanner: shouldShowBanner)
         case .resetStatsVersionStates:
             resetStatsVersionStates()
         }
@@ -250,8 +276,8 @@ private extension AppSettingsStore {
 // MARK: - Stats version
 //
 private extension AppSettingsStore {
-    func setStatsVersionLastShown(siteID: Int,
-                                  statsVersion: StatsVersion) {
+    func setStatsVersionLastShownOrFromUserPreference(siteID: Int,
+                                                      statsVersion: StatsVersion) {
         set(statsVersion: statsVersion, for: siteID, to: statsVersionLastShownURL, onCompletion: { error in
             if let error = error {
                 DDLogError("⛔️ Saving the last shown stats version failed: siteID \(siteID). Error: \(error)")
@@ -259,11 +285,29 @@ private extension AppSettingsStore {
         })
     }
 
-    func loadStatsVersionLastShown(siteID: Int, onCompletion: (StatsVersion?) -> Void) {
+    func setStatsVersionEligible(siteID: Int,
+                                 statsVersion: StatsVersion) {
+        set(statsVersion: statsVersion, for: siteID, to: statsVersionEligibleURL, onCompletion: { error in
+            if let error = error {
+                DDLogError("⛔️ Saving the last shown stats version failed: siteID \(siteID). Error: \(error)")
+            }
+        })
+    }
+
+    func loadInitialStatsVersionToShow(siteID: Int, onCompletion: (StatsVersion?) -> Void) {
         guard let existingData: StatsVersionBySite = read(from: statsVersionLastShownURL),
             let statsVersion = existingData.statsVersionBySite[siteID] else {
             onCompletion(nil)
             return
+        }
+        onCompletion(statsVersion)
+    }
+
+    func loadStatsVersionEligible(siteID: Int, onCompletion: (StatsVersion?) -> Void) {
+        guard let existingData: StatsVersionBySite = read(from: statsVersionEligibleURL),
+            let statsVersion = existingData.statsVersionBySite[siteID] else {
+                onCompletion(nil)
+                return
         }
         onCompletion(statsVersion)
     }
@@ -281,8 +325,42 @@ private extension AppSettingsStore {
         write(StatsVersionBySite(statsVersionBySite: statsVersionBySite), to: fileURL, onCompletion: onCompletion)
     }
 
+    func loadStatsV3ToV4BannerVisibility(onCompletion: (Bool) -> Void) {
+        guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL),
+            let shouldShowBanner = existingData.visibilityByBanner[.v3ToV4] else {
+                onCompletion(true)
+                return
+        }
+        onCompletion(shouldShowBanner)
+    }
+
+    func loadStatsV4ToV3BannerVisibility(onCompletion: (Bool) -> Void) {
+        guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL),
+            let shouldShowBanner = existingData.visibilityByBanner[.v4ToV3] else {
+                onCompletion(true)
+                return
+        }
+        onCompletion(shouldShowBanner)
+    }
+
+    func setStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner,
+                                         shouldShowBanner: Bool) {
+        let fileURL = statsVersionBannerVisibilityURL
+        guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL) else {
+            let statsVersionBySite: StatsVersionBannerVisibility = StatsVersionBannerVisibility(visibilityByBanner: [banner: shouldShowBanner])
+            write(statsVersionBySite, to: fileURL, onCompletion: { _ in })
+            return
+        }
+
+        var visibilityByBanner = existingData.visibilityByBanner
+        visibilityByBanner[banner] = shouldShowBanner
+        write(StatsVersionBannerVisibility(visibilityByBanner: visibilityByBanner), to: fileURL, onCompletion: { _ in })
+    }
+
     func resetStatsVersionStates() {
         do {
+            try fileStorage.deleteFile(at: statsVersionBannerVisibilityURL)
+            try fileStorage.deleteFile(at: statsVersionEligibleURL)
             try fileStorage.deleteFile(at: statsVersionLastShownURL)
         } catch {
             let error = AppSettingsStoreErrors.deleteStatsVersionStates
@@ -341,5 +419,7 @@ enum AppSettingsStoreErrors: Error {
 private enum Constants {
     static let shipmentProvidersFileName = "shipment-providers.plist"
     static let customShipmentProvidersFileName = "custom-shipment-providers.plist"
+    static let statsVersionBannerVisibilityFileName = "stats-version-banner-visibility.plist"
+    static let statsVersionEligibleFileName = "stats-version-eligible.plist"
     static let statsVersionLastShownFileName = "stats-version-last-shown.plist"
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
@@ -158,21 +158,21 @@ private final class MockInMemoryStorage: FileStorage {
     ///
     var deleteIsHit: Bool = false
 
-    private var dataByFileURL: [URL: Data] = [:]
+    private var data: Data?
 
     func data(for fileURL: URL) throws -> Data {
-        guard let data = dataByFileURL[fileURL] else {
+        guard let data = data else {
             throw AppSettingsStoreErrors.deletePreselectedProvider
         }
         return data
     }
 
     func write(_ data: Data, to fileURL: URL) throws {
-        dataByFileURL[fileURL] = data
+        self.data = data
     }
 
     func deleteFile(at fileURL: URL) throws {
-        dataByFileURL = [:]
+        data = nil
         deleteIsHit = true
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
@@ -96,40 +96,40 @@ class AppSettingsStoreTests_StatsVersion: XCTestCase {
     }
 
     func testStatsVersionBannerVisibilityActions() {
-        let initialV3ToV4ReadAction = AppSettingsAction.loadStatsV3ToV4BannerVisibility(onCompletion: { shouldShowBanner in
+        let initialV3ToV4ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v3ToV4, onCompletion: { shouldShowBanner in
             // Before any write actions, the default should be to show the banner.
             XCTAssertTrue(shouldShowBanner)
         })
         subject.onAction(initialV3ToV4ReadAction)
 
-        let initialV4ToV3ReadAction = AppSettingsAction.loadStatsV4ToV3BannerVisibility(onCompletion: { shouldShowBanner in
+        let initialV4ToV3ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v4ToV3, onCompletion: { shouldShowBanner in
             // Before any write actions, the default should be to show the banner.
             XCTAssertTrue(shouldShowBanner)
         })
         subject.onAction(initialV4ToV3ReadAction)
 
-        let v3ToV4WriteAction = AppSettingsAction.setStatsV3ToV4BannerVisibility(shouldShowBanner: false)
+        let v3ToV4WriteAction = AppSettingsAction.setStatsVersionBannerVisibility(banner: .v3ToV4, shouldShowBanner: false)
         subject.onAction(v3ToV4WriteAction)
 
-        let v3ToV4AfterHidingV3ToV4ReadAction = AppSettingsAction.loadStatsV3ToV4BannerVisibility(onCompletion: { shouldShowBanner in
+        let v3ToV4AfterHidingV3ToV4ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v3ToV4, onCompletion: { shouldShowBanner in
             XCTAssertFalse(shouldShowBanner)
         })
         subject.onAction(v3ToV4AfterHidingV3ToV4ReadAction)
 
-        let v4ToV3AfterHidingV3ToV4ReadAction = AppSettingsAction.loadStatsV4ToV3BannerVisibility(onCompletion: { shouldShowBanner in
+        let v4ToV3AfterHidingV3ToV4ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v4ToV3, onCompletion: { shouldShowBanner in
             XCTAssertTrue(shouldShowBanner)
         })
         subject.onAction(v4ToV3AfterHidingV3ToV4ReadAction)
 
-        let v4ToV3WriteAction = AppSettingsAction.setStatsV4ToV3BannerVisibility(shouldShowBanner: false)
+        let v4ToV3WriteAction = AppSettingsAction.setStatsVersionBannerVisibility(banner: .v4ToV3, shouldShowBanner: false)
         subject.onAction(v4ToV3WriteAction)
 
-        let v3ToV4AfterHidingV4ToV3ReadAction = AppSettingsAction.loadStatsV3ToV4BannerVisibility(onCompletion: { shouldShowBanner in
+        let v3ToV4AfterHidingV4ToV3ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v3ToV4, onCompletion: { shouldShowBanner in
             XCTAssertFalse(shouldShowBanner)
         })
         subject.onAction(v3ToV4AfterHidingV4ToV3ReadAction)
 
-        let v4ToV3AfterHidingV4ToV3ReadAction = AppSettingsAction.loadStatsV4ToV3BannerVisibility(onCompletion: { shouldShowBanner in
+        let v4ToV3AfterHidingV4ToV3ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v4ToV3, onCompletion: { shouldShowBanner in
             XCTAssertFalse(shouldShowBanner)
         })
         subject.onAction(v4ToV3AfterHidingV4ToV3ReadAction)


### PR DESCRIPTION
Task 2.3, 3.3, 4.2 for #1232 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Created `StatsVersionBannerVisibility` as a wrapper for stats version banner visibility by its type (v3->v4 or v4->v3) to be stored as app settings
- Updated stats version `AppSettings` action/store:
  - Renamed `loadStatsVersionLastShown` to `loadInitialStatsVersionToShow` since the initial stats version could be set by both the last shown UI and user preference in Settings > Beta features
  - Added `loadStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner, onCompletion: (Bool) -> Void)` to get the visibility for a stats version banner type
  - Added `setStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner, shouldShowBanner: Bool)` to set the visibility for a stats version banner type
  - Added `loadStatsVersionEligible(siteID: Int, onCompletion: (StatsVersion?) -> Void)` to get the highest eligible stats version
  - Added `setStatsVersionEligible(siteID: Int, statsVersion: StatsVersion)` to set the highest eligible stats version
  - Added `setStatsVersionPreference(siteID: Int, statsVersion: StatsVersion)` to set the user preferred stats version from Settings > Beta features (WIP)
  - Handled the above action updates in `AppSettingsStore`
- Updated `StatsVersionStateCoordinator` from `AppSettings` changes
- Updated test cases

## Testing
Since the Beta features UI isn't in yet, I'd like to defer the testing to the UI PR (coming soon). I added a few test cases for the banner dismiss actions, so just CI for this PR