### PR TITLE
Orders Badge: fix truncated "9+" label with bold text or on iOS 12

### DIFF
--- a/WooCommerce/Classes/ViewRelated/OrdersBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/OrdersBadgeController.swift
@@ -90,7 +90,7 @@ private extension OrdersBadgeController {
         static let horizontalPadding = CGFloat(2)
 
         // "9+" layout to account for longer text
-        static let widthForNinePlus = CGFloat(24)
+        static let widthForNinePlus = CGFloat(25)
         static let xOffsetForNinePlus = CGFloat(10)
         static let yOffsetForNinePlus = CGFloat(-1)
         static let xOffsetForNinePlusLandscape = CGFloat(8)


### PR DESCRIPTION
Fixes #1391 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- Increased the Orders badge width for 9+ case

## Testing

Prerequisites:
1. On an iOS 12 device, or on an iOS 13 simulator with larger font size (so that max 12pt font is shown) and Bold Text on
2. The store has more than 9 processing orders

- Launch the app --> the badge on the Orders tab shouldn't be truncated

## Example screenshots

device | before | after
-- | -- | --
iPhone SE iOS 13 + Bold Text on | ![Simulator Screen Shot - iPhone SE - 2019-10-23 at 15 02 32](https://user-images.githubusercontent.com/1945542/67367176-8e76ba80-f5a7-11e9-8ed3-c639293db0a2.png) | ![Simulator Screen Shot - iPhone SE - 2019-10-23 at 15 03 15](https://user-images.githubusercontent.com/1945542/67367178-8e76ba80-f5a7-11e9-8fae-fbfafae171ab.png)
iPhone 6s Plus iOS 12 + Bold Text on | ![IMG_7619](https://user-images.githubusercontent.com/1945542/67367290-c5e56700-f5a7-11e9-90b8-55458b2365d2.PNG) | ![IMG_7621](https://user-images.githubusercontent.com/1945542/67367292-c5e56700-f5a7-11e9-8f23-5c31f2f5f197.PNG)

