### PR TITLE
Product List: fixed dark mode appearance

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -18,6 +18,7 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureBackground()
         configureSubviews()
         configureNameLabel()
         configureDetailsLabel()
@@ -75,6 +76,14 @@ private extension ProductsTabProductTableViewCell {
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
         return contentStackView
+    }
+    
+    func configureBackground() {
+        backgroundColor = StyleManager.wooWhite
+        
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 
     func configureNameLabel() {


### PR DESCRIPTION
Fixes #1453 

The scope of the PR is limited to just making the Product List screen usable in Dark mode when building the codebase with the release version of Xcode 11.

## Testing

1) Activate dark mode
2) Navigate to Product List
3) Check that everything is visually ok (readable, and without dark background)

| Before             |  After |  With the cell selected |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2019-11-11 at 15 35 54](https://user-images.githubusercontent.com/495617/68597134-bbc6d200-049c-11ea-8d8b-f11ab9e1ec8c.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-11 at 15 57 49](https://user-images.githubusercontent.com/495617/68597139-bec1c280-049c-11ea-8c08-4a372a4c32c2.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-11 at 16 00 35](https://user-images.githubusercontent.com/495617/68597146-c1241c80-049c-11ea-811e-f1cb836643db.png)



Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
