### PR TITLE
Networking & Yosemite layers: update Product name

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */; };
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
+		457FC68C2382B2FD00B41B02 /* product-update-name.json in Resources */ = {isa = PBXBuildFile; fileRef = 457FC68B2382B2FD00B41B02 /* product-update-name.json */; };
 		45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E3EEBA237009CF00A826AC /* ShippingLine.swift */; };
 		6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */; };
 		74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */; };
@@ -289,6 +290,7 @@
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
 		02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-deactivated.json"; sourceTree = "<group>"; };
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
+		457FC68B2382B2FD00B41B02 /* product-update-name.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-update-name.json"; sourceTree = "<group>"; };
 		45E3EEBA237009CF00A826AC /* ShippingLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLine.swift; sourceTree = "<group>"; };
 		69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NetworkingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsMapperTests.swift; sourceTree = "<group>"; };
@@ -885,6 +887,7 @@
 				02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */,
 				CE19CB10222486A500E8AF7A /* order-statuses.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
+				457FC68B2382B2FD00B41B02 /* product-update-name.json */,
 				025FDD2E23715A8900824006 /* product-update-description.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				0282DD90233A120A006A5FDB /* products-search-photo.json */,
@@ -1254,6 +1257,7 @@
 				743E84F222172D0A00FAC9D7 /* shipment_tracking_plugin_not_active.json in Resources */,
 				74ABA1C9213F19FE00FFAD30 /* top-performers-month.json in Resources */,
 				743E84F622172D3E00FAC9D7 /* shipment_tracking_single.json in Resources */,
