### PR TITLE
Stats v4: fix currency stuck in USD

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -526,6 +526,9 @@ extension CurrencySettings {
         let settingTypePredicate = NSPredicate(format: "settingGroupKey ==[c] %@", SiteSettingGroup.general.rawValue)
         resultsController.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sitePredicate, settingTypePredicate])
         try? resultsController.performFetch()
+        resultsController.fetchedObjects.forEach {
+            updateCurrencyOptions(with: $0)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1319 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Updated currency options with fetched site settings from storage (`try? resultsController.performFetch()`) - according to the [official doc](https://developer.apple.com/documentation/coredata/nsfetchedresultscontroller/1622305-performfetch):

> After executing this method, you can access the receiver’s the fetched objects with the property fetchedObjects.

- Why this wasn't an issue for Stats v3? For Stats v3, we use the [`OrderStats`'s currency code](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Model/OrderStats+Woo.swift#L11-L17) for stats revenue (code [here](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift#L73)).

## Testing
Note: we only refresh site settings on app launch or store switch, the change of store currency will only be refreshed under these circumstances (e.g. not during pull to refresh on Dashboard)

Prerequisite: the store has WC admin activated
- Launch the app
- Make sure Stats v4 is used on the Dashboard (either by opting in from the announcement banner previously or in the store settings > Beta Features)
- On the Dashboard ("My store" tab) --> the stats revenue should be in the current store currency
- On web, update store currency to a different one
- Relaunch the app
- On the Dashboard ("My store" tab) --> the stats revenue should be in the new store currency

## Example screenshots

before currency switch | after currency switch
-- | --
![Simulator Screen Shot - iPhone SE - 2019-10-02 at 21 02 44](https://user-images.githubusercontent.com/1945542/66047118-cb780000-e559-11e9-8ffc-e958e999b6c3.png) | ![Simulator Screen Shot - iPhone SE - 2019-10-02 at 21 02 55](https://user-images.githubusercontent.com/1945542/66047119-cb780000-e559-11e9-8827-6e328f967b8e.png)