### PR TITLE
Pass the Order's currency symbol down to the ProductDetailsViewModel

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 2.7
 -----
 - bugfix: Reviews were not localized.
+- bugfix: Product Details page was displaying the Price in the wrong currency.
  
 2.6
 -----

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -191,7 +191,8 @@ extension OrderDetailsViewModel {
             let item = order.items[indexPath.row]
             let productID = item.variationID == 0 ? item.productID : item.variationID
             let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: order.siteID)
+                                                                   siteID: order.siteID,
+                                                                   currency: order.currency)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .details:

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -25,6 +25,10 @@ final class ProductDetailsViewModel {
         }
     }
 
+    /// Yosemite.Order.currency
+    ///
+    let currency: String
+
     /// Nav bar title
     ///
     var title: String {
@@ -135,8 +139,9 @@ final class ProductDetailsViewModel {
 
     /// Designated initializer.
     ///
-    init(product: Product) {
+    init(product: Product, currency: String) {
         self.product = product
+        self.currency = currency
 
         refreshResultsController()
     }
@@ -365,17 +370,18 @@ extension ProductDetailsViewModel {
             let salePrice = product.salePrice, !salePrice.isEmpty {
             let regularPricePrefix = NSLocalizedString("Regular price:",
                                                        comment: "A descriptive label prefix. Example: 'Regular price: $20.00'")
-            let regularPriceFormatted = currencyFormatter.formatAmount(regularPrice) ?? ""
+
+            let regularPriceFormatted = currencyFormatter.formatAmount(regularPrice, with: currency) ?? String()
             let bodyText = regularPricePrefix + " " + regularPriceFormatted
 
             let salePricePrefix = NSLocalizedString("Sale price:",
                                                     comment: "A descriptive label prefix. Example: 'Sale price: $18.00'")
-            let salePriceFormatted = currencyFormatter.formatAmount(salePrice) ?? ""
+            let salePriceFormatted = currencyFormatter.formatAmount(salePrice, with: currency) ?? String()
             let secondLineText = salePricePrefix + " " + salePriceFormatted
 
             cell.bodyLabel?.text = bodyText + "\n" + secondLineText
         } else {
-            cell.bodyLabel?.text = product.price.isEmpty ? "--" : currencyFormatter.formatAmount(product.price)
+            cell.bodyLabel?.text = product.price.isEmpty ? "--" : currencyFormatter.formatAmount(product.price, with: currency)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Fulfillment/FulfillViewController.swift
@@ -249,7 +249,9 @@ private extension FulfillViewController {
     /// Displays the product detail screen for the provided ProductID
     ///
     func productWasPressed(for productID: Int) {
-        let loaderViewController = ProductLoaderViewController(productID: productID, siteID: order.siteID)
+        let loaderViewController = ProductLoaderViewController(productID: productID,
+                                                               siteID: order.siteID,
+                                                               currency: order.currency)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ProductListViewController.swift
@@ -123,7 +123,9 @@ private extension ProductListViewController {
     /// Displays the product detail screen for the provided ProductID
     ///
     func productWasPressed(for productID: Int) {
-        let loaderViewController = ProductLoaderViewController(productID: productID, siteID: viewModel.order.siteID)
+        let loaderViewController = ProductLoaderViewController(productID: productID,
+                                                               siteID: viewModel.order.siteID,
+                                                               currency: viewModel.order.currency)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -20,6 +20,10 @@ final class ProductLoaderViewController: UIViewController {
     ///
     private let siteID: Int
 
+    /// The Target Product's Currency
+    ///
+    private let currency: String
+
     /// UI Active State
     ///
     private var state: State = .loading {
@@ -31,9 +35,10 @@ final class ProductLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(productID: Int, siteID: Int) {
+    init(productID: Int, siteID: Int, currency: String) {
         self.productID = productID
         self.siteID = siteID
+        self.currency = currency
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -168,7 +173,7 @@ private extension ProductLoaderViewController {
     /// Presents the ProductDetailsViewController, as a childViewController, for a given Product.
     ///
     func presentProductDetails(for product: Product) {
-        let detailsViewModel = ProductDetailsViewModel(product: product)
+        let detailsViewModel = ProductDetailsViewModel(product: product, currency: currency)
         let detailsViewController = ProductDetailsViewController(viewModel: detailsViewModel)
 
         // Attach


### PR DESCRIPTION
Fixes #1258 

This PR properly formats the currency for the "Price" cell in the ProductDetails page.

|<img src="https://user-images.githubusercontent.com/1062444/64435316-e30db700-d087-11e9-92f1-3e6929a7b27c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1062444/64435334-f15bd300-d087-11e9-8667-f6845f5a3ec5.png" width="300" /> |

## To Test

1. Set the currency in the store website to something other than USD, OR have a previous order that was paid for in a different currency than USD.
2. On the app, navigate to Orders > Order Details > tap on a product
3. On the Product Details page, scroll down to the "Pricing and Inventory" section. A "Price" or "Regular Price" / "Sale Price" title should appear in the cell. The product's price should have the correct formatting for the currency (currency symbol is correct and the currency symbol is correctly positioned to the left or right)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
