### PR TITLE
Fixed Shipping Method cell on Order Details with dark mode enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/CustomerNoteTableViewCell.swift
@@ -30,12 +30,26 @@ final class CustomerNoteTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
-        headlineLabel.applyHeadlineStyle()
-        bodyLabel.applyBodyStyle()
+        configureBackground()
+        configureLabels()
     }
 
 }
+
+
+// MARK: - Private Methods
+//
+private extension CustomerNoteTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureLabels() {
+        headlineLabel.applyHeadlineStyle()
+        bodyLabel.applyBodyStyle()
+    }
+}
+
 
 /// MARK: - Testability
 extension CustomerNoteTableViewCell {


### PR DESCRIPTION
Fixes #1479 

## Testing
1) Enable dark mode
2) Navigate to an order which contains shipping details
3) Check that everything is ok like in the screenshot

| Before            |  After |
:-------------------------:|:-------------------------:
![68933057-d7004d00-07ce-11ea-8699-8baaa1209cb6](https://user-images.githubusercontent.com/495617/68950582-b8915600-07bc-11ea-984f-ddc42ed57dd9.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-15 at 15 26 18](https://user-images.githubusercontent.com/495617/68950588-bc24dd00-07bc-11ea-9e7b-3dffc5090f76.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
