### PR TITLE
Readonly Product Variations: Storage layer schema update

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		023FA29523316A4D008C1769 /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */; };
 		023FA29623316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */; };
 		023FA29723316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */; };
+		028296F2237D404F00E84012 /* ProductVariation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */; };
+		028296F3237D404F00E84012 /* ProductVariation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EF237D404F00E84012 /* ProductVariation+CoreDataProperties.swift */; };
+		028296F4237D404F00E84012 /* Attribute+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F0237D404F00E84012 /* Attribute+CoreDataClass.swift */; };
+		028296F5237D404F00E84012 /* Attribute+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F1237D404F00E84012 /* Attribute+CoreDataProperties.swift */; };
 		02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */; };
 		02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64162313C26400284168 /* StatsVersionBySite.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
@@ -136,6 +140,10 @@
 		023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataClass.swift"; sourceTree = "<group>"; };
+		028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataClass.swift"; sourceTree = "<group>"; };
+		028296EF237D404F00E84012 /* ProductVariation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		028296F0237D404F00E84012 /* Attribute+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attribute+CoreDataClass.swift"; sourceTree = "<group>"; };
+		028296F1237D404F00E84012 /* Attribute+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attribute+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		028F00652331605000E6C283 /* Model 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 20.xcdatamodel"; sourceTree = "<group>"; };
 		02A9F16A22F9873600EE36EA /* Model 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 19.xcdatamodel"; sourceTree = "<group>"; };
 		02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionBannerVisibility.swift; sourceTree = "<group>"; };
@@ -467,6 +475,10 @@
 		B59E11D720A9CFF3004121A4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */,
+				028296EF237D404F00E84012 /* ProductVariation+CoreDataProperties.swift */,
+				028296F0237D404F00E84012 /* Attribute+CoreDataClass.swift */,
+				028296F1237D404F00E84012 /* Attribute+CoreDataProperties.swift */,
 				9302E3A8220DC7DF00DA5018 /* Mapping Models */,
 				746A9D12214071EB0013F6FF /* MIGRATIONS.md */,
 				B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */,
@@ -780,8 +792,10 @@
 				746A9D21214078080013F6FF /* TopEarnerStats+CoreDataClass.swift in Sources */,
 				74B7D6AD20F90CBB002667AC /* OrderNote+CoreDataClass.swift in Sources */,
 				B52B0F7920AA287C00477698 /* StorageManagerType.swift in Sources */,
+				028296F5237D404F00E84012 /* Attribute+CoreDataProperties.swift in Sources */,
 				7471A517216CF0FE00219F7E /* SiteVisitStats+CoreDataProperties.swift in Sources */,
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
+				028296F4237D404F00E84012 /* Attribute+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,
 				B505F6E020BEEA8100BB1B69 /* StorageType.swift in Sources */,
 				747453A82242C85E00E0B5EE /* ProductTag+CoreDataProperties.swift in Sources */,
@@ -796,6 +810,7 @@
 				74F009C12183B99B002B4566 /* Note+CoreDataProperties.swift in Sources */,
 				CE12FBE32220515600C59248 /* WooCommerceModelV9toV10.xcmappingmodel in Sources */,
 				747453A62242C85E00E0B5EE /* ProductDefaultAttribute+CoreDataProperties.swift in Sources */,
+				028296F3237D404F00E84012 /* ProductVariation+CoreDataProperties.swift in Sources */,
 				B54CA5C920A4C17800F38CD1 /* NSObject+Storage.swift in Sources */,
 				7471A516216CF0FE00219F7E /* SiteVisitStatsItem+CoreDataClass.swift in Sources */,
 				B505F6DA20BEEA3200BB1B69 /* Account+CoreDataProperties.swift in Sources */,
@@ -815,6 +830,7 @@
 				7474539B2242C85E00E0B5EE /* ProductDimensions+CoreDataClass.swift in Sources */,
 				B505255420EE6914008090F5 /* StorageType+Extensions.swift in Sources */,
 				937D6C47226E1D1F004FB8A5 /* AccountSettings+CoreDataClass.swift in Sources */,
