### PR TITLE
Orders: fix status filter being reset after changing the status of an Order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 2.9
 -----
+- bugfix: on Orders tab, the order status filter now stays after changing an Order status.
  
 2.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -422,7 +422,7 @@ private extension OrdersViewController {
             return
         }
 
-        if currentSiteStatuses.contains(statusFilter) == false {
+        if !currentSiteStatuses.contains(where: { $0.name == statusFilter.name && $0.slug == statusFilter.slug }) {
             self.statusFilter = nil
         }
     }


### PR DESCRIPTION
Fixes #1218 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Cause of the issue
In `OrdersViewController`, we refresh data from the server in `viewWillAppear`, and on completion we reset the status filter if needed (`resetStatusFilterIfNeeded`). There are 2 conditions where we reset the status filter if it was previously set:
1. The site no longer has any Order statuses
2. The site's Order statuses do not contain the previously set status

Condition 2 always becomes true after changing an Order status, because it's using the [Equatable implementation](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Model/OrderStatus.swift#L57-L61) to compare two Order statuses with `name`, `slug` and `total`. Since a status' `total` changes after an Order status update, the status filter is always considered not contained in the site's statuses and gets reset.

## Changes
- I didn't want to change the Equatable implementation, since ignoring `total` is specific to the use case. Instead, I added conditions for the `contains` check in `OrdersViewController`'s `resetStatusFilterIfNeeded`

## Testing

- Go to the Orders tab
- Apply a status filter by the right icon on the navigation bar, where there is at least one order
- Tap on an order
- Change the status of the order
- Navigate back to the Order list --> the status filter should stay as before