### PR TITLE
Extend `Array` to transform an array of integers into a string

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -224,6 +224,8 @@
 		CE6BFEE52236BF05005C79FB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE42236BF05005C79FB /* Product.swift */; };
 		CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE72236D133005C79FB /* ProductDimensions.swift */; };
 		CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE92236E191005C79FB /* ProductType.swift */; };
+		CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6D666B2379E19D007835A1 /* Array+Woo.swift */; };
+		CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */; };
 		CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */; };
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
@@ -504,6 +506,8 @@
 		CE6BFEE42236BF05005C79FB /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		CE6BFEE72236D133005C79FB /* ProductDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDimensions.swift; sourceTree = "<group>"; };
 		CE6BFEE92236E191005C79FB /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
+		CE6D666B2379E19D007835A1 /* Array+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Woo.swift"; sourceTree = "<group>"; };
+		CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayWooTests.swift; sourceTree = "<group>"; };
 		CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
@@ -988,10 +992,11 @@
 		B5BB1D0A20A204F400112D92 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				CE6D666B2379E19D007835A1 /* Array+Woo.swift */,
 				B58E5BE920FFB3D0003C986E /* CodingUserInfoKey+Woo.swift */,
 				B5BB1D0B20A2050300112D92 /* DateFormatter+Woo.swift */,
-				B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */,
 				B53EF5312180F21C003E146F /* Dictionary+Woo.swift */,
+				B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -999,6 +1004,7 @@
 		B5C6FCC620A32E3100A4F8E4 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */,
 				B5C6FCC720A32E4800A4F8E4 /* DateFormatterWooTests.swift */,
 			);
 			path = Extensions;
@@ -1435,6 +1441,7 @@
 				740211E321939C84002248DA /* CommentResultMapper.swift in Sources */,
 				45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */,
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
+				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
@@ -1459,6 +1466,7 @@
 				B524194321AC622500D6FC0A /* DotcomDeviceMapperTests.swift in Sources */,
 				74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */,
 				D8FBFF1C22D51C34006E3336 /* OrderStatsRemoteV4Tests.swift in Sources */,
+				CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */,
 				CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */,
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,

