### PR TITLE
Create keyboard frame observer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -1,0 +1,56 @@
+import UIKit
+
+/// Observes the keyboard frame and notifies its subscriber.
+final class KeyboardFrameObserver {
+    private let onKeyboardFrameUpdate: OnKeyboardFrameUpdate
+
+    /// Notifies the closure owner about any keyboard frame change.
+    /// Note that the frame is based on the keyboard window coordinate.
+    typealias OnKeyboardFrameUpdate = (_ keyboardFrame: CGRect) -> Void
+
+    private let notificationCenter: NotificationCenter
+
+    private var keyboardFrame: CGRect? {
+        didSet {
+            if let keyboardFrame = keyboardFrame, oldValue != keyboardFrame {
+                onKeyboardFrameUpdate(keyboardFrame)
+            }
+        }
+    }
+
+    init(notificationCenter: NotificationCenter = NotificationCenter.default,
+         onKeyboardFrameUpdate: @escaping OnKeyboardFrameUpdate) {
+        self.notificationCenter = notificationCenter
+        self.onKeyboardFrameUpdate = onKeyboardFrameUpdate
+    }
+
+    func startObservingKeyboardFrame() {
+        notificationCenter.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+}
+
+private extension KeyboardFrameObserver {
+    @objc func keyboardWillShow(_ notification: Foundation.Notification) {
+        guard let keyboardFrame = keyboardRect(from: notification) else {
+            return
+        }
+        self.keyboardFrame = keyboardFrame
+    }
+
+    @objc func keyboardWillHide(_ notification: Foundation.Notification) {
+        guard let keyboardFrame = keyboardRect(from: notification) else {
+            return
+        }
+        self.keyboardFrame = keyboardFrame
+    }
+}
+
+private extension KeyboardFrameObserver {
+    /// Returns the Keyboard Rect from a Keyboard Notification.
+    ///
+    func keyboardRect(from note: Notification) -> CGRect? {
+        let wrappedRect = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
+        return wrappedRect?.cgRectValue
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Observes the keyboard frame and notifies its subscriber.
-final class KeyboardFrameObserver {
+struct KeyboardFrameObserver {
     private let onKeyboardFrameUpdate: OnKeyboardFrameUpdate
 
     /// Notifies the closure owner about any keyboard frame change.
@@ -24,21 +24,31 @@ final class KeyboardFrameObserver {
         self.onKeyboardFrameUpdate = onKeyboardFrameUpdate
     }
 
-    func startObservingKeyboardFrame() {
-        notificationCenter.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        notificationCenter.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    mutating func startObservingKeyboardFrame() {
+        var observer = self
+        notificationCenter.addObserver(forName: UIResponder.keyboardWillShowNotification,
+                                       object: nil,
+                                       queue: nil) { notification in
+                                        observer.keyboardWillShow(notification)
+        }
+
+        notificationCenter.addObserver(forName: UIResponder.keyboardWillHideNotification,
+                                       object: nil,
+                                       queue: nil) { notification in
+                                        observer.keyboardWillHide(notification)
+        }
     }
 }
 
 private extension KeyboardFrameObserver {
-    @objc func keyboardWillShow(_ notification: Foundation.Notification) {
+    mutating func keyboardWillShow(_ notification: Foundation.Notification) {
         guard let keyboardFrame = keyboardRect(from: notification) else {
             return
         }
         self.keyboardFrame = keyboardFrame
     }
 
-    @objc func keyboardWillHide(_ notification: Foundation.Notification) {
+    mutating func keyboardWillHide(_ notification: Foundation.Notification) {
         guard let keyboardFrame = keyboardRect(from: notification) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+/// Adjusts its scrollable view to accommodate the keyboard height.
+protocol KeyboardScrollable {
+    var scrollable: UIScrollView { get }
+
+    func handleKeyboardFrameUpdate(keyboardFrame: CGRect)
+}
+
+extension KeyboardScrollable {
+    func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
+        let keyboardHeight = keyboardFrame.height
+        scrollable.contentInset.bottom = keyboardHeight
+        scrollable.scrollIndicatorInsets.bottom = keyboardHeight
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -24,6 +24,11 @@ final class ManualTrackingViewController: UIViewController {
         return noticePresenter
     }()
 
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: handleKeyboardFrameUpdate(keyboardFrame:))
+        return keyboardFrameObserver
+    }()
+
     init(viewModel: ManualTrackingViewModel) {
         self.viewModel = viewModel
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -561,34 +566,13 @@ private extension ManualTrackingViewController {
     /// Registers for all of the related Notifications
     ///
     func startListeningToNotifications() {
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        keyboardFrameObserver.startObservingKeyboardFrame()
     }
 
-    /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted
-    ///
-    @objc func keyboardWillShow(_ note: Notification) {
-        let bottomInset = keyboardHeight(from: note)
-
-        table.contentInset.bottom = bottomInset
-        table.scrollIndicatorInsets.bottom = bottomInset
-    }
-
-    /// Executed whenever `UIResponder.keyboardWillhideNotification` note is posted
-    ///
-    @objc func keyboardWillHide(_ note: Notification) {
-        table.contentInset.bottom = .zero
-        table.scrollIndicatorInsets.bottom = .zero
-    }
-
-    /// Returns the Keyboard Height from a (hopefully) Keyboard Notification.
-    ///
-    func keyboardHeight(from note: Notification) -> CGFloat {
-        let wrappedRect = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
-        let keyboardRect = wrappedRect?.cgRectValue ?? .zero
-
-        return keyboardRect.height
+    func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
+        let keyboardHeight = keyboardFrame.height
+        table.contentInset.bottom = keyboardHeight
+        table.scrollIndicatorInsets.bottom = keyboardHeight
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -568,11 +568,11 @@ private extension ManualTrackingViewController {
     func startListeningToNotifications() {
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
+}
 
-    func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
-        let keyboardHeight = keyboardFrame.height
-        table.contentInset.bottom = keyboardHeight
-        table.scrollIndicatorInsets.bottom = keyboardHeight
+extension ManualTrackingViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return table
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -162,11 +162,11 @@ private extension ShipmentProvidersViewController {
     func startListeningToNotifications() {
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
+}
 
-    func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
-        let keyboardHeight = keyboardFrame.height
-        table.contentInset.bottom = keyboardHeight
-        table.scrollIndicatorInsets.bottom = keyboardHeight
+extension ShipmentProvidersViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return table
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -36,6 +36,11 @@ final class ShipmentProvidersViewController: UIViewController {
         return FooterSpinnerView(tableViewStyle: table.style)
     }()
 
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: handleKeyboardFrameUpdate(keyboardFrame:))
+        return keyboardFrameObserver
+    }()
+
     /// Deinitializer
     ///
 
@@ -155,34 +160,13 @@ private extension ShipmentProvidersViewController {
     /// Registers for all of the related Notifications
     ///
     func startListeningToNotifications() {
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+        keyboardFrameObserver.startObservingKeyboardFrame()
     }
 
-    /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted
-    ///
-    @objc func keyboardWillShow(_ note: Notification) {
-        let bottomInset = keyboardHeight(from: note)
-
-        table.contentInset.bottom = bottomInset
-        table.scrollIndicatorInsets.bottom = bottomInset
-    }
-
-    /// Executed whenever `UIResponder.keyboardWillhideNotification` note is posted
-    ///
-    @objc func keyboardWillHide(_ note: Notification) {
-        table.contentInset.bottom = .zero
-        table.scrollIndicatorInsets.bottom = .zero
-    }
-
-    /// Returns the Keyboard Height from a (hopefully) Keyboard Notification.
-    ///
-    func keyboardHeight(from note: Notification) -> CGFloat {
-        let wrappedRect = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
-        let keyboardRect = wrappedRect?.cgRectValue ?? .zero
-
-        return keyboardRect.height
+    func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
+        let keyboardHeight = keyboardFrame.height
+        table.contentInset.bottom = keyboardHeight
+        table.scrollIndicatorInsets.bottom = keyboardHeight
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -169,17 +169,6 @@ where Cell.SearchModel == Command.CellViewModel {
         return true
     }
 
-    // MARK: - Notifications
-    //
-
-    /// Executed whenever keyboard frame changes
-    ///
-    private func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
-        let keyboardHeight = keyboardFrame.height
-        tableView.contentInset.bottom = keyboardHeight
-        tableView.scrollIndicatorInsets.bottom = keyboardHeight
-    }
-
     // MARK: - Actions
     //
 
@@ -189,6 +178,11 @@ where Cell.SearchModel == Command.CellViewModel {
     }
 }
 
+extension SearchViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return tableView
+    }
+}
 
 // MARK: - User Interface Initialization
 //

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -65,6 +65,11 @@ where Cell.SearchModel == Command.CellViewModel {
         }
     }
 
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: handleKeyboardFrameUpdate(keyboardFrame:))
+        return keyboardFrameObserver
+    }()
+
     private let searchUICommand: Command
 
 
@@ -167,22 +172,12 @@ where Cell.SearchModel == Command.CellViewModel {
     // MARK: - Notifications
     //
 
-    /// Executed whenever `UIResponder.keyboardWillShowNotification` note is posted
+    /// Executed whenever keyboard frame changes
     ///
-    @objc func keyboardWillShow(_ note: Notification) {
-        let bottomInset = keyboardHeight(from: note)
-
-        tableView.contentInset.bottom = bottomInset
-        tableView.scrollIndicatorInsets.bottom = bottomInset
-    }
-
-    /// Returns the Keyboard Height from a (hopefully) Keyboard Notification.
-    ///
-    func keyboardHeight(from note: Notification) -> CGFloat {
-        let wrappedRect = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue
-        let keyboardRect = wrappedRect?.cgRectValue ?? .zero
-
-        return keyboardRect.height
+    private func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
+        let keyboardHeight = keyboardFrame.height
+        tableView.contentInset.bottom = keyboardHeight
+        tableView.scrollIndicatorInsets.bottom = keyboardHeight
     }
 
     // MARK: - Actions
@@ -261,8 +256,7 @@ private extension SearchViewController {
     /// Registers for all of the related Notifications
     ///
     func startListeningToNotifications() {
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        keyboardFrameObserver.startObservingKeyboardFrame()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */; };
+		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
+		0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
@@ -499,6 +501,8 @@
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
+		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
+		0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserverTests.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopBannerFactory.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
@@ -990,6 +994,22 @@
 			path = Products;
 			sourceTree = "<group>";
 		};
+		02695768237262DE001BA0BF /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				0269576923726304001BA0BF /* KeyboardFrameObserver.swift */,
+			);
+			path = Keyboard;
+			sourceTree = "<group>";
+		};
+		0269576B237263F3001BA0BF /* Keyboard */ = {
+			isa = PBXGroup;
+			children = (
+				0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */,
+			);
+			path = Keyboard;
+			sourceTree = "<group>";
+		};
 		0282DD92233C9397006A5FDB /* Search */ = {
 			isa = PBXGroup;
 			children = (
@@ -1392,6 +1412,7 @@
 			isa = PBXGroup;
 			children = (
 				743E271E21AEF13E00D6DC82 /* Fancy Alerts */,
+				02695768237262DE001BA0BF /* Keyboard */,
 				CED6021A20B35FBF0032C639 /* ReusableViews */,
 				CE85FD5120F677460080B73E /* Dashboard */,
 				CE1CCB4920570B05000EE3AC /* Orders */,
@@ -2032,6 +2053,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				0269576B237263F3001BA0BF /* Keyboard */,
 				02E4FD7F2306AA770049610C /* Dashboard */,
 				0269177E23260090002AFC20 /* Products */,
 				D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */,
@@ -2684,6 +2706,7 @@
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				B57C744520F55BA600EEFC87 /* NSObject+Helpers.swift in Sources */,
 				D817586022BB614A00289CFE /* OrderMessageComposer.swift in Sources */,
+				0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */,
 				CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */,
 				B5F04D952194F2A300501EE1 /* NoteDetailsRow.swift in Sources */,
 				020F41E623163C0100776C4D /* TopBannerView.swift in Sources */,
@@ -2775,6 +2798,7 @@
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
 				B509FED521C052D1000076A9 /* MockupSupportManager.swift in Sources */,
 				02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */,
+				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */; };
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
+		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
@@ -497,6 +498,7 @@
 		0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelper.swift; sourceTree = "<group>"; };
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
+		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 			isa = PBXGroup;
 			children = (
 				0269576923726304001BA0BF /* KeyboardFrameObserver.swift */,
+				024DF3042372ADCD006658FE /* KeyboardScrollable.swift */,
 			);
 			path = Keyboard;
 			sourceTree = "<group>";
@@ -2572,6 +2575,7 @@
 				020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */,
 				B57C5C9621B80E5500FF82B2 /* Dictionary+Woo.swift in Sources */,
 				CE27257F21925AE8002B22EB /* ValueOneTableViewCell.swift in Sources */,
+				024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */,
 				747AA08B2107CF8D0047A89B /* TracksProvider.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+@testable import WooCommerce
+
+final class KeyboardFrameObserverTests: XCTestCase {
+
+    // If the keyboard frame is the same from multiple notification posts, it should only
+    // notify the subscriber once.
+    func testObservingKeyboardFrameChangesWithTheSameFrame() {
+        let notificationCenter = NotificationCenter()
+
+        let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
+
+        let expectedFrame = CGRect(origin: .zero, size: CGSize(width: 10, height: 18))
+        let expectedFrames: [CGRect] = [expectedFrame]
+
+        var actualFrames = [CGRect]()
+
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+            actualFrames.append(keyboardFrame)
+            if actualFrames.count >= expectedFrames.count {
+                XCTAssertEqual(actualFrames, expectedFrames)
+                expectationForKeyboardFrame.fulfill()
+            }
+        }
+        keyboardFrameObserver.startObservingKeyboardFrame()
+
+        notificationCenter.postKeyboardWillShowNotification(keyboardFrame: expectedFrame)
+        notificationCenter.postKeyboardWillHideNotification(keyboardFrame: expectedFrame)
+
+        // The expectation should only be fulfilled once.
+        expectationForKeyboardFrame.expectedFulfillmentCount = 1
+        expectationForKeyboardFrame.assertForOverFulfill = true
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testObservingKeyboardFrameChangesWithDifferentFrames() {
+        let notificationCenter = NotificationCenter()
+
+        let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
+
+        let expectedFrameForShow = CGRect(origin: .zero, size: CGSize(width: 10, height: 18))
+        let expectedFrameForHide = CGRect(origin: .zero, size: CGSize(width: 17, height: 10))
+        let expectedFrames: [CGRect] = [expectedFrameForShow, expectedFrameForHide]
+
+        var actualFrames = [CGRect]()
+
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+            actualFrames.append(keyboardFrame)
+            if actualFrames.count >= expectedFrames.count {
+                XCTAssertEqual(actualFrames, expectedFrames)
+                expectationForKeyboardFrame.fulfill()
+            }
+        }
+        keyboardFrameObserver.startObservingKeyboardFrame()
+
+        notificationCenter.postKeyboardWillShowNotification(keyboardFrame: expectedFrameForShow)
+        notificationCenter.postKeyboardWillHideNotification(keyboardFrame: expectedFrameForHide)
+
+        // The expectation should only be fulfilled once.
+        expectationForKeyboardFrame.expectedFulfillmentCount = 1
+        expectationForKeyboardFrame.assertForOverFulfill = true
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testObservingKeyboardFrameChangesWithNonKeyboardNotification() {
+        let notificationCenter = NotificationCenter()
+
+        let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
+
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+            expectationForKeyboardFrame.fulfill()
+        }
+        keyboardFrameObserver.startObservingKeyboardFrame()
+
+        notificationCenter.postNonKeyboardNotification()
+        notificationCenter.postNonKeyboardNotification()
+
+        // The expectation should not be fulfilled.
+        expectationForKeyboardFrame.isInverted = true
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testObservingKeyboardFrameChangesWithoutKeyboardUserInfo() {
+        let notificationCenter = NotificationCenter()
+
+        let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
+
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+            expectationForKeyboardFrame.fulfill()
+        }
+        keyboardFrameObserver.startObservingKeyboardFrame()
+
+        notificationCenter.postKeyboardFrameNotificationWithoutUserInfo()
+        notificationCenter.postKeyboardFrameNotificationWithoutUserInfo()
+
+        // The expectation should not be fulfilled.
+        expectationForKeyboardFrame.isInverted = true
+        waitForExpectations(timeout: 0.1)
+    }
+}
+
+private extension NotificationCenter {
+    func postKeyboardWillShowNotification(keyboardFrame: CGRect) {
+        post(name: UIResponder.keyboardWillShowNotification,
+             object: nil,
+             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: keyboardFrame])
+    }
+
+    func postKeyboardWillHideNotification(keyboardFrame: CGRect) {
+        post(name: UIResponder.keyboardWillHideNotification,
+             object: nil,
+             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: keyboardFrame])
+    }
+
+    func postKeyboardFrameNotificationWithoutUserInfo() {
+        post(name: UIResponder.keyboardWillShowNotification,
+             object: nil,
+             userInfo: nil)
+    }
+
+    func postNonKeyboardNotification() {
+        post(name: NSNotification.Name(rawValue: UIResponder.keyboardAnimationCurveUserInfoKey),
+             object: nil,
+             userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect.zero])
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -16,7 +16,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         var actualFrames = [CGRect]()
 
-        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             actualFrames.append(keyboardFrame)
             if actualFrames.count >= expectedFrames.count {
                 XCTAssertEqual(actualFrames, expectedFrames)
@@ -45,7 +45,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         var actualFrames = [CGRect]()
 
-        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             actualFrames.append(keyboardFrame)
             if actualFrames.count >= expectedFrames.count {
                 XCTAssertEqual(actualFrames, expectedFrames)
@@ -68,7 +68,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
-        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             expectationForKeyboardFrame.fulfill()
         }
         keyboardFrameObserver.startObservingKeyboardFrame()
@@ -86,7 +86,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
-        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             expectationForKeyboardFrame.fulfill()
         }
         keyboardFrameObserver.startObservingKeyboardFrame()


### PR DESCRIPTION
Part of #1421 

## Changes
- Created `KeyboardFrameObserver` helper with a keyboard frame update handler, and a function to start observing
  - Plus unit tests
  - I'm open to suggestions for its interface
- Replaced the `NSNotificationCenter` implementation with `KeyboardFrameObserver` in the following view controllers:
  - `ManualTrackingViewController`
  - `ShipmentProvidersViewController`
  - `SearchViewController`

## Testing

To make sure the keyboard behavior remains the same in the affected view controllers:

#### 1. Shipping provider
Prerequisite: the site has shipping extension activated so that shipment tracking feature is enabled
- Launch the app
- Go to "Orders" tab
- Tap on a processing Order
- Tap "Begin fulfillment"
- Tap "Add Tracking"
- Tap "Shipping provider" row --> should be able to scroll to the bottom whether the keyboard is up not
- Go back to "Add Tracking" screen
- Tap on "Tracking number" row --> should be able to scroll to the bottom whether the keyboard is up not in Portrait or Landscape
- Tap on "Date shipped" --> should still be able to scroll to the bottom whether the keyboard is up not in Portrait or Landscape

#### 2. Search Orders
- Launch the app
- Go to "Orders" tab
- Tap the search icon in the navigation bar --> on the Orders search screen, should be able to scroll to the bottom whether the keyboard is up not in Portrait or Landscape

#### 3. Search Products
- Launch the app
- Go to "Products" tab
- Tap the search icon in the navigation bar --> on the Products search screen, should be able to scroll to the bottom whether the keyboard is up not in Portrait or Landscape

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
