### PR TITLE
Fixed navigation bar appearance of MFMailComposeViewController on iOS 13

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 3.0
 -----
 - bugfix: for sites with empty site time zone in the API (usually with UTC specified in wp-admin settings) and when the site time zone is not GMT+0, the stats v4 data no longer has the wrong boundaries (example in #1357).
+- bugfix: fixed a UI appearance problem on mail composer on iOS 13.
  
 2.9
 -----

--- a/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationBar+Appearance.swift
@@ -22,6 +22,7 @@ extension UINavigationBar {
         let appearance = UINavigationBar.appearance()
         appearance.barTintColor = nil
         appearance.titleTextAttributes = nil
+        appearance.isTranslucent = true
         appearance.tintColor = nil
     }
 }


### PR DESCRIPTION
Fixes #1124 

Since iOS 13, the default modal presentation style became page sheet instead of fullscreen. When the user tries sending an email to the customer from the Order Details screen, the email composer modal navigation bar doesn't look like in other Apple apps. So in this PR I fixed the appearance of the navigation bar of MFMailComposeViewController on iOS 13.

## Testing instructions:
1) Configure a mail on your device
2) Navigate to Order Detail > Billing
3) Tap user's email
4) Everything should look like the screenshot.

## Screenshots

| iOS 13                               |  iOS 13 with dark mode     |                       iOS 12        |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 - 2019-10-29 at 16 56 01](https://user-images.githubusercontent.com/495617/67790107-786c6c80-fa75-11e9-8914-54bfad21e7c4.png)| ![Simulator Screen Shot - iPhone 11 - 2019-10-29 at 16 56 19](https://user-images.githubusercontent.com/495617/67790114-7c988a00-fa75-11e9-9da5-aa0940fb807e.png) | ![ios 12](https://user-images.githubusercontent.com/495617/67790119-80c4a780-fa75-11e9-8d80-b4f1ddfe72a5.png)




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
