### PR TITLE
Update Installable builds for AppCenter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-appcenter (1.6.0)
     fastlane-plugin-sentry (1.6.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -257,6 +258,7 @@ DEPENDENCIES
   cocoapods (~> 1.8.3)!
   dotenv!
   fastlane (~> 2)!
+  fastlane-plugin-appcenter (= 1.6.0)
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   rake!

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -274,13 +274,16 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
 
     sh("mv ../build/WooCommerce.ipa \"../build/WooCommerce Alpha.ipa\"")
     
-    hockey(
-      api_token: get_required_env("HOCKEY_API_TOKEN"),        
-      public_identifier: get_required_env("HOCKEY_INSTALLABLE_BUILDS_PUBLIC_ID"),
-      notify: "0",
-      status: "2",
+    # NOTE: "ipa" parameter is deprecated in appcenter_upload 1.6.0, but there's a bug in the action that
+    # makes the default gym output override the "file" parameter. 
+    appcenter_upload(
+      api_token: get_required_env("APPCENTER_API_TOKEN"),
+      owner_name: "Hogwarts-Organization",
+      owner_type: "organization", 
+      app_name: "WooCommerce-Installable-Builds",
       ipa: "build/WooCommerce Alpha.ipa",
-      dsym: "build/WooCommerce.app.dSYM.zip",
+      destinations: "All-users-of-WooCommerce-Installable-Builds",
+      notify_testers: false 
     )
 
     # Getting the download link from the HockeyApp Api, since `hockey(..)` only gives us the app link
@@ -290,6 +293,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     versions = JSON.parse(result)
 
     download_url = versions["app_versions"].find {|v| v["version"] == build_number}["download_url"]
+    UI.message("Provided URL: #{Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]}")
     UI.message("Successfully built and uploaded installable build here: #{download_url}")
 
     # Create a comment.json file so that Peril to comment with the build details, if this is running on CI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -286,18 +286,13 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       notify_testers: false 
     )
 
-    # Getting the download link from the HockeyApp Api, since `hockey(..)` only gives us the app link
-    # See documentation here: https://support.hockeyapp.net/kb/api/api-versions
-    url = "https://rink.hockeyapp.net/api/2/apps/#{get_required_env("HOCKEY_INSTALLABLE_BUILDS_PUBLIC_ID")}/app_versions"
-    result = open(url, {"X-HockeyAppToken" => get_required_env("HOCKEY_API_TOKEN")}).read
-    versions = JSON.parse(result)
 
-    download_url = versions["app_versions"].find {|v| v["version"] == build_number}["download_url"]
-    UI.message("Provided URL: #{Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]}")
+    download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]
     UI.message("Successfully built and uploaded installable build here: #{download_url}")
+    install_url = "https://install.appcenter.ms/orgs/Hogwarts-Organization/apps/WooCommerce-Installable-Builds"
 
     # Create a comment.json file so that Peril to comment with the build details, if this is running on CI
-    comment_body = "You can test the changes on this Pull Request by downloading it from HockeyApp [here](#{download_url}). If you need access to this, you can ask a maintainer to add you."
+    comment_body = "You can test the changes on this Pull Request by downloading it from AppCenter [here](#{install_url}) with build number: #{build_number}. IPA is available [here](#{download_url}). If you need access to this, you can ask a maintainer to add you."
     File.write("comment.json", { body: comment_body }.to_json)
   end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -8,3 +8,4 @@ end
 
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.1'
 gem 'fastlane-plugin-sentry'
+gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
This PR updates the Installable builds lane in order to make it work with AppCenter. 

Currently AppCenter doesn't support release URLs (related issue and discussion here: https://github.com/Microsoft/fastlane-plugin-appcenter/issues/49), so it's not possible to link to the version to download, but only to the general download page. 

I updated the message to make it show a link to the general download page and the build number (which is unique because it's the CircleCI build number) related to this PR. Users have to look for the right build on the page. 

I also added the direct link to the .ipa file, but it's only useful if you have XCode to install it. 

I'll monitor the AppCenter issue and update our tooling as soon as it's solved and, in the meantime, I'll post an update on the relevant blogs to make users aware of this. 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
