### PR TITLE
Hot fix: update stats v4 endpoint and banner message when reverting from stats v4 to v3

### DIFF
--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -29,7 +29,7 @@ public final class OrderStatsRemoteV4: Remote {
                           ParameterKeys.before: latestDateToInclude,
                           ParameterKeys.quantity: String(randomQuantity)]
 
-        let request = JetpackRequest(wooApiVersion: .mark4, method: .get, siteID: siteID, path: Constants.orderStatsPath, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics, method: .get, siteID: siteID, path: Constants.orderStatsPath, parameters: parameters)
         let mapper = OrderStatsV4Mapper(siteID: siteID, granularity: unit)
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Settings/WooAPIVersion.swift
+++ b/Networking/Networking/Settings/WooAPIVersion.swift
@@ -25,6 +25,11 @@ public enum WooAPIVersion: String {
     ///
     case mark4 = "wc/v4"
 
+    /// WooCommerce Analytics from the WooCommerce Admin plugin.
+    /// Only works for WC Admin v0.22 and up.
+    ///
+    case wcAnalytics = "wc-analytics"
+
     /// Returns the path for the current API Version
     ///
     var path: String {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - bugfix: Reviews no longer convert to partial dark mode. Dark mode coming soon!
 - bugfix: Order Details now has the right space between cells.
 - bugfix: Settings no longer convert to partial dark mode.
+- bugfix: update the new stats endpoint for WC Admin plugin version 0.22+, and notify the user about the minimum plugin version when they cannot see the new stats. It'd be great to also mention this in the App Store release notes: the new stats UI now requires WC Admin plugin version 0.22+.
 
 3.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -40,8 +40,9 @@ private extension DashboardTopBannerFactory {
 
     enum V4ToV3BannerConstants {
         static let title: String? = nil
-        static let info = NSLocalizedString("We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.22 or higher",
-                                            comment: "The info of the top banner on Dashboard that indicates new stats is unavailable")
+        static let info = NSLocalizedString(
+            "We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.22 or higher",
+            comment: "The info of the top banner on Dashboard that indicates new stats is unavailable")
         static let icon = UIImage.infoImage
         static let actionTitle = NSLocalizedString("Learn more",
                                                    comment: "The action of the top banner on Dashboard that indicates new stats is unavailable")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -40,7 +40,7 @@ private extension DashboardTopBannerFactory {
 
     enum V4ToV3BannerConstants {
         static let title: String? = nil
-        static let info = NSLocalizedString("We have reverted to the old stats as we couldn’t find the WooCommerce Admin plugin",
+        static let info = NSLocalizedString("We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.22 or higher",
                                             comment: "The info of the top banner on Dashboard that indicates new stats is unavailable")
         static let icon = UIImage.infoImage
         static let actionTitle = NSLocalizedString("Learn more",


### PR DESCRIPTION
Fixes #1489 

## Changes
- Created a new Woo API version case `wcAnalytics = "wc-analytics"` for the new API namespace that replaces `mark4 = "wc/v4"` for stats in WC Admin plugin v0.22+
- Used the new WC analytics API namespace for the stats v4 endpoint
- In the banner where we show when the user was previously seeing stats v4 UI and now is not eligible for stats v4 (with the new namespace), updated the messaging to mention the minimum WC Admin plugin version (0.22) for new stats UI

## Testing

### Test case 1: the store has WC Admin v0.22+

- In `wp-admin`, make sure the WC Admin plugin is v0.22+ and activated
- Launch the app from the PR branch --> should see the new stats, or the banner to view the new stats
- In `wp-admin`, deactivate the WC Admin plugin
- Back in the app, pull down to refresh or relaunch the app --> should see the stats reverted to v3 UI, and a banner suggesting updating the WC Admin plugin to v0.22+ as in the screenshot

### Test case 2: the store has WC Admin with a version lower than 0.22

- In `wp-admin`, make sure the WC Admin plugin is lower than v0.22 and activated (you can download an older WC Admin version from the [WC Admin GitHub releases page](https://github.com/woocommerce/woocommerce-admin/releases?after=v0.20.1))
- Launch the app from `develop` and opt-in the new stats if it's not currently shown
- Launch the app from the PR branch --> should see the stats reverted to v3 UI, and a banner suggesting updating the WC Admin plugin to v0.22+ as in the screenshot
- In `wp-admin`, update the WC Admin plugin to v0.22+ and make sure it's activated
- Launch the app from the PR branch --> should see the banner to view the new stats
- Tap "Try It Now" on the banner to view the new stats --> should see the new stats UI



## Example screenshots

When the user used to see stats v4 UI but isn't eligible for stats v4 anymore (either doesn't have WC Admin installed/activated or the WC Admin version is below 0.22), we show this banner:

<img src="https://user-images.githubusercontent.com/1945542/69119232-e6361200-0ad0-11ea-968b-f20aef79f2f5.png" width="350" />



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
