### PR TITLE
Xcode 11 + Dark mode: fix Order Details product SKU label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/ProductDetailsTableViewCell.swift
@@ -89,6 +89,7 @@ class ProductDetailsTableViewCell: UITableViewCell {
         configureProductImageView()
         configureNameLabel()
         configureQuantityLabel()
+        configureSKULabel()
         configurePriceLabel()
         configureSelectionStyle()
     }


### PR DESCRIPTION
Fixes #1342 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Called `configureSKULabel` to configure SKU label :) somehow it wasn't called before

## Testing
Prerequisite: Dark mode on
- Go to Orders tab
- Tap on an Order --> the SKU text on the Product cell should be visible

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone Xʀ - 2019-10-04 at 09 24 22](https://user-images.githubusercontent.com/1945542/66175254-6e7c6700-e68b-11e9-8682-cd43a8ffc830.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-10-04 at 09 39 42](https://user-images.githubusercontent.com/1945542/66175255-6e7c6700-e68b-11e9-8d14-9920c613588d.png)
