### PR TITLE
Aztec editor for Product description: part 1 - no format toolbar

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,6 +33,7 @@ target 'WooCommerce' do
   
   pod 'WordPressUI', '~> 1.3.5'
 
+  pod 'WordPress-Editor-iOS', '~> 1.11.0'
 
   # External Libraries
   # ==================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,6 +41,9 @@ PODS:
   - Sentry/Core (4.4.0)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
+  - WordPress-Aztec-iOS (1.11.0)
+  - WordPress-Editor-iOS (1.11.0):
+    - WordPress-Aztec-iOS (= 1.11.0)
   - WordPressAuthenticator (1.8.0):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -84,6 +87,7 @@ DEPENDENCIES:
   - CocoaLumberjack/Swift (~> 3.5)
   - Gridicons (~> 0.19)
   - KeychainAccess (~> 3.2)
+  - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.8.0)
   - WordPressShared (~> 1.8.2)
   - WordPressUI (~> 1.3.5)
@@ -110,6 +114,8 @@ SPEC REPOS:
     - Sentry
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPress-Aztec-iOS
+    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
@@ -137,6 +143,8 @@ SPEC CHECKSUMS:
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
+  WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
+  WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: 17ad69bd1fc4dc54af15fb706c61bfe81da12ddd
   WordPressKit: 87ba4cce3f5269e26a09568a749ec1b8b2ba2267
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
@@ -145,6 +153,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskSDK: f1c093a28ffcd0dc84b0cc1844801c7fc3a3dffd
 
