### PR TITLE
Fix a failing Currency Settings unit test

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -522,7 +522,12 @@ extension CurrencySettings {
     }
 
     private func refreshResultsPredicate() {
-        let sitePredicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            DDLogError("Error: no siteID found when attempting to refresh CurrencySettings results predicate.")
+            return
+        }
+        
+        let sitePredicate = NSPredicate(format: "siteID == %lld", siteID)
         let settingTypePredicate = NSPredicate(format: "settingGroupKey ==[c] %@", SiteSettingGroup.general.rawValue)
         resultsController.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [sitePredicate, settingTypePredicate])
         try? resultsController.performFetch()

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -23,7 +23,11 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithIndividualParameters() {
-        moneyFormat = CurrencySettings(currencyCode: .USD, currencyPosition: .right, thousandSeparator: "M", decimalSeparator: "X", numberOfDecimals: 10)
+        let moneyFormat = CurrencySettings(currencyCode: .USD,
+                                           currencyPosition: .right,
+                                           thousandSeparator: "M",
+                                           decimalSeparator: "X",
+                                           numberOfDecimals: 10)
 
         XCTAssertEqual(.USD, moneyFormat.currencyCode)
         XCTAssertEqual(.right, moneyFormat.currencyPosition)
@@ -44,16 +48,40 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithSiteSettings() {
-        let wooCurrencyCode = SiteSetting(siteID: 1, settingID: "woocommerce_currency", label: "", description: "",
-                                          value: "SHP", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let wooCurrencyPosition = SiteSetting(siteID: 1, settingID: "woocommerce_currency_pos", label: "", description: "",
-                                              value: "right", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let thousandsSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_thousand_sep", label: "", description: "",
-                                             value: "X", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let decimalSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_decimal_sep", label: "", description: "",
-                                           value: "Y", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let numberOfDecimals = SiteSetting(siteID: 1, settingID: "woocommerce_price_num_decimals", label: "", description: "",
-                                           value: "3", settingGroupKey: SiteSettingGroup.general.rawValue)
+        let wooCurrencyCode = SiteSetting(siteID: 1,
+                                          settingID: "woocommerce_currency",
+                                          label: "",
+                                          description: "",
+                                          value: "SHP",
+                                          settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let wooCurrencyPosition = SiteSetting(siteID: 1,
+                                              settingID: "woocommerce_currency_pos",
+                                              label: "",
+                                              description: "",
+                                              value: "right",
+                                              settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let thousandsSeparator = SiteSetting(siteID: 1,
+                                             settingID: "woocommerce_price_thousand_sep",
+                                             label: "",
+                                             description: "",
+                                             value: "X",
+                                             settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let decimalSeparator = SiteSetting(siteID: 1,
+                                           settingID: "woocommerce_price_decimal_sep",
+                                           label: "",
+                                           description: "",
+                                           value: "Y",
+                                           settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let numberOfDecimals = SiteSetting(siteID: 1,
+                                           settingID: "woocommerce_price_num_decimals",
+                                           label: "",
+                                           description: "",
+                                           value: "3",
+                                           settingGroupKey: SiteSettingGroup.general.rawValue)
 
         let siteSettings = [wooCurrencyCode,
                             wooCurrencyPosition,
@@ -71,15 +99,33 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithIncompleteSiteSettings() {
-        let wooCurrencyCode = SiteSetting(siteID: 1, settingID: "woocommerce_currency", label: "", description: "",
-                                          value: "SHP", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let wooCurrencyPosition = SiteSetting(siteID: 1, settingID: "woocommerce_currency_pos", label: "", description: "",
-                                              value: "right", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let thousandsSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_thousand_sep", label: "", description: "",
-                                             value: "X", settingGroupKey: SiteSettingGroup.general.rawValue)
-        let decimalSeparator = SiteSetting(siteID: 1, settingID: "woocommerce_price_decimal_sep", label: "", description: "",
-                                           value: "Y", settingGroupKey: SiteSettingGroup.general.rawValue)
-        // Missing number of decimals; should default to MoneyFormatSettings()
+        let wooCurrencyCode = SiteSetting(siteID: 1,
+                                          settingID: "woocommerce_currency",
+                                          label: "",
+                                          description: "",
+                                          value: "SHP",
+                                          settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let wooCurrencyPosition = SiteSetting(siteID: 1,
+                                              settingID: "woocommerce_currency_pos",
+                                              label: "",
+                                              description: "",
+                                              value: "right",
+                                              settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let thousandsSeparator = SiteSetting(siteID: 1,
+                                             settingID: "woocommerce_price_thousand_sep",
+                                             label: "",
+                                             description: "",
+                                             value: "X",
+                                             settingGroupKey: SiteSettingGroup.general.rawValue)
+
+        let decimalSeparator = SiteSetting(siteID: 1,
+                                           settingID: "woocommerce_price_decimal_sep",
+                                           label: "",
+                                           description: "",
+                                           value: "Y",
+                                           settingGroupKey: SiteSettingGroup.general.rawValue)
 
         // Note that the above is missing a declaration for the number of decimals; it should default to 2.
 

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -6,21 +6,15 @@ import Yosemite
 ///
 class CurrencySettingsTests: XCTestCase {
 
-    var moneyFormat = CurrencySettings()
-    var siteSettings = [SiteSetting]()
-
     override func setUp() {
+        ServiceLocator.stores.deauthenticate()
+
         super.setUp()
     }
 
-    override func tearDown() {
-        moneyFormat = CurrencySettings()
-        siteSettings = [SiteSetting]()
-
-        super.tearDown()
-    }
-
     func testInitDefault() {
+        let moneyFormat = CurrencySettings()
+
         XCTAssertEqual(.USD, moneyFormat.currencyCode)
         XCTAssertEqual(.left, moneyFormat.currencyPosition)
         XCTAssertEqual(".", moneyFormat.decimalSeparator)
@@ -39,7 +33,8 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithSiteSettingsEmptyArray() {
-        moneyFormat = CurrencySettings(siteSettings: siteSettings)
+        let siteSettings: [SiteSetting] = []
+        let moneyFormat = CurrencySettings(siteSettings: siteSettings)
 
         XCTAssertEqual(.USD, moneyFormat.currencyCode)
         XCTAssertEqual(.left, moneyFormat.currencyPosition)
@@ -60,8 +55,13 @@ class CurrencySettingsTests: XCTestCase {
         let numberOfDecimals = SiteSetting(siteID: 1, settingID: "woocommerce_price_num_decimals", label: "", description: "",
                                            value: "3", settingGroupKey: SiteSettingGroup.general.rawValue)
 
-        siteSettings = [wooCurrencyCode, wooCurrencyPosition, thousandsSeparator, decimalSeparator, numberOfDecimals]
-        moneyFormat = CurrencySettings(siteSettings: siteSettings)
+        let siteSettings = [wooCurrencyCode,
+                            wooCurrencyPosition,
+                            thousandsSeparator,
+                            decimalSeparator,
+                            numberOfDecimals]
+
+        let moneyFormat = CurrencySettings(siteSettings: siteSettings)
 
         XCTAssertEqual(.SHP, moneyFormat.currencyCode)
         XCTAssertEqual(.right, moneyFormat.currencyPosition)
@@ -81,7 +81,13 @@ class CurrencySettingsTests: XCTestCase {
                                            value: "Y", settingGroupKey: SiteSettingGroup.general.rawValue)
         // Missing number of decimals; should default to MoneyFormatSettings()
 
-        let siteSettings = [wooCurrencyCode, wooCurrencyPosition, thousandsSeparator, decimalSeparator]
+        // Note that the above is missing a declaration for the number of decimals; it should default to 2.
+
+        let siteSettings = [wooCurrencyCode,
+                            wooCurrencyPosition,
+                            thousandsSeparator,
+                            decimalSeparator]
+
         let moneyFormat = CurrencySettings(siteSettings: siteSettings)
 
         XCTAssertEqual(.SHP, moneyFormat.currencyCode)

--- a/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencySettingsTests.swift
@@ -5,9 +5,22 @@ import Yosemite
 /// CurrencySettings Tests
 ///
 class CurrencySettingsTests: XCTestCase {
-    func testInitDefault() {
-        let moneyFormat = CurrencySettings()
 
+    var moneyFormat = CurrencySettings()
+    var siteSettings = [SiteSetting]()
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        moneyFormat = CurrencySettings()
+        siteSettings = [SiteSetting]()
+
+        super.tearDown()
+    }
+
+    func testInitDefault() {
         XCTAssertEqual(.USD, moneyFormat.currencyCode)
         XCTAssertEqual(.left, moneyFormat.currencyPosition)
         XCTAssertEqual(".", moneyFormat.decimalSeparator)
@@ -16,7 +29,7 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithIndividualParameters() {
-        let moneyFormat = CurrencySettings(currencyCode: .USD, currencyPosition: .right, thousandSeparator: "M", decimalSeparator: "X", numberOfDecimals: 10)
+        moneyFormat = CurrencySettings(currencyCode: .USD, currencyPosition: .right, thousandSeparator: "M", decimalSeparator: "X", numberOfDecimals: 10)
 
         XCTAssertEqual(.USD, moneyFormat.currencyCode)
         XCTAssertEqual(.right, moneyFormat.currencyPosition)
@@ -26,8 +39,7 @@ class CurrencySettingsTests: XCTestCase {
     }
 
     func testInitWithSiteSettingsEmptyArray() {
-        let siteSettings: [SiteSetting] = []
-        let moneyFormat = CurrencySettings(siteSettings: siteSettings)
+        moneyFormat = CurrencySettings(siteSettings: siteSettings)
 
         XCTAssertEqual(.USD, moneyFormat.currencyCode)
         XCTAssertEqual(.left, moneyFormat.currencyPosition)
@@ -48,8 +60,8 @@ class CurrencySettingsTests: XCTestCase {
         let numberOfDecimals = SiteSetting(siteID: 1, settingID: "woocommerce_price_num_decimals", label: "", description: "",
                                            value: "3", settingGroupKey: SiteSettingGroup.general.rawValue)
 
-        let siteSettings = [wooCurrencyCode, wooCurrencyPosition, thousandsSeparator, decimalSeparator, numberOfDecimals]
-        let moneyFormat = CurrencySettings(siteSettings: siteSettings)
+        siteSettings = [wooCurrencyCode, wooCurrencyPosition, thousandsSeparator, decimalSeparator, numberOfDecimals]
+        moneyFormat = CurrencySettings(siteSettings: siteSettings)
 
         XCTAssertEqual(.SHP, moneyFormat.currencyCode)
         XCTAssertEqual(.right, moneyFormat.currencyPosition)


### PR DESCRIPTION
Fixes #1398.

I'm unable to create exact Steps To Reproduce, but this PR seems to fix the problem. The problem happens where you: switch to a branch you do not own, build the app, and run unit tests. The `testInitWithIndividualParameters()` unit test always fails on first run. After the first run, it usually shows the test as passing. Whatever the issue is, CI does not seem to catch the problem. It only happens when running unit tests locally.

~My theory is that the CurrencySettings class is not getting initialized and de-init'ed properly. So I changed the `moneyFormat` and `siteSettings` from local constants within each function to variables that have `setUp()` and `tearDown()`  implemented as needed. (Actually, I think I could delete `setUp()` since the variables are initialized upon declaration, but I wasn't sure what's good practice, since I do use `tearDown()`.)~

I believe @jaclync found the root problem. Updated code and ready for another review.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
