### PR TITLE
Stats v4: analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -74,6 +74,13 @@ public enum WooAnalyticsStat: String {
     case dashboardTopPerformersLoaded           = "dashboard_top_performers_loaded"
     case dashboardUnfulfilledOrdersLoaded       = "dashboard_unfulfilled_orders_loaded"
 
+    // Dashboard Stats v3/v4 Events
+    //
+    case dashboardNewStatsAvailabilityBannerCancelTapped = "dashboard_new_stats_availability_banner_cancel_tapped"
+    case dashboardNewStatsAvailabilityBannerTryTapped = "dashboard_new_stats_availability_banner_try_tapped"
+    case dashboardNewStatsRevertedBannerDismissTapped = "dashboard_new_stats_reverted_banner_dismiss_tapped"
+    case dashboardNewStatsRevertedBannerLearnMoreTapped = "dashboard_new_stats_reverted_banner_learn_more_tapped"
+
     // Site picker. Can be triggered by login epilogue or settings.
     //
     case sitePickerContinueTapped               = "site_picker_continue_tapped"
@@ -105,6 +112,9 @@ public enum WooAnalyticsStat: String {
     case settingsTapped                         = "main_menu_settings_tapped"
     case settingsSelectedStoreTapped            = "settings_selected_site_tapped"
     case settingsContactSupportTapped           = "main_menu_contact_support_tapped"
+
+    case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
+    case settingsBetaFeaturesNewStatsUIToggled  = "settings_beta_features_new_stats_ui_toggled"
 
     case settingsPrivacySettingsTapped          = "settings_privacy_settings_button_tapped"
     case settingsCollectInfoToggled             = "privacy_settings_collect_info_toggled"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -102,8 +102,10 @@ private extension DashboardUIFactory {
             }
 
             let topBannerView = DashboardTopBannerFactory.v3ToV4BannerView(actionHandler: { [weak self] in
+                ServiceLocator.analytics.track(.dashboardNewStatsAvailabilityBannerTryTapped)
                 self?.stateCoordinator.statsV4ButtonPressed()
                 }, dismissHandler: { [weak self] in
+                    ServiceLocator.analytics.track(.dashboardNewStatsAvailabilityBannerCancelTapped)
                     self?.stateCoordinator.dismissV3ToV4Banner()
             })
             updatedDashboardUI.hideTopBanner(animated: false)
@@ -122,8 +124,10 @@ private extension DashboardUIFactory {
                 guard let url = URL(string: "https://wordpress.org/plugins/woocommerce-admin/") else {
                     return
                 }
+                ServiceLocator.analytics.track(.dashboardNewStatsRevertedBannerLearnMoreTapped)
                 WebviewHelper.launch(url, with: updatedDashboardUI)
             }, dismissHandler: { [weak self] in
+                ServiceLocator.analytics.track(.dashboardNewStatsRevertedBannerDismissTapped)
                 self?.stateCoordinator.dismissV4ToV3Banner()
             })
             updatedDashboardUI.hideTopBanner(animated: false)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -125,6 +125,8 @@ private extension BetaFeaturesViewController {
             guard let siteID = self?.siteID else {
                 return
             }
+            ServiceLocator.analytics.track(.settingsBetaFeaturesNewStatsUIToggled)
+
             let statsVersion: StatsVersion = isSwitchOn ? .v4: .v3
             let action = AppSettingsAction.setStatsVersionPreference(siteID: siteID,
                                                                      statsVersion: statsVersion)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -341,6 +341,7 @@ private extension SettingsViewController {
             assertionFailure("Cannot find store ID")
             return
         }
+        ServiceLocator.analytics.track(.settingsBetaFeaturesButtonTapped)
         let betaFeaturesViewController = BetaFeaturesViewController(siteID: siteID)
         navigationController?.pushViewController(betaFeaturesViewController, animated: true)
     }


### PR DESCRIPTION
Fixes #1233 

- [x] ⚠️ update PR base to `develop` after dependent https://github.com/woocommerce/woocommerce-ios/pull/1254 is merged ⚠️ 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Added new events to `WooAnalyticsStat`
- Logged new events based on #1233 

## Testing
Prerequisite: the site has WC admin installed
- Log out of the app then log back in to the site with WC admin installed (so that the previous app settings are cleared)
- On web, deactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should be showing stats v3 UI
- On web, reactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should still be showing stats v3 UI with a banner announcing the new stats
- Tap "Try It Now” —> the Dashboard should be showing stats v4 UI with `🔵 Tracked dashboard_new_stats_availability_banner_try_tapped`
- Tap Settings icon, and tap into “Beta features” section —> the “Improved stats” switch should be on with `🔵 Tracked settings_beta_features_button_tapped`
- Turn off the “Improved stats” switch, and back on —> `🔵 Tracked settings_beta_features_new_stats_ui_toggled` should be fired twice
- Go back to Dashboard —> the Dashboard should still be showing stats v4 UI
- On web, deactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should be reverted to stats v3 UI with a banner
- Tap “Learn more” on the banner —> WC admin website should be shown with `🔵 Tracked dashboard_new_stats_reverted_banner_learn_more_tapped`
- Dismiss the WC admin website, and tap “x” on the banner —> `🔵 Tracked dashboard_new_stats_reverted_banner_dismiss_tapped`
- Pull down to refresh —> no banner should be shown
- On web, reactivate the WC admin plugin in `/wp-admin/plugins.php`
- In the app, pull down to refresh on Dashboard --> the Dashboard should still be stats v3 UI with a banner announcing the new stats
- Tap “x” on the banner —> `🔵 Tracked dashboard_new_stats_availability_banner_cancel_tapped`
- Pull down to refresh —> no banner should be shown anymore while v3 UI is shown