### PR TITLE
Stats v3/v4 corner cases: add Beta features settings to turn on/off stats v4 when eligible

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -92,7 +92,8 @@ private extension BetaFeaturesViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         guard type(of: cell) == row.type else {
-            fatalError()
+            assertionFailure("The type of cell (\(type(of: cell)) does not match the type (\(row.type)) for row: \(row)")
+            return
         }
 
         switch cell {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -66,6 +66,7 @@ private extension BetaFeaturesViewController {
 
         tableView.dataSource = self
 
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = StyleManager.tableViewBackgroundColor

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -1,0 +1,201 @@
+import Storage
+import UIKit
+import Yosemite
+
+/// Contains UI for Beta features that can be turned on and off.
+///
+class BetaFeaturesViewController: UIViewController {
+
+    /// Main TableView
+    ///
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .grouped)
+        return tableView
+    }()
+
+    /// Table Sections to be rendered
+    ///
+    private var sections = [Section]()
+
+    private let siteID: Int
+
+    init(siteID: Int) {
+        self.siteID = siteID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Overridden Methods
+    //
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBar()
+        configureMainView()
+        configureSections()
+        configureTableView()
+        registerTableViewCells()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension BetaFeaturesViewController {
+
+    /// Set the title.
+    ///
+    func configureNavigationBar() {
+        title = NSLocalizedString("Beta Features", comment: "Beta features navigation title")
+    }
+
+    /// Apply Woo styles.
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Configure common table properties.
+    ///
+    func configureTableView() {
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(tableView)
+
+        tableView.dataSource = self
+
+        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Configure sections for table view.
+    ///
+    func configureSections() {
+        sections = [
+            Section(rows: [.statsVersionSwitch,
+                           .statsVersionDescription])
+        ]
+    }
+
+    /// Register table cells.
+    ///
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+        }
+    }
+
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        guard type(of: cell) == row.type else {
+            fatalError()
+        }
+
+        switch cell {
+        case let cell as SwitchTableViewCell where row == .statsVersionSwitch:
+            configureStatsVersionSwitch(cell: cell)
+        case let cell as BasicTableViewCell where row == .statsVersionDescription:
+            configureStatsVersionDescription(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    // MARK: - Stats version feature
+
+    func configureStatsVersionSwitch(cell: SwitchTableViewCell) {
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
+        let statsVersionTitle = NSLocalizedString("Improved stats",
+                                                  comment: "My Store > Settings > Beta features > Switch stats version")
+        cell.title = statsVersionTitle
+
+        let action = AppSettingsAction.loadInitialStatsVersionToShow(siteID: siteID) { initialStatsVersion in
+            cell.isOn = initialStatsVersion == .v4
+        }
+        ServiceLocator.stores.dispatch(action)
+
+        cell.onChange = { [weak self] isSwitchOn in
+            guard let siteID = self?.siteID else {
+                return
+            }
+            let statsVersion: StatsVersion = isSwitchOn ? .v4: .v3
+            let action = AppSettingsAction.setStatsVersionPreference(siteID: siteID,
+                                                                     statsVersion: statsVersion)
+            ServiceLocator.stores.dispatch(action)
+        }
+    }
+
+    func configureStatsVersionDescription(cell: BasicTableViewCell) {
+        cell.accessoryType = .none
+        cell.selectionStyle = .none
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.text = NSLocalizedString("Try the new stats available with the WooCommerce Admin plugin",
+                                                 comment: "My Store > Settings > Beta features > Stats version description")
+    }
+}
+
+
+// MARK: - Convenience Methods
+//
+private extension BetaFeaturesViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension BetaFeaturesViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - Private Types
+//
+private struct Constants {
+    static let rowHeight = CGFloat(44)
+    static let footerHeight = 44
+}
+
+private struct Section {
+    let rows: [Row]
+}
+
+private enum Row: CaseIterable {
+    case statsVersionSwitch
+    case statsVersionDescription
+
+    var type: UITableViewCell.Type {
+        switch self {
+        case .statsVersionSwitch:
+            return SwitchTableViewCell.self
+        case .statsVersionDescription:
+            return BasicTableViewCell.self
+        }
+    }
+
+    var reuseIdentifier: String {
+        return type.reuseIdentifier
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -175,7 +175,6 @@ extension BetaFeaturesViewController: UITableViewDataSource {
 //
 private struct Constants {
     static let rowHeight = CGFloat(44)
-    static let footerHeight = 44
 }
 
 private struct Section {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -235,7 +235,7 @@ private extension SettingsViewController {
     func configureBetaFeatures(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Beta features", comment: "Navigates to Beta features screen")
+        cell.textLabel?.text = NSLocalizedString("Beta Features", comment: "Navigates to Beta features screen")
     }
 
     func configureFeatureSuggestions(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -133,14 +133,31 @@ private extension SettingsViewController {
         let storeRows: [Row] = sites.count > 1 ?
             [.selectedStore, .switchStore] : [.selectedStore]
 
-        sections = [
-            Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
-            Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
-            Section(title: improveTheAppTitle, rows: [.privacy, .featureRequest], footerHeight: UITableView.automaticDimension),
-            Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
-            Section(title: otherTitle, rows: [.appSettings], footerHeight: CGFloat.leastNonzeroMagnitude),
-            Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
-        ]
+        rowsForImproveTheAppSection { [weak self] improveTheAppRows in
+            self?.sections = [
+                Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
+                Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
+                Section(title: improveTheAppTitle, rows: improveTheAppRows, footerHeight: UITableView.automaticDimension),
+                Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
+                Section(title: otherTitle, rows: [.appSettings], footerHeight: CGFloat.leastNonzeroMagnitude),
+                Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
+            ]
+        }
+    }
+
+    func rowsForImproveTheAppSection(onCompletion: @escaping (_ rows: [Row]) -> Void) {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            assertionFailure("Cannot find store ID")
+            return
+        }
+        let action = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
+            guard eligibleStatsVersion == .v4 else {
+                onCompletion([.privacy, .featureRequest])
+                return
+            }
+            onCompletion([.privacy, .betaFeatures, .featureRequest])
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 
     func registerTableViewCells() {
@@ -161,6 +178,8 @@ private extension SettingsViewController {
             configureSupport(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
+        case let cell as BasicTableViewCell where row == .betaFeatures:
+            configureBetaFeatures(cell: cell)
         case let cell as BasicTableViewCell where row == .featureRequest:
             configureFeatureSuggestions(cell: cell)
         case let cell as BasicTableViewCell where row == .about:
@@ -200,6 +219,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Privacy Settings", comment: "Navigates to Privacy Settings screen")
+    }
+
+    func configureBetaFeatures(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Beta features", comment: "Navigates to Beta features screen")
     }
 
     func configureFeatureSuggestions(cell: BasicTableViewCell) {
@@ -298,6 +323,15 @@ private extension SettingsViewController {
     func licensesWasPressed() {
         ServiceLocator.analytics.track(.settingsLicensesLinkTapped)
         performSegue(withIdentifier: Segues.licensesSegue, sender: nil)
+    }
+
+    func betaFeaturesWasPressed() {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            assertionFailure("Cannot find store ID")
+            return
+        }
+        let betaFeaturesViewController = BetaFeaturesViewController(siteID: siteID)
+        navigationController?.pushViewController(betaFeaturesViewController, animated: true)
     }
 
     func featureRequestWasPressed() {
@@ -399,6 +433,8 @@ extension SettingsViewController: UITableViewDelegate {
             supportWasPressed()
         case .privacy:
             privacyWasPressed()
+        case .betaFeatures:
+            betaFeaturesWasPressed()
         case .featureRequest:
             featureRequestWasPressed()
         case .about:
@@ -435,6 +471,7 @@ private enum Row: CaseIterable {
     case support
     case logout
     case privacy
+    case betaFeatures
     case featureRequest
     case about
     case licenses
@@ -451,6 +488,8 @@ private enum Row: CaseIterable {
         case .logout:
             return BasicTableViewCell.self
         case .privacy:
+            return BasicTableViewCell.self
+        case .betaFeatures:
             return BasicTableViewCell.self
         case .featureRequest:
             return BasicTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -151,7 +151,7 @@ private extension SettingsViewController {
             return
         }
         let action = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
-            guard eligibleStatsVersion == .v4 else {
+            guard eligibleStatsVersion == .v4, FeatureFlag.stats.enabled else {
                 onCompletion([.privacy, .featureRequest])
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -133,11 +133,22 @@ private extension SettingsViewController {
         let storeRows: [Row] = sites.count > 1 ?
             [.selectedStore, .switchStore] : [.selectedStore]
 
-        rowsForImproveTheAppSection { [weak self] improveTheAppRows in
-            self?.sections = [
+        if FeatureFlag.stats.enabled {
+            rowsForImproveTheAppSection { [weak self] improveTheAppRows in
+                self?.sections = [
+                    Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
+                    Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
+                    Section(title: improveTheAppTitle, rows: improveTheAppRows, footerHeight: UITableView.automaticDimension),
+                    Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
+                    Section(title: otherTitle, rows: [.appSettings], footerHeight: CGFloat.leastNonzeroMagnitude),
+                    Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
+                ]
+            }
+        } else {
+            sections = [
                 Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
                 Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
-                Section(title: improveTheAppTitle, rows: improveTheAppRows, footerHeight: UITableView.automaticDimension),
+                Section(title: improveTheAppTitle, rows: [.privacy, .featureRequest], footerHeight: UITableView.automaticDimension),
                 Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
                 Section(title: otherTitle, rows: [.appSettings], footerHeight: CGFloat.leastNonzeroMagnitude),
                 Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
@@ -151,7 +162,7 @@ private extension SettingsViewController {
             return
         }
         let action = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
-            guard eligibleStatsVersion == .v4, FeatureFlag.stats.enabled else {
+            guard eligibleStatsVersion == .v4 else {
                 onCompletion([.privacy, .featureRequest])
                 return
             }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
+		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
@@ -461,6 +462,7 @@
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
+		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
@@ -920,6 +922,14 @@
 				029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */,
 			);
 			path = "Stats v3";
+			sourceTree = "<group>";
+		};
+		02D4564A231D059E008CF0A9 /* Beta features */ = {
+			isa = PBXGroup;
+			children = (
+				02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */,
+			);
+			path = "Beta features";
 			sourceTree = "<group>";
 		};
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
@@ -1649,6 +1659,7 @@
 			isa = PBXGroup;
 			children = (
 				74C6FEA321C2F189009286B6 /* About */,
+				02D4564A231D059E008CF0A9 /* Beta features */,
 				CE27257A219249B5002B22EB /* Help */,
 				CE22E3F821714639005A6BEF /* Privacy */,
 				B509112F2049E27A007D25DC /* SettingsViewController.swift */,
@@ -2325,6 +2336,7 @@
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
+				02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */,
 				CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,


### PR DESCRIPTION
Task 4.1 and 4.3 for #1232 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Created `BetaFeaturesViewController` with a table view and one section so far with stats version switch & description rows
  - In `configureStatsVersionSwitch`, the switch UI is initialized with the initial stats version. On switch state change, it saves the preference to app settings
- In `SettingsViewController`, updated the sections based on app settings eligible stats version if the feature flag is on
  - The Beta features section is only shown when the site is eligible for stats v4

## Testing

Sorry about the long list of steps! this includes testing on:
- Dismissing the v3 to v4 banner --> the banner shouldn't be shown again
- Dismissing the v4 to v3 banner --> the banner shouldn't be shown again
- Beta features section in Settings --> this section is only shown when stats v4 is eligible (whether v3 or v4 is currently shown), and user can turn on and off stats v4 from the Beta features screen

Prerequisite: the site has WC admin installed
- On web, deactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should be showing stats v3 UI
- On web, reactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should be showing stats v4 UI and a top banner with a gift icon and a red dot (note that once the banner is manually dismissed by tapping "x", it won't show again for the user in the same logged in session)
- Tap "x" on the banner, and pull down to refresh again --> the banner should not be shown again
- Tap Settings icon --> "Beta features" section should be shown under "HELP IMPROVE THE APP" under "Privacy Settings"
- Tap into "Beta features" section --> the "Improved stats" switch should be off (since it's currently showing stats v3 UI)
- Turn on the "Improved stats" switch, and go back to the Dashboard --> stats v4 UI should be shown now
- Tap Settings icon, and tap into "Beta features" section again --> the "Improved stats" switch should be on now
- Turn off the "Improved stats" switch, and go back to the Dashboard --> stats v3 UI should be shown now
- Tap Settings icon, tap into "Beta features" section again, turn on the "Improved stats" switch again, and go back to the Dashboard --> stats v4 UI should be shown again
- On web, deactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should be showing stats v3 UI with a banner notifying the downgraded stats version
- Tap Settings icon --> there should be no "Beta features" section since stats v4 is not available
- Go back to Dashboard, tap "x" on the banner, and pull down to refresh again --> the banner should not be shown
- On web, reactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should still be showing stats v3 UI without the banner
- Tap Settings icon, tap into "Beta features" section again, turn on the "Improved stats" switch again, and go back to the Dashboard --> stats v4 UI should be shown again
- On web, deactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should be reverted back to stats v3 UI without the banner

## Example screenshots

Settings | Settings > Beta features
--- | ---
![Simulator Screen Shot - iPhone 5s - 2019-09-04 at 09 38 00](https://user-images.githubusercontent.com/1945542/64219356-be82d500-cef7-11e9-9d26-abef038d6dd7.png) | ![Simulator Screen Shot - iPhone 5s - 2019-09-03 at 10 54 00](https://user-images.githubusercontent.com/1945542/64141962-a732e180-ce3c-11e9-87bf-d460bed41082.png)

iPad portrait | iPad landscape | iPhone XS landscape
--- | --- | ---
![Simulator Screen Shot - iPad Air 2 - 2019-09-03 at 17 40 17](https://user-images.githubusercontent.com/1945542/64162740-7a99bc80-ce72-11e9-9202-1da57c9f4e7c.png) | ![Simulator Screen Shot - iPad Air 2 - 2019-09-03 at 17 40 19](https://user-images.githubusercontent.com/1945542/64162741-7a99bc80-ce72-11e9-8dc9-df53be750e85.png) | <img width="924" alt="Screen Shot 2019-09-03 at 5 45 51 PM" src="https://user-images.githubusercontent.com/1945542/64162860-b5035980-ce72-11e9-8aae-a106638947eb.png">
