### PR TITLE
Set background colour of cells used in Settings

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EmptyStoresTableViewCell.swift
@@ -16,4 +16,17 @@ class EmptyStoresTableViewCell: UITableViewCell {
                                                  comment: "Displayed during the Login flow, whenever the user has no woo stores associated.")
         }
     }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        configureBackground()
+    }
+}
+
+
+private extension EmptyStoresTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StoreTableViewCell.swift
@@ -73,8 +73,9 @@ class StoreTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        nameLabel.textColor = StyleManager.wooSecondary
-        urlLabel.textColor = StyleManager.wooSecondary
+        configureBackground()
+        configureNameLabel()
+        configureUrlLabel()
     }
 
     /// Displays (or hides) the Checkmark ContainerView, based on the `allowsCheckmark` property.
@@ -87,5 +88,20 @@ class StoreTableViewCell: UITableViewCell {
     ///
     private func refreshCheckmarkImage() {
         checkmarkImageView.image = displaysCheckmark ? .checkmarkStyledImage : nil
+    }
+}
+
+
+private extension StoreTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureNameLabel() {
+        nameLabel.textColor = StyleManager.wooSecondary
+    }
+
+    func configureUrlLabel() {
+        urlLabel.textColor = StyleManager.wooSecondary
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
@@ -5,6 +5,7 @@ class BasicTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
         textLabel?.applyBodyStyle()
     }
 
@@ -13,5 +14,12 @@ class BasicTableViewCell: UITableViewCell {
 
         textLabel?.applyBodyStyle()
         textLabel?.textAlignment = .natural
+    }
+}
+
+
+private extension BasicTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/HeadlineLabelTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/HeadlineLabelTableViewCell.swift
@@ -32,7 +32,23 @@ final class HeadlineLabelTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
+        configureHeadline()
+        configureBody()
+    }
+}
+
+
+private extension HeadlineLabelTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureHeadline() {
         headlineLabel?.applyHeadlineStyle()
+    }
+
+    func configureBody() {
         bodyLabel?.applyBodyStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwitchTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwitchTableViewCell.swift
@@ -51,6 +51,7 @@ class SwitchTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
         setupTextLabels()
         setupSwitch()
         setupGestureRecognizers()
@@ -65,6 +66,10 @@ class SwitchTableViewCell: UITableViewCell {
 // MARK: - Private Methods
 //
 private extension SwitchTableViewCell {
+
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
 
     func setupTextLabels() {
         textLabel?.text = String()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TopLeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TopLeftImageTableViewCell.swift
@@ -7,14 +7,26 @@ class TopLeftImageTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        textLabel?.applyBodyStyle()
-        textLabel?.numberOfLines = 0
+        configureBackground()
+        configureTextLabel()
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         imageView?.frame.size = CGSize(width: Constants.iconW, height: Constants.iconH)
         imageView?.frame.origin.y = Constants.iconY
+    }
+}
+
+
+private extension TopLeftImageTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureTextLabel() {
+        textLabel?.applyBodyStyle()
+        textLabel?.numberOfLines = 0
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
@@ -5,7 +5,23 @@ class ValueOneTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
+        configureTextLabel()
+        configureDetailTextLabel()
+    }
+}
+
+
+private extension ValueOneTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureTextLabel() {
         textLabel?.applyBodyStyle()
+    }
+
+    func configureDetailTextLabel() {
         detailTextLabel?.applySubheadlineStyle()
         detailTextLabel?.lineBreakMode = .byWordWrapping
         detailTextLabel?.numberOfLines = 0


### PR DESCRIPTION
Fixes #1332 

The scope of the PR is limited to just making the Settings screen usable in Dark mode when building the codebase with the release version of Xcode 11.

Before:
<img src="https://user-images.githubusercontent.com/2722505/66148420-215baf00-e611-11e9-9c25-d3c2656d161d.PNG" width="350"/>

After:
<img src="https://user-images.githubusercontent.com/2722505/66149510-8d3f1700-e613-11e9-86c4-50846d9384ee.gif" width="350"/>

## Changes
This PR touches several cells. Those used in the SettingsViewController and those used also in other view controllers that can be reached from Settings. It has the nice side effect that it will solve another bunch of issues that we have not logged yet. 🤷‍♂ 

## Testing
- Set a device to dark mode. 
- Checkout the branch, build and navigate to Settings. Tap buttons all around!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
