### PR TITLE
Updated sorting in Product List

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -235,7 +235,7 @@ private extension ProductsViewController {
     func createResultsController(siteID: Int) -> ResultsController<StorageProduct> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(key: "dateModified", ascending: true)
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -19,7 +19,7 @@ final class ProductSearchUICommand: SearchUICommand {
     func createResultsController() -> ResultsController<ResultsControllerModel> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(key: "dateModified", ascending: true)
+        let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }


### PR DESCRIPTION
Fixes #1415 

Now the product list is sorted Alphabetically by product title, like in Android.

## Testing
1) Go to Product List
2) Check that product are sorted alphabetically
3) Check that product in search are sorted alphabetically

## Screenshot

<img src="https://user-images.githubusercontent.com/495617/68863950-98946080-06f0-11ea-9dc8-2f7d6a93855f.png" data-canonical-src="https://user-images.githubusercontent.com/495617/68863950-98946080-06f0-11ea-9dc8-2f7d6a93855f.png" width="350" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
