### PR TITLE
Order Detail: fixed wrong spacing between sections

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - Updated appearance of Order Details - temporarily disabling dark mode.
 - bugfix: fixed UI appearance on cells of Order List when tappen with dark mode enabled.
 - bugfix: Reviews no longer convert to partial dark mode. Dark mode coming soon!
+- bugfix: Order Details now has the right space between cells.
 
 3.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -79,7 +79,6 @@ private extension OrderDetailsViewController {
         view.backgroundColor = StyleManager.tableViewBackgroundColor
         tableView.backgroundColor = StyleManager.tableViewBackgroundColor
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
-        tableView.estimatedSectionFooterHeight = Constants.rowHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.refreshControl = refreshControl
@@ -363,7 +362,16 @@ extension OrderDetailsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        // Remove the first header
+        if section == 0{
+            return CGFloat.leastNormalMagnitude
+        }
+        
         return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return CGFloat.leastNormalMagnitude
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -363,13 +363,13 @@ extension OrderDetailsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         // Remove the first header
-        if section == 0{
+        if section == 0 {
             return CGFloat.leastNormalMagnitude
         }
-        
+
         return UITableView.automaticDimension
     }
-    
+
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return CGFloat.leastNormalMagnitude
     }


### PR DESCRIPTION
Fixes #1455 

## Testing
1) Navigate to an order detail
2) Check that the first section on the Order Screen with the customer name and status doesn't have any space above it
3) Check that the spacing between sections looks like in Fulfill order screen.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![68604987-e5d3c080-04ab-11ea-82c1-b70e8c101757](https://user-images.githubusercontent.com/495617/68687650-d321c000-056d-11ea-9819-6fe47784d1b4.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-12 at 16 48 17](https://user-images.githubusercontent.com/495617/68687659-d61cb080-056d-11ea-8bd2-f1a891bafb27.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
