### PR TITLE
Order detail flow: fixed UI appearance with Dark mode enabled

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 - Enhancement: The Reviews tab now presents all the Product Reviews
 - bugfix: fixed UI appearance on cells of Order List when tappen with dark mode enabled.
-- bugfix: fixed UI appearance on Order Detail flow with dark mode enabled.
+- Updated appearance of Order Details - temporarily disabling dark mode.
 
 3.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,8 @@
 3.1
 -----
 - Enhancement: The Reviews tab now presents all the Product Reviews
-- bugfix: now Order Detail should not have some dark cells when launching the app in Dark mode.
 - bugfix: fixed UI appearance on cells of Order List when tappen with dark mode enabled.
+- bugfix: fixed UI appearance on Order Detail flow with dark mode enabled.
 
 3.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/Cells/BillingAddressTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/Cells/BillingAddressTableViewCell.swift
@@ -27,9 +27,28 @@ final class BillingAddressTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureBackground()
+        configureLabels()
+    }
+}
+
+/// MARK: - Private Methods
+///
+private extension BillingAddressTableViewCell {
+
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
+    }
+    
+    func configureLabels(){
         nameLabel.applyBodyStyle()
         addressLabel.applyBodyStyle()
     }
+
 }
 
 /// MARK: - Testability

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
@@ -72,13 +72,45 @@ final class PickListTableViewCell: UITableViewCell {
         super.awakeFromNib()
 
         selectionStyle = .none
-
+        configureBackground()
         setupImageView()
         setupNameLabel()
         setupQuantityLabel()
         setupSkuLabel()
     }
+}
 
+
+// MARK: - Public Methods
+//
+extension PickListTableViewCell {
+    func configure(item: OrderItemViewModel) {
+        if item.productHasImage,
+        let imageURL = item.imageURL {
+                productImageView.downloadImage(from: imageURL,
+                                               placeholderImage: UIImage.productPlaceholderImage)
+        } else {
+            productImageView.image = .productPlaceholderImage
+        }
+
+        name = item.name
+        quantity = item.quantity
+        sku = item.sku
+    }
+}
+
+// MARK: - Private Methods
+//
+private extension PickListTableViewCell {
+
+    private func configureBackground() {
+        applyDefaultBackgroundStyle()
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
+    }
+    
     func setupImageView() {
         productImageView.image = .productImage
         productImageView.tintColor = StyleManager.wooGreyBorder
@@ -99,24 +131,5 @@ final class PickListTableViewCell: UITableViewCell {
     func setupSkuLabel() {
         skuLabel.applySecondaryFootnoteStyle()
         skuLabel?.text = ""
-    }
-}
-
-
-// MARK: - Public Methods
-//
-extension PickListTableViewCell {
-    func configure(item: OrderItemViewModel) {
-        if item.productHasImage,
-        let imageURL = item.imageURL {
-                productImageView.downloadImage(from: imageURL,
-                                               placeholderImage: UIImage.productPlaceholderImage)
-        } else {
-            productImageView.image = .productPlaceholderImage
-        }
-
-        name = item.name
-        quantity = item.quantity
-        sku = item.sku
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
@@ -85,14 +85,7 @@ final class PickListTableViewCell: UITableViewCell {
 ///
 extension PickListTableViewCell {
     func configure(item: OrderItemViewModel) {
-        if item.productHasImage,
-        let imageURL = item.imageURL {
-                productImageView.downloadImage(from: imageURL,
-                                               placeholderImage: UIImage.productPlaceholderImage)
-        } else {
-            productImageView.image = .productPlaceholderImage
-        }
-
+        productImageView.downloadImage(from: item.imageURL, placeholderImage: UIImage.productPlaceholderImage)
         name = item.name
         quantity = item.quantity
         sku = item.sku

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.swift
@@ -81,8 +81,8 @@ final class PickListTableViewCell: UITableViewCell {
 }
 
 
-// MARK: - Public Methods
-//
+/// MARK: - Public Methods
+///
 extension PickListTableViewCell {
     func configure(item: OrderItemViewModel) {
         if item.productHasImage,
@@ -99,11 +99,11 @@ extension PickListTableViewCell {
     }
 }
 
-// MARK: - Private Methods
-//
+/// MARK: - Private Methods
+///
 private extension PickListTableViewCell {
 
-    private func configureBackground() {
+    func configureBackground() {
         applyDefaultBackgroundStyle()
         
         //Background when selected

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/Cells/PickListTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,30 +14,30 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="123"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="122.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="123"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p6h-Fq-FjW">
-                        <rect key="frame" x="16" y="19" width="44" height="44"/>
+                        <rect key="frame" x="15" y="19" width="44" height="44"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="44" id="9vH-gW-wOd"/>
                             <constraint firstAttribute="height" constant="44" id="hcJ-qM-Kx2"/>
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="En5-gn-p39">
-                        <rect key="frame" x="76" y="19" width="228" height="85"/>
+                        <rect key="frame" x="75" y="19" width="230" height="85"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HX7-V5-bhX">
-                                <rect key="frame" x="0.0" y="0.0" width="228" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="230" height="50"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Title Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="14R-zK-tgC">
-                                        <rect key="frame" x="0.0" y="0.0" width="188.5" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="190.5" height="50"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="893" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pPE-SE-pY7">
-                                        <rect key="frame" x="196.5" y="0.0" width="31.5" height="50"/>
+                                        <rect key="frame" x="198.5" y="0.0" width="31.5" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="bIk-vq-m2l"/>
                                         </constraints>
@@ -48,7 +46,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="pPE-SE-pY7" secondAttribute="trailing" id="0CJ-5r-B3p"/>
                                     <constraint firstItem="14R-zK-tgC" firstAttribute="leading" secondItem="HX7-V5-bhX" secondAttribute="leading" id="BTS-zX-yTf"/>
@@ -60,7 +58,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SKU" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7JH-rt-n9v">
-                                <rect key="frame" x="0.0" y="69" width="228" height="16"/>
+                                <rect key="frame" x="0.0" y="69" width="230" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -99,6 +99,10 @@ class ProductDetailsTableViewCell: UITableViewCell {
 private extension ProductDetailsTableViewCell {
     func configureBackground() {
         applyDefaultBackgroundStyle()
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 
     func configureProductImageView() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LeftImageTableViewCell.swift
@@ -38,6 +38,10 @@ class LeftImageTableViewCell: UITableViewCell {
 
     private func configureBackground() {
         applyDefaultBackgroundStyle()
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/StatusListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/StatusListTableViewCell.swift
@@ -42,6 +42,10 @@ final class StatusListTableViewCell: UITableViewCell {
 private extension StatusListTableViewCell {
     func configureBackground() {
         applyDefaultBackgroundStyle()
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 
     func styleCheckmark() {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -33,6 +33,10 @@ class WooBasicTableViewCell: UITableViewCell {
 
     func configureBackground() {
         applyDefaultBackgroundStyle()
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 
     /// Set up the cell selection style


### PR DESCRIPTION
Fixes #1447 

I fixed all the issues on Order Detail and Order Fulfillment when dark mode is enabled (also some cell selection styles not mentioned on issue #1447). 

## TODO

- [x] Edit Order status
- [x] Processing Order: Product > Begin Fulfillment
- [x] Completed Order: Product > Details
- [x] Customer > View Billing Information

## Testing
1) Enable dark mode from device settings.
2) Navigate to an order detail.
3) Tap on every cell and check that every selection style it's ok.
4) Navigate on every sub-flow, and check that appearance of these sections it's ok. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
