### PR TITLE
Fixed content mode of product's images in Order Detail

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -104,6 +104,8 @@ private extension ProductDetailsTableViewCell {
     func configureProductImageView() {
         productImageView.image = .productPlaceholderImage
         productImageView.tintColor = StyleManager.wooGreyBorder
+        productImageView.contentMode = .scaleAspectFill
+        productImageView.clipsToBounds = true
     }
 
     func configureNameLabel() {


### PR DESCRIPTION
Fixes #1360 


#### Testing
- Navigate to an order detail.
- Check that product's images now are not skewed

#### Screenshots

| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-30 at 12 53 42](https://user-images.githubusercontent.com/495617/67857220-7d352d00-fb16-11e9-8a8e-07754d854196.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-30 at 12 58 02](https://user-images.githubusercontent.com/495617/67857225-80c8b400-fb16-11e9-8b44-dc63f6c76bb9.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
