### PR TITLE
Add `FeatureFlagService` dependency to `ServiceLocator`

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/FeatureFlagService.swift
+++ b/WooCommerce/Classes/ServiceLocator/FeatureFlagService.swift
@@ -1,0 +1,5 @@
+protocol FeatureFlagService {
+    /// Returns a boolean indicating if the feature is enabled
+    ///
+    func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool
+}

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -2,7 +2,6 @@ import Foundation
 import CocoaLumberjack
 import Storage
 
-
 /// Provides global depedencies.
 ///
 final class ServiceLocator {
@@ -20,6 +19,10 @@ final class ServiceLocator {
     /// WordPressAuthenticator Wrapper
     ///
     private static var _authenticationManager: Authentication = AuthenticationManager()
+
+    /// FeatureFlagService
+    ///
+    private static var _featureFlagService: FeatureFlagService = DefaultFeatureFlagService()
 
     /// In-App Notifications Presenter
     ///
@@ -44,6 +47,12 @@ final class ServiceLocator {
     /// - Returns: An implementation of the Analytics protocol. It defaults to WooAnalytics
     static var analytics: Analytics {
         return _analytics
+    }
+
+    /// Provides the access point to the feature flag service.
+    /// - Returns: An implementation of the FeatureFlagService protocol. It defaults to DefaultFeatureFlagService
+    static var featureFlagService: FeatureFlagService {
+        return _featureFlagService
     }
 
     /// Provides the access point to the stores.
@@ -96,6 +105,14 @@ extension ServiceLocator {
         }
 
         _analytics = mock
+    }
+
+    static func setFeatureFlagService(_ mock: FeatureFlagService) {
+        guard isRunningTests() else {
+            return
+        }
+
+        _featureFlagService = mock
     }
 
     static func setStores(_ mock: StoresManager) {

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -1,0 +1,10 @@
+struct DefaultFeatureFlagService: FeatureFlagService {
+    func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
+        switch featureFlag {
+        case .stats:
+            return BuildConfiguration.current == .localDeveloper
+        default:
+            return true
+        }
+    }
+}

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -9,15 +9,4 @@ enum FeatureFlag: Int {
     /// Store stats
     ///
     case stats
-
-    /// Returns a boolean indicating if the feature is enabled
-    ///
-    var enabled: Bool {
-        switch self {
-        case .stats:
-            return BuildConfiguration.current == .localDeveloper
-        default:
-            return true
-        }
-    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -126,7 +126,7 @@ private extension DashboardViewController {
             self.siteID = siteID
         }
 
-        dashboardUIFactory?.reloadDashboardUI(isFeatureFlagOn: FeatureFlag.stats.enabled,
+        dashboardUIFactory?.reloadDashboardUI(isFeatureFlagOn: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.stats),
                                               onUIUpdate: { [weak self] dashboardUI in
                                                 self?.onDashboardUIUpdate(updatedDashboardUI: dashboardUI)
         })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -133,7 +133,7 @@ private extension SettingsViewController {
         let storeRows: [Row] = sites.count > 1 ?
             [.selectedStore, .switchStore] : [.selectedStore]
 
-        if FeatureFlag.stats.enabled {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.stats) {
             rowsForImproveTheAppSection { [weak self] improveTheAppRows in
                 self?.sections = [
                     Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -48,12 +48,14 @@
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
-		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
+		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */; };
 		02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
 		02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */; };
+		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
+		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -463,12 +465,14 @@
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
-		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
+		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02E4FD79230688BA0049610C /* OrderStatsV4Interval+Chart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Chart.swift"; sourceTree = "<group>"; };
 		02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarView.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
 		02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModelTests.swift; sourceTree = "<group>"; };
+		02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagService.swift; sourceTree = "<group>"; };
+		02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -1434,6 +1438,7 @@
 				CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */,
 				B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */,
 				CE2409F0215D12D30091F887 /* WooNavigationController.swift */,
+				02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -1801,6 +1806,7 @@
 				D8C251DA230D288A00F49782 /* PushNotesManager.swift */,
 				D831E2DB230E0558000037D0 /* Authentication.swift */,
 				D831E2DF230E0BA7000037D0 /* Logs.swift */,
+				02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -2245,6 +2251,7 @@
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
 				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
+				02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */,
 				D843D5D322485009001BFA55 /* ShipmentProvidersViewController.swift in Sources */,
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
@@ -2376,6 +2383,7 @@
 				CE021535215BE3AB00C19555 /* LoginNavigationController+Woo.swift in Sources */,
 				B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
+				02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */,
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,


### PR DESCRIPTION
Fixes #1268 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Motivation: there are critical app changes (like the tab bar tabs) when I add a new feature flag for product list. I'd like to test the tab bar behavior when the feature is on and off. Right now, there is no easy way to mock a feature flag value for a view controller instantiated from the Storyboard. So I thought we could add a feature flag service dependency to `ServiceLocator` to allow mocking in tests. Please comment with any thoughts/concerns!
- Created `FeatureFlagService` protocol with a function to return whether a feature flag is enabled or not
- Moved the default implementation from `FeatureFlag.enabled` variable to `DefaultFeatureFlagService` that implements `FeatureFlagService`
- Added `FeatureFlagService` dependency to `ServiceLocator`

## Testing
Prerequisite: the site has WC admin plugin **activated**

- Launch the app --> the Dashboard should show either:
  - stats v4 UI
  - v3 UI while a "Beta Features" row is shown in Settings
- In `DefaultFeatureFlagService` code, return false for `stats` feature flag
- Relaunch the app --> the Dashboard should show stats v3 UI and there is no "Beta Features" row in Settings