### PR TITLE
Order Details: Icon on "Details" cell for fulfilled order can be wrong

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - bugfix: Product Details page was displaying the Price in the wrong currency.
 - Enhancement: removed the "New Orders" card from the My store tab, now that the Orders tab displays the same information.
 - Added brand new stats page for user with the WooCommerce Admin plugin and provided an option for users to opt in or out directly from the Settings page.
+- bugfix: Order Details: icon on "Details" cell for fulfilled order can be wrong.
  
 2.6
 -----

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
@@ -302,6 +302,7 @@ private extension OrderDetailsDataSource {
     func configureDetails(cell: WooBasicTableViewCell) {
         cell.bodyLabel?.text = Titles.productDetails
         cell.bodyLabel?.applyBodyStyle()
+        cell.accessoryImage = nil
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -46,6 +46,10 @@ class WooBasicTableViewCell: UITableViewCell {
     /// Add the accessoryView image, if any
     ///
     func configureAccessoryView() {
+        guard let accessoryImage = accessoryImage else {
+            accessoryView = nil
+            return
+        }
         let accessoryImageView = UIImageView(image: accessoryImage)
         accessoryImageView.tintColor = StyleManager.buttonPrimaryColor
         accessoryView = accessoryImageView


### PR DESCRIPTION
Fixes #1328 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Set table view cell's `accessoryImage` to nil before setting `accessoryType` to disclosure for Order Details details cell
- Reset `accessoryView` in `accessoryImage` nil case

## Testing
1. Go to the Orders tab.
2. Open an order with a "Processing" status and customer billing info (including customer email).
3. On the Order Details screen, scroll down to the customer information and tap "Show billing" to expand the information section.
4. Scroll back up and select "Fulfill order."
5. On the order fulfillment screen, mark the order complete.
6. When it goes back to the Order Details --> the "Details" cell should keep showing the disclosure indicator (>)
