### PR TITLE
Fixed Settings cells selection style with dark mode enabled

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - bugfix: fixed UI appearance on cells of Order List when tappen with dark mode enabled.
 - bugfix: Reviews no longer convert to partial dark mode. Dark mode coming soon!
 - bugfix: Order Details now has the right space between cells.
+- bugfix: Settings no longer convert to partial dark model.
 
 3.0
 -----

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
@@ -21,5 +21,9 @@ class BasicTableViewCell: UITableViewCell {
 private extension BasicTableViewCell {
     func configureBackground() {
         applyDefaultBackgroundStyle()
+
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/1465

## Testing
1) Enable dark mode
2) Navigate to settings
3) Make sure that cell selection background is grey and not black

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![68780524-bc936b80-0636-11ea-9053-6abfaa60fbdf](https://user-images.githubusercontent.com/495617/68845525-d9c64980-06cb-11ea-84cf-211e75933217.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-14 at 10 42 12](https://user-images.githubusercontent.com/495617/68845539-dcc13a00-06cb-11ea-9617-8d7df1bd47a1.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
