### PR TITLE
Update background colors of all cells in OrderDetails screen

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
@@ -11,4 +11,10 @@ extension UITableViewCell {
     class var reuseIdentifier: String {
         return classNameWithoutNamespaces
     }
+
+    /// Applies the default background color
+    ///
+    func applyDefaultBackgroundStyle() {
+        backgroundColor = StyleManager.wooWhite
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/CustomerInfoTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/CustomerInfoTableViewCell.swift
@@ -44,4 +44,17 @@ class CustomerInfoTableViewCell: UITableViewCell {
             addressLabel.text = newValue
         }
     }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureBackground()
+    }
+}
+
+
+private extension CustomerInfoTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/CustomerNoteTableViewCell.swift
@@ -23,4 +23,16 @@ class CustomerNoteTableViewCell: UITableViewCell {
             noteLabel.text = newValue
         }
     }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureBackground()
+    }
+}
+
+
+private extension CustomerNoteTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/FulfillButtonTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/FulfillButtonTableViewCell.swift
@@ -11,12 +11,24 @@ final class FulfillButtonTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        fulfillButton.applyPrimaryButtonStyle()
+        configureBackground()
+        configureFulfillButton()
     }
 }
 
 extension FulfillButtonTableViewCell {
     @IBAction func fulfillWasPressed() {
         onFullfillTouchUp?()
+    }
+}
+
+
+private extension FulfillButtonTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureFulfillButton() {
+        fulfillButton.applyPrimaryButtonStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderNoteTableViewCell.swift
@@ -28,6 +28,7 @@ class OrderNoteTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
         configureLabels()
         configureIconButton()
     }
@@ -90,6 +91,10 @@ private extension OrderNoteTableViewCell {
             iconButton.backgroundColor = StyleManager.wooGreyMid
             statusLabel.text = NSLocalizedString("Private note", comment: "Labels an order note to let the user know it's private and not seen by the customer")
         }
+    }
+
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 
     /// Setup: Labels

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTrackingTableViewCell.swift
@@ -43,10 +43,16 @@ final class OrderTrackingTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        
+        configureBackground()
         configureTopLine()
         configureMiddleLine()
         configureBottomLine()
         configureActionButton()
+    }
+
+    private func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 
     private func configureTopLine() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/PaymentTableViewCell.swift
@@ -45,20 +45,14 @@ final class PaymentTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        subtotalLabel.applyBodyStyle()
-        subtotalValue.applyBodyStyle()
-        discountLabel.applyBodyStyle()
-        discountValue.applyBodyStyle()
-        shippingLabel.applyBodyStyle()
-        shippingValue.applyBodyStyle()
-        taxesLabel.applyBodyStyle()
-        taxesValue.applyBodyStyle()
-        totalLabel.applyHeadlineStyle()
-        totalValue.applyHeadlineStyle()
-
-        footerLabel?.text = nil
-        footerLabel?.applyFootnoteStyle()
-        separatorLine?.backgroundColor = StyleManager.cellSeparatorColor
+        configureBackground()
+        configureSubTotal()
+        configureDiscount()
+        configureShipping()
+        configureTaxes()
+        configureTotal()
+        configureLabel()
+        configureSeparator()
     }
 
     func configure(with viewModel: OrderPaymentDetailsViewModel) {
@@ -95,6 +89,47 @@ final class PaymentTableViewCell: UITableViewCell {
         if let footerText = footerText {
             accessibilityElements?.append(footerText)
         }
+    }
+}
+
+
+private extension PaymentTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureSubTotal() {
+        subtotalLabel.applyBodyStyle()
+        subtotalValue.applyBodyStyle()
+    }
+
+    func configureDiscount() {
+        discountLabel.applyBodyStyle()
+        discountValue.applyBodyStyle()
+    }
+
+    func configureShipping() {
+        shippingLabel.applyBodyStyle()
+        shippingValue.applyBodyStyle()
+    }
+
+    func configureTaxes() {
+        taxesLabel.applyBodyStyle()
+        taxesValue.applyBodyStyle()
+    }
+
+    func configureTotal() {
+        totalLabel.applyHeadlineStyle()
+        totalValue.applyHeadlineStyle()
+    }
+
+    func configureLabel() {
+        footerLabel?.text = nil
+        footerLabel?.applyFootnoteStyle()
+    }
+
+    func configureSeparator() {
+        separatorLine?.backgroundColor = StyleManager.cellSeparatorColor
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
@@ -85,19 +85,48 @@ class ProductDetailsTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureBackground()
+        configureProductImageView()
+        configureNameLabel()
+        configureQuantityLabel()
+        configurePriceLabel()
+        configureSelectionStyle()
+    }
+}
+
+
+private extension ProductDetailsTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureProductImageView() {
         productImageView.image = .productPlaceholderImage
         productImageView.tintColor = StyleManager.wooGreyBorder
-        selectionStyle = .none
+    }
 
+    func configureNameLabel() {
         nameLabel.applyBodyStyle()
-        quantityLabel.applyBodyStyle()
-        priceLabel.applySecondaryFootnoteStyle()
-        skuLabel.applySecondaryFootnoteStyle()
-
         nameLabel?.text = ""
+    }
+
+    func configureQuantityLabel() {
+        quantityLabel.applyBodyStyle()
         quantityLabel?.text = ""
+    }
+
+    func configurePriceLabel() {
+        priceLabel.applySecondaryFootnoteStyle()
         priceLabel?.text = ""
+    }
+
+    func configureSKULabel() {
+        skuLabel.applySecondaryFootnoteStyle()
         skuLabel?.text = ""
+    }
+
+    func configureSelectionStyle() {
+        selectionStyle = .none
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/SummaryTableViewCell.swift
@@ -65,6 +65,8 @@ final class SummaryTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        configureBackground()
         configureLabels()
         configureIcon()
     }
@@ -102,6 +104,10 @@ private extension SummaryTableViewCell {
 
         paymentStatusLabel.backgroundColor = paymentColor
         paymentStatusLabel.layer.borderColor = borderColor
+    }
+
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 
     /// Setup: Labels

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
@@ -31,8 +31,13 @@ class LeftImageTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureBackground()
         imageView?.tintColor = StyleManager.wooCommerceBrandColor
         textLabel?.applyBodyStyle()
+    }
+
+    private func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -26,8 +26,13 @@ class WooBasicTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
         configureSelectionStyle()
         configureLabel()
+    }
+
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 
     /// Set up the cell selection style


### PR DESCRIPTION
Fixes #1325 

The scope of the PR is limited to just making the OrderDetails screen usable in Dark mode when building the codebase with the release version of Xcode 11.

Before:
<img src="https://user-images.githubusercontent.com/2722505/66080340-33ccde80-e566-11e9-9114-d6574bab7814.png" width="350"/>

After:
<img src="https://user-images.githubusercontent.com/2722505/66080368-447d5480-e566-11e9-923f-139bbf1a33b3.png" width="350"/>


## Changes
- Set the background color of the cells involved in the rendering of the Order Details screen

## Testing
- Set a device to dark mode.
- Checkout the branch, build the project, navigate to a single order. 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
