### PR TITLE
Xcode 11 + Dark mode: temporarily disable Dark mode for login UI

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -64,6 +64,11 @@ class AuthenticationManager: Authentication {
         let navigationController = LoginNavigationController(rootViewController: prologueViewController)
         navigationController.modalPresentationStyle = .fullScreen
 
+        // TODO-1335: properly handle login input field text color in Dark mode in `WordPressAuthenticator`.
+        if #available(iOS 13.0, *) {
+            navigationController.overrideUserInterfaceStyle = .light
+        }
+
         presenter.present(navigationController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Temporary change for #1335 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Set `LoginNavigationController`'s `overrideUserInterfaceStyle` to light mode, so that it always shows light mode UI regardless of the device preference. A proper fix would be in the `WordPressAuthenticator` pod, which might not fit in release 2.7 (but I'd defer the decision to code reviewers)

## Testing
Prerequisite: device is in Dark mode
- Log out from the app
- Log in to the app --> the text in the input fields should be legible

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone Xs - 2019-10-03 at 17 02 11](https://user-images.githubusercontent.com/1945542/66113558-96be8400-e5ff-11e9-8b69-7dbe1aca7415.png) | ![Simulator Screen Shot - iPhone Xs - 2019-10-03 at 17 01 29](https://user-images.githubusercontent.com/1945542/66113557-96be8400-e5ff-11e9-9420-8d22375ad3c9.png)