+				457FC68C2382B2FD00B41B02 /* product-update-name.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
 				74159628224D63CE003C21CF /* settings-product-alt.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -101,6 +101,25 @@ public class ProductsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
+    /// Updates the Name of a specific `Product`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site which hosts the Product.
+    ///     - productID: Identifier of the Product.
+    ///     - name: Name of the Product.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProductName(for siteID: Int, productID: Int, name: String, completion: @escaping (Product?, Error?) -> Void) {
+        let parameters = [
+            "name": name
+        ]
+        let path = "\(Path.products)/\(productID)"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+    
     /// Updates the description of a specific `Product`.
     ///
     /// - Parameters:

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -119,7 +119,7 @@ public class ProductsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
-    
+
     /// Updates the description of a specific `Product`.
     ///
     /// - Parameters:

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -137,6 +137,43 @@ class ProductsRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    
+    // MARK: - Update Product name
+
+    /// Verifies that updateProductName name properly parses the `product-update-name` sample response.
+    ///
+    func testUpdateProductNameProperlyReturnsParsedProduct() {
+        let remote = ProductsRemote(network: network)
+        let expectation = self.expectation(description: "Wait for product name update")
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-update-name")
+
+        let productName = "This is my new product name!"
+        remote.updateProductName(for: sampleSiteID, productID: sampleProductID, name: productName) { (product, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(product)
+            XCTAssertEqual(product?.name, productName)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that updateProductName name properly relays Networking Layer errors.
+    ///
+    func testUpdateProductNameProperlyRelaysNetwokingErrors() {
+        let remote = ProductsRemote(network: network)
+        let expectation = self.expectation(description: "Wait for product name update")
+
+        remote.updateProductName(for: sampleSiteID, productID: sampleProductID, name: "") { (product, error) in
+            XCTAssertNil(product)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+    
     // MARK: - Update Product Description
 
     /// Verifies that updateProductDescription description properly parses the `product-update-description` sample response.

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -137,7 +137,7 @@ class ProductsRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    
+
     // MARK: - Update Product name
 
     /// Verifies that updateProductName name properly parses the `product-update-name` sample response.
@@ -173,7 +173,7 @@ class ProductsRemoteTests: XCTestCase {
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
-    
+
     // MARK: - Update Product Description
 
     /// Verifies that updateProductDescription description properly parses the `product-update-description` sample response.

--- a/Networking/NetworkingTests/Responses/product-update-name.json
+++ b/Networking/NetworkingTests/Responses/product-update-name.json
@@ -1,0 +1,191 @@
+{
+    "data": {
+        "id": 847,
+        "name": "This is my new product name!",
+        "slug": "chocolate-3",
+        "permalink": "https://funtesting.com/product/chocolate-3/",
+        "date_created": "2019-10-02T10:03:50",
+        "date_created_gmt": "2019-10-02T07:33:50",
+        "date_modified": "2019-11-05T09:34:43",
+        "date_modified_gmt": "2019-11-05T07:04:43",
+        "type": "simple",
+        "status": "publish",
+        "featured": false,
+        "catalog_visibility": "visible",
+        "description": "Learn something!",
+        "short_description": "<blockquote>HEllloo!!!!</blockquote>",
+        "sku": "",
+        "price": "",
+        "regular_price": "",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "price_html": "",
+        "on_sale": false,
+        "purchasable": false,
+        "total_sales": 0,
+        "virtual": false,
+        "downloadable": false,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": -1,
+        "external_url": "",
+        "button_text": "",
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": false,
+        "stock_quantity": null,
+        "stock_status": "instock",
+        "backorders": "no",
+        "backorders_allowed": false,
+        "backordered": false,
+        "sold_individually": false,
+        "weight": "",
+        "dimensions": {
+            "length": "",
+            "width": "",
+            "height": ""
+        },
+        "shipping_required": true,
+        "shipping_taxable": true,
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "reviews_allowed": true,
+        "average_rating": "0",
+        "rating_count": 0,
+        "related_ids": [],
+        "upsell_ids": [],
+        "cross_sell_ids": [],
+        "parent_id": 0,
+        "purchase_note": "",
+        "categories": [],
+        "tags": [],
+        "images": [
+            {
+                "id": 1043,
+                "date_created": "2019-10-30T16:55:45",
+                "date_created_gmt": "2019-10-30T12:25:45",
+                "date_modified": "2019-10-30T16:55:45",
+                "date_modified_gmt": "2019-10-30T12:25:45",
+                "src": "https://i1.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/10/img_0111-4.jpeg?fit=4032%2C3024&ssl=1",
+                "name": "img_0111-4",
+                "alt": ""
+            },
+            {
+                "id": 1064,
+                "date_created": "2019-11-01T08:45:34",
+                "date_created_gmt": "2019-11-01T04:15:34",
+                "date_modified": "2019-11-01T08:45:34",
+                "date_modified_gmt": "2019-11-01T04:15:34",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0001-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0001",
+                "alt": ""
+            }
+        ],
+        "attributes": [
+            {
+                "id": 0,
+                "name": "Color 2",
+                "position": 0,
+                "visible": true,
+                "variation": true,
+                "options": [
+                    "Orange!",
+                    "Red",
+                    "Rad"
+                ]
+            },
+            {
+                "id": 0,
+                "name": "Type",
+                "position": 0,
+                "visible": true,
+                "variation": true,
+                "options": [
+                    "Original",
+                    "Print"
+                ]
+            },
+            {
+                "id": 0,
+                "name": "Canvas",
+                "position": 1,
+                "visible": false,
+                "variation": true,
+                "options": [
+                    "paper",
+                    "soil",
+                    "plastic",
+                    "map"
+                ]
+            },
+            {
+                "id": 0,
+                "name": "size",
+                "position": 2,
+                "visible": false,
+                "variation": true,
+                "options": [
+                    "Small",
+                    "Medium",
+                    "Large"
+                ]
+            },
+            {
+                "id": 0,
+                "name": "Has logo",
+                "position": 3,
+                "visible": true,
+                "variation": true,
+                "options": [
+                    "Yes",
+                    "No",
+                    "Maybe"
+                ]
+            }
+        ],
+        "default_attributes": [],
+        "variations": [],
+        "grouped_products": [],
+        "menu_order": 0,
+        "meta_data": [
+            {
+                "id": 3979,
+                "key": "_created_via",
+                "value": "rest-api-v3"
+            },
+            {
+                "id": 3980,
+                "key": "_wpas_done_all",
+                "value": "1"
+            },
+            {
+                "id": 4687,
+                "key": "_yoast_wpseo_content_score",
+                "value": "60"
+            },
+            {
+                "id": 4690,
+                "key": "_yoast_wpseo_primary_product_cat",
+                "value": ""
+            }
+        ],
+        "jetpack_publicize_connections": [],
+        "jetpack_likes_enabled": true,
+        "jetpack_sharing_enabled": true,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/847"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products"
+                }
+            ]
+        }
+    }
+}

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -30,6 +30,10 @@ public enum ProductAction: Action {
     ///
     case requestMissingProducts(for: Order, onCompletion: (Error?) -> Void)
 
+    /// Updates the name of a specified Product.
+    ///
+    case updateProductName(siteID: Int, productID: Int, name: String?, onCompletion: (Product?, Error?) -> Void)
+
     /// Updates the description of a specified Product.
     ///
     case updateProductDescription(siteID: Int, productID: Int, description: String?, onCompletion: (Product?, Error?) -> Void)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -38,6 +38,8 @@ public class ProductStore: Store {
             synchronizeProducts(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .requestMissingProducts(let order, let onCompletion):
             requestMissingProducts(for: order, onCompletion: onCompletion)
+        case .updateProductName(let siteID, let productID, let name, let onCompletion):
+            updateProduct(siteID: siteID, productID: productID, name: name, onCompletion: onCompletion)
         case .updateProductDescription(let siteID, let productID, let description, let onCompletion):
             updateProduct(siteID: siteID, productID: productID, description: description, onCompletion: onCompletion)
         }
@@ -165,12 +167,12 @@ private extension ProductStore {
             }
         }
     }
-    
+
     /// Updates the product name.
     ///
     func updateProduct(siteID: Int, productID: Int, name: String?, onCompletion: @escaping (Networking.Product?, Error?) -> Void) {
         let remote = ProductsRemote(network: network)
-        
+
         remote.updateProductName(for: siteID, productID: productID, name: name ?? "") { [weak self] (product, error) in
             guard let product = product else {
                 onCompletion(nil, error)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -165,6 +165,23 @@ private extension ProductStore {
             }
         }
     }
+    
+    /// Updates the product name.
+    ///
+    func updateProduct(siteID: Int, productID: Int, name: String?, onCompletion: @escaping (Networking.Product?, Error?) -> Void) {
+        let remote = ProductsRemote(network: network)
+        
+        remote.updateProductName(for: siteID, productID: productID, name: name ?? "") { [weak self] (product, error) in
+            guard let product = product else {
+                onCompletion(nil, error)
+                return
+            }
+
+            self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) {
+                onCompletion(product, nil)
+            }
+        }
+    }
 
     /// Updates the product description.
     ///

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -613,6 +613,131 @@ class ProductStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    // MARK: - ProductAction.updateProductName
+
+    /// Verifies that `ProductAction.updateProductName` returns the expected `Product`.
+    ///
+    func testUpdatingProductNameReturnsExpectedFields() {
+        let expectation = self.expectation(description: "Update product name")
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let expectedProductID = 847
+        let expectedProductName = "This is my new product name!"
+
+        network.simulateResponse(requestUrlSuffix: "products/\(expectedProductID)", filename: "product-update-name")
+        let action = ProductAction.updateProductName(siteID: sampleSiteID,
+                                                     productID: expectedProductID,
+                                                     name: expectedProductName) { (product, error) in
+                                                        XCTAssertNil(error)
+                                                        XCTAssertNotNil(product)
+                                                        XCTAssertEqual(product?.productID, expectedProductID)
+                                                        XCTAssertEqual(product?.name, expectedProductName)
+
+                                                        let storedProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProductID)
+                                                        let readOnlyStoredProduct = storedProduct?.toReadOnly()
+                                                        XCTAssertNotNil(storedProduct)
+                                                        XCTAssertNotNil(readOnlyStoredProduct)
+                                                        XCTAssertEqual(readOnlyStoredProduct?.productID, expectedProductID)
+                                                        XCTAssertEqual(readOnlyStoredProduct?.name, expectedProductName)
+
+                                                        expectation.fulfill()
+        }
+
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.updateProductName` effectively persists all of the remote product fields
+    /// correctly across all of the related `Product` entities (tags, categories, attributes, etc) for `variation` product types.
+    ///
+    func testUpdatingProductNameEffectivelyPersistsRelatedObjects() {
+        let expectation = self.expectation(description: "Update product name")
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let expectedProductID = 847
+
+        network.simulateResponse(requestUrlSuffix: "products/\(expectedProductID)", filename: "product-update-name")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+
+        let action = ProductAction.updateProductName(siteID: sampleSiteID, productID: expectedProductID, name: "") { (product, error) in
+            XCTAssertNotNil(product)
+            XCTAssertNil(error)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 1)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductTag.self), 0)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCategory.self), 0)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductImage.self), 2)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductDimensions.self), 1)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductAttribute.self), 5)
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductDefaultAttribute.self), 0)
+
+            let storedProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProductID)
+            let readOnlyStoredProduct = storedProduct?.toReadOnly()
+            XCTAssertNotNil(storedProduct)
+            XCTAssertNotNil(readOnlyStoredProduct)
+
+            expectation.fulfill()
+        }
+
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.updateProductName` returns an error whenever there is an error response from the backend.
+    ///
+    func testUpdatingProductNameReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Update product name")
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "generic_error")
+        let action = ProductAction.updateProductName(siteID: sampleSiteID, productID: sampleProductID, name: "") { (product, error) in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductAction.updateProductName` returns an error whenever there is no backend response.
+    ///
+    func testUpdatingProductNameReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Update product name")
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let action = ProductAction.updateProductName(siteID: sampleSiteID, productID: sampleProductID, name: "") { (product, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(product)
+            expectation.fulfill()
+        }
+
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that whenever a `ProductAction.updateProductName` action results in a response with statusCode = 404, the local entity is not deleted.
+    ///
+    func testUpdatingProductNameResultingInStatusCode404DoesNotCauseTheStoredProductToGetDeleted() {
+        let expectation = self.expectation(description: "Update product name")
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
+        productStore.upsertStoredProduct(readOnlyProduct: sampleProduct(), in: viewStorage)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 1)
+
+        network.simulateError(requestUrlSuffix: "products/\(sampleProductID)", error: NetworkError.notFound)
+        let action = ProductAction.updateProductName(siteID: sampleSiteID, productID: sampleProductID, name: "") { (product, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(product)
+            // The existing Product should not be deleted on 404 response.
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 1)
+
+            expectation.fulfill()
+        }
+
+        productStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     // MARK: - ProductAction.updateProductDescription
 
     /// Verifies that `ProductAction.updateProductDescription` returns the expected `Product`.

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -626,21 +626,21 @@ class ProductStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/\(expectedProductID)", filename: "product-update-name")
         let action = ProductAction.updateProductName(siteID: sampleSiteID,
-                                                     productID: expectedProductID,
-                                                     name: expectedProductName) { (product, error) in
-                                                        XCTAssertNil(error)
-                                                        XCTAssertNotNil(product)
-                                                        XCTAssertEqual(product?.productID, expectedProductID)
-                                                        XCTAssertEqual(product?.name, expectedProductName)
+                     productID: expectedProductID,
+                     name: expectedProductName) { (product, error) in
+                     XCTAssertNil(error)
+                     XCTAssertNotNil(product)
+                     XCTAssertEqual(product?.productID, expectedProductID)
+                     XCTAssertEqual(product?.name, expectedProductName)
 
-                                                        let storedProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProductID)
-                                                        let readOnlyStoredProduct = storedProduct?.toReadOnly()
-                                                        XCTAssertNotNil(storedProduct)
-                                                        XCTAssertNotNil(readOnlyStoredProduct)
-                                                        XCTAssertEqual(readOnlyStoredProduct?.productID, expectedProductID)
-                                                        XCTAssertEqual(readOnlyStoredProduct?.name, expectedProductName)
+                     let storedProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProductID)
+                     let readOnlyStoredProduct = storedProduct?.toReadOnly()
+                     XCTAssertNotNil(storedProduct)
+                     XCTAssertNotNil(readOnlyStoredProduct)
+                     XCTAssertEqual(readOnlyStoredProduct?.productID, expectedProductID)
+                     XCTAssertEqual(readOnlyStoredProduct?.name, expectedProductName)
 
-                                                        expectation.fulfill()
+                     expectation.fulfill()
         }
 
         productStore.onAction(action)


### PR DESCRIPTION
Backend tasks for #1419 

## Changes

- Added updateProductName to both ProductsRemote and ProductStore/ProductAction
   - Plus unit tests

## Testing
- CI

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
