### PR TITLE
Set a background color to OrderTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -54,6 +54,7 @@ final class OrderTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureBackground()
         configureLabels()
     }
 
@@ -90,6 +91,10 @@ private extension OrderTableViewCell {
 
         paymentStatusLabel.backgroundColor = paymentColor
         paymentStatusLabel.layer.borderColor = borderColor
+    }
+
+    func configureBackground() {
+        backgroundColor = StyleManager.wooWhite
     }
 
     /// Setup: Labels


### PR DESCRIPTION
Fix #1324 

Notice this PR is against the `release/2.7` branch.

I am almost positive this was not being a problem when building with versions of Xcode 11 previous to the release version. Who knows.

When building with the release version of Xcode 11, the Orders tab looks like this:

<img src="https://user-images.githubusercontent.com/2722505/66044621-47565600-e522-11e9-8bae-4e0e84f19fac.png" width="350"/>

## Changes
- Set the background color of the OrderTableViewCell to `StyleManager.mooWhite`. Eventually, when implementing proper support for dark mode, the colors in Style manager would have to be renamed, so this is fairly safe.

## Testing
- Checkout the branch, build and run, navigate to the Orders tab on a device/simulator configured in dark mode. It should look like this:

<img src="https://user-images.githubusercontent.com/2722505/66044713-7a98e500-e522-11e9-9765-ed578f9a8d38.png" width="350"/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
