### PR TITLE
Set background colour of cells when adding shipment tracking

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/StatusListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/StatusListTableViewCell.swift
@@ -18,6 +18,8 @@ final class StatusListTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        configureBackground()
         styleCheckmark()
     }
 
@@ -34,8 +36,15 @@ final class StatusListTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
         accessoryType = selected ? .checkmark : .none
     }
+}
 
-    private func styleCheckmark() {
+
+private extension StatusListTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func styleCheckmark() {
         tintColor = StyleManager.wooCommerceBrandColor
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell.swift
@@ -6,6 +6,7 @@ final class TitleAndEditableValueTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureBackground()
         configureAsNonSelectable()
         styleTitle()
         styleValue()
@@ -14,6 +15,10 @@ final class TitleAndEditableValueTableViewCell: UITableViewCell {
 
 
 private extension TitleAndEditableValueTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
     func configureAsNonSelectable() {
         selectionStyle = .none
     }


### PR DESCRIPTION
Fixes #1338 

The scope of the PR is limited to just making the screen to Add a Shipment Tracking usable in Dark mode when building the codebase with the release version of Xcode 11.

Before:
<img src="https://user-images.githubusercontent.com/2722505/66151124-f5432c80-e616-11e9-95e1-d6ec1b19a50f.png" width="350"/>

After:
<img src="https://user-images.githubusercontent.com/2722505/66151157-04c27580-e617-11e9-89c7-ced7a2d1abdd.png" width="350"/>

## Changes
- Update cells used for the Add Shipment Tracking feature

## Testing
- Setup a device on dark mode
- build the branch, navigate to an order in Pending status, and Add a shipment tracking

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
