### PR TITLE
UI fixes to review details screen.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
@@ -163,6 +163,8 @@ final class NoteDetailsCommentTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         configureActionButtons()
+        configureTitleLabel()
+        configureDetailsLabel()
         configureStarView()
         configureDefaultAppearance()
     }
@@ -193,6 +195,13 @@ private extension NoteDetailsCommentTableViewCell {
         approvalButton.accessibilityTraits = .button
     }
 
+    func configureTitleLabel() {
+        titleLabel.textColor = StyleManager.defaultTextColor
+    }
+
+    func configureDetailsLabel() {
+        detailsLabel.textColor = StyleManager.defaultTextColor
+    }
     /// Setup: Default Action(s) Style
     ///
     func configureDefaultAppearance() {

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.swift
@@ -6,7 +6,7 @@ import Gridicons
 
 // MARK: - NoteDetailsCommentTableViewCell
 //
-class NoteDetailsCommentTableViewCell: UITableViewCell {
+final class NoteDetailsCommentTableViewCell: UITableViewCell {
 
     /// Gravatar ImageView.
     ///

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsCommentTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,14 +13,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="244"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="ba1-rz-4HV" id="p0w-Eh-NgH">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="243.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="244"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="QbZ-zr-lT5">
-                        <rect key="frame" x="20" y="11" width="284" height="222"/>
+                        <rect key="frame" x="20" y="15" width="285" height="212"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="x22-fd-jyE">
-                                <rect key="frame" x="0.0" y="0.0" width="284" height="40"/>
+                                <rect key="frame" x="0.0" y="0.0" width="285" height="40"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="qcp-iw-3SL" customClass="CircularImageView" customModule="WooCommerce" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -48,16 +46,16 @@
                                         </variation>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CXQ-2a-6Fp">
-                                        <rect key="frame" x="56" y="0.0" width="228" height="40"/>
+                                        <rect key="frame" x="56" y="0.0" width="229" height="40"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="249" horizontalCompressionResistancePriority="250" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MB2-nk-Fuo">
-                                                <rect key="frame" x="0.0" y="0.0" width="228" height="24"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="229" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6d4-9R-dcK">
-                                                <rect key="frame" x="0.0" y="24" width="228" height="16"/>
+                                                <rect key="frame" x="0.0" y="24" width="229" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -67,21 +65,21 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P0O-u0-r7G">
-                                <rect key="frame" x="0.0" y="42" width="284" height="10"/>
+                                <rect key="frame" x="0.0" y="42" width="285" height="10"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="10" id="qsU-jb-cDi"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Iy-55-tos" customClass="RatingView" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="54" width="284" height="18"/>
+                                <rect key="frame" x="0.0" y="54" width="285" height="18"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="18" id="qAn-B5-boc"/>
                                 </constraints>
                             </view>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" editable="NO" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FpQ-yp-a6e">
-                                <rect key="frame" x="0.0" y="74" width="284" height="77"/>
+                                <rect key="frame" x="0.0" y="74" width="285" height="67"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="mhf-tZ-eCY"/>
@@ -93,17 +91,17 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vhZ-1A-FVO">
-                                <rect key="frame" x="0.0" y="153" width="284" height="15"/>
+                                <rect key="frame" x="0.0" y="143" width="285" height="15"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="15" id="k78-0j-dtf"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OJ1-WL-7rq">
-                                <rect key="frame" x="0.0" y="170" width="284" height="52"/>
+                                <rect key="frame" x="0.0" y="160" width="285" height="52"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qUJ-uA-W4N" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="88" height="52"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="88.5" height="52"/>
                                         <color key="backgroundColor" red="0.55453354119999998" green="0.35826593639999998" blue="0.52943503859999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <state key="normal" title="Spam">
@@ -114,7 +112,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6As-Iw-caM" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="98" y="0.0" width="88" height="52"/>
+                                        <rect key="frame" x="98.5" y="0.0" width="88" height="52"/>
                                         <color key="backgroundColor" red="0.55453354119999998" green="0.35826593639999998" blue="0.52943503859999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <state key="normal" title="Trash">
@@ -125,7 +123,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uc0-Kk-Npt" customClass="VerticalButton" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="196" y="0.0" width="88" height="52"/>
+                                        <rect key="frame" x="196.5" y="0.0" width="88.5" height="52"/>
                                         <color key="backgroundColor" red="0.55453354119999998" green="0.35826593639999998" blue="0.52943503859999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <state key="normal" title="Approve">
@@ -145,8 +143,8 @@
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="QbZ-zr-lT5" firstAttribute="top" secondItem="p0w-Eh-NgH" secondAttribute="topMargin" id="Rl1-g8-YkH"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="QbZ-zr-lT5" secondAttribute="bottom" id="Vfz-Zj-1v5"/>
+                    <constraint firstItem="QbZ-zr-lT5" firstAttribute="top" secondItem="p0w-Eh-NgH" secondAttribute="topMargin" constant="4" id="Rl1-g8-YkH"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="QbZ-zr-lT5" secondAttribute="bottom" constant="6" id="Vfz-Zj-1v5"/>
                     <constraint firstAttribute="trailingMargin" secondItem="QbZ-zr-lT5" secondAttribute="trailing" id="lYP-FG-ARa"/>
                     <constraint firstItem="QbZ-zr-lT5" firstAttribute="leading" secondItem="p0w-Eh-NgH" secondAttribute="leading" constant="20" symbolic="YES" id="nVZ-Fb-Nbv"/>
                 </constraints>

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.swift
@@ -53,6 +53,7 @@ final class NoteDetailsHeaderPlainTableViewCell: UITableViewCell {
         accessoryImageView.tintColor = StyleManager.wooCommerceBrandColor
         accessoryView = accessoryImageView
         textLabel?.font = UIFont.body
+        textLabel?.textColor = StyleManager.defaultTextColor
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.swift
@@ -4,7 +4,7 @@ import UIKit
 
 // MARK: - NoteDetailsHeaderPlainTableViewCell
 //
-class NoteDetailsHeaderPlainTableViewCell: UITableViewCell {
+final class NoteDetailsHeaderPlainTableViewCell: UITableViewCell {
 
     /// Accessory's Image View
     ///

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.xib
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="gqG-oH-lM4" style="IBUITableViewCellStyleDefault" id="TIK-Mv-tcP" customClass="NoteDetailsHeaderPlainTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TIK-Mv-tcP" id="orX-X0-Z67">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gqG-oH-lM4">
-                        <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                        <rect key="frame" x="16" y="0.0" width="343" height="48"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift
@@ -284,6 +284,16 @@ extension ReviewDetailsViewController: UITableViewDelegate {
             break
         }
     }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        let row = detailsForRow(at: indexPath)
+        switch row {
+        case .header:
+            return Constants.headerHeight
+        default:
+            return UITableView.automaticDimension
+        }
+    }
 }
 
 
@@ -514,6 +524,7 @@ private extension ReviewDetailsViewController {
         static let section = "notifications"
         static let title = NSLocalizedString("Product Review",
                                              comment: "Title of the view containing a single Product Review")
+        static let headerHeight = CGFloat(48)
     }
 }
 


### PR DESCRIPTION
Fixes #1303 

Before|After
-|-
<img src="https://user-images.githubusercontent.com/2722505/67845382-5b4da180-fb3a-11e9-9c44-c7d909d30531.png" width="250"/>|<img src="https://user-images.githubusercontent.com/2722505/67845234-19bcf680-fb3a-11e9-8ff4-b7a56e0dc4bc.png" width ="250"/>

## Changes
- Updated height of `NoteDetailsHeaderPlainTableViewCell`
- Add implementation of `estimatedHeightForRowAt` to `ReviewDetailsViewController`
- Update top and both margins of `NoteDetailsCommentTableViewCell`

## Testing
## Testing
- As with other PRs related to Reviews, testing is a bit cubmersome (courtesy of some of the storyboards):
- Checkout the branch, run the tests
- Undo the feature flag. Because the NotificationsViewController is instantiated in a Storyboard, it will be necessary to touch `FeatureFlag.swift` to:
```
        case .reviews:
            return BuildConfiguration.current == .localDeveloper
```
and it will also be necessary to change the class of the first view controller in the Notifications.storyboard from NotificationsViewController to ReviewsViewController

- Navigate to the reviews tab, check the new margins and font colors.

To avoid accidentally merging this, the build associated to the PR will not reflect the changes.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
