### PR TITLE
Fix `testDateStartAndDateEnd` test failures due to GMT offset of the current date

### DIFF
--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -6,13 +6,13 @@ class OrderStatsV4Interval_DateTests: XCTestCase {
                                                            refunds: 0, taxes: 0, shipping: 0, netRevenue: 0, totalProducts: nil)
 
     func testDateStartAndDateEnd() {
-        let dateInGMT = "2019-08-08 10:45:00"
+        let dateStringInSiteTimeZone = "2019-08-08 10:45:00"
         // GMT: Thursday, August 8, 2019 10:45:00 AM
         // Adjusted by the current time zone GMT offset to have the same "time" (day/hour/minute/second) in the current time zone.
         // (e.g. expectedDate` will be "2019-08-08 10:45:00" in the current device time zone)
         let expectedDate = Date(timeIntervalSince1970: 1565261100)
             .addingTimeInterval(-TimeInterval(TimeZone.current.secondsFromGMT()))
-        let interval = OrderStatsV4Interval(interval: "hour", dateStart: dateInGMT, dateEnd: dateInGMT, subtotals: mockIntervalSubtotals)
+        let interval = OrderStatsV4Interval(interval: "hour", dateStart: dateStringInSiteTimeZone, dateEnd: dateStringInSiteTimeZone, subtotals: mockIntervalSubtotals)
         XCTAssertEqual(interval.dateStart(), expectedDate)
         XCTAssertEqual(interval.dateEnd(), expectedDate)
     }

--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -7,13 +7,15 @@ class OrderStatsV4Interval_DateTests: XCTestCase {
 
     func testDateStartAndDateEnd() {
         let dateStringInSiteTimeZone = "2019-08-08 10:45:00"
-        // GMT: Thursday, August 8, 2019 10:45:00 AM
-        let expectedDateInGMT = Date(timeIntervalSince1970: 1565261100)
-        // Adjusts the GMT date by the current time zone GMT offset to have the same "time" (day/hour/minute/second) in the current time zone.
-        // (e.g. expectedDate` will be "2019-08-08 10:45:00" in the current device time zone)
-        let expectedDate = expectedDateInGMT.addingTimeInterval(-TimeInterval(TimeZone.current.secondsFromGMT(for: expectedDateInGMT)))
         let interval = OrderStatsV4Interval(interval: "hour", dateStart: dateStringInSiteTimeZone, dateEnd: dateStringInSiteTimeZone, subtotals: mockIntervalSubtotals)
-        XCTAssertEqual(interval.dateStart(), expectedDate)
-        XCTAssertEqual(interval.dateEnd(), expectedDate)
+        [interval.dateStart(), interval.dateEnd()].forEach { date in
+            let dateComponents = Calendar.current.dateComponents(in: .current, from: date)
+            XCTAssertEqual(dateComponents.year, 2019)
+            XCTAssertEqual(dateComponents.month, 8)
+            XCTAssertEqual(dateComponents.day, 8)
+            XCTAssertEqual(dateComponents.hour, 10)
+            XCTAssertEqual(dateComponents.minute, 45)
+            XCTAssertEqual(dateComponents.second, 0)
+        }
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -8,10 +8,10 @@ class OrderStatsV4Interval_DateTests: XCTestCase {
     func testDateStartAndDateEnd() {
         let dateStringInSiteTimeZone = "2019-08-08 10:45:00"
         // GMT: Thursday, August 8, 2019 10:45:00 AM
-        // Adjusted by the current time zone GMT offset to have the same "time" (day/hour/minute/second) in the current time zone.
+        let expectedDateInGMT = Date(timeIntervalSince1970: 1565261100)
+        // Adjusts the GMT date by the current time zone GMT offset to have the same "time" (day/hour/minute/second) in the current time zone.
         // (e.g. expectedDate` will be "2019-08-08 10:45:00" in the current device time zone)
-        let expectedDate = Date(timeIntervalSince1970: 1565261100)
-            .addingTimeInterval(-TimeInterval(TimeZone.current.secondsFromGMT()))
+        let expectedDate = expectedDateInGMT.addingTimeInterval(-TimeInterval(TimeZone.current.secondsFromGMT(for: expectedDateInGMT)))
         let interval = OrderStatsV4Interval(interval: "hour", dateStart: dateStringInSiteTimeZone, dateEnd: dateStringInSiteTimeZone, subtotals: mockIntervalSubtotals)
         XCTAssertEqual(interval.dateStart(), expectedDate)
         XCTAssertEqual(interval.dateEnd(), expectedDate)


### PR DESCRIPTION
Fixes #1427 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Changes
- The test failure is reproducible after changing the computer time zone to "Los Angeles/America".
- Why it failed: in `testDateStartAndDateEnd` test case, we're trying to verify that the `interval.dateStart()` and `interval.dateEnd()` would be `Date` of the same day and time in device time zone as in the date string ("2019-08-08 10:45:00"). Before this PR, we created a GMT date then offset by the timezone's GMT offset, but we didn't specify the date of the GMT offset (`TimeZone.current.secondsFromGMT()`). By default, the GMT offset is calculated with the current date, which is 1 hour off from the GMT offset on the **test date** (August 8) due to daily saving time. If we call `TimeZone.current.secondsFromGMT(for: expectedDateInGMT)`, the GMT offset would be correct and the test would pass.
- This PR updated the asserts by using date components instead of GMT date + offset calculation for easier readability.

## Testing
CI! 