### PR TITLE
Point pods to Fancy Button UI updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -25,13 +25,14 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 0.19'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
-  pod 'WordPressAuthenticator', '~> 1.10.0'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fancy-button-border-style'
+  # pod 'WordPressAuthenticator', '~> 1.8.0'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
   pod 'WordPressShared', '~> 1.8.2'
   
-  pod 'WordPressUI', '~> 1.3.5'
+  #pod 'WordPressUI', '~> 1.3.5'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :commit => 'd91de6a'
 
 
   # External Libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ PODS:
   - Sentry/Core (4.4.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPressAuthenticator (1.10.0):
+  - WordPressAuthenticator (1.10.1-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -63,7 +63,7 @@ PODS:
   - WordPressShared (1.8.7):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.3.5)
+  - WordPressUI (1.4-beta.1)
   - wpxmlrpc (0.8.4)
   - XLPagerTabStrip (9.0.0)
   - ZendeskSDK (3.0.2):
@@ -84,9 +84,9 @@ DEPENDENCIES:
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 0.19)
   - KeychainAccess (~> 3.2)
-  - WordPressAuthenticator (~> 1.10.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fancy-button-border-style`)
   - WordPressShared (~> 1.8.2)
-  - WordPressUI (~> 1.3.5)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS`, commit `d91de6a`)
   - XLPagerTabStrip (~> 9.0)
   - ZendeskSDK (~> 3.0.2)
 
@@ -110,13 +110,27 @@ SPEC REPOS:
     - Sentry
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
-    - WordPressUI
     - wpxmlrpc
     - XLPagerTabStrip
     - ZendeskSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: fancy-button-border-style
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressUI:
+    :commit: d91de6a
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 86d5d2c638df5d7b88f1c329bbe315d13f318c3c
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressUI:
+    :commit: d91de6a
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -137,14 +151,14 @@ SPEC CHECKSUMS:
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressAuthenticator: c4585d7a5a005df4f9dada8efbeebab32b12844f
+  WordPressAuthenticator: a646d809fbfd8e68ba198a989ddb8bad67e196c8
   WordPressKit: c35230114bbd380d63250b6d9a43337c29266c9b
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
-  WordPressUI: 1b006c7440e85e724b9773c7ebe3a2e783f70941
+  WordPressUI: b149c4291b558ac6e7b72c30e88d37ff37bd564a
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskSDK: f1c093a28ffcd0dc84b0cc1844801c7fc3a3dffd
 
-PODFILE CHECKSUM: a902a502e9051af9cff4b027417f04567f141111
+PODFILE CHECKSUM: 76e7b0dbd18358f682072b51ca92908aa83fc0d1
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
This draft PR is for demo purposes only. Do not merge.

In this PR we test out the new fancy button updates made in https://github.com/wordpress-mobile/WordPress-iOS/pull/12640. 



Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
