### PR TITLE
Product list & search: analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -237,6 +237,16 @@ public enum WooAnalyticsStat: String {
     case reviewsProductsLoaded                  = "reviews_products_loaded"
     case reviewsProductsLoadFailed              = "reviews_products_load_failed"
 
+    // Product List Events
+    //
+    case productListSelected                    = "main_tab_products_selected"
+    case productListReselected                  = "main_tab_products_reselected"
+    case productListLoaded                      = "product_list_loaded"
+    case productListProductTapped               = "product_list_product_tapped"
+    case productListPulledToRefresh             = "product_list_pulled_to_refresh"
+    case productListSearched                    = "product_list_searched"
+    case productListMenuSearchTapped            = "product_list_menu_search_tapped"
+
     // Jetpack Tunnel Events
     //
     case jetpackTunnelTimeout                   = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -242,6 +242,7 @@ public enum WooAnalyticsStat: String {
     case productListSelected                    = "main_tab_products_selected"
     case productListReselected                  = "main_tab_products_reselected"
     case productListLoaded                      = "product_list_loaded"
+    case productListLoadError                   = "product_list_load_error"
     case productListProductTapped               = "product_list_product_tapped"
     case productListPulledToRefresh             = "product_list_pulled_to_refresh"
     case productListSearched                    = "product_list_searched"

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -208,8 +208,7 @@ private extension MainTabBarController {
         case .orders:
             ServiceLocator.analytics.track(.ordersSelected)
         case .products:
-            // TODO-1263: analytics for product list
-            return
+            ServiceLocator.analytics.track(.productListSelected)
         case .reviews:
             ServiceLocator.analytics.track(.notificationsSelected)
         }
@@ -224,8 +223,7 @@ private extension MainTabBarController {
         case .orders:
             ServiceLocator.analytics.track(.ordersReselected)
         case .products:
-            // TODO-1263: analytics for product list
-            return
+            ServiceLocator.analytics.track(.productListReselected)
         case .reviews:
             ServiceLocator.analytics.track(.notificationsReselected)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -144,7 +144,8 @@ private extension ProductsViewController {
             return
         }
 
-        // TODO-1263: analytics
+        ServiceLocator.analytics.track(.productListMenuSearchTapped)
+
         let searchViewController = SearchViewController(storeID: storeID,
                                                         command: ProductSearchUICommand(siteID: storeID),
                                                         cellType: ProductsTabProductTableViewCell.self)
@@ -298,6 +299,8 @@ extension ProductsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
+        ServiceLocator.analytics.track(.productListProductTapped)
+
         let product = resultsController.object(at: indexPath)
         let currencyCode = CurrencySettings.shared.currencyCode
         let currency = CurrencySettings.shared.symbol(from: currencyCode)
@@ -321,7 +324,8 @@ extension ProductsViewController: UITableViewDelegate {
 
 private extension ProductsViewController {
     @objc private func pullToRefresh(sender: UIRefreshControl) {
-        // TODO-1263: analytics
+        ServiceLocator.analytics.track(.productListPulledToRefresh)
+
         syncingCoordinator.synchronizeFirstPage {
             sender.endRefreshing()
         }
@@ -407,7 +411,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                         DDLogError("⛔️ Error synchronizing products: \(error)")
                                         self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
                                     } else {
-                                        // TODO-1263: analytics
+                                        ServiceLocator.analytics.track(.productListLoaded)
                                     }
 
                                     self.transitionToResultsUpdatedState()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -408,6 +408,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                     }
 
                                     if let error = error {
+                                        ServiceLocator.analytics.track(.productListLoadError, withError: error)
                                         DDLogError("⛔️ Error synchronizing products: \(error)")
                                         self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
                                     } else {

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -43,7 +43,8 @@ final class ProductSearchUICommand: SearchUICommand {
         }
 
         ServiceLocator.stores.dispatch(action)
-        // TODO-1263: analytics
+
+        ServiceLocator.analytics.track(.productListSearched)
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -288,9 +288,9 @@ extension SearchViewController: SyncingCoordinatorDelegate {
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)? = nil) {
         let keyword = self.keyword
         searchUICommand.synchronizeModels(siteID: storeID,
-                                        keyword: keyword,
-                                        pageNumber: pageNumber,
-                                        pageSize: pageSize,
+                                          keyword: keyword,
+                                          pageNumber: pageNumber,
+                                          pageSize: pageSize,
                                         onCompletion: { [weak self] isCompleted in
                                             // Disregard OPs that don't really match the latest keyword
                                             if keyword == self?.keyword {


### PR DESCRIPTION
Fixes #1263 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes

- Added Tracks events for Product list & search (details in #1263)

## Testing

- Launch the app from a debug build
- Go to "Products" tab --> should see `🔵 Tracked main_tab_products_selected` followed by `🔵 Tracked product_list_loaded` after the products are synced
- Tap on the "Products" tab again --> should see `🔵 Tracked main_tab_products_reselected`
- Tap on a Product --> should see `🔵 Tracked product_list_product_tapped`
- Go back to the Products tab, then pull down to refresh --> should see `🔵 Tracked product_list_pulled_to_refresh`
- Tap on the search icon on the navigation bar --> should see `🔵 Tracked product_list_menu_search_tapped`
- Enter some search query --> should see `🔵 Tracked product_list_searched` while search results come in
