### PR TITLE
Remove a warning

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -636,7 +636,6 @@ private extension FulfillViewController {
         let address: Section = {
             var rows: [Row] = []
             
-            let productsList = self.products ?? []
             if shippingLines.count > 0 {
                 rows.append(.shippingMethod)
             }


### PR DESCRIPTION
There seems to be a warning on develop, on a variable that is initialised but never used.

## Changes
- Remove the warning by removing the initialisation of the unused variable

## Testing
- Build the branch, check if the warning is gone.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