+				028296F2237D404F00E84012 /* ProductVariation+CoreDataClass.swift in Sources */,
 				B52B0F7B20AA28A800477698 /* Object.swift in Sources */,
 				02D45649231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift in Sources */,
 				7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataClass.swift"; sourceTree = "<group>"; };
+		026CF636237D9E84009563D4 /* Model 23.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 23.xcdatamodel"; sourceTree = "<group>"; };
 		028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataClass.swift"; sourceTree = "<group>"; };
 		028296EF237D404F00E84012 /* ProductVariation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		028296F0237D404F00E84012 /* Attribute+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attribute+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -1261,6 +1262,7 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				026CF636237D9E84009563D4 /* Model 23.xcdatamodel */,
 				45E1862C2370415C009241F3 /* Model 22.xcdatamodel */,
 				CE4FD43E2350D2FA00A16B31 /* Model 21.xcdatamodel */,
 				028F00652331605000E6C283 /* Model 20.xcdatamodel */,
@@ -1284,7 +1286,7 @@
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = 45E1862C2370415C009241F3 /* Model 22.xcdatamodel */;
+			currentVersion = 026CF636237D9E84009563D4 /* Model 23.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage/Model/Attribute+CoreDataClass.swift
+++ b/Storage/Storage/Model/Attribute+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(Attribute)
+public class Attribute: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/Attribute+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Attribute+CoreDataProperties.swift
@@ -9,7 +9,8 @@ extension Attribute {
     }
 
     @NSManaged public var id: Int64
-    @NSManaged public var key: String?
-    @NSManaged public var value: String?
+    @NSManaged public var key: String
+    @NSManaged public var value: String
+    @NSManaged public var productVariation: ProductVariation?
 
 }

--- a/Storage/Storage/Model/Attribute+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Attribute+CoreDataProperties.swift
@@ -1,0 +1,15 @@
+import Foundation
+import CoreData
+
+
+extension Attribute {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Attribute> {
+        return NSFetchRequest<Attribute>(entityName: "Attribute")
+    }
+
+    @NSManaged public var id: Int64
+    @NSManaged public var key: String?
+    @NSManaged public var value: String?
+
+}

--- a/Storage/Storage/Model/MIGRATIONS.md
+++ b/Storage/Storage/Model/MIGRATIONS.md
@@ -2,6 +2,12 @@
 
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
+## Model 23 (Release 3.2.0.0)
+- @jaclync 2019-11-15
+- New `Attribute` entity
+- New `ProductVariation` entity
+- New `Product.productVariations` relationship
+
 ## Model 22 (Release 3.1.0.0)
 - @pmusolino 2019-11-4
 - New `ShippingLine` entity

--- a/Storage/Storage/Model/Product+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Product+CoreDataProperties.swift
@@ -67,6 +67,7 @@ extension Product {
     @NSManaged public var images: Set<ProductImage>?
     @NSManaged public var tags: Set<ProductTag>?
     @NSManaged public var searchResults: Set<ProductSearchResults>?
+    @NSManaged public var productVariations: Set<ProductVariation>?
 
 }
 
@@ -186,5 +187,22 @@ extension Product {
 
     @objc(removeSearchResults:)
     @NSManaged public func removeFromSearchResults(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for productVariations
+extension Product {
+
+    @objc(addProductVariationsObject:)
+    @NSManaged public func addToProductVariations(_ value: ProductVariation)
+
+    @objc(removeProductVariationsObject:)
+    @NSManaged public func removeFromProductVariations(_ value: ProductVariation)
+
+    @objc(addProductVariations:)
+    @NSManaged public func addToProductVariations(_ values: NSSet)
+
+    @objc(removeProductVariations:)
+    @NSManaged public func removeFromProductVariations(_ values: NSSet)
 
 }

--- a/Storage/Storage/Model/ProductDimensions+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductDimensions+CoreDataProperties.swift
@@ -12,5 +12,6 @@ extension ProductDimensions {
     @NSManaged public var width: String
     @NSManaged public var height: String
     @NSManaged public var product: Product?
+    @NSManaged public var productVariation: ProductVariation?
 
 }

--- a/Storage/Storage/Model/ProductDownload+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductDownload+CoreDataProperties.swift
@@ -12,5 +12,6 @@ extension ProductDownload {
     @NSManaged public var name: String?
     @NSManaged public var fileURL: String?
     @NSManaged public var product: Product?
+    @NSManaged public var productVariation: ProductVariation?
 
 }

--- a/Storage/Storage/Model/ProductVariation+CoreDataClass.swift
+++ b/Storage/Storage/Model/ProductVariation+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(ProductVariation)
+public class ProductVariation: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
@@ -38,6 +38,8 @@ extension ProductVariation {
     @NSManaged public var menuOrder: Int64
     @NSManaged public var dateOnSaleStart: Date?
     @NSManaged public var dateOnSaleEnd: Date?
+    @NSManaged public var siteID: Int64
+    @NSManaged public var productID: Int64
     @NSManaged public var dimensions: ProductDimensions?
     @NSManaged public var image: ProductImage?
     @NSManaged public var downloads: Set<ProductDownload>?

--- a/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CoreData
+
+
+extension ProductVariation {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ProductVariation> {
+        return NSFetchRequest<ProductVariation>(entityName: "ProductVariation")
+    }
+
+    @NSManaged public var dateModified: Date?
+    @NSManaged public var dateCreated: Date
+    @NSManaged public var fullDescription: String?
+    @NSManaged public var permalink: String
+    @NSManaged public var productVariationID: Int64
+    @NSManaged public var sku: String?
+    @NSManaged public var price: String
+    @NSManaged public var regularPrice: String?
+    @NSManaged public var salePrice: String?
+    @NSManaged public var onSale: Bool
+    @NSManaged public var statusKey: String
+    @NSManaged public var purchasable: Bool
+    @NSManaged public var virtual: Bool
+    @NSManaged public var downloadable: Bool
+    @NSManaged public var downloadLimit: Int64
+    @NSManaged public var downloadExpiry: Int64
+    @NSManaged public var taxStatusKey: String
+    @NSManaged public var taxClass: String?
+    @NSManaged public var manageStock: Bool
+    @NSManaged public var stockQuantity: String?
+    @NSManaged public var stockStatusKey: String
+    @NSManaged public var backordersKey: String
+    @NSManaged public var backordersAllowed: Bool
+    @NSManaged public var backordered: Bool
+    @NSManaged public var weight: String?
+    @NSManaged public var shippingClass: String?
+    @NSManaged public var shippingClassID: Int64
+    @NSManaged public var menuOrder: Int64
+    @NSManaged public var dateOnSaleStart: Date?
+    @NSManaged public var dateOnSaleEnd: Date?
+    @NSManaged public var attributes: [Attribute]?
+    @NSManaged public var dimensions: ProductDimensions?
+    @NSManaged public var image: ProductImage?
+    @NSManaged public var downloads: NSSet?
+    @NSManaged public var product: Product?
+
+}
+
+// MARK: Generated accessors for downloads
+extension ProductVariation {
+
+    @objc(addDownloadsObject:)
+    @NSManaged public func addToDownloads(_ value: ProductDownload)
+
+    @objc(removeDownloadsObject:)
+    @NSManaged public func removeFromDownloads(_ value: ProductDownload)
+
+    @objc(addDownloads:)
+    @NSManaged public func addToDownloads(_ values: NSSet)
+
+    @objc(removeDownloads:)
+    @NSManaged public func removeFromDownloads(_ values: NSSet)
+
+}

--- a/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductVariation+CoreDataProperties.swift
@@ -27,7 +27,7 @@ extension ProductVariation {
     @NSManaged public var taxStatusKey: String
     @NSManaged public var taxClass: String?
     @NSManaged public var manageStock: Bool
-    @NSManaged public var stockQuantity: String?
+    @NSManaged public var stockQuantity: Int64
     @NSManaged public var stockStatusKey: String
     @NSManaged public var backordersKey: String
     @NSManaged public var backordersAllowed: Bool
@@ -38,11 +38,11 @@ extension ProductVariation {
     @NSManaged public var menuOrder: Int64
     @NSManaged public var dateOnSaleStart: Date?
     @NSManaged public var dateOnSaleEnd: Date?
-    @NSManaged public var attributes: [Attribute]?
     @NSManaged public var dimensions: ProductDimensions?
     @NSManaged public var image: ProductImage?
-    @NSManaged public var downloads: NSSet?
+    @NSManaged public var downloads: Set<ProductDownload>?
     @NSManaged public var product: Product?
+    @NSManaged public var attributes: NSOrderedSet
 
 }
 
@@ -60,5 +60,40 @@ extension ProductVariation {
 
     @objc(removeDownloads:)
     @NSManaged public func removeFromDownloads(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for attributes
+extension ProductVariation {
+
+    @objc(insertObject:inAttributesAtIndex:)
+    @NSManaged public func insertIntoAttributes(_ value: Attribute, at idx: Int)
+
+    @objc(removeObjectFromAttributesAtIndex:)
+    @NSManaged public func removeFromAttributes(at idx: Int)
+
+    @objc(insertAttributes:atIndexes:)
+    @NSManaged public func insertIntoAttributes(_ values: [Attribute], at indexes: NSIndexSet)
+
+    @objc(removeAttributesAtIndexes:)
+    @NSManaged public func removeFromAttributes(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInAttributesAtIndex:withObject:)
+    @NSManaged public func replaceAttributes(at idx: Int, with value: Attribute)
+
+    @objc(replaceAttributesAtIndexes:withAttributes:)
+    @NSManaged public func replaceAttributes(at indexes: NSIndexSet, with values: [Attribute])
+
+    @objc(addAttributesObject:)
+    @NSManaged public func addToAttributes(_ value: Attribute)
+
+    @objc(removeAttributesObject:)
+    @NSManaged public func removeFromAttributes(_ value: Attribute)
+
+    @objc(addAttributes:)
+    @NSManaged public func addToAttributes(_ values: NSOrderedSet)
+
+    @objc(removeAttributes:)
+    @NSManaged public func removeFromAttributes(_ values: NSOrderedSet)
 
 }

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 22.xcdatamodel</string>
+	<string>Model 23.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 22.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 22.xcdatamodel/contents
@@ -11,7 +11,7 @@
         <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
-    <entity name="Attribute" representedClassName="Attribute" syncable="YES" codeGenerationType="class">
+    <entity name="Attribute" representedClassName="Attribute" syncable="YES">
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="key" attributeType="String"/>
         <attribute name="value" optional="YES" attributeType="String"/>
@@ -288,6 +288,7 @@
         <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions"/>
         <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload"/>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage"/>
+        <relationship name="productVariations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariation" inverseName="product" inverseEntity="ProductVariation"/>
         <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag"/>
     </entity>
@@ -359,7 +360,8 @@
         <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product"/>
     </entity>
-    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES" codeGenerationType="class">
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
+        <attribute name="attributes" attributeType="Transformable" customClassName="[Attribute]"/>
         <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="backordersKey" attributeType="String"/>
@@ -390,10 +392,10 @@
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="virtual" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
-        <relationship name="attributes" maxCount="1" deletionRule="Nullify" destinationEntity="Attribute"/>
-        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
-        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
-        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="productVariations" inverseEntity="Product"/>
     </entity>
     <entity name="Refund" representedClassName="Refund" syncable="YES">
         <attribute name="amount" optional="YES" attributeType="String"/>
@@ -500,7 +502,7 @@
         <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
         <element name="OrderStatsV4Totals" positionX="-519.01171875" positionY="96.5546875" width="128" height="225"/>
         <element name="OrderStatus" positionX="-64.2578125" positionY="807.0234375" width="128" height="105"/>
-        <element name="Product" positionX="-669.6796875" positionY="1015.5859375" width="128" height="915"/>
+        <element name="Product" positionX="-669.6796875" positionY="1015.5859375" width="128" height="928"/>
         <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
         <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
         <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
@@ -521,7 +523,7 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
-        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="553"/>
+        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="568"/>
         <element name="Attribute" positionX="-684" positionY="45" width="128" height="88"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 22.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 22.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15400" systemVersion="18G103" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14903" systemVersion="18F132" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
@@ -10,6 +10,11 @@
     <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
         <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Attribute" representedClassName="Attribute" syncable="YES" codeGenerationType="class">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES">
         <attribute name="body" optional="YES" attributeType="Binary"/>
@@ -312,12 +317,14 @@
         <attribute name="length" attributeType="String"/>
         <attribute name="width" attributeType="String"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
         <attribute name="downloadID" attributeType="String"/>
         <attribute name="fileURL" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="downloads" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
         <attribute name="alt" optional="YES" attributeType="String"/>
@@ -327,6 +334,7 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="src" attributeType="String"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
         <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -350,6 +358,42 @@
         <attribute name="slug" attributeType="String"/>
         <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES" codeGenerationType="class">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="manageStock" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="onSale" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productVariationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="virtual" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="attributes" maxCount="1" deletionRule="Nullify" destinationEntity="Attribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
     </entity>
     <entity name="Refund" representedClassName="Refund" syncable="YES">
         <attribute name="amount" optional="YES" attributeType="String"/>
@@ -460,9 +504,9 @@
         <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
         <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
         <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
-        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
-        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="105"/>
-        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="118"/>
+        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="118"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="163"/>
         <element name="ProductReview" positionX="-693" positionY="36" width="128" height="210"/>
         <element name="ProductSearchResults" positionX="-693" positionY="36" width="128" height="75"/>
         <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
@@ -477,5 +521,7 @@
         <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="105"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="553"/>
+        <element name="Attribute" positionX="-684" positionY="45" width="128" height="88"/>
     </elements>
 </model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 23.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 23.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15400" systemVersion="18G103" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15400" systemVersion="18F132" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Account" representedClassName="Account" syncable="YES">
         <attribute name="displayName" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
@@ -10,6 +10,12 @@
     <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
         <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Attribute" representedClassName="Attribute" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES">
         <attribute name="body" optional="YES" attributeType="Binary"/>
@@ -283,6 +289,7 @@
         <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions"/>
         <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload"/>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage"/>
+        <relationship name="productVariations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariation" inverseName="product" inverseEntity="ProductVariation"/>
         <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults"/>
         <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductTag" inverseName="product" inverseEntity="ProductTag"/>
     </entity>
@@ -312,12 +319,14 @@
         <attribute name="length" attributeType="String"/>
         <attribute name="width" attributeType="String"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
         <attribute name="downloadID" attributeType="String"/>
         <attribute name="fileURL" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="downloads" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
         <attribute name="alt" optional="YES" attributeType="String"/>
@@ -327,6 +336,7 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="src" attributeType="String"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation"/>
     </entity>
     <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
         <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -350,6 +360,43 @@
         <attribute name="slug" attributeType="String"/>
         <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="tags" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="manageStock" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="onSale" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productVariationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="virtual" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="attributes" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Attribute" inverseName="productVariation" inverseEntity="Attribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="productVariations" inverseEntity="Product"/>
     </entity>
     <entity name="Refund" representedClassName="Refund" syncable="YES">
         <attribute name="amount" optional="YES" attributeType="String"/>
@@ -438,6 +485,7 @@
     <elements>
         <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
         <element name="AccountSettings" positionX="-846" positionY="270" width="128" height="75"/>
+        <element name="Attribute" positionX="-684" positionY="45" width="128" height="103"/>
         <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
         <element name="Order" positionX="-41.5859375" positionY="23.53125" width="128" height="748"/>
         <element name="OrderCount" positionX="-693" positionY="36" width="128" height="75"/>
@@ -456,16 +504,17 @@
         <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
         <element name="OrderStatsV4Totals" positionX="-519.01171875" positionY="96.5546875" width="128" height="225"/>
         <element name="OrderStatus" positionX="-64.2578125" positionY="807.0234375" width="128" height="105"/>
-        <element name="Product" positionX="-669.6796875" positionY="1015.5859375" width="128" height="915"/>
+        <element name="Product" positionX="-669.6796875" positionY="1015.5859375" width="128" height="928"/>
         <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="148"/>
         <element name="ProductCategory" positionX="-773.3125" positionY="94.1328125" width="128" height="103"/>
         <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
-        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="105"/>
-        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="105"/>
-        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="148"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="118"/>
+        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="118"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="163"/>
         <element name="ProductReview" positionX="-693" positionY="36" width="128" height="210"/>
         <element name="ProductSearchResults" positionX="-693" positionY="36" width="128" height="75"/>
         <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
+        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="568"/>
         <element name="Refund" positionX="-657" positionY="81" width="128" height="28"/>
         <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
         <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 23.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 23.xcdatamodel/contents
@@ -378,12 +378,14 @@
         <attribute name="onSale" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="permalink" attributeType="String"/>
         <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="productVariationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="purchasable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
         <attribute name="shippingClassID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="sku" optional="YES" attributeType="String"/>
         <attribute name="statusKey" attributeType="String"/>
         <attribute name="stockQuantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -514,7 +516,7 @@
         <element name="ProductReview" positionX="-693" positionY="36" width="128" height="210"/>
         <element name="ProductSearchResults" positionX="-693" positionY="36" width="128" height="75"/>
         <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="103"/>
-        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="568"/>
+        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="598"/>
         <element name="Refund" positionX="-657" positionY="81" width="128" height="28"/>
         <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
         <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -320,6 +320,33 @@ public extension StorageType {
         return firstObject(ofType: ProductReview.self, matching: predicate)
     }
 
+    /// Retrieves all of the stored ProductVariation's for the provided siteID and productID.
+    /// Sorted by dateCreated, descending
+    ///
+    func loadProductVariations(siteID: Int, productID: Int) -> [ProductVariation]? {
+        let predicate = NSPredicate(format: "product.siteID = %lld AND product.productID = %lld", siteID, productID)
+        let descriptor = NSSortDescriptor(keyPath: \ProductVariation.dateCreated, ascending: false)
+        return allObjects(ofType: ProductVariation.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Retrieves a stored ProductVariation for the provided siteID and productID.
+    ///
+    func loadProductVariation(siteID: Int, productVariationID: Int64) -> ProductVariation? {
+        let predicate = NSPredicate(format: "product.siteID = %lld AND productVariationID = %lld", siteID, productVariationID)
+        return firstObject(ofType: ProductVariation.self, matching: predicate)
+    }
+
+    /// Retrieves a stored Product Variation Attribute.
+    ///
+    /// Note: WC attribute ID's often have an ID of `0` (local Product attributes), so we need to
+    /// also look them up by key and value
+    ///
+    func loadProductVariationAttribute(attributeID: Int64, name: String, option: String) -> Attribute? {
+        let predicate = NSPredicate(format: "id = %lld AND key = %@ AND value = %@",
+                                    attributeID, name, option)
+        return firstObject(ofType: Attribute.self, matching: predicate)
+    }
+
     // MARK: - Refunds
 
     /// Retrieves a stored Refund for the provided siteID, orderID, and refundID.

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -323,16 +323,16 @@ public extension StorageType {
     /// Retrieves all of the stored ProductVariation's for the provided siteID and productID.
     /// Sorted by dateCreated, descending
     ///
-    func loadProductVariations(siteID: Int, productID: Int) -> [ProductVariation]? {
-        let predicate = NSPredicate(format: "product.siteID = %lld AND product.productID = %lld", siteID, productID)
+    func loadProductVariations(siteID: Int64, productID: Int64) -> [ProductVariation]? {
+        let predicate = NSPredicate(format: "siteID = %lld AND productID = %lld", siteID, productID)
         let descriptor = NSSortDescriptor(keyPath: \ProductVariation.dateCreated, ascending: false)
         return allObjects(ofType: ProductVariation.self, matching: predicate, sortedBy: [descriptor])
     }
 
     /// Retrieves a stored ProductVariation for the provided siteID and productVariationID.
     ///
-    func loadProductVariation(siteID: Int, productVariationID: Int64) -> ProductVariation? {
-        let predicate = NSPredicate(format: "product.siteID = %lld AND productVariationID = %lld", siteID, productVariationID)
+    func loadProductVariation(siteID: Int64, productVariationID: Int64) -> ProductVariation? {
+        let predicate = NSPredicate(format: "siteID = %lld AND productVariationID = %lld", siteID, productVariationID)
         return firstObject(ofType: ProductVariation.self, matching: predicate)
     }
 

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -329,7 +329,7 @@ public extension StorageType {
         return allObjects(ofType: ProductVariation.self, matching: predicate, sortedBy: [descriptor])
     }
 
-    /// Retrieves a stored ProductVariation for the provided siteID and productID.
+    /// Retrieves a stored ProductVariation for the provided siteID and productVariationID.
     ///
     func loadProductVariation(siteID: Int, productVariationID: Int64) -> ProductVariation? {
         let predicate = NSPredicate(format: "product.siteID = %lld AND productVariationID = %lld", siteID, productVariationID)


### PR DESCRIPTION
Fixes #1467 

## Changes
- Discussion: p99K0U-1Za-p2
- 530 diffs are on the Core Data model
- Added the following entities to a new model version 23:
  - `Attribute`: meant to be a generic attribute with 3 core properties: `id`, `key`, `value`
  - `ProductVariation`: following the attributes as defined on the WC API doc in the table below
    - READ-ONLY attributes are non-optional
    - Plus `productID` and `siteID` attributes so that we can look up the variations given a site ID and product ID later

## Testing
- Launch the app from `develop`, logged in
- Launch the app from the PR branch --> the app should run normally and not crash

API attribute | type | description
-- | -- | --
id | integer | Unique identifier for the resource.READ-ONLY
date_created | date-time | The date the variation was created, in the site's timezone.READ-ONLY
date_created_gmt | date-time | The date the variation was created, as GMT.READ-ONLY
date_modified | date-time | The date the variation was last modified, in the site's timezone.READ-ONLY
date_modified_gmt | date-time | The date the variation was last modified, as GMT.READ-ONLY
description | string | Variation description.
permalink | string | Variation URL.READ-ONLY
sku | string | Unique identifier.
price | string | Current variation price.READ-ONLY
regular_price | string | Variation regular price.
sale_price | string | Variation sale price.
date_on_sale_from | date-time | Start date of sale price, in the site's timezone.
date_on_sale_from_gmt | date-time | Start date of sale price, as GMT.
date_on_sale_to | date-time | End date of sale price, in the site's timezone.
date_on_sale_to_gmt | date-time | End date of sale price, as GMT.
on_sale | boolean | Shows if the variation is on sale.READ-ONLY
status | string | Variation status. Options:draft,pending,privateandpublish. Default ispublish.
purchasable | boolean | Shows if the variation can be bought.READ-ONLY
virtual | boolean | If the variation is virtual. Default isfalse.
downloadable | boolean | If the variation is downloadable. Default isfalse.
downloads | array | List of downloadable files. SeeProduct variation - Downloads properties
download_limit | integer | Number of times downloadable files can be downloaded after purchase. Default is-1.
download_expiry | integer | Number of days until access to downloadable files expires. Default is-1.
tax_status | string | Tax status. Options:taxable,shippingandnone. Default istaxable.
tax_class | string | Tax class.
manage_stock | boolean | Stock management at variation level. Default isfalse.
stock_quantity | integer | Stock quantity.
stock_status | string | Controls the stock status of the product. Options:instock,outofstock,onbackorder. Default isinstock.
backorders | string | If managing stock, this controls if backorders are allowed. Options:no,notifyandyes. Default isno.
backorders_allowed | boolean | Shows if backorders are allowed.READ-ONLY
backordered | boolean | Shows if the variation is on backordered.READ-ONLY
weight | string | Variation weight.
dimensions | object | Variation dimensions. SeeProduct variation - Dimensions properties
shipping_class | string | Shipping class slug.
shipping_class_id | string | Shipping class ID.READ-ONLY
image | object | Variation image data. SeeProduct variation - Image properties
attributes | array | List of attributes. SeeProduct variation - Attributes properties
menu_order | integer | Menu order, used to custom sort products.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
