### PR TITLE
Fix bug where notifications were not localized

### DIFF
--- a/Networking/Networking/Remote/NotificationsRemote.swift
+++ b/Networking/Networking/Remote/NotificationsRemote.swift
@@ -117,7 +117,7 @@ private extension NotificationsRemote {
     ///     - completion: Callback to be executed on completion.
     ///
     func requestForNotifications(fields: Fields? = nil, noteIds: [Int64]? = nil, pageSize: Int?) -> DotcomRequest {
-        var parameters = [String: String]()
+        var parameters = [ParameterKeys.locale: Locale.current.description]
         if let fields = fields {
             parameters[ParameterKeys.fields] = fields.rawValue
         }
@@ -162,5 +162,6 @@ private extension NotificationsRemote {
         static let identifiers = "ids"
         static let number = "number"
         static let time = "time"
+        static let locale = "locale"
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.7
 -----
+- bugfix: Reviews were not localized.
  
 2.6
 -----


### PR DESCRIPTION
Fixes #1164.

The string "left a review on" wasn't localizing for review notifications.

Fixed:
<img src="https://user-images.githubusercontent.com/1062444/64354398-fd329100-cfc4-11e9-987f-3c45bb999a06.png" width="350" />

### To test
- in the simulator, setting the language to English
- check out the branch and run
- use a store that has reviews
- navigate to the reviews tab  
- return to the Settings app and change the language to Italian
- "left a review on" partial string translate into Italian 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