--- a/Networking/Networking/Extensions/Array+Woo.swift
+++ b/Networking/Networking/Extensions/Array+Woo.swift
@@ -5,9 +5,9 @@ import Foundation
 //
 extension Array where Element == Int {
 
-    /// Returns a de-duplicated array of integer values as a comma-separated String.
+    /// Returns a sorted, de-duplicated array of integer values as a comma-separated String.
     ///
-    func intToString() -> String {
+    func sortedUniqueIntToString() -> String {
         let uniqued: Array = Array(Set<Int>(self))
 
         let items = uniqued.sorted()

--- a/Networking/Networking/Extensions/Array+Woo.swift
+++ b/Networking/Networking/Extensions/Array+Woo.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+
+// MARK: - Array Helpers
+//
+extension Array where Element == Int {
+
+    /// Returns a de-duplicated array of integer values as a comma-separated String.
+    ///
+    func intToString() -> String {
+        let uniqued: Array = Array(Set<Int>(self))
+
+        let items = uniqued.sorted()
+        .map { String($0) }
+        .filter { !$0.isEmpty }
+        .joined(separator: ",")
+
+        return items
+    }
+}

--- a/Networking/Networking/Remote/RefundsRemote.swift
+++ b/Networking/Networking/Remote/RefundsRemote.swift
@@ -47,9 +47,7 @@ public final class RefundsRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadRefunds(for siteID: Int, by orderID: Int, with refundIDs: [Int], completion: @escaping ([Refund]?, Error?) -> Void) {
-        let stringOfRefundIDs = refundIDs.map { String($0) }
-            .filter { !$0.isEmpty }
-            .joined(separator: ",")
+        let stringOfRefundIDs = refundIDs.intToString()
         let parameters = [ ParameterKey.include: stringOfRefundIDs ]
         let path = "\(Path.orders)/" + String(orderID) + "/" + "\(Path.refunds)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)

--- a/Networking/Networking/Remote/RefundsRemote.swift
+++ b/Networking/Networking/Remote/RefundsRemote.swift
@@ -47,7 +47,7 @@ public final class RefundsRemote: Remote {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadRefunds(for siteID: Int, by orderID: Int, with refundIDs: [Int], completion: @escaping ([Refund]?, Error?) -> Void) {
-        let stringOfRefundIDs = refundIDs.intToString()
+        let stringOfRefundIDs = refundIDs.sortedUniqueIntToString()
         let parameters = [ ParameterKey.include: stringOfRefundIDs ]
         let path = "\(Path.orders)/" + String(orderID) + "/" + "\(Path.refunds)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)

--- a/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
@@ -11,7 +11,7 @@ class ArrayWooTests: XCTestCase {
     func testArrayWithZeroValueReturnsAString() {
         let exampleIDs = [0]
         let expected = "0"
-        let actual = exampleIDs.intToString()
+        let actual = exampleIDs.sortedUniqueIntToString()
 
         XCTAssertEqual(expected, actual)
     }
@@ -21,7 +21,7 @@ class ArrayWooTests: XCTestCase {
     func testArrayWithSingleValueReturnsAString() {
         let exampleIDs = [999]
         let expected = "999"
-        let actual = exampleIDs.intToString()
+        let actual = exampleIDs.sortedUniqueIntToString()
 
         XCTAssertEqual(expected, actual)
     }
@@ -31,7 +31,7 @@ class ArrayWooTests: XCTestCase {
     func testEmptyArrayReturnsAnEmptyString() {
         let exampleIDs = [Int]()
         let expected = ""
-        let actual = exampleIDs.intToString()
+        let actual = exampleIDs.sortedUniqueIntToString()
 
         XCTAssertEqual(expected, actual)
     }
@@ -41,7 +41,7 @@ class ArrayWooTests: XCTestCase {
     func testArrayWithValuesReturnsSortedValuesAsString() {
         let exampleIDs = [75, 37, 259, 16, 83]
         let expected = "16,37,75,83,259"
-        let actual = exampleIDs.intToString()
+        let actual = exampleIDs.sortedUniqueIntToString()
 
         XCTAssertEqual(expected, actual)
     }
@@ -51,7 +51,7 @@ class ArrayWooTests: XCTestCase {
     func testArrayWithDuplicateValuesReturnsWithNoDuplicates() {
         let exampleIDs = [123, 6, 13, 259, 3, 321, 7, 6, 87, 3, 9, 17, 85, 87]
         let expected = "3,6,7,9,13,17,85,87,123,259,321"
-        let actual = exampleIDs.intToString()
+        let actual = exampleIDs.sortedUniqueIntToString()
 
         XCTAssertEqual(expected, actual)
     }

--- a/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
@@ -39,9 +39,19 @@ class ArrayWooTests: XCTestCase {
     /// Verifies that an array with int values produces a valid String.
     ///
     func testArrayWithValuesReturnsSortedValuesAsString() {
-        let refundIDs = [75, 37, 259, 16, 83]
+        let exampleIDs = [75, 37, 259, 16, 83]
         let expected = "16,37,75,83,259"
-        let actual = refundIDs.intToString()
+        let actual = exampleIDs.intToString()
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    /// Verifies that an array with duplicate entries produces a de-duplicated, valid String.
+    ///
+    func testArrayWithDuplicateValuesReturnsWithNoDuplicates() {
+        let exampleIDs = [123, 6, 13, 259, 3, 321, 7, 6, 87, 3, 9, 17, 85, 87]
+        let expected = "3,6,7,9,13,17,85,87,123,259,321"
+        let actual = exampleIDs.intToString()
 
         XCTAssertEqual(expected, actual)
     }

--- a/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Networking
+
+
+/// Array+Woo Unit Tests
+///
+class ArrayWooTests: XCTestCase {
+
+    /// Verifies that a zero value in an array produces a valid String.
+    ///
+    func testArrayWithZeroValueReturnsAString() {
+        let exampleIDs = [0]
+        let expected = "0"
+        let actual = exampleIDs.intToString()
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    /// Verifies that a single value in an array produces a valid String.
+    ///
+    func testArrayWithSingleValueReturnsAString() {
+        let exampleIDs = [999]
+        let expected = "999"
+        let actual = exampleIDs.intToString()
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    /// Verifies that an empty array produces an emtpy String.
+    ///
+    func testEmptyArrayReturnsAnEmptyString() {
+        let exampleIDs = [Int]()
+        let expected = ""
+        let actual = exampleIDs.intToString()
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    /// Verifies that an array with int values produces a valid String.
+    ///
+    func testArrayWithValuesReturnsSortedValuesAsString() {
+        let refundIDs = [75, 37, 259, 16, 83]
+        let expected = "16,37,75,83,259"
+        let actual = refundIDs.intToString()
+
+        XCTAssertEqual(expected, actual)
+    }
+}


### PR DESCRIPTION
Per [Cesar's comment](https://github.com/woocommerce/woocommerce-ios/pull/1390/files#r340346944), I added a new function that extends `Array`. It convert arrays of ints to a single comma-separated string.

### To test
- run the unit tests and ensure they pass

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
