### PR TITLE
NotificationCenter : cleaned some removeObserver() since they are no more needed after iOS 9

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -34,9 +34,6 @@ public class WooAnalytics: Analytics {
         self.analyticsProvider = analyticsProvider
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
 }
 
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -59,13 +59,7 @@ class ZendeskManager: NSObject {
 
         return ZDKPushProvider(zendesk: zendesk)
     }
-
-
-    /// Deinitializer
-    ///
-    deinit {
-        stopListeningToNotifications()
-    }
+    
 
     /// Designated Initialier
     ///
@@ -750,12 +744,6 @@ private extension ZendeskManager {
                                                name: NSNotification.Name(rawValue: ZD_HC_SearchSuccess), object: nil)
     }
 
-
-    /// Removes all of the Notification Hooks.
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
-    }
 
     /// Handles (all of the) Zendesk Notifications
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -22,11 +22,7 @@ class DashboardViewController: UIViewController {
     }()
 
     // MARK: View Lifecycle
-
-    deinit {
-        stopListeningToNotifications()
-    }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         startListeningToNotifications()
@@ -177,12 +173,6 @@ extension DashboardViewController {
     func startListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
-    }
-
-    /// Stops listening to all related Notifications
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Runs whenever the default Account is updated.

--- a/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/NotificationsViewController.swift
@@ -114,10 +114,6 @@ class NotificationsViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
@@ -607,12 +603,6 @@ private extension NotificationsViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(defaultSiteWasUpdated), name: .StoresManagerDidUpdateDefaultSite, object: nil)
         nc.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
-    }
-
-    /// Tear down the Notifications Hooks
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Default Site Updated Handler

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
@@ -92,10 +92,6 @@ final class ReviewsViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
@@ -371,12 +367,6 @@ private extension ReviewsViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(defaultSiteWasUpdated), name: .StoresManagerDidUpdateDefaultSite, object: nil)
         nc.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
-    }
-
-    /// Tear down the Notifications Hooks
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Default Site Updated Handler

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -38,9 +38,6 @@ final class ShipmentProvidersViewController: UIViewController {
 
     /// Deinitializer
     ///
-    deinit {
-        stopListeningToNotifications()
-    }
 
     init(viewModel: ShippingProvidersViewModel, delegate: ShipmentProviderListDelegate) {
         self.viewModel = viewModel
@@ -161,12 +158,6 @@ private extension ShipmentProvidersViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-    }
-
-    /// Unregisters from the Notification Center
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -104,10 +104,6 @@ class OrdersViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         fatalError()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -67,10 +67,6 @@ final class ProductsViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -68,12 +68,6 @@ where Cell.SearchModel == Command.CellViewModel {
     private let searchUICommand: Command
 
 
-    /// Deinitializer
-    ///
-    deinit {
-        stopListeningToNotifications()
-    }
-
     /// Designated Initializer
     ///
     init(storeID: Int,
@@ -269,12 +263,6 @@ private extension SearchViewController {
     func startListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-    }
-
-    /// Unregisters from the Notification Center
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 }
 

--- a/Yosemite/Yosemite/Tools/EntityListener.swift
+++ b/Yosemite/Yosemite/Tools/EntityListener.swift
@@ -29,13 +29,6 @@ public class EntityListener<T: ReadOnlyType> {
     public var onDelete: (() -> Void)?
 
 
-
-    /// Deinitializer
-    ///
-    deinit {
-        NotificationCenter.default.removeObserver(notificationsToken as Any)
-    }
-
     /// Designated Initializer.
     ///
     public init(viewContext: NSManagedObjectContext, readOnlyEntity: T) {

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -111,13 +111,6 @@ public class ResultsController<T: ResultsControllerMutableType> {
                   sortedBy: descriptors)
     }
 
-    /// Deinit!
-    ///
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-
 
     /// Executes the fetch request on the store to get objects.
     ///


### PR DESCRIPTION
Closes #1410 

Since our app targets iOS 12.0, we don't need to unregister an observer in its *dealloc method*.

Doc: https://developer.apple.com/documentation/foundation/notificationcenter/1413994-removeobserver

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
