### PR TITLE
Fixed cell selection style in Reviews with dark mode enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/ProductReviewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/ProductReviewTableViewCell.swift
@@ -103,6 +103,10 @@ private extension ProductReviewTableViewCell {
 
     func configureBackground() {
         applyDefaultBackgroundStyle()
+
+        //Background when selected
+        selectedBackgroundView = UIView()
+        selectedBackgroundView?.backgroundColor = StyleManager.tableViewCellSelectionStyle
     }
 
     func configureSubjectLabel() {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/1475

This should be the last PR for just making the app usable in Dark mode when building the codebase with the release version of Xcode 11 on iOS 13.

## Testing
1) Enable dark mode
2) Navigate to product reviews
3) Make sure that cell selection background is grey and not black

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2019-11-14 at 10 48 29](https://user-images.githubusercontent.com/495617/68847074-55c19100-06ce-11ea-9ea9-d7ea58d2f04c.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-14 at 10 59 02](https://user-images.githubusercontent.com/495617/68847084-59551800-06ce-11ea-9a50-708bfdbeec26.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