-PODFILE CHECKSUM: e294f33e34682e98f0c245711f604c60e5dbb32f
+PODFILE CHECKSUM: 84e32c6d5f6593e3144e98e1a0e445e56c964c81
 
 COCOAPODS: 1.8.4

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -1,0 +1,863 @@
+import Foundation
+import UIKit
+import Aztec
+import CocoaLumberjack
+import Gridicons
+import WordPressShared
+import MobileCoreServices
+import WordPressEditor
+import AutomatticTracks
+
+// MARK: - Aztec's Native Editor!
+//
+class AztecEditorViewController: UIViewController, Editor {
+    var onContentSave: OnContentSave?
+
+    private let content: String
+
+    /// The editor view.
+    ///
+    private(set) lazy var editorView: Aztec.EditorView = {
+
+        let paragraphStyle = ParagraphStyle.default
+
+        // Paragraph style customizations will go here.
+        paragraphStyle.lineSpacing = 4
+        let missingIcon = UIImage.errorStateImage
+
+        let editorView = Aztec.EditorView(
+            defaultFont: StyleManager.subheadlineFont,
+            defaultHTMLFont: StyleManager.subheadlineFont,
+            defaultParagraphStyle: paragraphStyle,
+            defaultMissingImage: missingIcon)
+
+        editorView.clipsToBounds = false
+        setupHTMLTextView(editorView.htmlTextView)
+        setupRichTextView(editorView.richTextView)
+
+        return editorView
+    }()
+
+    /// Format Bar
+    ///
+    fileprivate(set) lazy var formatBar: Aztec.FormatBar = {
+        return createToolbar()
+    }()
+
+    private var scrollableItemsForToolbar: [FormatBarItem] {
+        let headerButton = makeToolbarButton(identifier: .p)
+
+        var alternativeIcons = [String: UIImage]()
+        let headings = Constants.headers.suffix(from: 1) // Remove paragraph style
+        for heading in headings {
+            alternativeIcons[heading.formattingIdentifier.rawValue] = heading.iconImage
+        }
+
+        headerButton.alternativeIcons = alternativeIcons
+
+
+        let listButton = makeToolbarButton(identifier: .unorderedlist)
+        var listIcons = [String: UIImage]()
+        for list in Constants.lists {
+            listIcons[list.formattingIdentifier.rawValue] = list.iconImage
+        }
+
+        listButton.alternativeIcons = listIcons
+
+        return [
+            headerButton,
+            listButton,
+            makeToolbarButton(identifier: .blockquote),
+            makeToolbarButton(identifier: .bold),
+            makeToolbarButton(identifier: .italic),
+            makeToolbarButton(identifier: .link)
+        ]
+    }
+
+    var overflowItemsForToolbar: [FormatBarItem] {
+        return [
+            makeToolbarButton(identifier: .underline),
+            makeToolbarButton(identifier: .strikethrough),
+            makeToolbarButton(identifier: .horizontalruler),
+            makeToolbarButton(identifier: .more),
+            makeToolbarButton(identifier: .sourcecode)
+        ]
+    }
+
+    // MARK: - Styling Options
+
+    private lazy var optionsTablePresenter = OptionsTablePresenter(presentingViewController: self, presentingTextView: editorView.richTextView)
+
+    /// Aztec's Awesomeness
+    ///
+    private var richTextView: Aztec.TextView {
+        get {
+            return editorView.richTextView
+        }
+    }
+
+    /// Raw HTML Editor
+    ///
+    private var htmlTextView: UITextView {
+        get {
+            return editorView.htmlTextView
+        }
+    }
+
+    /// Aztec's Text Placeholder
+    ///
+    fileprivate(set) lazy var placeholderLabel: UILabel = {
+        let label = UILabel()
+        label.text = NSLocalizedString("Start writing...", comment: "Aztec's Text Placeholder")
+        label.textColor = StyleManager.wooGreyMid
+        label.font = StyleManager.subheadlineFont
+        label.isUserInteractionEnabled = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.textAlignment = .natural
+        label.accessibilityIdentifier = "aztec-content-placeholder"
+        return label
+    }()
+
+    /// Current keyboard rect used to help size the inline media picker
+    ///
+    fileprivate var currentKeyboardFrame: CGRect = .zero
+
+    required init(content: String?) {
+        self.content = content ?? ""
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        registerAttachmentImageProviders()
+
+        configureNavigationBar()
+        configureView()
+        configureSubviews()
+
+        configureConstraints()
+
+        setHTML(content)
+
+        refreshPlaceholderVisibility()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        startListeningToNotifications()
+    }
+
+    deinit {
+        stopListeningToNotifications()
+    }
+}
+
+private extension AztecEditorViewController {
+    func configureNavigationBar() {
+        title = NSLocalizedString("Description", comment: "The navigation bar title of the Product description editor screen.")
+
+        navigationController?.navigationBar.isTranslucent = false
+        navigationController?.navigationBar.accessibilityIdentifier = "Aztec Editor Navigation Bar"
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(saveButtonTapped))
+    }
+
+    func configureView() {
+        edgesForExtendedLayout = UIRectEdge()
+        view.backgroundColor = StyleManager.wooWhite
+    }
+
+    func configureSubviews() {
+        view.addSubview(richTextView)
+        view.addSubview(htmlTextView)
+        view.addSubview(placeholderLabel)
+    }
+
+    private func setupHTMLTextView(_ textView: UITextView) {
+        let accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
+        configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+
+        textView.isHidden = true
+        textView.delegate = self
+        textView.accessibilityIdentifier = "HTMLContentView"
+        textView.autocorrectionType = .no
+        textView.autocapitalizationType = .none
+
+        // We need this false to be able to set negative `scrollInset` values.
+        textView.clipsToBounds = false
+
+        textView.adjustsFontForContentSizeCategory = true
+        textView.smartDashesType = .no
+        textView.smartQuotesType = .no
+    }
+
+    private func setupRichTextView(_ textView: TextView) {
+        textView.load(WordPressPlugin())
+
+        let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
+        self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+
+        let linkAttributes: [NSAttributedString.Key: Any] = [.underlineStyle: NSUnderlineStyle.single.rawValue,
+                                                             .foregroundColor: StyleManager.wooCommerceBrandColor]
+
+        textView.delegate = self
+        textView.textAttachmentDelegate = self
+        textView.backgroundColor = StyleManager.wooWhite
+        textView.linkTextAttributes = linkAttributes
+
+        // We need this false to be able to set negative `scrollInset` values.
+        textView.clipsToBounds = false
+
+        textView.smartDashesType = .no
+        textView.smartQuotesType = .no
+    }
+
+    private func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
+        textView.accessibilityLabel = accessibilityLabel
+        textView.keyboardDismissMode = .interactive
+        textView.textColor = UIColor.darkText
+        textView.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            richTextView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
+            richTextView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
+            richTextView.topAnchor.constraint(equalTo: view.topAnchor),
+            richTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
+
+        NSLayoutConstraint.activate([
+            htmlTextView.leftAnchor.constraint(equalTo: richTextView.leftAnchor),
+            htmlTextView.rightAnchor.constraint(equalTo: richTextView.rightAnchor),
+            htmlTextView.topAnchor.constraint(equalTo: richTextView.topAnchor),
+            htmlTextView.bottomAnchor.constraint(equalTo: richTextView.bottomAnchor)
+            ])
+
+        let insets = richTextView.textContainerInset
+
+        NSLayoutConstraint.activate([
+            placeholderLabel.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: insets.left + richTextView.textContainer.lineFragmentPadding),
+            placeholderLabel.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: -insets.right - richTextView.textContainer.lineFragmentPadding),
+            placeholderLabel.topAnchor.constraint(equalTo: richTextView.topAnchor, constant: insets.top),
+            placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: insets.bottom)
+            ])
+    }
+
+    func registerAttachmentImageProviders() {
+        let providers: [TextViewAttachmentImageProvider] = [
+            SpecialTagAttachmentRenderer(),
+            CommentAttachmentRenderer(font: StyleManager.subheadlineBoldFont),
+            HTMLAttachmentRenderer(font: StyleManager.subheadlineBoldFont),
+            GutenpackAttachmentRenderer()
+        ]
+
+        for provider in providers {
+            richTextView.registerAttachmentImageProvider(provider)
+        }
+    }
+
+    func createToolbar() -> Aztec.FormatBar {
+        let toolbar = Aztec.FormatBar()
+
+        toolbar.tintColor = StyleManager.wooCommerceBrandColor
+        toolbar.highlightedTintColor = StyleManager.wooCommerceBrandColor.withAlphaComponent(0.5)
+        toolbar.selectedTintColor = StyleManager.wooSecondary
+        toolbar.disabledTintColor = StyleManager.buttonDisabledColor
+        toolbar.dividerTintColor = StyleManager.cellSeparatorColor
+        toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
+
+        updateToolbar(toolbar)
+
+        toolbar.barItemHandler = { [weak self] item in
+            self?.handleAction(for: item)
+        }
+
+        return toolbar
+    }
+
+    func updateToolbar(_ toolbar: Aztec.FormatBar) {
+        toolbar.trailingItem = nil
+
+        toolbar.setDefaultItems(scrollableItemsForToolbar,
+                                overflowItems: overflowItemsForToolbar)
+    }
+
+    func makeToolbarButton(identifier: FormattingIdentifier) -> FormatBarItem {
+        return makeToolbarButton(identifier: identifier.rawValue, provider: identifier)
+    }
+
+    func makeToolbarButton(identifier: String, provider: FormatBarItemProvider) -> FormatBarItem {
+        let button = FormatBarItem(image: provider.iconImage, identifier: identifier)
+        button.accessibilityLabel = provider.accessibilityLabel
+        button.accessibilityIdentifier = provider.accessibilityIdentifier
+        return button
+    }
+}
+
+private extension AztecEditorViewController {
+    func setHTML(_ html: String) {
+        editorView.setHTML(html)
+    }
+
+    func getHTML() -> String {
+        return editorView.getHTML()
+    }
+
+    func refreshPlaceholderVisibility() {
+        placeholderLabel.isHidden = richTextView.isHidden || !richTextView.text.isEmpty
+    }
+}
+
+// MARK: FormatBar Actions
+//
+extension AztecEditorViewController {
+    func handleAction(for barItem: FormatBarItem) {
+        guard let identifier = barItem.identifier else { return }
+
+        if let formattingIdentifier = FormattingIdentifier(rawValue: identifier) {
+            switch formattingIdentifier {
+            case .bold:
+                toggleBold()
+            case .italic:
+                toggleItalic()
+            case .underline:
+                toggleUnderline()
+            case .strikethrough:
+                toggleStrikethrough()
+            case .blockquote:
+                toggleBlockquote()
+            case .unorderedlist, .orderedlist:
+                toggleList(fromItem: barItem)
+            case .link:
+                toggleLink()
+            case .sourcecode:
+                toggleEditingMode()
+            case .p, .header1, .header2, .header3, .header4, .header5, .header6:
+                toggleHeader(fromItem: barItem)
+            case .horizontalruler:
+                insertHorizontalRuler()
+            case .more:
+                insertMore()
+            case .code:
+                toggleCode()
+            default:
+                break
+            }
+
+            updateFormatBar()
+        }
+    }
+
+    @objc func toggleBold() {
+//        trackFormatBarAnalytics(stat: .editorTappedBold)
+        richTextView.toggleBold(range: richTextView.selectedRange)
+    }
+
+    @objc func toggleCode() {
+        richTextView.toggleCode(range: richTextView.selectedRange)
+    }
+
+    @objc func toggleItalic() {
+//        trackFormatBarAnalytics(stat: .editorTappedItalic)
+        richTextView.toggleItalic(range: richTextView.selectedRange)
+    }
+
+    @objc func toggleUnderline() {
+//        trackFormatBarAnalytics(stat: .editorTappedUnderline)
+        richTextView.toggleUnderline(range: richTextView.selectedRange)
+    }
+
+    @objc func toggleStrikethrough() {
+//        trackFormatBarAnalytics(stat: .editorTappedStrikethrough)
+        richTextView.toggleStrikethrough(range: richTextView.selectedRange)
+    }
+
+    @objc func toggleOrderedList() {
+//        trackFormatBarAnalytics(stat: .editorTappedOrderedList)
+        richTextView.toggleOrderedList(range: richTextView.selectedRange)
+    }
+
+    @objc func toggleUnorderedList() {
+//        trackFormatBarAnalytics(stat: .editorTappedUnorderedList)
+        richTextView.toggleUnorderedList(range: richTextView.selectedRange)
+    }
+
+    func toggleList(fromItem item: FormatBarItem) {
+        let listOptions = Constants.lists.map { listType -> OptionsTableViewOption in
+            let title = NSAttributedString(string: listType.description, attributes: [:])
+            return OptionsTableViewOption(image: listType.iconImage,
+                                          title: title,
+                                          accessibilityLabel: listType.accessibilityLabel)
+        }
+
+        var index: Int? = nil
+        if let listType = listTypeForSelectedText() {
+            index = Constants.lists.firstIndex(of: listType)
+        }
+
+        let optionsTableViewController = OptionsTableViewController(options: listOptions)
+        optionsTableViewController.applyDefaultStyles()
+
+        optionsTablePresenter.present(
+            optionsTableViewController,
+            fromBarItem: item,
+            selectedRowIndex: index,
+            onSelect: { [weak self] selected in
+                let listType = Constants.lists[selected]
+
+                switch listType {
+                case .unordered:
+                    self?.toggleUnorderedList()
+                case .ordered:
+                    self?.toggleOrderedList()
+                }
+        })
+    }
+
+
+    @objc func toggleBlockquote() {
+//        trackFormatBarAnalytics(stat: .editorTappedBlockquote)
+        richTextView.toggleBlockquote(range: richTextView.selectedRange)
+    }
+
+
+    func listTypeForSelectedText() -> TextList.Style? {
+        var identifiers = Set<FormattingIdentifier>()
+        if richTextView.selectedRange.length > 0 {
+            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
+        } else {
+            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
+        }
+        let mapping: [FormattingIdentifier: TextList.Style] = [
+            .orderedlist: .ordered,
+            .unorderedlist: .unordered
+        ]
+        for (key, value) in mapping {
+            if identifiers.contains(key) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
+    @objc func toggleEditingMode() {
+//        trackFormatBarAnalytics(stat: .editorTappedHTML)
+        formatBar.overflowToolbar(expand: true)
+
+        editorView.toggleEditingMode()
+//        editorSession.switch(editor: analyticsEditor)
+    }
+
+    // MARK: Link Actions
+
+    @objc func toggleLink() {
+//        trackFormatBarAnalytics(stat: .editorTappedLink)
+
+        var linkTitle = ""
+        var linkURL: URL? = nil
+        var linkTarget: String?
+        var linkRange = richTextView.selectedRange
+        // Let's check if the current range already has a link assigned to it.
+        if let expandedRange = richTextView.linkFullRange(forRange: richTextView.selectedRange) {
+            linkRange = expandedRange
+            linkURL = richTextView.linkURL(forRange: expandedRange)
+            linkTarget = richTextView.linkTarget(forRange: expandedRange)
+        }
+
+        linkTitle = richTextView.attributedText.attributedSubstring(from: linkRange).string
+        showLinkDialog(forURL: linkURL, title: linkTitle, target: linkTarget, range: linkRange)
+    }
+
+    func showLinkDialog(forURL url: URL?, title: String?, target: String?, range: NSRange) {
+
+        let isInsertingNewLink = (url == nil)
+        var urlToUse = url
+
+        if isInsertingNewLink {
+            if UIPasteboard.general.hasURLs,
+                let pastedURL = UIPasteboard.general.url {
+                urlToUse = pastedURL
+            }
+        }
+
+        let alertController = UIAlertController(title: NSLocalizedString("Link Settings", comment: ""), message: nil, preferredStyle: .alert)
+        let removeLinkAction = UIAlertAction(title: NSLocalizedString("Remove link", comment: ""), style: .destructive, handler: { [weak self] _ in
+            self?.removeLink(in: range)
+        })
+        let addLinkAction = UIAlertAction(title: NSLocalizedString("Add link", comment: ""), style: .default) { [weak self] _ in
+            guard let urlTextField = alertController.textFields?[0],
+                let url = urlTextField.text else {
+                return
+            }
+            self?.insertLink(url: url, text: title, target: nil, range: range)
+        }
+        let addLinkToNewWindowAction = UIAlertAction(title: NSLocalizedString("Add link to a new window", comment: ""), style: .default) { [weak self] _ in
+            guard let urlTextField = alertController.textFields?[0],
+                let url = urlTextField.text else {
+                return
+            }
+            self?.insertLink(url: url, text: title, target: "_blank", range: range)
+        }
+
+        alertController.addTextField(configurationHandler: { textField in
+            textField.placeholder = NSLocalizedString("Enter link URL", comment: "")
+            textField.text = urlToUse?.absoluteString ?? ""
+        })
+
+        alertController.addAction(addLinkAction)
+        alertController.addAction(addLinkToNewWindowAction)
+
+        if urlToUse != nil {
+            alertController.addAction(removeLinkAction)
+        }
+
+        alertController.addActionWithTitle(NSLocalizedString("Cancel", comment: ""), style: .cancel)
+        present(alertController, animated: true, completion: nil)
+
+        // TODO: replace the alert implementation with something nicer like `LinkSettingsViewController` on WPiOS.
+
+        richTextView.resignFirstResponder()
+    }
+
+    func insertLink(url: String, text: String?, target: String?, range: NSRange) {
+        let linkURLString = url
+        var linkText = text
+
+        if linkText == nil || linkText!.isEmpty {
+            linkText = linkURLString
+        }
+
+        guard let url = URL(string: linkURLString), let title = linkText else {
+            return
+        }
+
+        richTextView.setLink(url.normalizedURLForWordPressLink(), title: title, target: target, inRange: range)
+    }
+
+    func removeLink(in range: NSRange) {
+//        trackFormatBarAnalytics(stat: .editorTappedUnlink)
+        richTextView.removeLink(inRange: range)
+    }
+
+    func toggleHeader(fromItem item: FormatBarItem) {
+        guard !optionsTablePresenter.isOnScreen() else {
+            optionsTablePresenter.dismiss()
+            return
+        }
+
+//        trackFormatBarAnalytics(stat: .editorTappedHeader)
+
+        let headerOptions = Constants.headers.map { headerType -> OptionsTableViewOption in
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: CGFloat(headerType.fontSize)),
+            ]
+
+            let title = NSAttributedString(string: headerType.description, attributes: attributes)
+
+            return OptionsTableViewOption(image: headerType.iconImage,
+                                          title: title,
+                                          accessibilityLabel: headerType.accessibilityLabel)
+        }
+
+        let selectedIndex = Constants.headers.firstIndex(of: self.headerLevelForSelectedText())
+
+        let optionsTableViewController = OptionsTableViewController(options: headerOptions)
+        optionsTableViewController.applyDefaultStyles()
+
+        optionsTablePresenter.present(
+            optionsTableViewController,
+            fromBarItem: item,
+            selectedRowIndex: selectedIndex,
+            onSelect: { [weak self] selected in
+                guard let range = self?.richTextView.selectedRange else { return }
+
+//                let selectedStyle = Analytics.headerStyleValues[selected]
+//                self?.trackFormatBarAnalytics(stat: .editorTappedHeaderSelection, headingStyle: selectedStyle)
+
+                self?.richTextView.toggleHeader(Constants.headers[selected], range: range)
+                self?.optionsTablePresenter.dismiss()
+        })
+    }
+
+    func insertHorizontalRuler() {
+//        trackFormatBarAnalytics(stat: .editorTappedHorizontalRule)
+        richTextView.replaceWithHorizontalRuler(at: richTextView.selectedRange)
+    }
+
+    func insertMore() {
+//        trackFormatBarAnalytics(stat: .editorTappedMore)
+        richTextView.replace(richTextView.selectedRange, withComment: Constants.moreAttachmentText)
+    }
+
+    func headerLevelForSelectedText() -> Header.HeaderType {
+        var identifiers = Set<FormattingIdentifier>()
+        if richTextView.selectedRange.length > 0 {
+            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
+        } else {
+            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
+        }
+        let mapping: [FormattingIdentifier: Header.HeaderType] = [
+            .header1: .h1,
+            .header2: .h2,
+            .header3: .h3,
+            .header4: .h4,
+            .header5: .h5,
+            .header6: .h6,
+        ]
+        for (key, value) in mapping {
+            if identifiers.contains(key) {
+                return value
+            }
+        }
+        return .none
+    }
+}
+
+extension AztecEditorViewController {
+    // MARK: - Keyboard Handling
+
+    override var keyCommands: [UIKeyCommand] {
+
+        if richTextView.isFirstResponder {
+            return [
+                UIKeyCommand(input: "B", modifierFlags: .command, action: #selector(toggleBold), discoverabilityTitle: NSLocalizedString("Bold", comment: "Discoverability title for bold formatting keyboard shortcut.")),
+                UIKeyCommand(input: "I", modifierFlags: .command, action: #selector(toggleItalic), discoverabilityTitle: NSLocalizedString("Italic", comment: "Discoverability title for italic formatting keyboard shortcut.")),
+                UIKeyCommand(input: "S", modifierFlags: [.command], action: #selector(toggleStrikethrough), discoverabilityTitle: NSLocalizedString("Strikethrough", comment: "Discoverability title for strikethrough formatting keyboard shortcut.")),
+                UIKeyCommand(input: "U", modifierFlags: .command, action: #selector(toggleUnderline(_:)), discoverabilityTitle: NSLocalizedString("Underline", comment: "Discoverability title for underline formatting keyboard shortcut.")),
+                UIKeyCommand(input: "Q", modifierFlags: [.command, .alternate], action: #selector(toggleBlockquote), discoverabilityTitle: NSLocalizedString("Block Quote", comment: "Discoverability title for block quote keyboard shortcut.")),
+                UIKeyCommand(input: "K", modifierFlags: .command, action: #selector(toggleLink), discoverabilityTitle: NSLocalizedString("Insert Link", comment: "Discoverability title for insert link keyboard shortcut.")),
+                UIKeyCommand(input: "U", modifierFlags: [.command, .alternate], action: #selector(toggleUnorderedList), discoverabilityTitle: NSLocalizedString("Bullet List", comment: "Discoverability title for bullet list keyboard shortcut.")),
+                UIKeyCommand(input: "O", modifierFlags: [.command, .alternate], action: #selector(toggleOrderedList), discoverabilityTitle: NSLocalizedString("Numbered List", comment: "Discoverability title for numbered list keyboard shortcut.")),
+                UIKeyCommand(input: "H", modifierFlags: [.command, .shift], action: #selector(toggleEditingMode), discoverabilityTitle: NSLocalizedString("Toggle HTML Source ", comment: "Discoverability title for HTML keyboard shortcut."))
+            ]
+        }
+
+        if htmlTextView.isFirstResponder {
+            return [
+                UIKeyCommand(input: "H", modifierFlags: [.command, .shift], action: #selector(toggleEditingMode), discoverabilityTitle: NSLocalizedString("Toggle HTML Source ", comment: "Discoverability title for HTML keyboard shortcut."))
+            ]
+        }
+
+        return []
+    }
+}
+
+private extension AztecEditorViewController {
+
+    @objc func keyboardWillShow(_ notification: Foundation.Notification) {
+        guard
+            let userInfo = notification.userInfo as? [String: AnyObject],
+            let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            else {
+                return
+        }
+        // Convert the keyboard frame from window base coordinate
+        currentKeyboardFrame = view.convert(keyboardFrame, from: nil)
+        refreshInsets(forKeyboardFrame: keyboardFrame)
+    }
+
+    @objc func keyboardDidHide(_ notification: Foundation.Notification) {
+        guard
+            let userInfo = notification.userInfo as? [String: AnyObject],
+            let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            else {
+                return
+        }
+
+        currentKeyboardFrame = .zero
+        refreshInsets(forKeyboardFrame: keyboardFrame)
+    }
+
+    func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
+        let referenceView = editorView.activeView
+
+        let contentInsets  = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: 0)
+
+        htmlTextView.contentInset = contentInsets
+        richTextView.contentInset = contentInsets
+
+        updateScrollInsets()
+    }
+
+    func updateScrollInsets() {
+        let referenceView = editorView.activeView
+        var scrollInsets = referenceView.contentInset
+        var rightMargin = (view.frame.maxX - referenceView.frame.maxX)
+        rightMargin -= view.safeAreaInsets.right
+        scrollInsets.right = -rightMargin
+        referenceView.scrollIndicatorInsets = scrollInsets
+    }
+}
+
+// MARK: - Notifications
+//
+private extension AztecEditorViewController {
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
+        nc.addObserver(self, selector: #selector(applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
+    }
+
+    /// Unregisters from the Notification Center
+    ///
+    func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc func applicationWillResignActive(_ notification: Foundation.Notification) {
+
+        // [2018-03-05] Need to close the options VC on backgrounding to prevent view hierarchy inconsistency crasher.
+        optionsTablePresenter.dismiss()
+    }
+}
+
+// MARK: - Navigation actions
+//
+private extension AztecEditorViewController {
+    @objc func cancelButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+
+    @objc func saveButtonTapped() {
+        let content = getHTML()
+        onContentSave?(content)
+
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+// MARK: - TextViewAttachmentDelegate Conformance
+//
+extension AztecEditorViewController: TextViewAttachmentDelegate {
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+
+    }
+
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
+        return nil
+    }
+
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
+        return UIImage.cameraImage
+    }
+
+    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
+
+    }
+
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
+
+    }
+
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
+
+    }
+}
+
+private extension AztecEditorViewController {
+    func updateFormatBar() {
+        switch editorView.editingMode {
+        case .html:
+            updateFormatBarForHTMLMode()
+        case .richText:
+            updateFormatBarForVisualMode()
+        }
+    }
+
+    /// Updates the format bar for HTML mode.
+    ///
+    func updateFormatBarForHTMLMode() {
+        assert(editorView.editingMode == .html)
+
+        guard let toolbar = richTextView.inputAccessoryView as? Aztec.FormatBar else {
+            return
+        }
+
+        toolbar.selectItemsMatchingIdentifiers([FormattingIdentifier.sourcecode.rawValue])
+    }
+
+    /// Updates the format bar for visual mode.
+    ///
+    func updateFormatBarForVisualMode() {
+        assert(editorView.editingMode == .richText)
+
+        guard let toolbar = richTextView.inputAccessoryView as? Aztec.FormatBar else {
+            return
+        }
+
+        var identifiers = Set<FormattingIdentifier>()
+
+        if richTextView.selectedRange.length > 0 {
+            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
+        } else {
+            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
+        }
+
+        toolbar.selectItemsMatchingIdentifiers(identifiers.map({ $0.rawValue }))
+    }
+}
+
+// MARK: - UITextViewDelegate methods
+//
+extension AztecEditorViewController: UITextViewDelegate {
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        return true
+    }
+
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        refreshPlaceholderVisibility()
+        updateFormatBar()
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+        refreshPlaceholderVisibility()
+
+        switch textView {
+        case richTextView:
+            updateFormatBar()
+        default:
+            break
+        }
+    }
+
+    func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        textView.textAlignment = .natural
+
+        let htmlButton = formatBar.items.first(where: { $0.identifier == FormattingIdentifier.sourcecode.rawValue })
+
+        switch textView {
+        case richTextView:
+            formatBar.enabled = true
+        case htmlTextView:
+            formatBar.enabled = false
+        default:
+            break
+        }
+
+        htmlButton?.isEnabled = true
+
+        textView.inputAccessoryView = formatBar
+
+        return true
+    }
+}
+
+// MARK: - Constants
+//
+extension AztecEditorViewController {
+    enum Constants {
+        static let headers = [Header.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
+        static let lists = [TextList.Style.unordered, .ordered]
+        static let moreAttachmentText = "more"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -1,12 +1,7 @@
-import Foundation
 import UIKit
 import Aztec
-import CocoaLumberjack
 import Gridicons
-import WordPressShared
-import MobileCoreServices
 import WordPressEditor
-import AutomatticTracks
 
 // MARK: - Aztec's Native Editor!
 //
@@ -45,43 +40,11 @@ class AztecEditorViewController: UIViewController, Editor {
     }()
 
     private var scrollableItemsForToolbar: [FormatBarItem] {
-        let headerButton = makeToolbarButton(identifier: .p)
-
-        var alternativeIcons = [String: UIImage]()
-        let headings = Constants.headers.suffix(from: 1) // Remove paragraph style
-        for heading in headings {
-            alternativeIcons[heading.formattingIdentifier.rawValue] = heading.iconImage
-        }
-
-        headerButton.alternativeIcons = alternativeIcons
-
-
-        let listButton = makeToolbarButton(identifier: .unorderedlist)
-        var listIcons = [String: UIImage]()
-        for list in Constants.lists {
-            listIcons[list.formattingIdentifier.rawValue] = list.iconImage
-        }
-
-        listButton.alternativeIcons = listIcons
-
-        return [
-            headerButton,
-            listButton,
-            makeToolbarButton(identifier: .blockquote),
-            makeToolbarButton(identifier: .bold),
-            makeToolbarButton(identifier: .italic),
-            makeToolbarButton(identifier: .link)
-        ]
+        return []
     }
 
     var overflowItemsForToolbar: [FormatBarItem] {
-        return [
-            makeToolbarButton(identifier: .underline),
-            makeToolbarButton(identifier: .strikethrough),
-            makeToolbarButton(identifier: .horizontalruler),
-            makeToolbarButton(identifier: .more),
-            makeToolbarButton(identifier: .sourcecode)
-        ]
+        return []
     }
 
     // MARK: - Styling Options
@@ -96,7 +59,7 @@ class AztecEditorViewController: UIViewController, Editor {
         }
     }
 
-    /// Raw HTML Editor
+    /// Aztec's Raw HTML Editor
     ///
     private var htmlTextView: UITextView {
         get {
@@ -114,7 +77,6 @@ class AztecEditorViewController: UIViewController, Editor {
         label.isUserInteractionEnabled = false
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
-        label.textAlignment = .natural
         label.accessibilityIdentifier = "aztec-content-placeholder"
         return label
     }()
@@ -151,10 +113,6 @@ class AztecEditorViewController: UIViewController, Editor {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         startListeningToNotifications()
-    }
-
-    deinit {
-        stopListeningToNotifications()
     }
 }
 
@@ -275,10 +233,6 @@ private extension AztecEditorViewController {
 
         updateToolbar(toolbar)
 
-        toolbar.barItemHandler = { [weak self] item in
-            self?.handleAction(for: item)
-        }
-
         return toolbar
     }
 
@@ -287,17 +241,6 @@ private extension AztecEditorViewController {
 
         toolbar.setDefaultItems(scrollableItemsForToolbar,
                                 overflowItems: overflowItemsForToolbar)
-    }
-
-    func makeToolbarButton(identifier: FormattingIdentifier) -> FormatBarItem {
-        return makeToolbarButton(identifier: identifier.rawValue, provider: identifier)
-    }
-
-    func makeToolbarButton(identifier: String, provider: FormatBarItemProvider) -> FormatBarItem {
-        let button = FormatBarItem(image: provider.iconImage, identifier: identifier)
-        button.accessibilityLabel = provider.accessibilityLabel
-        button.accessibilityIdentifier = provider.accessibilityIdentifier
-        return button
     }
 }
 
@@ -312,341 +255,6 @@ private extension AztecEditorViewController {
 
     func refreshPlaceholderVisibility() {
         placeholderLabel.isHidden = richTextView.isHidden || !richTextView.text.isEmpty
-    }
-}
-
-// MARK: FormatBar Actions
-//
-extension AztecEditorViewController {
-    func handleAction(for barItem: FormatBarItem) {
-        guard let identifier = barItem.identifier else { return }
-
-        if let formattingIdentifier = FormattingIdentifier(rawValue: identifier) {
-            switch formattingIdentifier {
-            case .bold:
-                toggleBold()
-            case .italic:
-                toggleItalic()
-            case .underline:
-                toggleUnderline()
-            case .strikethrough:
-                toggleStrikethrough()
-            case .blockquote:
-                toggleBlockquote()
-            case .unorderedlist, .orderedlist:
-                toggleList(fromItem: barItem)
-            case .link:
-                toggleLink()
-            case .sourcecode:
-                toggleEditingMode()
-            case .p, .header1, .header2, .header3, .header4, .header5, .header6:
-                toggleHeader(fromItem: barItem)
-            case .horizontalruler:
-                insertHorizontalRuler()
-            case .more:
-                insertMore()
-            case .code:
-                toggleCode()
-            default:
-                break
-            }
-
-            updateFormatBar()
-        }
-    }
-
-    @objc func toggleBold() {
-//        trackFormatBarAnalytics(stat: .editorTappedBold)
-        richTextView.toggleBold(range: richTextView.selectedRange)
-    }
-
-    @objc func toggleCode() {
-        richTextView.toggleCode(range: richTextView.selectedRange)
-    }
-
-    @objc func toggleItalic() {
-//        trackFormatBarAnalytics(stat: .editorTappedItalic)
-        richTextView.toggleItalic(range: richTextView.selectedRange)
-    }
-
-    @objc func toggleUnderline() {
-//        trackFormatBarAnalytics(stat: .editorTappedUnderline)
-        richTextView.toggleUnderline(range: richTextView.selectedRange)
-    }
-
-    @objc func toggleStrikethrough() {
-//        trackFormatBarAnalytics(stat: .editorTappedStrikethrough)
-        richTextView.toggleStrikethrough(range: richTextView.selectedRange)
-    }
-
-    @objc func toggleOrderedList() {
-//        trackFormatBarAnalytics(stat: .editorTappedOrderedList)
-        richTextView.toggleOrderedList(range: richTextView.selectedRange)
-    }
-
-    @objc func toggleUnorderedList() {
-//        trackFormatBarAnalytics(stat: .editorTappedUnorderedList)
-        richTextView.toggleUnorderedList(range: richTextView.selectedRange)
-    }
-
-    func toggleList(fromItem item: FormatBarItem) {
-        let listOptions = Constants.lists.map { listType -> OptionsTableViewOption in
-            let title = NSAttributedString(string: listType.description, attributes: [:])
-            return OptionsTableViewOption(image: listType.iconImage,
-                                          title: title,
-                                          accessibilityLabel: listType.accessibilityLabel)
-        }
-
-        var index: Int? = nil
-        if let listType = listTypeForSelectedText() {
-            index = Constants.lists.firstIndex(of: listType)
-        }
-
-        let optionsTableViewController = OptionsTableViewController(options: listOptions)
-        optionsTableViewController.applyDefaultStyles()
-
-        optionsTablePresenter.present(
-            optionsTableViewController,
-            fromBarItem: item,
-            selectedRowIndex: index,
-            onSelect: { [weak self] selected in
-                let listType = Constants.lists[selected]
-
-                switch listType {
-                case .unordered:
-                    self?.toggleUnorderedList()
-                case .ordered:
-                    self?.toggleOrderedList()
-                }
-        })
-    }
-
-
-    @objc func toggleBlockquote() {
-//        trackFormatBarAnalytics(stat: .editorTappedBlockquote)
-        richTextView.toggleBlockquote(range: richTextView.selectedRange)
-    }
-
-
-    func listTypeForSelectedText() -> TextList.Style? {
-        var identifiers = Set<FormattingIdentifier>()
-        if richTextView.selectedRange.length > 0 {
-            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
-        } else {
-            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
-        }
-        let mapping: [FormattingIdentifier: TextList.Style] = [
-            .orderedlist: .ordered,
-            .unorderedlist: .unordered
-        ]
-        for (key, value) in mapping {
-            if identifiers.contains(key) {
-                return value
-            }
-        }
-
-        return nil
-    }
-
-    @objc func toggleEditingMode() {
-//        trackFormatBarAnalytics(stat: .editorTappedHTML)
-        formatBar.overflowToolbar(expand: true)
-
-        editorView.toggleEditingMode()
-//        editorSession.switch(editor: analyticsEditor)
-    }
-
-    // MARK: Link Actions
-
-    @objc func toggleLink() {
-//        trackFormatBarAnalytics(stat: .editorTappedLink)
-
-        var linkTitle = ""
-        var linkURL: URL? = nil
-        var linkTarget: String?
-        var linkRange = richTextView.selectedRange
-        // Let's check if the current range already has a link assigned to it.
-        if let expandedRange = richTextView.linkFullRange(forRange: richTextView.selectedRange) {
-            linkRange = expandedRange
-            linkURL = richTextView.linkURL(forRange: expandedRange)
-            linkTarget = richTextView.linkTarget(forRange: expandedRange)
-        }
-
-        linkTitle = richTextView.attributedText.attributedSubstring(from: linkRange).string
-        showLinkDialog(forURL: linkURL, title: linkTitle, target: linkTarget, range: linkRange)
-    }
-
-    func showLinkDialog(forURL url: URL?, title: String?, target: String?, range: NSRange) {
-
-        let isInsertingNewLink = (url == nil)
-        var urlToUse = url
-
-        if isInsertingNewLink {
-            if UIPasteboard.general.hasURLs,
-                let pastedURL = UIPasteboard.general.url {
-                urlToUse = pastedURL
-            }
-        }
-
-        let alertController = UIAlertController(title: NSLocalizedString("Link Settings", comment: ""), message: nil, preferredStyle: .alert)
-        let removeLinkAction = UIAlertAction(title: NSLocalizedString("Remove link", comment: ""), style: .destructive, handler: { [weak self] _ in
-            self?.removeLink(in: range)
-        })
-        let addLinkAction = UIAlertAction(title: NSLocalizedString("Add link", comment: ""), style: .default) { [weak self] _ in
-            guard let urlTextField = alertController.textFields?[0],
-                let url = urlTextField.text else {
-                return
-            }
-            self?.insertLink(url: url, text: title, target: nil, range: range)
-        }
-        let addLinkToNewWindowAction = UIAlertAction(title: NSLocalizedString("Add link to a new window", comment: ""), style: .default) { [weak self] _ in
-            guard let urlTextField = alertController.textFields?[0],
-                let url = urlTextField.text else {
-                return
-            }
-            self?.insertLink(url: url, text: title, target: "_blank", range: range)
-        }
-
-        alertController.addTextField(configurationHandler: { textField in
-            textField.placeholder = NSLocalizedString("Enter link URL", comment: "")
-            textField.text = urlToUse?.absoluteString ?? ""
-        })
-
-        alertController.addAction(addLinkAction)
-        alertController.addAction(addLinkToNewWindowAction)
-
-        if urlToUse != nil {
-            alertController.addAction(removeLinkAction)
-        }
-
-        alertController.addActionWithTitle(NSLocalizedString("Cancel", comment: ""), style: .cancel)
-        present(alertController, animated: true, completion: nil)
-
-        // TODO: replace the alert implementation with something nicer like `LinkSettingsViewController` on WPiOS.
-
-        richTextView.resignFirstResponder()
-    }
-
-    func insertLink(url: String, text: String?, target: String?, range: NSRange) {
-        let linkURLString = url
-        var linkText = text
-
-        if linkText == nil || linkText!.isEmpty {
-            linkText = linkURLString
-        }
-
-        guard let url = URL(string: linkURLString), let title = linkText else {
-            return
-        }
-
-        richTextView.setLink(url.normalizedURLForWordPressLink(), title: title, target: target, inRange: range)
-    }
-
-    func removeLink(in range: NSRange) {
-//        trackFormatBarAnalytics(stat: .editorTappedUnlink)
-        richTextView.removeLink(inRange: range)
-    }
-
-    func toggleHeader(fromItem item: FormatBarItem) {
-        guard !optionsTablePresenter.isOnScreen() else {
-            optionsTablePresenter.dismiss()
-            return
-        }
-
-//        trackFormatBarAnalytics(stat: .editorTappedHeader)
-
-        let headerOptions = Constants.headers.map { headerType -> OptionsTableViewOption in
-            let attributes: [NSAttributedString.Key: Any] = [
-                .font: UIFont.systemFont(ofSize: CGFloat(headerType.fontSize)),
-            ]
-
-            let title = NSAttributedString(string: headerType.description, attributes: attributes)
-
-            return OptionsTableViewOption(image: headerType.iconImage,
-                                          title: title,
-                                          accessibilityLabel: headerType.accessibilityLabel)
-        }
-
-        let selectedIndex = Constants.headers.firstIndex(of: self.headerLevelForSelectedText())
-
-        let optionsTableViewController = OptionsTableViewController(options: headerOptions)
-        optionsTableViewController.applyDefaultStyles()
-
-        optionsTablePresenter.present(
-            optionsTableViewController,
-            fromBarItem: item,
-            selectedRowIndex: selectedIndex,
-            onSelect: { [weak self] selected in
-                guard let range = self?.richTextView.selectedRange else { return }
-
-//                let selectedStyle = Analytics.headerStyleValues[selected]
-//                self?.trackFormatBarAnalytics(stat: .editorTappedHeaderSelection, headingStyle: selectedStyle)
-
-                self?.richTextView.toggleHeader(Constants.headers[selected], range: range)
-                self?.optionsTablePresenter.dismiss()
-        })
-    }
-
-    func insertHorizontalRuler() {
-//        trackFormatBarAnalytics(stat: .editorTappedHorizontalRule)
-        richTextView.replaceWithHorizontalRuler(at: richTextView.selectedRange)
-    }
-
-    func insertMore() {
-//        trackFormatBarAnalytics(stat: .editorTappedMore)
-        richTextView.replace(richTextView.selectedRange, withComment: Constants.moreAttachmentText)
-    }
-
-    func headerLevelForSelectedText() -> Header.HeaderType {
-        var identifiers = Set<FormattingIdentifier>()
-        if richTextView.selectedRange.length > 0 {
-            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
-        } else {
-            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
-        }
-        let mapping: [FormattingIdentifier: Header.HeaderType] = [
-            .header1: .h1,
-            .header2: .h2,
-            .header3: .h3,
-            .header4: .h4,
-            .header5: .h5,
-            .header6: .h6,
-        ]
-        for (key, value) in mapping {
-            if identifiers.contains(key) {
-                return value
-            }
-        }
-        return .none
-    }
-}
-
-extension AztecEditorViewController {
-    // MARK: - Keyboard Handling
-
-    override var keyCommands: [UIKeyCommand] {
-
-        if richTextView.isFirstResponder {
-            return [
-                UIKeyCommand(input: "B", modifierFlags: .command, action: #selector(toggleBold), discoverabilityTitle: NSLocalizedString("Bold", comment: "Discoverability title for bold formatting keyboard shortcut.")),
-                UIKeyCommand(input: "I", modifierFlags: .command, action: #selector(toggleItalic), discoverabilityTitle: NSLocalizedString("Italic", comment: "Discoverability title for italic formatting keyboard shortcut.")),
-                UIKeyCommand(input: "S", modifierFlags: [.command], action: #selector(toggleStrikethrough), discoverabilityTitle: NSLocalizedString("Strikethrough", comment: "Discoverability title for strikethrough formatting keyboard shortcut.")),
-                UIKeyCommand(input: "U", modifierFlags: .command, action: #selector(toggleUnderline(_:)), discoverabilityTitle: NSLocalizedString("Underline", comment: "Discoverability title for underline formatting keyboard shortcut.")),
-                UIKeyCommand(input: "Q", modifierFlags: [.command, .alternate], action: #selector(toggleBlockquote), discoverabilityTitle: NSLocalizedString("Block Quote", comment: "Discoverability title for block quote keyboard shortcut.")),
-                UIKeyCommand(input: "K", modifierFlags: .command, action: #selector(toggleLink), discoverabilityTitle: NSLocalizedString("Insert Link", comment: "Discoverability title for insert link keyboard shortcut.")),
-                UIKeyCommand(input: "U", modifierFlags: [.command, .alternate], action: #selector(toggleUnorderedList), discoverabilityTitle: NSLocalizedString("Bullet List", comment: "Discoverability title for bullet list keyboard shortcut.")),
-                UIKeyCommand(input: "O", modifierFlags: [.command, .alternate], action: #selector(toggleOrderedList), discoverabilityTitle: NSLocalizedString("Numbered List", comment: "Discoverability title for numbered list keyboard shortcut.")),
-                UIKeyCommand(input: "H", modifierFlags: [.command, .shift], action: #selector(toggleEditingMode), discoverabilityTitle: NSLocalizedString("Toggle HTML Source ", comment: "Discoverability title for HTML keyboard shortcut."))
-            ]
-        }
-
-        if htmlTextView.isFirstResponder {
-            return [
-                UIKeyCommand(input: "H", modifierFlags: [.command, .shift], action: #selector(toggleEditingMode), discoverabilityTitle: NSLocalizedString("Toggle HTML Source ", comment: "Discoverability title for HTML keyboard shortcut."))
-            ]
-        }
-
-        return []
     }
 }
 
@@ -705,12 +313,6 @@ private extension AztecEditorViewController {
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         nc.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
         nc.addObserver(self, selector: #selector(applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
-    }
-
-    /// Unregisters from the Notification Center
-    ///
-    func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     @objc func applicationWillResignActive(_ notification: Foundation.Notification) {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -8,6 +8,8 @@ final class AztecEditorViewController: UIViewController, Editor {
 
     private let content: String
 
+    private let viewProperties: EditorViewProperties
+
     private let aztecUIConfigurator = AztecUIConfigurator()
 
     /// The editor view.
@@ -64,9 +66,12 @@ final class AztecEditorViewController: UIViewController, Editor {
 
     private let textViewAttachmentDelegate: TextViewAttachmentDelegate
 
-    required init(content: String?, textViewAttachmentDelegate: TextViewAttachmentDelegate = AztecTextViewAttachmentHandler()) {
+    required init(content: String?,
+                  viewProperties: EditorViewProperties,
+                  textViewAttachmentDelegate: TextViewAttachmentDelegate = AztecTextViewAttachmentHandler()) {
         self.content = content ?? ""
         self.textViewAttachmentDelegate = textViewAttachmentDelegate
+        self.viewProperties = viewProperties
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -100,7 +105,7 @@ final class AztecEditorViewController: UIViewController, Editor {
 
 private extension AztecEditorViewController {
     func configureNavigationBar() {
-        title = NSLocalizedString("Description", comment: "The navigation bar title of the Aztec editor screen.")
+        title = viewProperties.navigationTitle
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(saveButtonTapped))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -85,8 +85,11 @@ class AztecEditorViewController: UIViewController, Editor {
     ///
     fileprivate var currentKeyboardFrame: CGRect = .zero
 
-    required init(content: String?) {
+    private weak var textViewAttachmentDelegate: TextViewAttachmentDelegate?
+
+    required init(content: String?, textViewAttachmentDelegate: TextViewAttachmentDelegate? = AztecTextViewAttachmentHandler()) {
         self.content = content ?? ""
+        self.textViewAttachmentDelegate = textViewAttachmentDelegate
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -165,7 +168,7 @@ private extension AztecEditorViewController {
                                                              .foregroundColor: StyleManager.wooCommerceBrandColor]
 
         textView.delegate = self
-        textView.textAttachmentDelegate = self
+        textView.textAttachmentDelegate = textViewAttachmentDelegate
         textView.backgroundColor = StyleManager.wooWhite
         textView.linkTextAttributes = linkAttributes
 
@@ -334,34 +337,6 @@ private extension AztecEditorViewController {
         onContentSave?(content)
 
         navigationController?.popViewController(animated: true)
-    }
-}
-
-// MARK: - TextViewAttachmentDelegate Conformance
-//
-extension AztecEditorViewController: TextViewAttachmentDelegate {
-    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
-
-    }
-
-    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
-        return nil
-    }
-
-    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
-        return UIImage.cameraImage
-    }
-
-    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
-
-    }
-
-    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
-
-    }
-
-    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
-
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -85,9 +85,9 @@ class AztecEditorViewController: UIViewController, Editor {
     ///
     fileprivate var currentKeyboardFrame: CGRect = .zero
 
-    private weak var textViewAttachmentDelegate: TextViewAttachmentDelegate?
+    private let textViewAttachmentDelegate: TextViewAttachmentDelegate
 
-    required init(content: String?, textViewAttachmentDelegate: TextViewAttachmentDelegate? = AztecTextViewAttachmentHandler()) {
+    required init(content: String?, textViewAttachmentDelegate: TextViewAttachmentDelegate = AztecTextViewAttachmentHandler()) {
         self.content = content ?? ""
         self.textViewAttachmentDelegate = textViewAttachmentDelegate
         super.init(nibName: nil, bundle: nil)
@@ -426,15 +426,5 @@ extension AztecEditorViewController: UITextViewDelegate {
         textView.inputAccessoryView = formatBar
 
         return true
-    }
-}
-
-// MARK: - Constants
-//
-extension AztecEditorViewController {
-    enum Constants {
-        static let headers = [Header.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
-        static let lists = [TextList.Style.unordered, .ordered]
-        static let moreAttachmentText = "more"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -154,9 +154,10 @@ private extension AztecEditorViewController {
     func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
         let referenceView = editorView.activeView
 
+        let bottomInset = view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom)
         let contentInsets  = UIEdgeInsets(top: referenceView.contentInset.top,
                                           left: 0,
-                                          bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom),
+                                          bottom: max(0, bottomInset),
                                           right: 0)
 
         htmlTextView.contentInset = contentInsets

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecTextViewAttachmentHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecTextViewAttachmentHandler.swift
@@ -1,0 +1,24 @@
+import Aztec
+
+/// Implements Aztec's `TextViewAttachmentDelegate` without media support.
+final class AztecTextViewAttachmentHandler: TextViewAttachmentDelegate {
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+    }
+
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
+        return nil
+    }
+
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
+        return UIImage.cameraImage
+    }
+
+    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
+    }
+
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
+    }
+
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
@@ -1,0 +1,94 @@
+import Aztec
+import UIKit
+import WordPressEditor
+
+/// Configures the Aztec UI components, like the styling and Auto Layout constraints.
+struct AztecUIConfigurator {
+    func configureEditorView(_ editorView: EditorView,
+                             textViewDelegate: UITextViewDelegate,
+                             textViewAttachmentDelegate: TextViewAttachmentDelegate) {
+        editorView.clipsToBounds = false
+        configureHTMLTextView(editorView.htmlTextView, textViewDelegate: textViewDelegate)
+        configureRichTextView(editorView.richTextView,
+                              textViewDelegate: textViewDelegate,
+                              textViewAttachmentDelegate: textViewAttachmentDelegate)
+    }
+
+    func configureConstraints(editorView: EditorView, editorContainerView: UIView, placeholderView: UIView) {
+        let richTextView = editorView.richTextView
+        let htmlTextView = editorView.htmlTextView
+
+        NSLayoutConstraint.activate([
+            richTextView.leadingAnchor.constraint(equalTo: editorContainerView.readableContentGuide.leadingAnchor),
+            richTextView.trailingAnchor.constraint(equalTo: editorContainerView.readableContentGuide.trailingAnchor),
+            richTextView.topAnchor.constraint(equalTo: editorContainerView.topAnchor),
+            richTextView.bottomAnchor.constraint(equalTo: editorContainerView.bottomAnchor)
+            ])
+
+        NSLayoutConstraint.activate([
+            htmlTextView.leftAnchor.constraint(equalTo: richTextView.leftAnchor),
+            htmlTextView.rightAnchor.constraint(equalTo: richTextView.rightAnchor),
+            htmlTextView.topAnchor.constraint(equalTo: richTextView.topAnchor),
+            htmlTextView.bottomAnchor.constraint(equalTo: richTextView.bottomAnchor)
+            ])
+
+        let insets = richTextView.textContainerInset
+
+        NSLayoutConstraint.activate([
+            placeholderView.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: insets.left + richTextView.textContainer.lineFragmentPadding),
+            placeholderView.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: -insets.right - richTextView.textContainer.lineFragmentPadding),
+            placeholderView.topAnchor.constraint(equalTo: richTextView.topAnchor, constant: insets.top),
+            placeholderView.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: insets.bottom)
+            ])
+    }
+}
+
+private extension AztecUIConfigurator {
+    func configureHTMLTextView(_ textView: UITextView, textViewDelegate: UITextViewDelegate) {
+        let accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
+        configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+
+        textView.isHidden = true
+        textView.delegate = textViewDelegate
+        textView.accessibilityIdentifier = "HTMLContentView"
+        textView.autocorrectionType = .no
+        textView.autocapitalizationType = .none
+
+        // We need this false to be able to set negative `scrollInset` values.
+        textView.clipsToBounds = false
+
+        textView.adjustsFontForContentSizeCategory = true
+        textView.smartDashesType = .no
+        textView.smartQuotesType = .no
+    }
+
+    func configureRichTextView(_ textView: TextView,
+                               textViewDelegate: UITextViewDelegate,
+                               textViewAttachmentDelegate: TextViewAttachmentDelegate) {
+        textView.load(WordPressPlugin())
+
+        let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
+        self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+
+        let linkAttributes: [NSAttributedString.Key: Any] = [.underlineStyle: NSUnderlineStyle.single.rawValue,
+                                                             .foregroundColor: StyleManager.wooCommerceBrandColor]
+
+        textView.delegate = textViewDelegate
+        textView.textAttachmentDelegate = textViewAttachmentDelegate
+        textView.backgroundColor = StyleManager.wooWhite
+        textView.linkTextAttributes = linkAttributes
+
+        // We need this false to be able to set negative `scrollInset` values.
+        textView.clipsToBounds = false
+
+        textView.smartDashesType = .no
+        textView.smartQuotesType = .no
+    }
+
+    func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
+        textView.accessibilityLabel = accessibilityLabel
+        textView.keyboardDismissMode = .interactive
+        textView.textColor = UIColor.darkText
+        textView.translatesAutoresizingMaskIntoConstraints = false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
@@ -68,7 +68,7 @@ private extension AztecUIConfigurator {
         textView.load(WordPressPlugin())
 
         let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
-        self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+        configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
 
         let linkAttributes: [NSAttributedString.Key: Any] = [.underlineStyle: NSUnderlineStyle.single.rawValue,
                                                              .foregroundColor: StyleManager.wooCommerceBrandColor]

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -7,14 +7,14 @@ protocol Editor {
     init(content: String?)
 }
 
-/// This class takes care of instantiating the correct editor based on the App settings, feature flags,
-/// etc.
+/// This class takes care of instantiating the editor.
 ///
 final class EditorFactory {
 
     // MARK: - Editor: Instantiation
 
-    func instantiateEditor(for product: Product, onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
+    func productDescriptionEditor(product: Product,
+                                  onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
         let editor = AztecEditorViewController(content: product.fullDescription)
         editor.onContentSave = onContentSave
         return editor

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -13,7 +13,9 @@ final class EditorFactory {
 
     func productDescriptionEditor(product: Product,
                                   onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
-        let editor = AztecEditorViewController(content: product.fullDescription)
+        let navigationTitle = NSLocalizedString("Description", comment: "The navigation bar title of the Aztec editor screen.")
+        let viewProperties = EditorViewProperties(navigationTitle: navigationTitle)
+        let editor = AztecEditorViewController(content: product.fullDescription, viewProperties: viewProperties)
         editor.onContentSave = onContentSave
         return editor
     }

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -3,8 +3,6 @@ import Yosemite
 protocol Editor {
     typealias OnContentSave = (_ content: String) -> Void
     var onContentSave: OnContentSave? { get }
-
-    init(content: String?)
 }
 
 /// This class takes care of instantiating the editor.

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -1,0 +1,22 @@
+import Yosemite
+
+protocol Editor {
+    typealias OnContentSave = (_ content: String) -> Void
+    var onContentSave: OnContentSave? { get }
+
+    init(content: String?)
+}
+
+/// This class takes care of instantiating the correct editor based on the App settings, feature flags,
+/// etc.
+///
+final class EditorFactory {
+
+    // MARK: - Editor: Instantiation
+
+    func instantiateEditor(for product: Product, onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
+        let editor = AztecEditorViewController(content: product.fullDescription)
+        editor.onContentSave = onContentSave
+        return editor
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorViewProperties.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorViewProperties.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+/// Configurable UI properties for a text editor.
+struct EditorViewProperties {
+    let navigationTitle: String
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
+		024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3062372C18D006658FE /* AztecUIConfigurator.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
 		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
@@ -502,6 +503,7 @@
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
+		024DF3062372C18D006658FE /* AztecUIConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUIConfigurator.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
 		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				025FDD3123717D2900824006 /* EditorFactory.swift */,
 				025FDD3323717D4900824006 /* AztecEditorViewController.swift */,
 				0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */,
+				024DF3062372C18D006658FE /* AztecUIConfigurator.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -2545,6 +2548,7 @@
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
+				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
 		024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3062372C18D006658FE /* AztecUIConfigurator.swift */; };
+		024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3082372CA00006658FE /* EditorViewProperties.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
 		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
@@ -504,6 +505,7 @@
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
 		024DF3062372C18D006658FE /* AztecUIConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUIConfigurator.swift; sourceTree = "<group>"; };
+		024DF3082372CA00006658FE /* EditorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorViewProperties.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
 		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
@@ -1002,6 +1004,7 @@
 				025FDD3323717D4900824006 /* AztecEditorViewController.swift */,
 				0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */,
 				024DF3062372C18D006658FE /* AztecUIConfigurator.swift */,
+				024DF3082372CA00006658FE /* EditorViewProperties.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -2534,6 +2537,7 @@
 			files = (
 				B5F571A421BEC90D0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.swift in Sources */,
 				D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */,
+				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
 				CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */,
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
+		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
+		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */; };
@@ -500,6 +502,8 @@
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
+		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
+		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -987,6 +991,15 @@
 			path = Developer;
 			sourceTree = "<group>";
 		};
+		025FDD3023717D1A00824006 /* Editor */ = {
+			isa = PBXGroup;
+			children = (
+				025FDD3123717D2900824006 /* EditorFactory.swift */,
+				025FDD3323717D4900824006 /* AztecEditorViewController.swift */,
+			);
+			path = Editor;
+			sourceTree = "<group>";
+		};
 		0269177E23260090002AFC20 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1414,6 +1427,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				025FDD3023717D1A00824006 /* Editor */,
 				743E271E21AEF13E00D6DC82 /* Fancy Alerts */,
 				02695768237262DE001BA0BF /* Keyboard */,
 				CED6021A20B35FBF0032C639 /* ReusableViews */,
@@ -2424,6 +2438,8 @@
 				"${BUILT_PRODUCTS_DIR}/SVProgressHUD/SVProgressHUD.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/UIDeviceIdentifier/UIDeviceIdentifier.framework",
+				"${BUILT_PRODUCTS_DIR}/WordPress-Aztec-iOS/Aztec.framework",
+				"${BUILT_PRODUCTS_DIR}/WordPress-Editor-iOS/WordPressEditor.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressKit/WordPressKit.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressUI/WordPressUI.framework",
@@ -2453,6 +2469,8 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SVProgressHUD.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UIDeviceIdentifier.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Aztec.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressEditor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressShared.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressUI.framework",
@@ -2683,6 +2701,7 @@
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,
 				74AAF6A5212A04A900C612B0 /* ChartMarker.swift in Sources */,
 				CE32B11520BF8779006FBCF4 /* FulfillButtonTableViewCell.swift in Sources */,
+				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,
 				020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
@@ -2695,6 +2714,7 @@
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
+				025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */,
 				743EDD9F214B05350039071B /* TopEarnerStatsItem+Woo.swift in Sources */,
 				B5BBD6DE21B1703700E3207E /* PushNotificationsManager.swift in Sources */,
 				CE1EC8EC20B8A3FF009762BF /* LeftImageTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
 		0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */; };
+		02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
@@ -509,6 +510,7 @@
 		02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
 		0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserverTests.swift; sourceTree = "<group>"; };
+		0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecTextViewAttachmentHandler.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopBannerFactory.swift; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
@@ -996,6 +998,7 @@
 			children = (
 				025FDD3123717D2900824006 /* EditorFactory.swift */,
 				025FDD3323717D4900824006 /* AztecEditorViewController.swift */,
+				0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -2623,6 +2626,7 @@
 				B57C744720F55BC800EEFC87 /* UIView+Helpers.swift in Sources */,
 				B5A82EE221025C450053ADC8 /* FulfillViewController.swift in Sources */,
 				B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */,
+				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
 				B57C5C9221B80E3C00FF82B2 /* APNSDevice+Woo.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,


### PR DESCRIPTION
Aztec view controller - part 1 - without format bar for #1421 

- [x] ⚠️ update PR base after https://github.com/woocommerce/woocommerce-ios/pull/1430 is merged

## Changes
- Added Aztec editor pod `WordPress-Editor-iOS`
- Created `AztecEditorViewController` that contains the Aztec editor views (HTML/Rich Text views) and a placeholder without any formatting support yet (#1421 subtask: Aztec view controller - part 2 - format bar support)
  - Moved some configurable editor UI properties to `EditorViewProperties` (lemme know if there is a better naming!)
  - Extracted UI configurations to `AztecUIConfigurator`
  - Extracted `TextViewAttachmentDelegate` implementation to `AztecTextViewAttachmentHandler` without media support yet (a separate subtask in #1421)
- Created `EditorFactory` to instantiate a `Editor & UIViewController` for Product description
- In `ProductsViewController`, temporarily navigated to edit Product description screen on tapping a Product

## Testing
- Launch the app
- Go to the Products tab
- Tap on a Product --> try editing the product description, removing all the text to see the placeholder, and adding some text again

## Example screenshots

some text | empty text
-- | --
![Simulator Screen Shot - iPhone SE - 2019-11-06 at 17 27 37](https://user-images.githubusercontent.com/1945542/68286709-8006c380-00bc-11ea-9732-c7081c40b1ab.png) | ![Simulator Screen Shot - iPhone SE - 2019-11-06 at 17 27 42](https://user-images.githubusercontent.com/1945542/68286710-8006c380-00bc-11ea-8d27-e4b6ad91a4eb.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
