### PR TITLE
Update anonymous author name to “Someone”

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewViewModel.swift
@@ -23,7 +23,7 @@ final class ReviewViewModel {
         let reviewerName = review.reviewer
 
         if reviewerName.isEmpty {
-            return Strings.anonymous
+            return Strings.someone
         }
 
         return reviewerName
@@ -83,7 +83,7 @@ private extension ReviewViewModel {
     enum Strings {
         static let pendingReviews = NSLocalizedString("Pending Review",
                                                       comment: "Indicates a review is pending approval. It reads { Pending Review · Content of the review}")
-        static let anonymous = NSLocalizedString("Anonymous",
-                                                      comment: "Indicates the reviewer does not have a name. It reads { Anonymous left a review}")
+        static let someone = NSLocalizedString("Someone",
+                                               comment: "Indicates the reviewer does not have a name. It reads { Someone left a review}")
     }
 }

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewViewModelTests.swift
@@ -40,7 +40,7 @@ final class ReviewViewModelTests: XCTestCase {
 
         let reviewSubject = viewModel.subject
 
-        XCTAssertTrue(reviewSubject!.contains("Anonymous"))
+        XCTAssertTrue(reviewSubject!.contains("Someone"))
     }
 
     func testNotIconIsCommentIcon() {


### PR DESCRIPTION
Fixes #1276 

Some low hanging fruit, but I need a quick win for morale. 

## Changes
- When a review has an empty reviewer name, rename the review author to Someone instead of Anonymous, to match the payload of the good old notifications, and what Android is doing.
- Updated the unit test that covers that case.

## Testing
- I have never been able to reproduce this case (a review without author name) so I can not add screenshots, but there is a test that covers it and has been updated to match the desired behaviour

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
