### PR TITLE
Xcode 11 + Dark mode: Order details > Product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductReviewsTableViewCell.swift
@@ -24,8 +24,16 @@ final class ProductReviewsTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
         configureLabels()
         configureStarView()
+    }
+}
+
+
+private extension ProductReviewsTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
     }
 
     func configureLabels() {

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/TitleBodyTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/TitleBodyTableViewCell.swift
@@ -8,7 +8,23 @@ final class TitleBodyTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        configureBackground()
+        configureTitleLabel()
+        configureBodyLabel()
+    }
+}
+
+
+private extension TitleBodyTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureTitleLabel() {
         titleLabel?.applyHeadlineStyle()
+    }
+
+    func configureBodyLabel() {
         bodyLabel?.applySecondaryBodyStyle()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnTableViewCell.swift
@@ -12,7 +12,23 @@ final class TwoColumnTableViewCell: UITableViewCell {
         super.awakeFromNib()
 
         stackView.isLayoutMarginsRelativeArrangement = true
+        configureBackground()
+        configureLeftLabel()
+        configureRightLabel()
+    }
+}
+
+
+private extension TwoColumnTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureLeftLabel() {
         leftLabel.applyBodyStyle()
+    }
+
+    func configureRightLabel() {
         rightLabel.applyBodyStyle()
     }
 }


### PR DESCRIPTION
Fixes #1344 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Configured background color for the following table view cells used in Order details > Product 
details
  - `ProductReviewsTableViewCell`
  - `TitleBodyTableViewCell`
  - `TwoColumnTableViewCell`

## Testing

Prerequisite: Dark mode enabled
- Go to Orders tab
- Tap on an Order
- Tap on a Product on the Order details page --> all the cells should look as in Light mode

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone Xʀ - 2019-10-04 at 10 00 11](https://user-images.githubusercontent.com/1945542/66175845-cd42e000-e68d-11e9-8e9b-4e4bf7388e3c.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-10-04 at 09 56 45](https://user-images.githubusercontent.com/1945542/66175851-d5028480-e68d-11e9-8bdb-c8480b61a19c.png)
