### PR TITLE
Product List: product search UI

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -15,7 +15,7 @@ public class ProductsRemote: Remote {
     ///     - context: view or edit. Scope under which the request is made;
     ///                determines fields present in response. Default is view.
     ///     - pageNumber: Number of page that should be retrieved.
-    ///     - pageSize: Number of Orders to be retrieved per page.
+    ///     - pageSize: Number of products to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllProducts(for siteID: Int,
@@ -73,6 +73,33 @@ public class ProductsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Retrieves all of the `Product`s available.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote products.
+    ///     - keyword: Search string that should be matched by the products.
+    ///     - pageNumber: Number of page that should be retrieved.
+    ///     - pageSize: Number of products to be retrieved per page.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func searchProducts(for siteID: Int,
+                               keyword: String,
+                               pageNumber: Int,
+                               pageSize: Int,
+                               completion: @escaping ([Product]?, Error?) -> Void) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.search: keyword
+        ]
+
+        let path = Path.products
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -94,5 +121,6 @@ public extension ProductsRemote {
         static let perPage: String    = "per_page"
         static let contextKey: String = "context"
         static let include: String    = "include"
+        static let search: String     = "search"
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -95,4 +95,45 @@ class ProductsRemoteTests: XCTestCase {
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    // MARK: - Search Products
+
+    /// Verifies that searchProducts properly parses the `products-load-all` sample response.
+    ///
+    func testSearchProductsProperlyReturnsParsedProducts() {
+        let remote = ProductsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Products")
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+
+        remote.searchProducts(for: sampleSiteID,
+                              keyword: String(),
+                              pageNumber: 0,
+                              pageSize: 100) { (products, error) in
+                                XCTAssertNil(error)
+                                XCTAssertNotNil(products)
+                                XCTAssert(products!.count == 10)
+                                expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that searchProducts properly relays Networking Layer errors.
+    ///
+    func testSearchProductsProperlyRelaysNetwokingErrors() {
+        let remote = ProductsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Products")
+
+        remote.searchProducts(for: sampleSiteID,
+                              keyword: String(),
+                              pageNumber: 0,
+                              pageSize: 100) { (products, error) in
+                                XCTAssertNil(products)
+                                XCTAssertNotNil(error)
+                                expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		028F0069233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028F0068233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift */; };
+		028F006B233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028F0067233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift */; };
 		02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */; };
 		02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64162313C26400284168 /* StatsVersionBySite.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
@@ -120,6 +122,8 @@
 
 /* Begin PBXFileReference section */
 		028F00652331605000E6C283 /* Model 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 20.xcdatamodel"; sourceTree = "<group>"; };
+		028F0067233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductSearchResults+CoreDataProperties.swift"; path = "/Users/jaclynchen/Developer/woocommerce-ios/Storage/Storage/Model/ProductSearchResults+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
+		028F0068233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductSearchResults+CoreDataClass.swift"; path = "/Users/jaclynchen/Developer/woocommerce-ios/Storage/Storage/Model/ProductSearchResults+CoreDataClass.swift"; sourceTree = "<absolute>"; };
 		02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 19.xcdatamodel"; sourceTree = "<group>"; };
 		02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBannerVisibility.swift; sourceTree = "<group>"; };
 		02DA64162313C26400284168 /* StatsVersionBySite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBySite.swift; sourceTree = "<group>"; };
@@ -474,6 +478,8 @@
 				747453922242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift */,
 				D8550D01230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift */,
 				D8550D00230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift */,
+				028F0068233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift */,
+				028F0067233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift */,
 				747453992242C85E00E0B5EE /* ProductTag+CoreDataClass.swift */,
 				7474539A2242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift */,
 				7499FA42221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift */,
@@ -731,6 +737,7 @@
 				74B7D6AD20F90CBB002667AC /* OrderNote+CoreDataClass.swift in Sources */,
 				B52B0F7920AA287C00477698 /* StorageManagerType.swift in Sources */,
 				7471A517216CF0FE00219F7E /* SiteVisitStats+CoreDataProperties.swift in Sources */,
+				028F006B233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift in Sources */,
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
@@ -775,6 +782,7 @@
 				D8550D02230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
+				028F0069233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,
 				CE43A8FE229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -1095,7 +1095,7 @@
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = 02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */;
+			currentVersion = 028F00652331605000E6C283 /* Model 20.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -7,8 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		028F0069233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028F0068233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift */; };
-		028F006B233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028F0067233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift */; };
+		023FA29523316A4D008C1769 /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */; };
+		023FA29623316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */; };
+		023FA29723316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */; };
 		02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */; };
 		02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64162313C26400284168 /* StatsVersionBySite.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
@@ -35,7 +36,6 @@
 		747453A12242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453932242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift */; };
 		747453A22242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453942242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift */; };
 		747453A32242C85E00E0B5EE /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453952242C85E00E0B5EE /* Product+CoreDataClass.swift */; };
-		747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */; };
 		747453A52242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453972242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift */; };
 		747453A62242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453982242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift */; };
 		747453A72242C85E00E0B5EE /* ProductTag+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747453992242C85E00E0B5EE /* ProductTag+CoreDataClass.swift */; };
@@ -121,9 +121,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataClass.swift"; sourceTree = "<group>"; };
 		028F00652331605000E6C283 /* Model 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 20.xcdatamodel"; sourceTree = "<group>"; };
-		028F0067233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductSearchResults+CoreDataProperties.swift"; path = "/Users/jaclynchen/Developer/woocommerce-ios/Storage/Storage/Model/ProductSearchResults+CoreDataProperties.swift"; sourceTree = "<absolute>"; };
-		028F0068233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ProductSearchResults+CoreDataClass.swift"; path = "/Users/jaclynchen/Developer/woocommerce-ios/Storage/Storage/Model/ProductSearchResults+CoreDataClass.swift"; sourceTree = "<absolute>"; };
 		02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 19.xcdatamodel"; sourceTree = "<group>"; };
 		02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBannerVisibility.swift; sourceTree = "<group>"; };
 		02DA64162313C26400284168 /* StatsVersionBySite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBySite.swift; sourceTree = "<group>"; };
@@ -157,7 +158,6 @@
 		747453932242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductCategory+CoreDataClass.swift"; sourceTree = "<group>"; };
 		747453942242C85E00E0B5EE /* ProductCategory+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductCategory+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		747453952242C85E00E0B5EE /* Product+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataClass.swift"; sourceTree = "<group>"; };
-		747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		747453972242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductDefaultAttribute+CoreDataClass.swift"; sourceTree = "<group>"; };
 		747453982242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductDefaultAttribute+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		747453992242C85E00E0B5EE /* ProductTag+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductTag+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -463,7 +463,7 @@
 				CE3B7AD02225E62C0050FE4B /* OrderStatus+CoreDataClass.swift */,
 				CE3B7AD12225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift */,
 				747453952242C85E00E0B5EE /* Product+CoreDataClass.swift */,
-				747453962242C85E00E0B5EE /* Product+CoreDataProperties.swift */,
+				023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */,
 				7474538F2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift */,
 				747453902242C85E00E0B5EE /* ProductAttribute+CoreDataProperties.swift */,
 				747453932242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift */,
@@ -478,8 +478,8 @@
 				747453922242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift */,
 				D8550D01230D3F8B00AAC4F8 /* ProductReview+CoreDataClass.swift */,
 				D8550D00230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift */,
-				028F0068233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift */,
-				028F0067233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift */,
+				023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */,
+				023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */,
 				747453992242C85E00E0B5EE /* ProductTag+CoreDataClass.swift */,
 				7474539A2242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift */,
 				7499FA42221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift */,
@@ -724,6 +724,7 @@
 				74938EC8216FA9B200540BA1 /* OrderStatsItem+CoreDataClass.swift in Sources */,
 				D8736B6822F0AC9000A14A29 /* OrderCountItem+CoreDataClass.swift in Sources */,
 				747453A32242C85E00E0B5EE /* Product+CoreDataClass.swift in Sources */,
+				023FA29723316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift in Sources */,
 				D821645B2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataClass.swift in Sources */,
 				D821645C2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataProperties.swift in Sources */,
 				7499FA45221C7A60004EC0B4 /* ShipmentTracking+CoreDataProperties.swift in Sources */,
@@ -737,7 +738,6 @@
 				74B7D6AD20F90CBB002667AC /* OrderNote+CoreDataClass.swift in Sources */,
 				B52B0F7920AA287C00477698 /* StorageManagerType.swift in Sources */,
 				7471A517216CF0FE00219F7E /* SiteVisitStats+CoreDataProperties.swift in Sources */,
-				028F006B233165B000E6C283 /* ProductSearchResults+CoreDataProperties.swift in Sources */,
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
@@ -746,8 +746,9 @@
 				7474539F2242C85E00E0B5EE /* ProductImage+CoreDataClass.swift in Sources */,
 				D8736B6922F0AC9000A14A29 /* OrderCountItem+CoreDataProperties.swift in Sources */,
 				7474539D2242C85E00E0B5EE /* ProductAttribute+CoreDataClass.swift in Sources */,
-				747453A42242C85E00E0B5EE /* Product+CoreDataProperties.swift in Sources */,
+				023FA29623316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift in Sources */,
 				746A9D22214078080013F6FF /* TopEarnerStats+CoreDataProperties.swift in Sources */,
+				023FA29523316A4D008C1769 /* Product+CoreDataProperties.swift in Sources */,
 				937D6C48226E1D1F004FB8A5 /* AccountSettings+CoreDataProperties.swift in Sources */,
 				74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */,
 				CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */,
@@ -782,7 +783,6 @@
 				D8550D02230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
 				D821645E2239F5FC00F46F89 /* ShipmentTrackingProviderGroup+CoreDataProperties.swift in Sources */,
-				028F0069233165B000E6C283 /* ProductSearchResults+CoreDataClass.swift in Sources */,
 				CE3B7AD32225E62C0050FE4B /* OrderStatus+CoreDataProperties.swift in Sources */,
 				746A9D24214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift in Sources */,
 				CE43A8FE229F498D00A4FF29 /* ProductDownload+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		028F00652331605000E6C283 /* Model 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 20.xcdatamodel"; sourceTree = "<group>"; };
 		02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 19.xcdatamodel"; sourceTree = "<group>"; };
 		02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBannerVisibility.swift; sourceTree = "<group>"; };
 		02DA64162313C26400284168 /* StatsVersionBySite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBySite.swift; sourceTree = "<group>"; };
@@ -1073,6 +1074,7 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				028F00652331605000E6C283 /* Model 20.xcdatamodel */,
 				02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */,
 				D8736B6322F0AB4E00A14A29 /* Model 18.xcdatamodel */,
 				D8FBFF2A22D63B12006E3336 /* Model 17.xcdatamodel */,

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,11 @@
 
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 20 (Release 2.8.0.0)
+- @jaclync 2019-09-17
+- New `ProductSearchResults` entity
+- New `Product.searchResults` relationship
+
 ## Model 19 (Release 2.6.0.0)
 - @ctarda 2019-08-21
 - Add `ProductReview` entity

--- a/Storage/Storage/Model/Product+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Product+CoreDataProperties.swift
@@ -66,6 +66,7 @@ extension Product {
     @NSManaged public var downloads: Set<ProductDownload>?
     @NSManaged public var images: Set<ProductImage>?
     @NSManaged public var tags: Set<ProductTag>?
+    @NSManaged public var searchResults: Set<ProductSearchResults>
 
 }
 
