### PR TITLE
Updated the README with steps for configuring app with API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In order to login to WordPress.com using the app:
 7. Fill in the dotcomSecret with the Client Secret
 8. Recompile and run the app on a device or inside simulator.
 
-Please, remember to not push these information on your commit and PRs.
+Please, remember to not add these information on your commits and PRs.
   
 #### SwiftLint
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ A Jetpack-powered companion app for WooCommerce.
 
 #### Credentials for external contributors
 In order to login to WordPress.com using the app:
-1. Create a WordPress.com account at https://wordpress.com/start/user (if you don't already have one).
-2. Create an application at https://developer.wordpress.com/apps/.
-Set "Redirect URLs"= https://localhost and "Type" = Native and click "Create" then "Update".
-3. Copy the Client ID and Client Secret from the OAuth Information.
-Build the app
-4. Navigate to WooCommerce/DerivedSources/ApiCredentials.swift
-5. fill in the dotcomAppId with the Client ID
-6. fill in the dotcomSecret with the Client Secret
-7. run the app
+1. Create a [WordPress.com account](https://wordpress.com/start/user) (if you don't already have one).
+2. Create a new developer application [here](https://developer.wordpress.com/apps/).
+3. Set **"Redirect URLs"** = `https://localhost` and **"Type"** = `Native` and click **Create** then **Update**.
+4. Copy the *Client ID* and *Client Secret* from the OAuth Information. Build the app.
+5. Navigate to *WooCommerce/DerivedSources/ApiCredentials.swift*
+6. Fill in the dotcomAppId with the Client ID
+7. Fill in the dotcomSecret with the Client Secret
+8. Recompile and run the app on a device or inside simulator.
+
+Please, remember to not push these information on your commit and PRs.
   
 #### SwiftLint
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ A Jetpack-powered companion app for WooCommerce.
   - We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line: `bundle exec pod install`
   - In some cases, you may also have to: `bundle install`
 - Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
+
+#### Credentials for external contributors
+In order to login to WordPress.com using the app:
+1. Create a WordPress.com account at https://wordpress.com/start/user (if you don't already have one).
+2. Create an application at https://developer.wordpress.com/apps/.
+Set "Redirect URLs"= https://localhost and "Type" = Native and click "Create" then "Update".
+3. Copy the Client ID and Client Secret from the OAuth Information.
+Build the app
+4. Navigate to WooCommerce/DerivedSources/ApiCredentials.swift
+5. fill in the dotcomAppId with the Client ID
+6. fill in the dotcomSecret with the Client Secret
+7. run the app
   
 #### SwiftLint
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In order to login to WordPress.com using the app:
 7. Fill in the dotcomSecret with the Client Secret
 8. Recompile and run the app on a device or inside simulator.
 
-Please, remember to not add these information on your commits and PRs.
+Please, remember to not add this information on your commits and PRs.
   
 #### SwiftLint
 


### PR DESCRIPTION
Closes #1220 

Since it's not so easy for external contributors to understand all the steps for login into the app with a Wordpress.com account, this doc improvement explains all the steps for configuring credentials inside the app.
