### PR TITLE
Product List: search - Yosemite layer

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -263,6 +263,13 @@ public extension StorageType {
         return firstObject(ofType: ProductCategory.self, matching: predicate)
     }
 
+    /// Retrieves the Stored ProductSearchResults Lookup.
+    ///
+    func loadProductSearchResults(keyword: String) -> ProductSearchResults? {
+        let predicate = NSPredicate(format: "keyword = %@", keyword)
+        return firstObject(ofType: ProductSearchResults.self, matching: predicate)
+    }
+
     /// Retrieves the Stored Product Tag.
     ///
     func loadProductTag(siteID: Int, productID: Int, tagID: Int) -> ProductTag? {

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -6,6 +6,10 @@ import Networking
 ///
 public enum ProductAction: Action {
 
+    /// Searches products that contain a given keyword.
+    ///
+    case searchProducts(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+
     /// Synchronizes the Products matching the specified criteria.
     ///
     case synchronizeProducts(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -492,12 +492,15 @@ class ProductStoreTests: XCTestCase {
     func testSearchProductsEffectivelyPersistsRetrievedSearchProducts() {
         let expectation = self.expectation(description: "Search Products")
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let expectedProduct = sampleProduct()
 
-        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-search-photo")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
-        let keyword = "Book"
+        // A product that is expected to be in the search results.
+        let expectedProductID = 67
+        let expectedProductName = "Photo"
+
+        let keyword = "photo"
         let action = ProductAction.searchProducts(siteID: sampleSiteID,
                                                   keyword: keyword,
                                                   pageNumber: defaultPageNumber,
@@ -507,10 +510,14 @@ class ProductStoreTests: XCTestCase {
                                                         XCTFail()
                                                         return
                                                     }
-                                                    let readOnlyProduct = self.viewStorage
+
+                                                    let expectedProduct = self.viewStorage
                                                         .loadProduct(siteID: self.sampleSiteID,
-                                                                     productID: expectedProduct.productID)?.toReadOnly()
-                                                    XCTAssertEqual(readOnlyProduct, expectedProduct)
+                                                                     productID: expectedProductID)?.toReadOnly()
+                                                    XCTAssertEqual(expectedProduct?.name, expectedProductName)
+
+                                                    XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 2)
+
                                                     XCTAssertNil(error)
 
                                                     expectation.fulfill()

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -507,7 +507,9 @@ class ProductStoreTests: XCTestCase {
                                                         XCTFail()
                                                         return
                                                     }
-                                                    let readOnlyProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProduct.productID)?.toReadOnly()
+                                                    let readOnlyProduct = self.viewStorage
+                                                        .loadProduct(siteID: self.sampleSiteID,
+                                                                     productID: expectedProduct.productID)?.toReadOnly()
                                                     XCTAssertEqual(readOnlyProduct, expectedProduct)
                                                     XCTAssertNil(error)
 
@@ -565,31 +567,32 @@ class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
         let keyword = "hiii"
-        let nestedAction = ProductAction.searchProducts(siteID: sampleSiteID,
-                                                        keyword: keyword,
-                                                        pageNumber: defaultPageNumber,
-                                                        pageSize: defaultPageSize,
-                                                        onCompletion: { [weak self] error in
-                                                            guard let self = self else {
-                                                                XCTFail()
-                                                                return
-                                                            }
-                                                            let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
-                                                            XCTAssertEqual(products.count, 10)
-                                                            for product in products {
-                                                                XCTAssertEqual(product.searchResults?.count, 1)
-                                                                XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
-                                                            }
+        let nestedAction = ProductAction
+            .searchProducts(siteID: sampleSiteID,
+                            keyword: keyword,
+                            pageNumber: defaultPageNumber,
+                            pageSize: defaultPageSize,
+                            onCompletion: { [weak self] error in
+                                guard let self = self else {
+                                    XCTFail()
+                                    return
+                                }
+                                let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
+                                XCTAssertEqual(products.count, 10)
+                                for product in products {
+                                    XCTAssertEqual(product.searchResults?.count, 1)
+                                    XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
+                                }
 
-                                                            let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
-                                                            XCTAssertEqual(searchResults.count, 1)
-                                                            XCTAssertEqual(searchResults.first?.products?.count, 10)
-                                                            XCTAssertEqual(searchResults.first?.keyword, keyword)
+                                let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
+                                XCTAssertEqual(searchResults.count, 1)
+                                XCTAssertEqual(searchResults.first?.products?.count, 10)
+                                XCTAssertEqual(searchResults.first?.keyword, keyword)
 
-                                                            XCTAssertNil(error)
+                                XCTAssertNil(error)
 
-                                                            expectation.fulfill()
-        })
+                                expectation.fulfill()
+            })
 
         let firstAction = ProductAction.searchProducts(siteID: sampleSiteID,
                                                        keyword: keyword,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -484,6 +484,124 @@ class ProductStoreTests: XCTestCase {
 
         wait(for: [backgroundSaveExpectation], timeout: Constants.expectationTimeout)
     }
+
+    // MARK: - ProductAction.searchProducts
+
+    /// Verifies that `ProductAction.searchProducts` effectively persists the retrieved products.
+    ///
+    func testSearchProductsEffectivelyPersistsRetrievedSearchProducts() {
+        let expectation = self.expectation(description: "Search Products")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedProduct = sampleProduct()
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "Book"
+        let action = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                  keyword: keyword,
+                                                  pageNumber: defaultPageNumber,
+                                                  pageSize: defaultPageSize,
+                                                  onCompletion: { [weak self] error in
+                                                    guard let self = self else {
+                                                        XCTFail()
+                                                        return
+                                                    }
+                                                    let readOnlyProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProduct.productID)?.toReadOnly()
+                                                    XCTAssertEqual(readOnlyProduct, expectedProduct)
+                                                    XCTAssertNil(error)
+
+                                                    expectation.fulfill()
+        })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.searchProducts` effectively upserts the `ProductSearchResults` entity.
+    ///
+    func testSearchProductsEffectivelyPersistsSearchResultsEntity() {
+        let expectation = self.expectation(description: "Search Products")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "hiii"
+        let anotherKeyword = "hello"
+        let action = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                  keyword: keyword,
+                                                  pageNumber: defaultPageNumber,
+                                                  pageSize: defaultPageSize,
+                                                  onCompletion: { [weak self] error in
+                                                    guard let self = self else {
+                                                        XCTFail()
+                                                        return
+                                                    }
+
+                                                    XCTAssertNil(error)
+
+                                                    let searchResults = self.viewStorage.loadProductSearchResults(keyword: keyword)
+                                                    XCTAssertEqual(searchResults?.keyword, keyword)
+                                                    XCTAssertEqual(searchResults?.products?.count, self.viewStorage.countObjects(ofType: Storage.Product.self))
+
+                                                    let searchResultsWithAnotherKeyword = self.viewStorage.loadProductSearchResults(keyword: anotherKeyword)
+                                                    XCTAssertNil(searchResultsWithAnotherKeyword)
+
+                                                    expectation.fulfill()
+        })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.searchProducts` does not result in duplicated entries in the ProductSearchResults entity.
+    ///
+    func testSearchProductsDoesNotProduceDuplicatedReferences() {
+        let expectation = self.expectation(description: "Search Products")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "hiii"
+        let nestedAction = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                        keyword: keyword,
+                                                        pageNumber: defaultPageNumber,
+                                                        pageSize: defaultPageSize,
+                                                        onCompletion: { [weak self] error in
+                                                            guard let self = self else {
+                                                                XCTFail()
+                                                                return
+                                                            }
+                                                            let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
+                                                            XCTAssertEqual(products.count, 10)
+                                                            for product in products {
+                                                                XCTAssertEqual(product.searchResults?.count, 1)
+                                                                XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
+                                                            }
+
+                                                            let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
+                                                            XCTAssertEqual(searchResults.count, 1)
+                                                            XCTAssertEqual(searchResults.first?.products?.count, 10)
+                                                            XCTAssertEqual(searchResults.first?.keyword, keyword)
+
+                                                            XCTAssertNil(error)
+
+                                                            expectation.fulfill()
+        })
+
+        let firstAction = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                       keyword: keyword,
+                                                       pageNumber: defaultPageNumber,
+                                                       pageSize: defaultPageSize,
+                                                       onCompletion: { error in
+                                                        store.onAction(nestedAction)
+        })
+
+        store.onAction(firstAction)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }
 
 // MARK: - Private Helpers


### PR DESCRIPTION
Yosemite layer for #1264 

- [x] ⚠️ Update PR branch to `develop` before merging after base branch https://github.com/woocommerce/woocommerce-ios/pull/1288 is merged

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Added `searchProducts` to `ProductAction` and implemented it in `ProductStore` with basic unit tests

## Testing
CI, since the new search action is not used yet