@@ -168,5 +169,22 @@ extension Product {
 
     @objc(removeTags:)
     @NSManaged public func removeFromTags(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for searchResults
+extension Product {
+
+    @objc(addSearchResultsObject:)
+    @NSManaged public func addToSearchResults(_ value: ProductSearchResults)
+
+    @objc(removeSearchResultsObject:)
+    @NSManaged public func removeFromSearchResults(_ value: ProductSearchResults)
+
+    @objc(addSearchResults:)
+    @NSManaged public func addToSearchResults(_ values: NSSet)
+
+    @objc(removeSearchResults:)
+    @NSManaged public func removeFromSearchResults(_ values: NSSet)
 
 }

--- a/Storage/Storage/Model/Product+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Product+CoreDataProperties.swift
@@ -66,7 +66,7 @@ extension Product {
     @NSManaged public var downloads: Set<ProductDownload>?
     @NSManaged public var images: Set<ProductImage>?
     @NSManaged public var tags: Set<ProductTag>?
-    @NSManaged public var searchResults: Set<ProductSearchResults>
+    @NSManaged public var searchResults: Set<ProductSearchResults>?
 
 }
 

--- a/Storage/Storage/Model/ProductSearchResults+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductSearchResults+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(ProductSearchResults)
+public class ProductSearchResults: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductSearchResults+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductSearchResults+CoreDataProperties.swift
@@ -1,0 +1,31 @@
+import Foundation
+import CoreData
+
+
+extension ProductSearchResults {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductSearchResults> {
+        return NSFetchRequest<ProductSearchResults>(entityName: "ProductSearchResults")
+    }
+
+    @NSManaged public var keyword: String?
+    @NSManaged public var products: Set<Product>?
+
+}
+
+// MARK: Generated accessors for products
+extension ProductSearchResults {
+
+    @objc(addProductsObject:)
+    @NSManaged public func addToProducts(_ value: Product)
+
+    @objc(removeProductsObject:)
+    @NSManaged public func removeFromProducts(_ value: Product)
+
+    @objc(addProducts:)
+    @NSManaged public func addToProducts(_ values: NSSet)
+
+    @objc(removeProducts:)
+    @NSManaged public func removeFromProducts(_ values: NSSet)
+
+}

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 19.xcdatamodel</string>
+	<string>Model 20.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 20.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 20.xcdatamodel/contents
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary" syncable="YES"/>
+        <attribute name="subtype" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timestamp" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="billingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="number" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem" syncable="YES"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote" syncable="YES"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults" syncable="YES"/>
+    </entity>
+    <entity name="OrderCount" representedClassName="OrderCount" syncable="YES">
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCountItem" inverseName="orderCount" inverseEntity="OrderCountItem" syncable="YES"/>
+    </entity>
+    <entity name="OrderCountItem" representedClassName="OrderCountItem" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="orderCount" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderCount" inverseName="items" inverseEntity="OrderCount" syncable="YES"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="discountTax" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotal" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="note" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String" syncable="YES"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order" syncable="YES"/>
+    </entity>
+    <entity name="OrderStats" representedClassName="OrderStats" syncable="YES">
+        <attribute name="averageGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageNetSales" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageOrders" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="averageProducts" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="totalGrossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalNetSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderStatsItem" inverseName="stats" inverseEntity="OrderStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsItem" representedClassName="OrderStatsItem" syncable="YES">
+        <attribute name="avgOrderValue" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="avgProductsPerOrder" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="couponDiscount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="coupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="grossSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="netSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="orders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="products" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalSales" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShipping" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalShippingTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTax" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalTaxRefund" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStats" inverseName="items" inverseEntity="OrderStats" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <attribute name="granularity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="timeRange" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
+        <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES">
+        <attribute name="dateEnd" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateStart" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="interval" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="intervals" inverseEntity="OrderStatsV4" syncable="YES"/>
+        <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
+        <attribute name="couponDiscount" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="grossRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="netRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="refunds" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="shipping" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="taxes" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
+        <attribute name="totalCoupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalItemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4" syncable="YES"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String" syncable="YES"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="backordersKey" attributeType="String" syncable="YES"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="catalogVisibilityKey" attributeType="String" syncable="YES"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="permalink" attributeType="String" syncable="YES"/>
+        <attribute name="price" attributeType="String" syncable="YES"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productTypeKey" attributeType="String" syncable="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" attributeType="String" syncable="YES"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="stockStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="taxClass" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="taxStatusKey" attributeType="String" syncable="YES"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]" syncable="YES"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductCategory" inverseName="product" inverseEntity="ProductCategory" syncable="YES"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute" syncable="YES"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions" syncable="YES"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload" syncable="YES"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage" syncable="YES"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag" syncable="YES"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]" syncable="YES"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="categories" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="option" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String" syncable="YES"/>
+        <attribute name="length" attributeType="String" syncable="YES"/>
+        <attribute name="width" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
+        <attribute name="downloadID" attributeType="String" syncable="YES"/>
+        <attribute name="fileURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="src" attributeType="String" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="review" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="reviewer" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="reviewerEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="reviewID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="statusKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="verified" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="trackingID" attributeType="String" syncable="YES"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup" syncable="YES"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider" syncable="YES"/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="plan" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timezone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="settingID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String" syncable="YES"/>
+        <attribute name="granularity" attributeType="String" syncable="YES"/>
+        <attribute name="limit" attributeType="String" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem" syncable="YES"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
+        <element name="AccountSettings" positionX="-846" positionY="270" width="128" height="75"/>
+        <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
+        <element name="Order" positionX="-20" positionY="27" width="128" height="720"/>
+        <element name="OrderCount" positionX="-693" positionY="36" width="128" height="75"/>
+        <element name="OrderCountItem" positionX="-684" positionY="45" width="128" height="105"/>
+        <element name="OrderCoupon" positionX="-206.01953125" positionY="379.74609375" width="128" height="120"/>
+        <element name="OrderItem" positionX="-364.890625" positionY="379.453125" width="128" height="240"/>
+        <element name="OrderNote" positionX="-365.16796875" positionY="630.2109375" width="128" height="135"/>
+        <element name="OrderSearchResults" positionX="144.44140625" positionY="743.43359375" width="128" height="75"/>
+        <element name="OrderStats" positionX="137.859375" positionY="388.33203125" width="128" height="225"/>
+        <element name="OrderStatsItem" positionX="321.74609375" positionY="425.51171875" width="128" height="330"/>
+        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="120"/>
+        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
+        <element name="OrderStatsV4Totals" positionX="-684" positionY="45" width="128" height="225"/>
+        <element name="OrderStatus" positionX="-29.671875" positionY="781.29296875" width="128" height="105"/>
+        <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="900"/>
+        <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
+        <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
+        <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
+        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="105"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductReview" positionX="-693" positionY="36" width="128" height="195"/>
+        <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
+        <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
+        <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
+        <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
+        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="165"/>
+        <element name="SiteSetting" positionX="-362.54296875" positionY="217.9921875" width="128" height="135"/>
+        <element name="SiteVisitStats" positionX="134.515625" positionY="224.62109375" width="128" height="90"/>
+        <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
+        <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
+        <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+    </elements>
+</model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 20.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 20.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18F132" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
@@ -246,6 +246,7 @@
         <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions" syncable="YES"/>
         <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload" syncable="YES"/>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage" syncable="YES"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults" syncable="YES"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag" syncable="YES"/>
     </entity>
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
@@ -301,6 +302,10 @@
         <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="statusKey" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="verified" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <entity name="ProductSearchResults" representedClassName="ProductSearchResults" syncable="YES" codeGenerationType="class">
+        <attribute name="keyword" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="searchResults" inverseEntity="Product" syncable="YES"/>
     </entity>
     <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
@@ -389,7 +394,7 @@
         <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
         <element name="OrderStatsV4Totals" positionX="-684" positionY="45" width="128" height="225"/>
         <element name="OrderStatus" positionX="-29.671875" positionY="781.29296875" width="128" height="105"/>
-        <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="900"/>
+        <element name="Product" positionX="-534.98046875" positionY="-73.34765625" width="128" height="915"/>
         <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
         <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
         <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
@@ -407,5 +412,6 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+        <element name="ProductSearchResults" positionX="-693" positionY="36" width="128" height="75"/>
     </elements>
 </model>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -263,6 +263,13 @@ public extension StorageType {
         return firstObject(ofType: ProductCategory.self, matching: predicate)
     }
 
+    /// Retrieves the Stored ProductSearchResults Lookup.
+    ///
+    func loadProductSearchResults(keyword: String) -> ProductSearchResults? {
+        let predicate = NSPredicate(format: "keyword = %@", keyword)
+        return firstObject(ofType: ProductSearchResults.self, matching: predicate)
+    }
+
     /// Retrieves the Stored Product Tag.
     ///
     func loadProductTag(siteID: Int, productID: Int, tagID: Int) -> ProductTag? {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -178,6 +178,15 @@ extension UIImage {
         return Gridicon.iconOfType(.product).imageWithTintColor(tintColor)!
     }
 
+    /// Product Placeholder Image on Products Tab Cell
+    ///
+    static var productsTabProductCellPlaceholderImage: UIImage {
+        let tintColor = StyleManager.wooGreyBorder
+        return Gridicon
+            .iconOfType(.product, withSize: CGSize(width: 20, height: 20))
+            .imageWithTintColor(tintColor)!
+    }
+
     /// Product Image
     ///
     static var productImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIViewController+AppReview.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+AppReview.swift
@@ -1,0 +1,20 @@
+import UIKit
+import StoreKit
+
+extension UIViewController {
+    // MARK: - App Store Review Prompt
+    //
+    func displayRatingPrompt() {
+        defer {
+            if let wooEvent = WooAnalyticsStat.valueOf(stat: .appReviewsRatedApp) {
+                ServiceLocator.analytics.track(wooEvent)
+            }
+        }
+
+        // Show the app store ratings alert
+        // Note: Optimistically assuming our prompting succeeds since we try to stay
+        // in line and not prompt more than two times a year
+        AppRatingManager.shared.ratedCurrentVersion()
+        SKStoreReviewController.requestReview()
+    }
+}

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -331,7 +331,7 @@ class StyleManager {
         return active.destructiveActionColor
     }
 
-    static var hightlightTextColor: UIColor {
+    static var highlightTextColor: UIColor {
         return active.highlightTextColor
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -163,7 +163,7 @@ private extension MainTabBarController {
         var tabViewControllers = viewControllers
 
         let productsViewController = ProductsViewController(nibName: nil, bundle: nil)
-        
+
         let navController = WooNavigationController(rootViewController: productsViewController)
         navController.tabBarItem = UITabBarItem(title: NSLocalizedString("Products",
                                                                          comment: "Title of the Products tab — plural form of Product"),

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -163,7 +163,7 @@ private extension MainTabBarController {
         var tabViewControllers = viewControllers
 
         // TODO-1262: replace the products tab with a view controller that shows the product list
-        let productsViewController = UIViewController(nibName: nil, bundle: nil)
+        let productsViewController = ProductsViewController(nibName: nil, bundle: nil)
         productsViewController.view.backgroundColor = .white
 
         let navController = WooNavigationController(rootViewController: productsViewController)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -162,10 +162,8 @@ private extension MainTabBarController {
     func configureProductsTab() {
         var tabViewControllers = viewControllers
 
-        // TODO-1262: replace the products tab with a view controller that shows the product list
         let productsViewController = ProductsViewController(nibName: nil, bundle: nil)
-        productsViewController.view.backgroundColor = .white
-
+        
         let navController = WooNavigationController(rootViewController: productsViewController)
         navController.tabBarItem = UITabBarItem(title: NSLocalizedString("Products",
                                                                          comment: "Title of the Products tab — plural form of Product"),

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -332,23 +332,6 @@ private extension NotificationsViewController {
     }
 }
 
-// MARK: - App Store Review Prompt
-//
-private extension NotificationsViewController {
-    func displayRatingPrompt() {
-        defer {
-            if let wooEvent = WooAnalyticsStat.valueOf(stat: .appReviewsRatedApp) {
-                ServiceLocator.analytics.track(wooEvent)
-            }
-        }
-
-        // Show the app store ratings alert
-        // Note: Optimistically assuming our prompting succeeds since we try to stay
-        // in line and not prompt more than two times a year
-        AppRatingManager.shared.ratedCurrentVersion()
-        SKStoreReviewController.requestReview()
-    }
-}
 
 // MARK: - ResultsController
 //

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewViewModel.swift
@@ -33,7 +33,7 @@ final class ReviewViewModel {
             return NSAttributedString(string: review.review.strippedHTML).trimNewlines()
         }
 
-        let accentColor = StyleManager.hightlightTextColor
+        let accentColor = StyleManager.highlightTextColor
         let textColor = StyleManager.wooGreyTextMin
 
         let pendingReviewLiteral = NSAttributedString(string: Strings.pendingReviews,

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
@@ -235,23 +235,6 @@ private extension ReviewsViewController {
     }
 }
 
-// MARK: - App Store Review Prompt
-//
-private extension ReviewsViewController {
-    func displayRatingPrompt() {
-        defer {
-            if let wooEvent = WooAnalyticsStat.valueOf(stat: .appReviewsRatedApp) {
-                ServiceLocator.analytics.track(wooEvent)
-            }
-        }
-
-        // Show the app store ratings alert
-        // Note: Optimistically assuming our prompting succeeds since we try to stay
-        // in line and not prompt more than two times a year
-        AppRatingManager.shared.ratedCurrentVersion()
-        SKStoreReviewController.requestReview()
-    }
-}
 
 // MARK: - ResultsController
 //

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -596,24 +596,6 @@ private extension OrdersViewController {
     }
 }
 
-// MARK: - App Store Review Prompt
-//
-private extension OrdersViewController {
-    func displayRatingPrompt() {
-        defer {
-            if let wooEvent = WooAnalyticsStat.valueOf(stat: .appReviewsRatedApp) {
-                ServiceLocator.analytics.track(wooEvent)
-            }
-        }
-
-        // Show the app store ratings alert
-        // Note: Optimistically assuming our prompting succeeds since we try to stay
-        // in line and not prompt more than two times a year
-        AppRatingManager.shared.ratedCurrentVersion()
-        SKStoreReviewController.requestReview()
-    }
-}
-
 
 // MARK: - Convenience Methods
 //

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -39,7 +39,7 @@ extension ProductsTabProductTableViewCell {
         productImageView.image = .productsTabProductCellPlaceholderImage
         if let productURLString = viewModel.imageUrl {
             productImageView.downloadImage(from: URL(string: productURLString), placeholderImage: nil, success: { [weak self] _ in
-                self?.productImageView.contentMode = .scaleAspectFit
+                self?.productImageView.contentMode = .scaleAspectFill
             })
         }
     }
@@ -79,6 +79,7 @@ private extension ProductsTabProductTableViewCell {
         productImageView.layer.cornerRadius = CGFloat(2.0)
         productImageView.layer.borderWidth = 1
         productImageView.layer.borderColor = StyleManager.wooGreyBorder.cgColor
+        productImageView.clipsToBounds = true
 
         NSLayoutConstraint.activate([
             productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1),

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -1,0 +1,84 @@
+import UIKit
+
+final class ProductsTabProductTableViewCell: UITableViewCell {
+    private lazy var productImageView: UIImageView = {
+        let image = UIImageView(frame: .zero)
+        return image
+    }()
+
+    private lazy var nameLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        return label
+    }()
+
+    private lazy var detailsLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureSubviews()
+        configureNameLabel()
+        configureDetailsLabel()
+        configureProductImageView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension ProductsTabProductTableViewCell {
+    func update(viewModel: ProductsTabProductViewModel) {
+        nameLabel.text = viewModel.name
+
+        detailsLabel.attributedText = viewModel.detailsAttributedString
+
+        if let productURLString = viewModel.imageUrl {
+            productImageView.downloadImage(from: URL(string: productURLString), placeholderImage: UIImage.productPlaceholderImage)
+        } else {
+            productImageView.image = .productPlaceholderImage
+        }
+    }
+}
+
+private extension ProductsTabProductTableViewCell {
+    func configureSubviews() {
+        let contentStackView = createContentStackView()
+        let stackView = UIStackView(arrangedSubviews: [productImageView, contentStackView])
+        stackView.axis = .horizontal
+        stackView.spacing = 16
+        stackView.alignment = .leading
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stackView)
+        contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
+    }
+
+    func createContentStackView() -> UIView {
+        let contentStackView = UIStackView(arrangedSubviews: [nameLabel, detailsLabel])
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.axis = .vertical
+        return contentStackView
+    }
+
+    func configureNameLabel() {
+        nameLabel.applyBodyStyle()
+        nameLabel.numberOfLines = 2
+    }
+
+    func configureDetailsLabel() {
+        detailsLabel.numberOfLines = 1
+    }
+
+    func configureProductImageView() {
+        productImageView.contentMode = .scaleAspectFit
+        productImageView.layer.cornerRadius = CGFloat(8.0)
+
+        NSLayoutConstraint.activate([
+            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1),
+            productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor)
+            ])
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -35,10 +35,12 @@ extension ProductsTabProductTableViewCell {
 
         detailsLabel.attributedText = viewModel.detailsAttributedString
 
+        productImageView.contentMode = .center
+        productImageView.image = .productsTabProductCellPlaceholderImage
         if let productURLString = viewModel.imageUrl {
-            productImageView.downloadImage(from: URL(string: productURLString), placeholderImage: UIImage.productPlaceholderImage)
-        } else {
-            productImageView.image = .productPlaceholderImage
+            productImageView.downloadImage(from: URL(string: productURLString), placeholderImage: nil, success: { [weak self] _ in
+                self?.productImageView.contentMode = .scaleAspectFit
+            })
         }
     }
 }
@@ -73,8 +75,10 @@ private extension ProductsTabProductTableViewCell {
     }
 
     func configureProductImageView() {
-        productImageView.contentMode = .scaleAspectFit
-        productImageView.layer.cornerRadius = CGFloat(8.0)
+
+        productImageView.layer.cornerRadius = CGFloat(2.0)
+        productImageView.layer.borderWidth = 1
+        productImageView.layer.borderColor = StyleManager.wooGreyBorder.cgColor
 
         NSLayoutConstraint.activate([
             productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1),

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
@@ -1,0 +1,549 @@
+import UIKit
+import Yosemite
+
+class ProductSearchViewController: UIViewController {
+
+    /// Top container view that contains search bar, cancel button 
+    ///
+    private lazy var topContainerView: BordersView = BordersView(frame: .zero)
+
+    /// Dismiss Action
+    ///
+    private lazy var cancelButton: UIButton = UIButton(frame: .zero)
+
+    /// Empty State Legend
+    ///
+    private lazy var emptyStateLabel: UILabel = UILabel(frame: .zero)
+
+    /// Main SearchBar
+    ///
+    private lazy var searchBar: UISearchBar = UISearchBar(frame: .zero)
+
+    /// TableView
+    ///
+    private lazy var tableView: UITableView = UITableView(frame: .zero, style: .grouped)
+
+    /// Footer "Loading More" Spinner.
+    ///
+    private lazy var footerSpinnerView = FooterSpinnerView()
+
+    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Orders in sync.
+    ///
+    private lazy var resultsController: ResultsController<StorageOrder> = {
+        let storageManager = ServiceLocator.storageManager
+        let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
+
+        return ResultsController<StorageOrder>(storageManager: storageManager, sortedBy: [descriptor])
+    }()
+
+    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) OrderStatuses in sync.
+    ///
+    private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        let descriptor = NSSortDescriptor(key: "slug", ascending: true)
+
+        return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
+    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    ///
+    private let syncingCoordinator = SyncingCoordinator()
+
+    /// Search Store ID
+    ///
+    private let storeID: Int
+
+    /// Indicates if there are no results onscreen.
+    ///
+    private var isEmpty: Bool {
+        return resultsController.isEmpty
+    }
+
+    /// Returns the active Keyword
+    ///
+    private var keyword: String {
+        return searchBar.text ?? String()
+    }
+
+    /// UI Active State
+    ///
+    private var state: State = .results {
+        didSet {
+            didLeave(state: oldValue)
+            didEnter(state: state)
+        }
+    }
+
+
+    /// Deinitializer
+    ///
+    deinit {
+        stopListeningToNotifications()
+    }
+
+    /// Designated Initializer
+    ///
+    init(storeID: Int) {
+        self.storeID = storeID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    /// Unsupported: NSCoder
+    ///
+    required init?(coder aDecoder: NSCoder) {
+        assertionFailure()
+        return nil
+    }
+
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        registerTableViewCells()
+
+        configureSyncingCoordinator()
+        configureActions()
+        configureEmptyStateLabel()
+        configureMainView()
+        configureSubviews()
+        configureSearchBar()
+        configureTableView()
+        configureResultsController()
+
+        startListeningToNotifications()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.setNavigationBarHidden(true, animated: true)
+        searchBar.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+}
+
+
+// MARK: - User Interface Initialization
+//
+private extension ProductSearchViewController {
+
+    /// Setup: Main View
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Setup: layout subviews
+    func configureSubviews() {
+        configureTopContainerView()
+
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
+            view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: tableView.bottomAnchor),
+            tableView.topAnchor.constraint(equalTo: topContainerView.bottomAnchor)
+            ])
+
+        view.addSubview(emptyStateLabel)
+        emptyStateLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            emptyStateLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+            emptyStateLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            emptyStateLabel.topAnchor.constraint(equalTo: topContainerView.bottomAnchor, constant: 100),
+            emptyStateLabel.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor)
+            ])
+    }
+
+    func configureTopContainerView() {
+        topContainerView.bottomVisible = true
+        view.addSubview(topContainerView)
+        topContainerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: topContainerView.leadingAnchor),
+            view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: topContainerView.trailingAnchor),
+            view.topAnchor.constraint(equalTo: topContainerView.topAnchor)
+            ])
+
+        topContainerView.addSubview(searchBar)
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            searchBar.leadingAnchor.constraint(equalTo: topContainerView.leadingAnchor, constant: 8),
+            searchBar.bottomAnchor.constraint(equalTo: topContainerView.bottomAnchor),
+            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+            ])
+
+        topContainerView.addSubview(cancelButton)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            cancelButton.trailingAnchor.constraint(equalTo: topContainerView.trailingAnchor),
+            cancelButton.centerYAnchor.constraint(equalTo: searchBar.centerYAnchor, constant: -1),
+            cancelButton.leadingAnchor.constraint(equalTo: searchBar.trailingAnchor, constant: 3)
+            ])
+    }
+
+    /// Setup: TableView
+    ///
+    func configureTableView() {
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+        tableView.estimatedRowHeight = Settings.estimatedRowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.tableFooterView = footerSpinnerView
+    }
+
+    /// Setup: Search Bar
+    ///
+    func configureSearchBar() {
+        searchBar.searchBarStyle = .minimal
+        searchBar.placeholder = NSLocalizedString("Search all products", comment: "Products Search Placeholder")
+        searchBar.tintColor = .black
+    }
+
+    /// Setup: Actions
+    ///
+    func configureActions() {
+        let title = NSLocalizedString("Cancel", comment: "")
+        cancelButton.setTitle(title, for: .normal)
+        cancelButton.applyLinkButtonStyle()
+        cancelButton.contentEdgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 16)
+        cancelButton.titleLabel?.font = UIFont.body
+        cancelButton.addTarget(self, action: #selector(dismissWasPressed), for: .touchUpInside)
+    }
+
+    /// Setup: No Results
+    ///
+    func configureEmptyStateLabel() {
+        emptyStateLabel.text = NSLocalizedString("No products found", comment: "Search Products (Empty State)")
+        emptyStateLabel.textColor = StyleManager.wooGreyMid
+        emptyStateLabel.font = .headline
+        emptyStateLabel.adjustsFontForContentSizeCategory = true
+        emptyStateLabel.numberOfLines = 0
+        emptyStateLabel.textAlignment = .center
+    }
+
+    /// Setup: Results Controller
+    ///
+    func configureResultsController() {
+        resultsController.startForwardingEvents(to: tableView)
+        try? resultsController.performFetch()
+        try? statusResultsController.performFetch()
+    }
+
+    /// Setup: Sync'ing Coordinator
+    ///
+    func configureSyncingCoordinator() {
+        syncingCoordinator.delegate = self
+    }
+
+    /// Registers all of the available TableViewCells
+    ///
+    func registerTableViewCells() {
+        let cells = [ OrderTableViewCell.self ]
+
+        for cell in cells {
+            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        }
+    }
+
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
+
+    /// Unregisters from the Notification Center
+    ///
+    func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+}
+
+
+// MARK: - Notifications
+//
+extension ProductSearchViewController {
+
+    /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted
+    ///
+    @objc func keyboardWillShow(_ note: Notification) {
+        let bottomInset = keyboardHeight(from: note)
+
+        tableView.contentInset.bottom = bottomInset
+        tableView.scrollIndicatorInsets.bottom = bottomInset
+    }
+
+    /// Returns the Keyboard Height from a (hopefully) Keyboard Notification.
+    ///
+    func keyboardHeight(from note: Notification) -> CGFloat {
+        let wrappedRect = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+        let keyboardRect = wrappedRect?.cgRectValue ?? .zero
+
+        return keyboardRect.height
+    }
+}
+
+
+// MARK: - UISearchBarDelegate Conformance
+//
+extension ProductSearchViewController: UISearchBarDelegate {
+
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        synchronizeSearchResults(with: searchText)
+    }
+
+    func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
+        return true
+    }
+}
+
+
+// MARK: - SyncingCoordinatorDelegate Conformance
+//
+extension ProductSearchViewController: SyncingCoordinatorDelegate {
+
+    /// Synchronizes the Orders for the Default Store (if any).
+    ///
+    func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)? = nil) {
+        synchronizeOrders(keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+    }
+}
+
+
+// MARK: - Actions
+//
+private extension ProductSearchViewController {
+
+    /// Updates the Predicate + Triggers a Sync Event
+    ///
+    func synchronizeSearchResults(with keyword: String) {
+        resultsController.predicate = NSPredicate(format: "ANY searchResults.keyword = %@", keyword)
+
+        tableView.setContentOffset(.zero, animated: false)
+        tableView.reloadData()
+
+        syncingCoordinator.resynchronize()
+    }
+
+    /// Synchronizes the Orders matching a given Keyword
+    ///
+    func synchronizeOrders(keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+        let action = OrderAction.searchOrders(siteID: storeID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
+            if let error = error {
+                DDLogError("☠️ Order Search Failure! \(error)")
+            }
+
+            // Disregard OPs that don't really match the latest keyword
+            if keyword == self?.keyword {
+                self?.transitionToResultsUpdatedState()
+            }
+
+            onCompletion?(error == nil)
+        }
+
+        transitionToSyncingState()
+        ServiceLocator.stores.dispatch(action)
+        ServiceLocator.analytics.track(.ordersListFilterOrSearch, withProperties: ["filter": "", "search": "\(keyword)"])
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductSearchViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return resultsController.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return resultsController.sections[section].numberOfObjects
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
+            fatalError()
+        }
+
+        let viewModel = detailsViewModel(at: indexPath)
+        let orderStatus = lookUpOrderStatus(for: viewModel.order)
+        cell.configureCell(viewModel: viewModel, orderStatus: orderStatus)
+
+        return cell
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductSearchViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        presentOrderDetails(for: detailsViewModel(at: indexPath))
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let orderIndex = resultsController.objectIndex(from: indexPath)
+        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
+    }
+}
+
+
+// MARK: - Convenience Methods
+//
+private extension ProductSearchViewController {
+
+    func detailsViewModel(at indexPath: IndexPath) -> OrderDetailsViewModel {
+        let order = resultsController.object(at: indexPath)
+
+        return OrderDetailsViewModel(order: order)
+    }
+
+    func lookUpOrderStatus(for order: Order) -> OrderStatus? {
+        let listAll = statusResultsController.fetchedObjects
+        for orderStatus in listAll where orderStatus.slug == order.statusKey {
+            return orderStatus
+        }
+
+        return nil
+    }
+}
+
+
+// MARK: - Actions
+//
+extension ProductSearchViewController {
+
+    @IBAction func dismissWasPressed() {
+        view.endEditing(true)
+        dismiss(animated: true, completion: nil)
+    }
+
+    private func presentOrderDetails(for order: OrderDetailsViewModel) {
+        let identifier = OrderDetailsViewController.classNameWithoutNamespaces
+        guard let detailsViewController = UIStoryboard.orders.instantiateViewController(withIdentifier: identifier) as? OrderDetailsViewController else {
+            fatalError()
+        }
+
+        detailsViewController.viewModel = order
+
+        navigationController?.pushViewController(detailsViewController, animated: true)
+    }
+}
+
+
+// MARK: - Spinner Helpers
+//
+extension ProductSearchViewController {
+
+    /// Starts the Footer Spinner animation, whenever `mustStartFooterSpinner` returns *true*.
+    ///
+    private func ensureFooterSpinnerIsStarted() {
+        guard mustStartFooterSpinner() else {
+            return
+        }
+
+        footerSpinnerView.startAnimating()
+    }
+
+    /// Whenever we're sync'ing an Orders Page that's beyond what we're currently displaying, this method will return *true*.
+    ///
+    private func mustStartFooterSpinner() -> Bool {
+        guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
+            return false
+        }
+
+        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > resultsController.numberOfObjects
+    }
+
+    /// Stops animating the Footer Spinner.
+    ///
+    private func ensureFooterSpinnerIsStopped() {
+        footerSpinnerView.stopAnimating()
+    }
+}
+
+
+// MARK: - Placeholders
+//
+private extension ProductSearchViewController {
+
+    /// Displays the Empty State Legend.
+    ///
+    func displayEmptyState() {
+        emptyStateLabel.isHidden = false
+    }
+
+    /// Removes the Empty State Legend.
+    ///
+    func removeEmptyState() {
+        emptyStateLabel.isHidden = true
+    }
+}
+
+
+// MARK: - FSM
+//
+private extension ProductSearchViewController {
+
+    func didEnter(state: State) {
+        switch state {
+        case .empty:
+            displayEmptyState()
+        case .syncing:
+            ensureFooterSpinnerIsStarted()
+        case .results:
+            break
+        }
+    }
+
+    func didLeave(state: State) {
+        switch state {
+        case .empty:
+            removeEmptyState()
+        case .syncing:
+            ensureFooterSpinnerIsStopped()
+        case .results:
+            break
+        }
+    }
+
+    /// Should be called before Sync'ing. Transitions to either `results` state.
+    ///
+    func transitionToSyncingState() {
+        state = .syncing
+    }
+
+    /// Should be called whenever new results have been retrieved. Transitions to `.results` / `.empty` accordingly.
+    ///
+    func transitionToResultsUpdatedState() {
+        state = isEmpty ? .empty : .results
+    }
+}
+
+
+// MARK: - Private Settings
+//
+private enum Settings {
+    static let estimatedHeaderHeight = CGFloat(43)
+    static let estimatedRowHeight = CGFloat(86)
+}
+
+
+// MARK: - FSM States
+//
+private enum State {
+    case syncing
+    case results
+    case empty
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
@@ -375,7 +375,8 @@ extension ProductSearchViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier, for: indexPath) as? ProductsTabProductTableViewCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier,
+                                                       for: indexPath) as? ProductsTabProductTableViewCell else {
             fatalError()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
@@ -29,7 +29,7 @@ class ProductSearchViewController: UIViewController {
     ///
     private lazy var footerSpinnerView = FooterSpinnerView()
 
-    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Orders in sync.
+    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Products in sync.
     ///
     private lazy var resultsController: ResultsController<StorageProduct> = {
         let storageManager = ServiceLocator.storageManager

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewController.swift
@@ -23,7 +23,7 @@ class ProductSearchViewController: UIViewController {
 
     /// TableView
     ///
-    private lazy var tableView: UITableView = UITableView(frame: .zero, style: .grouped)
+    private lazy var tableView: UITableView = UITableView(frame: .zero, style: .plain)
 
     /// Footer "Loading More" Spinner.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewControllerStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSearchViewControllerStateCoordinator.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+/// UI state of `ProductSearchViewController`.
+///
+/// - noResultsPlaceholder: a no results placeholder is displayed
+/// - syncing: syncing data UI
+/// - results: the results are shown
+enum ProductSearchViewControllerState {
+    case noResultsPlaceholder
+    case syncing
+    case results
+}
+
+/// Keeps track of the Product Search view controller UI state, and allows the owning view controller to update UI when
+/// leaving and entering a state.
+///
+final class ProductSearchViewControllerStateCoordinator {
+    typealias State = ProductSearchViewControllerState
+
+    private let onLeavingState: (_ state: State) -> Void
+    private let onEnteringState: (_ state: State) -> Void
+
+    init(onLeavingState: @escaping (_ state: State) -> Void,
+         onEnteringState: @escaping (_ state: State) -> Void) {
+        self.onLeavingState = onLeavingState
+        self.onEnteringState = onEnteringState
+    }
+
+    /// UI Active State
+    ///
+    private var state: State = .noResultsPlaceholder {
+        didSet {
+            guard oldValue != state else {
+                return
+            }
+
+            onLeavingState(oldValue)
+            onEnteringState(state)
+        }
+    }
+
+    /// Should be called before Sync'ing. Transitions to either `results` state.
+    ///
+    func transitionToSyncingState() {
+        state = .syncing
+    }
+
+    /// Should be called whenever new results have been retrieved. Transitions to `.results` / `.noResultsPlaceholder` accordingly.
+    ///
+    func transitionToResultsUpdatedState(hasData: Bool) {
+        state = hasData ? .results : .noResultsPlaceholder
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -196,7 +196,7 @@ private extension ProductsViewController {
     func createResultsController(siteID: Int) -> ResultsController<StorageProduct> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+        let descriptor = NSSortDescriptor(key: "dateModified", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -85,6 +85,10 @@ final class ProductsViewController: UIViewController {
         super.viewWillAppear(animated)
 
         syncingCoordinator.synchronizeFirstPage()
+
+        if AppRatingManager.shared.shouldPromptForAppReview() {
+            displayRatingPrompt()
+        }
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -198,6 +198,7 @@ private extension ProductsViewController {
     func createResultsController(siteID: Int) -> ResultsController<StorageProduct> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
+//        let predicate = NSPredicate(format: "siteID == %lld AND name = 'hi'", siteID)
         let descriptor = NSSortDescriptor(key: "dateModified", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -324,7 +325,7 @@ private extension ProductsViewController {
     func displayNoResultsOverlay() {
         let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
         overlayView.messageImage = nil
-        overlayView.messageText = NSLocalizedString("No Products yet",
+        overlayView.messageText = NSLocalizedString("No products yet",
                                                     comment: "The text on the placeholder overlay when there are no products on the Products tab")
         overlayView.actionVisible = false
         overlayView.attach(to: view)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -130,6 +130,21 @@ private extension ProductsViewController {
     }
 }
 
+// MARK: - Navigation Bar Actions
+private extension ProductsViewController {
+    @IBAction func displaySearchProducts() {
+        guard let storeID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return
+        }
+
+        // TODO-1263: analytics
+        let searchViewController = ProductSearchViewController(storeID: storeID)
+        let navigationController = WooNavigationController(rootViewController: searchViewController)
+
+        present(navigationController, animated: true, completion: nil)
+    }
+}
+
 // MARK: - View Configuration
 //
 private extension ProductsViewController {
@@ -141,6 +156,22 @@ private extension ProductsViewController {
             "Products",
             comment: "Title that appears on top of the Product List screen (plural form of the word Product)."
         )
+
+        navigationItem.leftBarButtonItem = {
+            let button = UIBarButtonItem(image: .searchImage,
+                                         style: .plain,
+                                         target: self,
+                                         action: #selector(displaySearchProducts))
+            button.tintColor = .white
+            button.accessibilityTraits = .button
+            button.accessibilityLabel = NSLocalizedString("Search products", comment: "Search Products")
+            button.accessibilityHint = NSLocalizedString(
+                "Retrieves a list of products that contain a given keyword.",
+                comment: "VoiceOver accessibility hint, informing the user the button can be used to search products."
+            )
+
+            return button
+        }()
     }
 
     /// Apply Woo styles.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -131,6 +131,7 @@ private extension ProductsViewController {
 }
 
 // MARK: - Navigation Bar Actions
+//
 private extension ProductsViewController {
     @IBAction func displaySearchProducts() {
         guard let storeID = ServiceLocator.stores.sessionManager.defaultStoreID else {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1,0 +1,519 @@
+import UIKit
+import WordPressUI
+import Yosemite
+
+class ProductsViewController: UIViewController {
+
+    /// Main TableView
+    ///
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .plain)
+        return tableView
+    }()
+
+    /// Pull To Refresh Support.
+    ///
+    private lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(pullToRefresh(sender:)), for: .valueChanged)
+        return refreshControl
+    }()
+
+    /// Footer "Loading More" Spinner.
+    ///
+    private lazy var footerSpinnerView = FooterSpinnerView()
+
+    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Orders in sync.
+    ///
+    private lazy var resultsController: ResultsController<StorageProduct> = {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+
+        return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
+    /// Keep track of the (Autosizing Cell's) Height. This helps us prevent UI flickers, due to sizing recalculations.
+    ///
+    private var estimatedRowHeights = [IndexPath: CGFloat]()
+
+    /// Indicates if there are no results onscreen.
+    ///
+    private var isEmpty: Bool {
+        return resultsController.isEmpty
+    }
+
+    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    ///
+    private let syncingCoordinator = SyncingCoordinator()
+
+    /// UI Active State
+    ///
+    private var state: State = .results {
+        didSet {
+            guard oldValue != state else {
+                return
+            }
+
+            didLeave(state: oldValue)
+            didEnter(state: state)
+        }
+    }
+
+    // MARK: - View Lifecycle
+
+    deinit {
+        stopListeningToNotifications()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBar()
+        configureMainView()
+        configureSections()
+        configureTableView()
+        registerTableViewCells()
+        configureResultsController { [weak self] in
+            self?.tableView.reloadData()
+        }
+    }
+
+}
+
+// MARK: - Notifications
+//
+extension ProductsViewController {
+
+    /// Wires all of the Notification Hooks
+    ///
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+        nc.addObserver(self, selector: #selector(stopListeningToNotifications), name: .logOutEventReceived, object: nil)
+    }
+
+    /// Stops listening to all related Notifications
+    ///
+    @objc func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// Runs whenever the default Account is updated.
+    ///
+    @objc func defaultAccountWasUpdated() {
+//        statusFilter = nil
+//        refreshStatusPredicate()
+        syncingCoordinator.resetInternalState()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ProductsViewController {
+
+    /// Set the title.
+    ///
+    func configureNavigationBar() {
+        title = NSLocalizedString(
+            "Products",
+            comment: "Title that appears on top of the Product List screen (plural form of the word Product)."
+        )
+    }
+
+    /// Apply Woo styles.
+    ///
+    func configureMainView() {
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Configure common table properties.
+    ///
+    func configureTableView() {
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(tableView)
+
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        tableView.cellLayoutMarginsFollowReadableWidth = true
+//        tableView.estimatedRowHeight = Constants.rowHeight
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+    }
+
+    /// Configure sections for table view.
+    ///
+    func configureSections() {
+//        sections = [
+//            Section(rows: [.statsVersionSwitch,
+//                           .statsVersionDescription])
+//        ]
+    }
+
+    /// Register table cells.
+    ///
+    func registerTableViewCells() {
+        tableView.register(ProductTableViewCell.loadNib(), forCellReuseIdentifier: ProductTableViewCell.reuseIdentifier)
+//        for row in Row.allCases {
+//            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+//        }
+    }
+
+    func configureResultsController(onReload: @escaping () -> Void) {
+        resultsController.onDidChangeContent = {
+            onReload()
+        }
+
+        resultsController.onDidResetContent = {
+            onReload()
+        }
+
+        try? resultsController.performFetch()
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductsViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return resultsController.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return resultsController.sections[section].numberOfObjects
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductTableViewCell.reuseIdentifier, for: indexPath) as? ProductTableViewCell else {
+            fatalError()
+        }
+
+        let product = resultsController.object(at: indexPath)
+        cell.nameText = product.name
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        let rawAge = resultsController.sections[section].name
+        return Age(rawValue: rawAge)?.description
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductsViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return Settings.estimatedHeaderHeight
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return estimatedRowHeights[indexPath] ?? Settings.estimatedRowHeight
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        guard state != .placeholder else {
+            return
+        }
+
+        let product = resultsController.object(at: indexPath)
+        let productViewController = ProductLoaderViewController(productID: product.productID, siteID: product.siteID)
+        navigationController?.pushViewController(productViewController, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let orderIndex = resultsController.objectIndex(from: indexPath)
+        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
+
+        // Preserve the Cell Height
+        // Why: Because Autosizing Cells, upon reload, will need to be laid yout yet again. This might cause
+        // UI glitches / unwanted animations. By preserving it, *then* the estimated will be extremely close to
+        // the actual value. AKA no flicker!
+        //
+        estimatedRowHeights[indexPath] = cell.frame.height
+    }
+}
+
+private extension ProductsViewController {
+    @objc private func pullToRefresh(sender: UIRefreshControl) {
+        ServiceLocator.analytics.track(.ordersListPulledToRefresh)
+        syncOrderStatus()
+        syncingCoordinator.synchronizeFirstPage {
+            sender.endRefreshing()
+        }
+    }
+}
+
+// MARK: - Placeholders
+//
+private extension ProductsViewController {
+
+    /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
+    ///
+    func displayPlaceholderOrders() {
+        let options = GhostOptions(reuseIdentifier: ProductTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
+        tableView.displayGhostContent(options: options)
+
+        resultsController.stopForwardingEvents()
+    }
+
+    /// Removes the Placeholder Orders (and restores the ResultsController <> UITableView link).
+    ///
+    func removePlaceholderOrders() {
+        tableView.removeGhostContent()
+        resultsController.startForwardingEvents(to: self.tableView)
+        tableView.reloadData()
+    }
+
+    /// Displays the Error Notice.
+    ///
+    func displaySyncingErrorNotice(pageNumber: Int, pageSize: Int) {
+        let message = NSLocalizedString("Unable to refresh list", comment: "Refresh Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            self?.syncOrderStatus()
+            self?.sync(pageNumber: pageNumber, pageSize: pageSize)
+        }
+
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Displays the Empty State Overlay.
+    ///
+    func displayEmptyUnfilteredOverlay() {
+        let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
+        overlayView.messageImage = .waitingForCustomersImage
+        overlayView.messageText = NSLocalizedString("Waiting for Customers", comment: "Orders List (Empty State / No Filters)")
+        overlayView.actionText = NSLocalizedString("Share your Store", comment: "Action: Opens the Store in a browser")
+        overlayView.onAction = { [weak self] in
+            guard let `self` = self else {
+                return
+            }
+            guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+                return
+            }
+            guard let url = URL(string: site.url) else {
+                return
+            }
+
+            ServiceLocator.analytics.track(.orderShareStoreButtonTapped)
+            SharingHelper.shareURL(url: url, title: site.name, from: overlayView.actionButtonView, in: self)
+        }
+
+        overlayView.attach(to: view)
+    }
+
+    /// Displays the Empty State (with filters applied!) Overlay.
+    ///
+    func displayEmptyFilteredOverlay() {
+        let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
+        overlayView.messageImage = .waitingForCustomersImage
+        overlayView.messageText = NSLocalizedString("No results for the selected criteria", comment: "Orders List (Empty State + Filters)")
+        overlayView.actionText = NSLocalizedString("Remove Filters", comment: "Action: Opens the Store in a browser")
+        overlayView.onAction = { [weak self] in
+//            self?.statusFilter = nil
+        }
+
+        overlayView.attach(to: view)
+    }
+
+    /// Removes all of the the OverlayMessageView instances in the view hierarchy.
+    ///
+    func removeAllOverlays() {
+        for subview in view.subviews where subview is OverlayMessageView {
+            subview.removeFromSuperview()
+        }
+    }
+}
+
+// MARK: - Sync'ing Helpers
+//
+extension ProductsViewController: SyncingCoordinatorDelegate {
+
+    /// Synchronizes the Orders for the Default Store (if any).
+    ///
+    func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)? = nil) {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            onCompletion?(false)
+            return
+        }
+
+        transitionToSyncingState()
+
+//        let action = OrderAction.synchronizeOrders(siteID: siteID,
+//                                                   statusKey: statusFilter?.slug,
+//                                                   pageNumber: pageNumber,
+//                                                   pageSize: pageSize) { [weak self] error in
+//                                                    guard let `self` = self else {
+//                                                        return
+//                                                    }
+//
+//                                                    if let error = error {
+//                                                        DDLogError("⛔️ Error synchronizing orders: \(error)")
+//                                                        self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
+//                                                    } else {
+//                                                        ServiceLocator.analytics.track(.ordersListLoaded, withProperties: ["status": self.statusFilter?.slug ?? String()])
+//                                                    }
+//
+//                                                    self.transitionToResultsUpdatedState()
+//                                                    onCompletion?(error == nil)
+//        }
+
+//        ServiceLocator.stores.dispatch(action)
+    }
+
+    func syncOrderStatus(onCompletion: ((Error?) -> Void)? = nil) {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            onCompletion?(nil)
+            return
+        }
+
+        // First, let's verify our FRC predicate is up to date
+//        refreshStatusPredicate()
+
+        let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { [weak self] (_, error) in
+            if let error = error {
+                DDLogError("⛔️ Order List — Error synchronizing order statuses: \(error)")
+            }
+//            self?.resetStatusFilterIfNeeded()
+            onCompletion?(error)
+        }
+
+        ServiceLocator.stores.dispatch(action)
+    }
+}
+
+// MARK: - Finite State Machine Management
+//
+private extension ProductsViewController {
+
+    func didEnter(state: State) {
+        switch state {
+        case .emptyUnfiltered:
+            displayEmptyUnfilteredOverlay()
+        case .emptyFiltered:
+            displayEmptyFilteredOverlay()
+        case .placeholder:
+            displayPlaceholderOrders()
+        case .syncing:
+            ensureFooterSpinnerIsStarted()
+        case .results:
+            break
+        }
+    }
+
+    func didLeave(state: State) {
+        switch state {
+        case .emptyFiltered:
+            removeAllOverlays()
+        case .emptyUnfiltered:
+            removeAllOverlays()
+        case .placeholder:
+            removePlaceholderOrders()
+        case .syncing:
+            ensureFooterSpinnerIsStopped()
+        case .results:
+            break
+        }
+    }
+
+    /// Should be called before Sync'ing. Transitions to either `results` or `placeholder` state, depending on whether if
+    /// we've got cached results, or not.
+    ///
+    func transitionToSyncingState() {
+        state = isEmpty ? .placeholder : .syncing
+    }
+
+    /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
+    /// Transitions to `.results` / `.emptyFiltered` / `.emptyUnfiltered` accordingly.
+    ///
+    func transitionToResultsUpdatedState() {
+        if isEmpty == false {
+            state = .results
+            return
+        }
+
+//        if isFiltered {
+//            state = .emptyFiltered
+//            return
+//        }
+
+        state = .emptyUnfiltered
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension ProductsViewController {
+
+    func detailsViewModel(at indexPath: IndexPath) -> ProductDetailsViewModel {
+        let product = resultsController.object(at: indexPath)
+
+        return ProductDetailsViewModel(product: product)
+    }
+}
+
+// MARK: - Spinner Helpers
+//
+extension ProductsViewController {
+
+    /// Starts the Footer Spinner animation, whenever `mustStartFooterSpinner` returns *true*.
+    ///
+    private func ensureFooterSpinnerIsStarted() {
+        guard mustStartFooterSpinner() else {
+            return
+        }
+
+        footerSpinnerView.startAnimating()
+    }
+
+    /// Whenever we're sync'ing an Orders Page that's beyond what we're currently displaying, this method will return *true*.
+    ///
+    private func mustStartFooterSpinner() -> Bool {
+        guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
+            return false
+        }
+
+        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > resultsController.numberOfObjects
+    }
+
+    /// Stops animating the Footer Spinner.
+    ///
+    private func ensureFooterSpinnerIsStopped() {
+        footerSpinnerView.stopAnimating()
+    }
+}
+
+// MARK: - Nested Types
+//
+private extension ProductsViewController {
+
+    enum Settings {
+        static let estimatedHeaderHeight = CGFloat(43)
+        static let estimatedRowHeight = CGFloat(86)
+        static let placeholderRowsPerSection = [3]
+    }
+
+    enum State {
+        case placeholder
+        case syncing
+        case results
+        case emptyUnfiltered
+        case emptyFiltered
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -2,7 +2,9 @@ import UIKit
 import WordPressUI
 import Yosemite
 
-class ProductsViewController: UIViewController {
+/// Shows a list of products with pull to refresh and infinite scroll
+///
+final class ProductsViewController: UIViewController {
 
     /// Main TableView
     ///
@@ -156,7 +158,7 @@ private extension ProductsViewController {
     /// Register table cells.
     ///
     func registerTableViewCells() {
-        tableView.register(ProductTableViewCell.loadNib(), forCellReuseIdentifier: ProductTableViewCell.reuseIdentifier)
+        tableView.register(ProductsTabProductTableViewCell.self, forCellReuseIdentifier: ProductsTabProductTableViewCell.reuseIdentifier)
     }
 
     func configureResultsController(onReload: @escaping () -> Void) {
@@ -185,12 +187,13 @@ extension ProductsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductTableViewCell.reuseIdentifier, for: indexPath) as? ProductTableViewCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier, for: indexPath) as? ProductsTabProductTableViewCell else {
             fatalError()
         }
 
         let product = resultsController.object(at: indexPath)
-        cell.nameText = product.name
+        let viewModel = ProductsTabProductViewModel(product: product)
+        cell.update(viewModel: viewModel)
 
         return cell
     }
@@ -263,7 +266,7 @@ private extension ProductsViewController {
     /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
     ///
     func displayPlaceholderOrders() {
-        let options = GhostOptions(reuseIdentifier: ProductTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
+        let options = GhostOptions(reuseIdentifier: ProductsTabProductTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
         tableView.displayGhostContent(options: options)
 
         resultsController.stopForwardingEvents()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -229,7 +229,8 @@ extension ProductsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier, for: indexPath) as? ProductsTabProductTableViewCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier,
+                                                       for: indexPath) as? ProductsTabProductTableViewCell else {
             fatalError()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -253,7 +253,8 @@ extension ProductsViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let product = resultsController.object(at: indexPath)
-        let productViewController = ProductLoaderViewController(productID: product.productID, siteID: product.siteID)
+        let viewModel = ProductDetailsViewModel(product: product)
+        let productViewController = ProductDetailsViewController(viewModel: viewModel)
         navigationController?.pushViewController(productViewController, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewControllerStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewControllerStateCoordinator.swift
@@ -3,12 +3,27 @@ import UIKit
 /// UI state of `ProductsViewController`.
 ///
 /// - noResultsPlaceholder: a no results placeholder is displayed
-/// - syncing: <#syncing description#>
+/// - syncing: syncing data UI with a parameter that indicates whether there is existing data
 /// - results: the results are shown
 enum ProductsViewControllerState {
     case noResultsPlaceholder
-    case syncing
+    case syncing(withExistingData: Bool)
     case results
+}
+
+extension ProductsViewControllerState: Equatable {
+    static func ==(lhs: ProductsViewControllerState, rhs: ProductsViewControllerState) -> Bool {
+            switch (lhs, rhs) {
+            case let (.syncing(lhs), .syncing(rhs)):
+                return lhs == rhs
+            case (.noResultsPlaceholder, .noResultsPlaceholder):
+                return true
+            case (.results, .results):
+                return true
+            default:
+                return false
+            }
+    }
 }
 
 /// Keeps track of the Products view controller UI state, and allows the owning view controller to update UI when leaving and entering a state.
@@ -41,8 +56,8 @@ final class ProductsViewControllerStateCoordinator {
     /// Should be called before Sync'ing. Transitions to either `results` or `placeholder` state, depending on whether if
     /// we've got cached results, or not.
     ///
-    func transitionToSyncingState(hasData: Bool) {
-        state = hasData ? .syncing: .noResultsPlaceholder
+    func transitionToSyncingState(withExistingData: Bool) {
+        state = .syncing(withExistingData: withExistingData)
     }
 
     /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewControllerStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewControllerStateCoordinator.swift
@@ -2,17 +2,13 @@ import UIKit
 
 /// UI state of `ProductsViewController`.
 ///
-/// - placeholder: <#placeholder description#>
+/// - noResultsPlaceholder: a no results placeholder is displayed
 /// - syncing: <#syncing description#>
-/// - results: <#results description#>
-/// - emptyUnfiltered: <#emptyUnfiltered description#>
-/// - emptyFiltered: <#emptyFiltered description#>
+/// - results: the results are shown
 enum ProductsViewControllerState {
-    case placeholder
+    case noResultsPlaceholder
     case syncing
     case results
-    case emptyUnfiltered
-    case emptyFiltered
 }
 
 /// Keeps track of the Products view controller UI state, and allows the owning view controller to update UI when leaving and entering a state.
@@ -46,18 +42,12 @@ final class ProductsViewControllerStateCoordinator {
     /// we've got cached results, or not.
     ///
     func transitionToSyncingState(hasData: Bool) {
-        state = hasData ? .syncing: .placeholder
+        state = hasData ? .syncing: .noResultsPlaceholder
     }
 
     /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
-    /// Transitions to `.results` / `.emptyFiltered` / `.emptyUnfiltered` accordingly.
     ///
     func transitionToResultsUpdatedState(hasData: Bool) {
-        if hasData {
-            state = .results
-            return
-        }
-
-        state = .emptyUnfiltered
+        state = hasData ? .results: .noResultsPlaceholder
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewControllerStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewControllerStateCoordinator.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+/// UI state of `ProductsViewController`.
+///
+/// - placeholder: <#placeholder description#>
+/// - syncing: <#syncing description#>
+/// - results: <#results description#>
+/// - emptyUnfiltered: <#emptyUnfiltered description#>
+/// - emptyFiltered: <#emptyFiltered description#>
+enum ProductsViewControllerState {
+    case placeholder
+    case syncing
+    case results
+    case emptyUnfiltered
+    case emptyFiltered
+}
+
+/// Keeps track of the Products view controller UI state, and allows the owning view controller to update UI when leaving and entering a state.
+///
+final class ProductsViewControllerStateCoordinator {
+    typealias State = ProductsViewControllerState
+
+    private let onLeavingState: (_ state: State) -> Void
+    private let onEnteringState: (_ state: State) -> Void
+
+    init(onLeavingState: @escaping (_ state: State) -> Void,
+         onEnteringState: @escaping (_ state: State) -> Void) {
+        self.onLeavingState = onLeavingState
+        self.onEnteringState = onEnteringState
+    }
+
+    /// UI Active State
+    ///
+    private var state: State = .results {
+        didSet {
+            guard oldValue != state else {
+                return
+            }
+
+            onLeavingState(oldValue)
+            onEnteringState(state)
+        }
+    }
+
+    /// Should be called before Sync'ing. Transitions to either `results` or `placeholder` state, depending on whether if
+    /// we've got cached results, or not.
+    ///
+    func transitionToSyncingState(hasData: Bool) {
+        state = hasData ? .syncing: .placeholder
+    }
+
+    /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
+    /// Transitions to `.results` / `.emptyFiltered` / `.emptyUnfiltered` accordingly.
+    ///
+    func transitionToResultsUpdatedState(hasData: Bool) {
+        if hasData {
+            state = .results
+            return
+        }
+
+        state = .emptyUnfiltered
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -30,7 +30,7 @@ private extension Product {
                                                             .font: StyleManager.footerLabelFont
             ])
         if let statusText = statusText {
-            attributedString.addAttributes([.foregroundColor : StyleManager.highlightTextColor],
+            attributedString.addAttributes([.foregroundColor: StyleManager.highlightTextColor],
                                            range: NSRange(location: 0, length: statusText.count))
         }
         return attributedString

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -1,6 +1,19 @@
 import Foundation
 import Yosemite
 
+/// Converts the input product model to properties ready to be shown on `ProductsTabProductTableViewCell`.
+struct ProductsTabProductViewModel {
+    let imageUrl: String?
+    let name: String
+    let detailsAttributedString: NSAttributedString
+
+    init(product: Product) {
+        imageUrl = product.images.first?.src
+        name = product.name
+        detailsAttributedString = product.createDetailsAttributedString()
+    }
+}
+
 private extension Product {
     func createDetailsAttributedString() -> NSAttributedString {
         let statusText = createStatusText()
@@ -55,17 +68,5 @@ private extension Product {
         let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
         let format = String.pluralize(numberOfVariations, singular: singularFormat, plural: pluralFormat)
         return String.localizedStringWithFormat(format, numberOfVariations)
-    }
-}
-
-struct ProductsTabProductViewModel {
-    let imageUrl: String?
-    let name: String
-    let detailsAttributedString: NSAttributedString
-
-    init(product: Product) {
-        imageUrl = product.images.first?.src
-        name = product.name
-        detailsAttributedString = product.createDetailsAttributedString()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Yosemite
+
+private extension Product {
+    func createDetailsAttributedString() -> NSAttributedString {
+        let attributedString = NSAttributedString(string: productStatus.description, attributes: [.foregroundColor: StyleManager.defaultTextColor])
+        return attributedString
+    }
+}
+
+struct ProductsTabProductViewModel {
+    let imageUrl: String?
+    let name: String
+    let detailsAttributedString: NSAttributedString
+
+    init(product: Product) {
+        imageUrl = product.images.first?.src
+        name = product.name
+        detailsAttributedString = product.createDetailsAttributedString()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -3,8 +3,58 @@ import Yosemite
 
 private extension Product {
     func createDetailsAttributedString() -> NSAttributedString {
-        let attributedString = NSAttributedString(string: productStatus.description, attributes: [.foregroundColor: StyleManager.defaultTextColor])
+        let statusText = createStatusText()
+        let stockText = createStockText()
+        let variationsText = createVariationsText()
+
+        let detailsText = [statusText, stockText, variationsText]
+            .compactMap({ $0 })
+            .joined(separator: " • ")
+
+        let attributedString = NSMutableAttributedString(string: detailsText,
+                                                         attributes: [
+                                                            .foregroundColor: StyleManager.wooGreyMid,
+                                                            .font: StyleManager.footerLabelFont
+            ])
+        if let statusText = statusText {
+            attributedString.addAttributes([.foregroundColor : StyleManager.highlightTextColor],
+                                           range: NSRange(location: 0, length: statusText.count))
+        }
         return attributedString
+    }
+
+    func createStatusText() -> String? {
+        switch productStatus {
+        case .pending, .draft:
+            return productStatus.description
+        default:
+            return nil
+        }
+    }
+
+    func createStockText() -> String? {
+        switch productStockStatus {
+        case .inStock:
+            if let stockQuantity = stockQuantity {
+                let format = NSLocalizedString("%ld in stock", comment: "Label about product's inventory stock status shown on Products tab")
+                return String.localizedStringWithFormat(format, stockQuantity)
+            } else {
+                return NSLocalizedString("In stock", comment: "Label about product's inventory stock status shown on Products tab")
+            }
+        default:
+            return productStockStatus.description
+        }
+    }
+
+    func createVariationsText() -> String? {
+        guard !variations.isEmpty else {
+            return nil
+        }
+        let numberOfVariations = variations.count
+        let singularFormat = NSLocalizedString("%ld variant", comment: "Label about one product variation shown on Products tab")
+        let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
+        let format = String.pluralize(numberOfVariations, singular: singularFormat, plural: pluralFormat)
+        return String.localizedStringWithFormat(format, numberOfVariations)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
+		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
@@ -454,6 +456,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
+		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
@@ -907,6 +911,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		020DD48B2322A5F9005822B1 /* View Models */ = {
+			isa = PBXGroup;
+			children = (
+				020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */,
+			);
+			path = "View Models";
+			sourceTree = "<group>";
+		};
 		02404EE52315272C00FF1170 /* Top Banner */ = {
 			isa = PBXGroup;
 			children = (
@@ -1024,6 +1036,7 @@
 				7441EBC8226A71AA008BF83D /* TitleBodyTableViewCell.xib */,
 				CE1D5A57228A1C2C00DF3715 /* ProductReviewsTableViewCell.swift */,
 				CE1D5A58228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib */,
+				020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -1068,6 +1081,7 @@
 		74EC34A3225FE1F3004BBC2E /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				020DD48B2322A5F9005822B1 /* View Models */,
 				7447F9D8226A701B0031E10B /* Cells */,
 				74EC34A4225FE21F004BBC2E /* ProductLoaderViewController.swift */,
 				74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */,
@@ -2405,6 +2419,7 @@
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
+				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* FulfillButtonTableViewCell.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
@@ -2412,6 +2427,7 @@
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
 				02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */,
 				CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */,
+				020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
 		022DAD772332D71300DEF02F /* ProductSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022DAD762332D71300DEF02F /* ProductSearchViewController.swift */; };
+		022DAD792332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022DAD782332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift */; };
 		02404ED82314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */; };
 		02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */; };
 		02404EDC2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EDB2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift */; };
@@ -469,6 +470,7 @@
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
 		022DAD762332D71300DEF02F /* ProductSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchViewController.swift; sourceTree = "<group>"; };
+		022DAD782332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV3ToV4BannerActionHandler.swift; sourceTree = "<group>"; };
 		02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinator.swift; sourceTree = "<group>"; };
 		02404EDB2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV4ToV3BannerActionHandler.swift; sourceTree = "<group>"; };
@@ -1108,6 +1110,7 @@
 				0260F40023224E8100EDA10A /* ProductsViewController.swift */,
 				020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */,
 				022DAD762332D71300DEF02F /* ProductSearchViewController.swift */,
+				022DAD782332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2358,6 +2361,7 @@
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSource.swift in Sources */,
 				CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */,
+				022DAD792332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				B50911322049E27A007D25DC /* SettingsViewController.swift in Sources */,
 				B541B226218A412C008FE7C1 /* UIFont+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
+		02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
@@ -478,6 +479,7 @@
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
+		02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopBannerFactory.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
@@ -947,6 +949,7 @@
 			isa = PBXGroup;
 			children = (
 				0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */,
+				02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2548,6 +2551,7 @@
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
 				B509FED521C052D1000076A9 /* MockupSupportManager.swift in Sources */,
+				02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
+		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
@@ -466,6 +467,7 @@
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
+		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopBannerFactory.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
@@ -1070,6 +1072,7 @@
 				74EC34A4225FE21F004BBC2E /* ProductLoaderViewController.swift */,
 				74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */,
 				74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */,
+				0260F40023224E8100EDA10A /* ProductsViewController.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2241,6 +2244,7 @@
 				CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */,
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,
 				B5DB01B52114AB2D00A4F797 /* CrashLogging.swift in Sources */,
+				0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */,
 				02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */,
 				7459A6C621B0680300F83A78 /* RequirementsChecker.swift in Sources */,
 				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
 		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
+		020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
@@ -458,6 +459,7 @@
 /* Begin PBXFileReference section */
 		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
 		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
+		020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AppReview.swift"; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
@@ -1656,6 +1658,7 @@
 				02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */,
 				02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */,
 				02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */,
+				020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2422,6 +2425,7 @@
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* FulfillButtonTableViewCell.swift in Sources */,
+				020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
 		022DAD772332D71300DEF02F /* ProductSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022DAD762332D71300DEF02F /* ProductSearchViewController.swift */; };
 		022DAD792332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022DAD782332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift */; };
+		022DAD7B2332F0E800DEF02F /* ProductSearchControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022DAD7A2332F0E800DEF02F /* ProductSearchControllerStateCoordinatorTests.swift */; };
 		02404ED82314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */; };
 		02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */; };
 		02404EDC2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EDB2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift */; };
@@ -471,6 +472,7 @@
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
 		022DAD762332D71300DEF02F /* ProductSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchViewController.swift; sourceTree = "<group>"; };
 		022DAD782332E90300DEF02F /* ProductSearchViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
+		022DAD7A2332F0E800DEF02F /* ProductSearchControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV3ToV4BannerActionHandler.swift; sourceTree = "<group>"; };
 		02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinator.swift; sourceTree = "<group>"; };
 		02404EDB2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV4ToV3BannerActionHandler.swift; sourceTree = "<group>"; };
@@ -954,6 +956,7 @@
 			children = (
 				0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */,
 				02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */,
+				022DAD7A2332F0E800DEF02F /* ProductSearchControllerStateCoordinatorTests.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2574,6 +2577,7 @@
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
 				D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */,
+				022DAD7B2332F0E800DEF02F /* ProductSearchControllerStateCoordinatorTests.swift in Sources */,
 				02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */,
 				02404EE2231501E000FF1170 /* StatsVersionStateCoordinatorTests.swift in Sources */,
 				D83F5939225B424B00626E75 /* AddManualTrackingViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
 		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
 		020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */; };
+		020DD49123239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
@@ -460,6 +461,7 @@
 		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
 		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
 		020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AppReview.swift"; sourceTree = "<group>"; };
+		020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
@@ -1089,6 +1091,7 @@
 				74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */,
 				74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */,
 				0260F40023224E8100EDA10A /* ProductsViewController.swift */,
+				020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2473,6 +2476,7 @@
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,
+				020DD49123239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,
 				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B57B678E21078C5400AF8905 /* OrderItemViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
+		022DAD772332D71300DEF02F /* ProductSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022DAD762332D71300DEF02F /* ProductSearchViewController.swift */; };
 		02404ED82314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */; };
 		02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */; };
 		02404EDC2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EDB2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift */; };
@@ -467,6 +468,7 @@
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
+		022DAD762332D71300DEF02F /* ProductSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchViewController.swift; sourceTree = "<group>"; };
 		02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV3ToV4BannerActionHandler.swift; sourceTree = "<group>"; };
 		02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinator.swift; sourceTree = "<group>"; };
 		02404EDB2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV4ToV3BannerActionHandler.swift; sourceTree = "<group>"; };
@@ -1105,6 +1107,7 @@
 				74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */,
 				0260F40023224E8100EDA10A /* ProductsViewController.swift */,
 				020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */,
+				022DAD762332D71300DEF02F /* ProductSearchViewController.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -2486,6 +2489,7 @@
 				D8C2A28B231931D100F503E9 /* ReviewViewModel.swift in Sources */,
 				B541B223218A29A6008FE7C1 /* NSParagraphStyle+Woo.swift in Sources */,
 				B50BB4162141828F00AF0F3C /* FooterSpinnerView.swift in Sources */,
+				022DAD772332D71300DEF02F /* ProductSearchViewController.swift in Sources */,
 				02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */,
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
+		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
@@ -476,6 +477,7 @@
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
+		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopBannerFactory.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
@@ -939,6 +941,14 @@
 				024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */,
 			);
 			path = Developer;
+			sourceTree = "<group>";
+		};
+		0269177E23260090002AFC20 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */,
+			);
+			path = Products;
 			sourceTree = "<group>";
 		};
 		028BAC4322F3AE3B008BB4AF /* Stats v4 */ = {
@@ -1842,6 +1852,7 @@
 			isa = PBXGroup;
 			children = (
 				02E4FD7F2306AA770049610C /* Dashboard */,
+				0269177E23260090002AFC20 /* Products */,
 				D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
@@ -2560,6 +2571,7 @@
 				B56C721421B5BBC000E5E85B /* MockupStoresManager.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
+				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,
 				CE50345A21B1F8F7007573C6 /* ZendeskManagerTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductSearchControllerStateCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductSearchControllerStateCoordinatorTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+class ProductSearchControllerStateCoordinatorTests: XCTestCase {
+
+    func testTransitioningToResultsUpdatedState() {
+        let hasExistingData = true
+
+        let expectationForLeavingState = expectation(description: "Wait for leaving state")
+        expectationForLeavingState.expectedFulfillmentCount = 1
+        let onLeavingState = { (state: ProductSearchViewControllerState) in
+            XCTAssertEqual(state, .noResultsPlaceholder)
+            expectationForLeavingState.fulfill()
+        }
+
+        let expectationForEnteringState = expectation(description: "Wait for entering state")
+        expectationForEnteringState.expectedFulfillmentCount = 1
+        let onEnteringState = { (state: ProductSearchViewControllerState) in
+            XCTAssertEqual(state, .results)
+            expectationForEnteringState.fulfill()
+        }
+        let stateCoordinator = ProductSearchViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+
+        stateCoordinator.transitionToResultsUpdatedState(hasData: hasExistingData)
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testTransitioningToSyncingState() {
+        let expectationForLeavingState = expectation(description: "Wait for leaving state")
+        expectationForLeavingState.expectedFulfillmentCount = 1
+        let onLeavingState = { (state: ProductSearchViewControllerState) in
+            XCTAssertEqual(state, .noResultsPlaceholder)
+            expectationForLeavingState.fulfill()
+        }
+
+        let expectationForEnteringState = expectation(description: "Wait for entering state")
+        expectationForEnteringState.expectedFulfillmentCount = 1
+        let onEnteringState = { (state: ProductSearchViewControllerState) in
+            XCTAssertEqual(state, .syncing)
+            expectationForEnteringState.fulfill()
+        }
+        let stateCoordinator = ProductSearchViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+
+        stateCoordinator.transitionToSyncingState()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testTransitioningToResultsUpdatedStateTwice() {
+        let expectationForLeavingState = expectation(description: "Wait for leaving state")
+        expectationForLeavingState.expectedFulfillmentCount = 1
+        let onLeavingState = { (state: ProductSearchViewControllerState) in
+            XCTAssertEqual(state, .noResultsPlaceholder)
+            expectationForLeavingState.fulfill()
+        }
+
+        let expectationForEnteringState = expectation(description: "Wait for entering state")
+        expectationForEnteringState.expectedFulfillmentCount = 1
+        let onEnteringState = { (state: ProductSearchViewControllerState) in
+            XCTAssertEqual(state, .results)
+            expectationForEnteringState.fulfill()
+        }
+        let stateCoordinator = ProductSearchViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+
+        // .noResultsPlaceholder --> .noResultsPlaceholder (no state change)
+        stateCoordinator.transitionToResultsUpdatedState(hasData: false)
+        // .noResultsPlaceholder --> .results
+        stateCoordinator.transitionToResultsUpdatedState(hasData: true)
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+class ProductsTabProductViewModelTests: XCTestCase {
+
+    // MARK: Stock status
+
+    func testDetailsForProductInStockWithoutQuantity() {
+        let product = productMock(name: "Yay", stockQuantity: nil, stockStatus: .inStock)
+        let viewModel = ProductsTabProductViewModel(product: product)
+        let detailsText = viewModel.detailsAttributedString.string
+        let expectedStockDetail = NSLocalizedString("In stock", comment: "Label about product's inventory stock status shown on Products tab")
+        XCTAssertTrue(detailsText.contains(expectedStockDetail))
+    }
+
+    func testDetailsForProductInStockWithQuantity() {
+        let stockQuantity = 6
+        let product = productMock(name: "Yay", stockQuantity: stockQuantity, stockStatus: .inStock)
+        let viewModel = ProductsTabProductViewModel(product: product)
+        let detailsText = viewModel.detailsAttributedString.string
+        let format = NSLocalizedString("%ld in stock", comment: "Label about product's inventory stock status shown on Products tab")
+        let expectedStockDetail = String.localizedStringWithFormat(format, stockQuantity)
+        XCTAssertTrue(detailsText.contains(expectedStockDetail))
+    }
+
+    func testDetailsForProductOutOfStock() {
+        let product = productMock(name: "Yay", stockQuantity: 1099, stockStatus: .outOfStock)
+        let viewModel = ProductsTabProductViewModel(product: product)
+        let detailsText = viewModel.detailsAttributedString.string
+        let expectedStockDetail = NSLocalizedString("Out of stock", comment: "Display label for the product's inventory stock status")
+        XCTAssertTrue(detailsText.contains(expectedStockDetail))
+    }
+
+    // MARK: Variations
+
+    func testDetailsForProductWithOneVariation() {
+        let variations = [134]
+        let product = productMock(name: "Yay", variations: variations)
+        let viewModel = ProductsTabProductViewModel(product: product)
+        let detailsText = viewModel.detailsAttributedString.string
+        let singularFormat = NSLocalizedString("%ld variant", comment: "Label about one product variation shown on Products tab")
+        let expectedStockDetail = String.localizedStringWithFormat(singularFormat, variations.count)
+        XCTAssertTrue(detailsText.contains(expectedStockDetail))
+    }
+
+    func testDetailsForProductWithMultipleVariations() {
+        let variations = [201, 134]
+        let product = productMock(name: "Yay", variations: variations)
+        let viewModel = ProductsTabProductViewModel(product: product)
+        let detailsText = viewModel.detailsAttributedString.string
+        let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
+        let expectedStockDetail = String.localizedStringWithFormat(pluralFormat, variations.count)
+        XCTAssertTrue(detailsText.contains(expectedStockDetail))
+    }
+
+}
+
+extension ProductsTabProductViewModelTests {
+    func productMock(name: String = "Hogsmeade",
+                     stockQuantity: Int? = nil,
+                     stockStatus: ProductStockStatus = .inStock,
+                     variations: [Int] = [],
+                     images: [ProductImage] = []) -> Product {
+        let testSiteID = 2019
+        let testProductID = 2020
+        return Product(siteID: testSiteID,
+                       productID: testProductID,
+                       name: name,
+                       slug: "book-the-green-room",
+                       permalink: "https://example.com/product/book-the-green-room/",
+                       dateCreated: Date(),
+                       dateModified: Date(),
+                       productTypeKey: "booking",
+                       statusKey: "publish",
+                       featured: false,
+                       catalogVisibilityKey: "visible",
+                       fullDescription: "<p>This is the party room!</p>\n",
+                       briefDescription: """
+                           [contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. \
+                           We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us \
+                           know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests \
+                           for $100.</p>\n
+                           """,
+                       sku: "",
+                       price: "0",
+                       regularPrice: "",
+                       salePrice: "",
+                       onSale: false,
+                       purchasable: true,
+                       totalSales: 0,
+                       virtual: true,
+                       downloadable: false,
+                       downloads: [],
+                       downloadLimit: -1,
+                       downloadExpiry: -1,
+                       externalURL: "http://somewhere.com",
+                       taxStatusKey: "taxable",
+                       taxClass: "",
+                       manageStock: false,
+                       stockQuantity: stockQuantity,
+                       stockStatusKey: stockStatus.rawValue,
+                       backordersKey: "no",
+                       backordersAllowed: false,
+                       backordered: false,
+                       soldIndividually: true,
+                       weight: "213",
+                       dimensions: ProductDimensions(length: "0", width: "0", height: "0"),
+                       shippingRequired: false,
+                       shippingTaxable: false,
+                       shippingClass: "",
+                       shippingClassID: 0,
+                       reviewsAllowed: true,
+                       averageRating: "4.30",
+                       ratingCount: 23,
+                       relatedIDs: [31, 22, 369, 414, 56],
+                       upsellIDs: [99, 1234566],
+                       crossSellIDs: [1234, 234234, 3],
+                       parentID: 0,
+                       purchaseNote: "Thank you!",
+                       categories: [],
+                       tags: [],
+                       images: images,
+                       attributes: [],
+                       defaultAttributes: [],
+                       variations: variations,
+                       groupedProducts: [],
+                       menuOrder: 0)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsViewControllerStateCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsViewControllerStateCoordinatorTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+class ProductsViewControllerStateCoordinatorTests: XCTestCase {
+
+    func testTransitioningToSyncingState() {
+        let hasExistingData = true
+
+        let expectationForLeavingState = expectation(description: "Wait for leaving state")
+        expectationForLeavingState.expectedFulfillmentCount = 1
+        let onLeavingState = { (state: ProductsViewControllerState) in
+            XCTAssertEqual(state, .results)
+            expectationForLeavingState.fulfill()
+        }
+
+        let expectationForEnteringState = expectation(description: "Wait for entering state")
+        expectationForEnteringState.expectedFulfillmentCount = 1
+        let onEnteringState = { (state: ProductsViewControllerState) in
+            XCTAssertEqual(state, .syncing(withExistingData: hasExistingData))
+            expectationForEnteringState.fulfill()
+        }
+        let stateCoordinator = ProductsViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+
+        stateCoordinator.transitionToSyncingState(withExistingData: hasExistingData)
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testTransitioningToResultsUpdatedStateTwice() {
+        let expectationForLeavingState = expectation(description: "Wait for leaving state")
+        expectationForLeavingState.expectedFulfillmentCount = 1
+        let onLeavingState = { (state: ProductsViewControllerState) in
+            XCTAssertEqual(state, .results)
+            expectationForLeavingState.fulfill()
+        }
+
+        let expectationForEnteringState = expectation(description: "Wait for entering state")
+        expectationForEnteringState.expectedFulfillmentCount = 1
+        let onEnteringState = { (state: ProductsViewControllerState) in
+            XCTAssertEqual(state, .noResultsPlaceholder)
+            expectationForEnteringState.fulfill()
+        }
+        let stateCoordinator = ProductsViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+
+        // .results --> .results (no state change)
+        stateCoordinator.transitionToResultsUpdatedState(hasData: true)
+        // .results --> .noResultsPlaceholder
+        stateCoordinator.transitionToResultsUpdatedState(hasData: false)
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+}

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -6,6 +6,10 @@ import Networking
 ///
 public enum ProductAction: Action {
 
+    /// Searches products that contain a given keyword.
+    ///
+    case searchProducts(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+
     /// Synchronizes the Products matching the specified criteria.
     ///
     case synchronizeProducts(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -507,7 +507,9 @@ class ProductStoreTests: XCTestCase {
                                                         XCTFail()
                                                         return
                                                     }
-                                                    let readOnlyProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProduct.productID)?.toReadOnly()
+                                                    let readOnlyProduct = self.viewStorage
+                                                        .loadProduct(siteID: self.sampleSiteID,
+                                                                     productID: expectedProduct.productID)?.toReadOnly()
                                                     XCTAssertEqual(readOnlyProduct, expectedProduct)
                                                     XCTAssertNil(error)
 
@@ -565,31 +567,32 @@ class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
         let keyword = "hiii"
-        let nestedAction = ProductAction.searchProducts(siteID: sampleSiteID,
-                                                        keyword: keyword,
-                                                        pageNumber: defaultPageNumber,
-                                                        pageSize: defaultPageSize,
-                                                        onCompletion: { [weak self] error in
-                                                            guard let self = self else {
-                                                                XCTFail()
-                                                                return
-                                                            }
-                                                            let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
-                                                            XCTAssertEqual(products.count, 10)
-                                                            for product in products {
-                                                                XCTAssertEqual(product.searchResults?.count, 1)
-                                                                XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
-                                                            }
+        let nestedAction = ProductAction
+            .searchProducts(siteID: sampleSiteID,
+                            keyword: keyword,
+                            pageNumber: defaultPageNumber,
+                            pageSize: defaultPageSize,
+                            onCompletion: { [weak self] error in
+                                guard let self = self else {
+                                    XCTFail()
+                                    return
+                                }
+                                let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
+                                XCTAssertEqual(products.count, 10)
+                                for product in products {
+                                    XCTAssertEqual(product.searchResults?.count, 1)
+                                    XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
+                                }
 
-                                                            let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
-                                                            XCTAssertEqual(searchResults.count, 1)
-                                                            XCTAssertEqual(searchResults.first?.products?.count, 10)
-                                                            XCTAssertEqual(searchResults.first?.keyword, keyword)
+                                let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
+                                XCTAssertEqual(searchResults.count, 1)
+                                XCTAssertEqual(searchResults.first?.products?.count, 10)
+                                XCTAssertEqual(searchResults.first?.keyword, keyword)
 
-                                                            XCTAssertNil(error)
+                                XCTAssertNil(error)
 
-                                                            expectation.fulfill()
-        })
+                                expectation.fulfill()
+            })
 
         let firstAction = ProductAction.searchProducts(siteID: sampleSiteID,
                                                        keyword: keyword,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -484,6 +484,124 @@ class ProductStoreTests: XCTestCase {
 
         wait(for: [backgroundSaveExpectation], timeout: Constants.expectationTimeout)
     }
+
+    // MARK: - ProductAction.searchProducts
+
+    /// Verifies that `ProductAction.searchProducts` effectively persists the retrieved products.
+    ///
+    func testSearchProductsEffectivelyPersistsRetrievedSearchProducts() {
+        let expectation = self.expectation(description: "Search Products")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedProduct = sampleProduct()
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "Book"
+        let action = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                  keyword: keyword,
+                                                  pageNumber: defaultPageNumber,
+                                                  pageSize: defaultPageSize,
+                                                  onCompletion: { [weak self] error in
+                                                    guard let self = self else {
+                                                        XCTFail()
+                                                        return
+                                                    }
+                                                    let readOnlyProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProduct.productID)?.toReadOnly()
+                                                    XCTAssertEqual(readOnlyProduct, expectedProduct)
+                                                    XCTAssertNil(error)
+
+                                                    expectation.fulfill()
+        })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.searchProducts` effectively upserts the `ProductSearchResults` entity.
+    ///
+    func testSearchProductsEffectivelyPersistsSearchResultsEntity() {
+        let expectation = self.expectation(description: "Search Products")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "hiii"
+        let anotherKeyword = "hello"
+        let action = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                  keyword: keyword,
+                                                  pageNumber: defaultPageNumber,
+                                                  pageSize: defaultPageSize,
+                                                  onCompletion: { [weak self] error in
+                                                    guard let self = self else {
+                                                        XCTFail()
+                                                        return
+                                                    }
+
+                                                    XCTAssertNil(error)
+
+                                                    let searchResults = self.viewStorage.loadProductSearchResults(keyword: keyword)
+                                                    XCTAssertEqual(searchResults?.keyword, keyword)
+                                                    XCTAssertEqual(searchResults?.products?.count, self.viewStorage.countObjects(ofType: Storage.Product.self))
+
+                                                    let searchResultsWithAnotherKeyword = self.viewStorage.loadProductSearchResults(keyword: anotherKeyword)
+                                                    XCTAssertNil(searchResultsWithAnotherKeyword)
+
+                                                    expectation.fulfill()
+        })
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.searchProducts` does not result in duplicated entries in the ProductSearchResults entity.
+    ///
+    func testSearchProductsDoesNotProduceDuplicatedReferences() {
+        let expectation = self.expectation(description: "Search Products")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let keyword = "hiii"
+        let nestedAction = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                        keyword: keyword,
+                                                        pageNumber: defaultPageNumber,
+                                                        pageSize: defaultPageSize,
+                                                        onCompletion: { [weak self] error in
+                                                            guard let self = self else {
+                                                                XCTFail()
+                                                                return
+                                                            }
+                                                            let products = self.viewStorage.allObjects(ofType: Storage.Product.self, matching: nil, sortedBy: nil)
+                                                            XCTAssertEqual(products.count, 10)
+                                                            for product in products {
+                                                                XCTAssertEqual(product.searchResults?.count, 1)
+                                                                XCTAssertEqual(product.searchResults?.first?.keyword, keyword)
+                                                            }
+
+                                                            let searchResults = self.viewStorage.allObjects(ofType: Storage.ProductSearchResults.self, matching: nil, sortedBy: nil)
+                                                            XCTAssertEqual(searchResults.count, 1)
+                                                            XCTAssertEqual(searchResults.first?.products?.count, 10)
+                                                            XCTAssertEqual(searchResults.first?.keyword, keyword)
+
+                                                            XCTAssertNil(error)
+
+                                                            expectation.fulfill()
+        })
+
+        let firstAction = ProductAction.searchProducts(siteID: sampleSiteID,
+                                                       keyword: keyword,
+                                                       pageNumber: defaultPageNumber,
+                                                       pageSize: defaultPageSize,
+                                                       onCompletion: { error in
+                                                        store.onAction(nestedAction)
+        })
+
+        store.onAction(firstAction)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }
 
 // MARK: - Private Helpers


### PR DESCRIPTION
Fixes #1264 

- [ ] ⚠️ Update PR branch to `develop` before merging after base branch https://github.com/woocommerce/woocommerce-ios/pull/1289 is merged

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Created `ProductSearchViewController` similar to `OrderSearchViewController`
- Created `ProductSearchViewControllerStateCoordinator` to handle view controller state `ProductSearchViewControllerState`
  - Unit tests on state transitions
- Added search to the navigation bar left button in `ProductsViewController`, and navigated to `ProductSearchViewController` when tapped

## Testing
If possible, try testing with a store that has more than 25 products
- Launch the app
- Go to Products tab
- Tap Search icon on the left of the navigation bar --> observe the initial products, they should be the same as the products that have been loaded before on Products tab
- Enter a search query that has some results --> the products in the search results should contain the query
- Enter another query that has some results **that have not been fetched on Products tab yet** (this only works if the store has more than 25 products) --> the products containing the query but haven't been loaded should show up eventually
- Enter another query that has no results --> "No products found" placeholder should be shown
- Try switching to another store and repeat the steps above

## Example screenshots

no products | initial products before search | product search results
-- | -- | --
![Simulator Screen Shot - iPhone Xs - 2019-09-18 at 16 09 32](https://user-images.githubusercontent.com/1945542/65193707-e8c4ae80-da30-11e9-91ef-2482149ac014.png) | ![Simulator Screen Shot - iPhone Xs - 2019-09-19 at 10 00 25](https://user-images.githubusercontent.com/1945542/65264841-58d04480-dac4-11e9-9a5f-5866b30f65e2.png) | ![Simulator Screen Shot - iPhone Xs - 2019-09-19 at 09 59 59](https://user-images.githubusercontent.com/1945542/65264856-5ff75280-dac4-11e9-9671-aebfe141b3af.png)

