### PR TITLE
Shipment tracking: fix picker covered by keyboard

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -29,7 +29,7 @@ final class ManualTrackingViewController: UIViewController {
     deinit {
         stopListeningToNotifications()
     }
-    
+
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -24,6 +24,12 @@ final class ManualTrackingViewController: UIViewController {
         return noticePresenter
     }()
 
+    /// Deinitializer
+    ///
+    deinit {
+        stopListeningToNotifications()
+    }
+    
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -38,6 +44,7 @@ final class ManualTrackingViewController: UIViewController {
         configureBackground()
         configureNavigation()
         configureTable()
+        startListeningToNotifications()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -554,6 +561,48 @@ private extension ManualTrackingViewController {
 
 }
 
+// MARK: - Keyboard management
+//
+private extension ManualTrackingViewController {
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    /// Unregisters from the Notification Center
+    ///
+    func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted
+    ///
+    @objc func keyboardWillShow(_ note: Notification) {
+        let bottomInset = keyboardHeight(from: note)
+
+        table.contentInset.bottom = bottomInset
+        table.scrollIndicatorInsets.bottom = bottomInset
+    }
+
+    /// Executed whenever `UIResponder.keyboardWillhideNotification` note is posted
+    ///
+    @objc func keyboardWillHide(_ note: Notification) {
+        table.contentInset.bottom = .zero
+        table.scrollIndicatorInsets.bottom = .zero
+    }
+
+    /// Returns the Keyboard Height from a (hopefully) Keyboard Notification.
+    ///
+    func keyboardHeight(from note: Notification) -> CGFloat {
+        let wrappedRect = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+        let keyboardRect = wrappedRect?.cgRectValue ?? .zero
+
+        return keyboardRect.height
+    }
+}
 
 // MARK: - Error handling
 //

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -367,8 +367,8 @@ private extension ManualTrackingViewController {
 
     func displayDatePicker(at indexPath: IndexPath) {
         datePickerVisible = true
-
         reloadDatePicker(at: indexPath)
+        table.scrollToRow(at: indexPath, at: .top, animated: true)
     }
 
     func showAllShipmentProviders() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -24,12 +24,6 @@ final class ManualTrackingViewController: UIViewController {
         return noticePresenter
     }()
 
-    /// Deinitializer
-    ///
-    deinit {
-        stopListeningToNotifications()
-    }
-
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -570,12 +564,6 @@ private extension ManualTrackingViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-
-    /// Unregisters from the Notification Center
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted


### PR DESCRIPTION
Fixes #1057 


#### Testing
1) Launch the app with a store that has at least one order.
2) Go to "Orders" tab, tap on an order
3) Tap "Fulfill order"
4) Tap "Add Tracking"
5) Tap "Shipping provider"
6) Tap "Custom Provider" row in "CUSTOM" section
7) Enter some text in any field like tracking number
8) Tap on date in "Date shipped" field --> now the date picker will be visible also with the keyboard opened.

#### Screenshots

| Before             |  Now |
:-------------------------:|:-------------------------:
![60373823-a2caf200-99cf-11e9-9402-6a9f4cf8cd79](https://user-images.githubusercontent.com/495617/67863461-3817f780-fb24-11e9-92cc-94632a31bb48.PNG) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-10-30 at 14 39 55](https://user-images.githubusercontent.com/495617/67863470-3bab7e80-fb24-11e9-9bcc-c2b8c5ecfca9.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
