### PR TITLE
Set background colour of notifications/review cells.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.swift
@@ -123,6 +123,7 @@ private extension NoteTableViewCell {
     /// Refreshes the Cell's Colors.
     ///
     func refreshColors() {
+        backgroundColor = StyleManager.wooWhite
         sidebarView.backgroundColor = read ? UIColor.clear : StyleManager.wooAccent
     }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zeC-WV-Edy" id="6jk-CV-iAi">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="87.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MDO-G5-bNl">
@@ -29,23 +27,22 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="fNu-km-jyX">
-                        <rect key="frame" x="55" y="11" width="304" height="56.5"/>
+                        <rect key="frame" x="55" y="11" width="305" height="56.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Subject" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ow4-CR-HAI" userLabel="Subject Label">
-                                <rect key="frame" x="0.0" y="0.0" width="304" height="20.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="305" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="752" text="Snippet" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQs-0C-rb6" userLabel="Snippet Label">
-                                <rect key="frame" x="0.0" y="23.5" width="304" height="16"/>
+                                <rect key="frame" x="0.0" y="23.5" width="305" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dNq-nY-Zo0" customClass="RatingView" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="42.5" width="304" height="14"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="0.0" y="42.5" width="305" height="14"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="14" id="PU1-eo-Wum"/>
                                 </constraints>
@@ -53,7 +50,7 @@
                         </subviews>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UhB-G7-KD0" userLabel="Sidebar View">
-                        <rect key="frame" x="0.0" y="0.0" width="2" height="88.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="2" height="89"/>
                         <color key="backgroundColor" red="0.58188301320000002" green="0.21569153669999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="2" id="jKh-ml-k7R"/>


### PR DESCRIPTION
Fix #1322

Notice this review is against the `release/2.7` branch

I would bet some serious money on this not being a problem when building with versions of Xcode 11 previous to the release version. Who knows.

When building with the release version of Xcode 11, the Reviews tab looks like this:

<img src="https://user-images.githubusercontent.com/2722505/66043027-563b0980-e51e-11e9-8e18-cb12f89fadbe.png" width="350"/>


## Changes
- Remove the background color of the stars view, that was set in IB.
- Set the background color of the cell to `StyleManager.mooWhite`. Eventually, when implementing proper support for dark mode, the colors in Style manager would have to be renamed, so this is fairly safe.

After those changes, the Reviews tab looks like it used to look. Like this:
<img src="https://user-images.githubusercontent.com/2722505/66043106-97331e00-e51e-11e9-8f7c-eb54f99086d1.png" width="350"/>

## Testing
- Checkout the branch, build and run, navigate to the reviews tab on a device/simulator configured in dark mode

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
