### PR TITLE
Fulfill Order: fixed content mode of product's images

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
@@ -82,6 +82,8 @@ final class PickListTableViewCell: UITableViewCell {
     func setupImageView() {
         productImageView.image = .productImage
         productImageView.tintColor = StyleManager.wooGreyBorder
+        productImageView.contentMode = .scaleAspectFill
+        productImageView.clipsToBounds = true
     }
 
     func setupNameLabel() {


### PR DESCRIPTION
Fixes #1360

## Testing
- Navigate to a Fulfill Order screen
- Check that product's images now are not skewed

## Screenshots

| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2019-11-07 at 16 36 32](https://user-images.githubusercontent.com/495617/68403576-72fdd900-017d-11ea-9bc8-18a55b9b5c6b.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-07 at 16 35 38](https://user-images.githubusercontent.com/495617/68403582-7729f680-017d-11ea-87fe-8e6404ab560e.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
