### PR TITLE
Fix all lint warnings

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -181,7 +181,8 @@ public extension OrdersRemote {
 
     enum ParameterValues {
         static let fieldValues: String = """
-            id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method_title,line_items,shipping,billing,coupon_lines
+            id,parent_id,number,status,currency,customer_id,customer_note,date_created_gmt,date_modified_gmt,date_paid_gmt,\
+            discount_total,discount_tax,shipping_total,shipping_tax,total,total_tax,payment_method_title,line_items,shipping,billing,coupon_lines
             """
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -137,7 +137,10 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         let isSelfHosted = false
 
         guard let site = siteInfo, site.hasJetpack == true else {
-            let errorInfo = NSLocalizedString("Looks like your site isn't set up to use this app. Make sure your site has Jetpack installed to continue.", comment: "Error message that displays on the 'Log in by entering your site address.' screen. Jetpack is required for logging into the WooCommerce mobile apps.")
+            let errorInfo = NSLocalizedString(
+                "Looks like your site isn't set up to use this app. Make sure your site has Jetpack installed to continue.",
+                comment: "Error message that displays on the 'Log in by entering your site address.' screen. " +
+                "Jetpack is required for logging into the WooCommerce mobile apps.")
             let error = NSError(domain: "WooCommerceAuthenticationErrorDomain",
                                 code: 555,
                                 userInfo: [NSLocalizedDescriptionKey: errorInfo])

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -405,8 +405,10 @@ private extension StorePickerViewController {
     ///
     func displayVersionCheckErrorNotice(siteID: Int, siteName: String) {
         let message = String.localizedStringWithFormat(
-            NSLocalizedString("Unable to successfully connect to %@",
-                              comment: "On the site picker screen, the error displayed when connecting to a site fails. It reads: Unable to successfully connect to {site name}"
+            NSLocalizedString(
+                "Unable to successfully connect to %@",
+                comment: "On the site picker screen, the error displayed when connecting to a site fails. " +
+                "It reads: Unable to successfully connect to {site name}"
             ),
             siteName
         )

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -172,8 +172,16 @@ private extension LoginPrologueViewController {
     /// Returns the Disclaimer Attributed Text (which contains a link to the Jetpack Setup URL).
     ///
     var disclaimerAttributedText: NSAttributedString {
-        let disclaimerText = NSLocalizedString("This app requires Jetpack to connect to your Store. <br /> Read the <a href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
-                             comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. Place the second sentence after the `<br />` tag. Place the noun, \'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. If a literal translation of 'Read the configuration instructions' does not make sense in your language, please use a contextually appropriate substitution. For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language."
+        let disclaimerText = NSLocalizedString(
+            "This app requires Jetpack to connect to your Store. <br /> Read the <a " +
+                "href=\"https://jetpack.com/support/getting-started-with-jetpack/\">configuration instructions</a>.",
+            comment: "Login Disclaimer Text and Jetpack config instructions. It reads: 'This app requires Jetpack to connect to your Store. " +
+            "Read the configuration instructions.' and it links to a web page on the words 'configuration instructions'. " +
+            "Place the second sentence after the `<br />` tag. " +
+            "Place the noun, \'configuration instructions' between the opening `<a` tag and the closing `</a>` tags. " +
+            "If a literal translation of 'Read the configuration instructions' does not make sense in your language, " +
+            "please use a contextually appropriate substitution. " +
+            "For example, you can translate it to say 'See: instructions' or any alternative that sounds natural in your language."
         )
         let disclaimerAttributes: [NSAttributedString.Key: Any] = [
             .font: StyleManager.thinCaptionFont,

--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -80,19 +80,23 @@ private extension Date {
         )
         static let singularMinuteUpdateStatment = NSLocalizedString(
             "Updated %ld minute ago",
-            comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. Usage example: Updated 1 minute ago"
+            comment: "Singular of 'minute' — date and time string that represents the time interval since last data update when exactly 1 minute ago. " +
+            "Usage example: Updated 1 minute ago"
         )
         static let pluralMinuteUpdateStatment = NSLocalizedString(
             "Updated %ld minutes ago",
-            comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. Usage example: Updated 55 minutes ago"
+            comment: "Plural of 'minute' — date and time string that represents the time interval since last data update when greater than 1 minute ago. " +
+            "Usage example: Updated 55 minutes ago"
         )
         static let singularHourUpdateStatment = NSLocalizedString(
             "Updated %ld hour ago",
-            comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. Usage example: Updated 1 hour ago"
+            comment: "Singular of 'hour' — date and time string that represents the time interval since last data update when exactly 1 hour ago. " +
+            "Usage example: Updated 1 hour ago"
         )
         static let pluralHourUpdateStatment = NSLocalizedString(
             "Updated %ld hours ago",
-            comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. Usage example: Updated 14 hours ago"
+            comment: "Plural of 'hour' — date and time string that represents the time interval since last data update when greater than 1 hour ago. " +
+            "Usage example: Updated 14 hours ago"
         )
         static let longFormUpdateStatement = NSLocalizedString(
             "Updated on %@",

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -641,7 +641,7 @@ extension ProductDetailsViewModel {
         let title = NSLocalizedString("Purchase Details",
                                       comment: "Product Details - purchase details section title")
         switch product.productType {
-        case .simple, .variable, .custom(_):
+        case .simple, .variable, .custom:
             var rows = [Row]()
 
             // downloadable and a download is specified

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -383,7 +383,8 @@ private extension PeriodDataViewController {
         yAxisAccessibilityView.accessibilityValue = String.localizedStringWithFormat(
             NSLocalizedString(
                 "Minimum value %@, maximum value %@",
-                comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. It reads: Minimum value {value}, maximum value {value}."
+                comment: "VoiceOver accessibility value, informs the user about the Y-axis min/max values. " +
+                "It reads: Minimum value {value}, maximum value {value}."
             ),
             yAxisMinimum,
             yAxisMaximum
@@ -418,7 +419,8 @@ private extension PeriodDataViewController {
             chartSummaryString += String.localizedStringWithFormat(
                 NSLocalizedString(
                     "Bar number %i, %@, ",
-                    comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. It reads: Bar number {bar number} {summary of bar}."
+                    comment: "VoiceOver accessibility value, informs the user about a specific bar in the revenue chart. " +
+                    "It reads: Bar number {bar number} {summary of bar}."
                 ),
                 i+1,
                 entrySummaryString

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -200,7 +200,8 @@ private extension PrivacySettingsViewController {
         cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .white
         cell.textLabel?.text = NSLocalizedString(
-            "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.",
+            "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, " +
+            "and more as detailed in our privacy policy.",
             comment: "Settings > Privacy Settings > privacy info section. Explains what we do with the information we collect."
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -124,7 +124,8 @@ private extension SettingsViewController {
     func configureSections() {
         let selectedStoreTitle = NSLocalizedString(
             "Selected Store",
-            comment: "My Store > Settings > Selected Store information section. This is the heading listed above the information row that displays the store website and their username."
+            comment: "My Store > Settings > Selected Store information section. " +
+            "This is the heading listed above the information row that displays the store website and their username."
             ).uppercased()
         let improveTheAppTitle = NSLocalizedString("Help Improve The App", comment: "My Store > Settings > Privacy settings section").uppercased()
         let aboutSettingsTitle = NSLocalizedString("About the app", comment: "My Store > Settings > About app section").uppercased()

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -765,11 +765,13 @@ private extension NotificationsViewController {
                 )
             case .orders:
                 return NSLocalizedString("Orders",
-                                         comment: "Name of the Orders filter on the Notifications screen - it means only order notifications will be displayed. Plural form of the word Order."
+                                         comment: "Name of the Orders filter on the Notifications screen - " +
+                    "it means only order notifications will be displayed. Plural form of the word Order."
                 )
             case .reviews:
                 return NSLocalizedString("Reviews",
-                                         comment: "Name of the Reviews filter on the Notifications screen - it means only review notifications will be displayed. Plural form of the word Review."
+                                         comment: "Name of the Reviews filter on the Notifications screen - " +
+                    "it means only review notifications will be displayed. Plural form of the word Review."
                 )
             }
         }


### PR DESCRIPTION
Fixes #1222 

Since we run `rake lint` locally quite often from missing 🐕, I thought it'd be nice to clear all existing lint warnings so that we don't have to search for the files we changed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Separated long localized string into multiple lines by concatenating shorter strings with `+`
  - Verified with `./Scripts/localize.py` that these changes did not create diffs on `WooCommerce/Resources/en.lproj/Localizable.strings` compared to `develop`
  - I've also tried multi-line literals but would create empty space in `Localizable.strings`
  - Lemme know if there are other ways to do this!
- Removed empty enum parameter
- In `OrdersRemote`'s `fieldValues`, Separated multiline literal string to two lines without line break

## Testing
Hound 🐕 