### PR TITLE
Configure backgrounds for add note view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -31,13 +31,32 @@ class TextViewTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        noteTextView.delegate = self
+
+        configureBackground()
+        configureTextView()
+
         noteIconButton.accessibilityTraits = .image
     }
 }
 
+
 extension TextViewTableViewCell: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         onTextChange?(noteTextView.text)
+    }
+}
+
+private extension TextViewTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureTextView() {
+        noteTextView.delegate = self
+        // Overriding the textview user interface style until Dark Mode
+        // is fully supported
+        if #available(iOS 13.0, *) {
+            noteTextView.overrideUserInterfaceStyle = .light
+        }
     }
 }


### PR DESCRIPTION
Fixes #1340 

The scope of the PR is limited to just making the screen to Add a Note usable in Dark mode when building the codebase with the release version of Xcode 11.

Before: 
<img src="https://user-images.githubusercontent.com/2722505/66154810-9a153800-e61e-11e9-8c69-ae3b584e618e.png" width="350"/>

After:
<img src="https://user-images.githubusercontent.com/2722505/66154831-a8fbea80-e61e-11e9-815b-06bd093a0aae.png" width="350"/>

Note that the cell view marked with an arrow is fixed in PR #1337 

## Changes
- Update the background of TextViewTableViewCell
- Override dark mode for the text view embedded in it. It seemed to be a simpler solution, and simpler to revert, that preparing its background and font colors to support dark mode later on.

## Review
- Set a device in dark mode
- Build the branch, navigate to an order in Processing status, and Add a Note.
- If PR #1337 has already been merged, the view should look ok. If it hasn't, the view should only look fine, except for the section corresponding to "Email note to customer:

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
