### PR TITLE
Readonly Product Variations: Networking layer changes

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -10,6 +10,12 @@
 		022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 022902D122E2436300059692 /* stats_module_disabled_error.json */; };
 		022902D622E2436400059692 /* no_stats_permission_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 022902D322E2436400059692 /* no_stats_permission_error.json */; };
 		025FDD2F23715A8900824006 /* product-update-description.json in Resources */ = {isa = PBXBuildFile; fileRef = 025FDD2E23715A8900824006 /* product-update-description.json */; };
+		026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF619237D607A009563D4 /* ProductVariationAttribute.swift */; };
+		026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */; };
+		026CF620237D69D6009563D4 /* ProductVariationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF61F237D69D6009563D4 /* ProductVariationsRemote.swift */; };
+		026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF621237D7E61009563D4 /* ProductVariationsRemoteTests.swift */; };
+		026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 026CF623237D839A009563D4 /* product-variations-load-all.json */; };
+		028296F7237D588700E84012 /* ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F6237D588700E84012 /* ProductVariation.swift */; };
 		0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */ = {isa = PBXBuildFile; fileRef = 0282DD90233A120A006A5FDB /* products-search-photo.json */; };
 		02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */; };
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
@@ -286,6 +292,12 @@
 		022902D122E2436300059692 /* stats_module_disabled_error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = stats_module_disabled_error.json; sourceTree = "<group>"; };
 		022902D322E2436400059692 /* no_stats_permission_error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = no_stats_permission_error.json; sourceTree = "<group>"; };
 		025FDD2E23715A8900824006 /* product-update-description.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-update-description.json"; sourceTree = "<group>"; };
+		026CF619237D607A009563D4 /* ProductVariationAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationAttribute.swift; sourceTree = "<group>"; };
+		026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationListMapper.swift; sourceTree = "<group>"; };
+		026CF61F237D69D6009563D4 /* ProductVariationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsRemote.swift; sourceTree = "<group>"; };
+		026CF621237D7E61009563D4 /* ProductVariationsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsRemoteTests.swift; sourceTree = "<group>"; };
+		026CF623237D839A009563D4 /* product-variations-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all.json"; sourceTree = "<group>"; };
+		028296F6237D588700E84012 /* ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariation.swift; sourceTree = "<group>"; };
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
 		02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-deactivated.json"; sourceTree = "<group>"; };
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
@@ -669,6 +681,7 @@
 				74D5BECD217E0F98007B0348 /* SiteSettingsRemoteTests.swift */,
 				74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */,
 				74CF5E8321402C04000CED0A /* TopEarnerStatsRemoteTests.swift */,
+				026CF621237D7E61009563D4 /* ProductVariationsRemoteTests.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -774,6 +787,7 @@
 				74046E1A217A684D007DD7BF /* SiteSettingsRemote.swift */,
 				74A1D26E21189EA000931DFA /* SiteVisitStatsRemote.swift */,
 				74ABA1D0213F22CA00FFAD30 /* TopEarnersStatsRemote.swift */,
+				026CF61F237D69D6009563D4 /* ProductVariationsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -886,6 +900,7 @@
 				CE19CB10222486A500E8AF7A /* order-statuses.json */,
 				74749B98224135C4005C4CF2 /* product.json */,
 				025FDD2E23715A8900824006 /* product-update-description.json */,
+				026CF623237D839A009563D4 /* product-variations-load-all.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				0282DD90233A120A006A5FDB /* products-search-photo.json */,
 				CEC4BF90234E40B5008D9195 /* refund-single.json */,
@@ -960,6 +975,7 @@
 				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
 				B53EF53B21814900003E146F /* SuccessResultMapper.swift */,
 				74ABA1D2213F25AE00FFAD30 /* TopEarnerStatsMapper.swift */,
+				026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -1069,6 +1085,8 @@
 				CE132BBB223859710029DB6C /* ProductTag.swift */,
 				D88D5A46230BC838007B6E01 /* ProductReview.swift */,
 				D88D5A48230BC8C7007B6E01 /* ProductReviewStatus.swift */,
+				028296F6237D588700E84012 /* ProductVariation.swift */,
+				026CF619237D607A009563D4 /* ProductVariationAttribute.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -1182,6 +1200,7 @@
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
 				74A7B4BE217A841400E85A8B /* broken-settings-general.json in Resources */,
+				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
@@ -1394,11 +1413,13 @@
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
 				CE0A0F19223987DF0075ED8D /* ProductListMapper.swift in Sources */,
 				7452387321124B7700A973CD /* AnyCodable.swift in Sources */,
+				026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */,
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,
 				B567AF2920A0FA1E00AB6C62 /* Mapper.swift in Sources */,
 				CE50345E21B571A7007573C6 /* SitePlanMapper.swift in Sources */,
 				D8FBFF2022D52553006E3336 /* OrderStatsV4Totals.swift in Sources */,
 				CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */,
+				026CF620237D69D6009563D4 /* ProductVariationsRemote.swift in Sources */,
 				7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */,
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,
 				CE43A8F9229F463000A4FF29 /* ProductDownload.swift in Sources */,
@@ -1418,6 +1439,7 @@
 				B5C6FCCF20A3592900A4F8E4 /* OrderItem.swift in Sources */,
 				B524193F21AC5FE400D6FC0A /* DotcomDeviceMapper.swift in Sources */,
 				74749B97224134FF005C4CF2 /* ProductMapper.swift in Sources */,
+				026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */,
 				748D424A210F92EA00CF7D1B /* OrderStatsItem.swift in Sources */,
 				D8FBFF1A22D4DF7A006E3336 /* OrderStatsV4.swift in Sources */,
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
@@ -1454,6 +1476,7 @@
 				D8FBFF0B22D3ADB1006E3336 /* OrderStatsRemoteV4.swift in Sources */,
 				CE430674234BA6AD0073CBFF /* RefundMapper.swift in Sources */,
 				CE0A0F1B223989670075ED8D /* ProductsRemote.swift in Sources */,
+				028296F7237D588700E84012 /* ProductVariation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1479,6 +1502,7 @@
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
 				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
+				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
 				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductVariationListMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationListMapper.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+
+/// Mapper: ProductVariation List
+///
+struct ProductVariationListMapper: Mapper {
+    /// Site Identifier associated to the product variation that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Variation Endpoints.
+    ///
+    let siteID: Int64
+
+    /// Product Identifier associated to the product variation that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because ProductID is not returned in any of the Product Variation Endpoints.
+    ///
+    let productID: Int64
+    
+    /// (Attempts) to convert a dictionary into ProductVariation.
+    ///
+    func map(response: Data) throws -> [ProductVariation] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID,
+            .productID: productID
+        ]
+
+        return try decoder.decode(ProductVariationsEnvelope.self, from: response).productVariations
+    }
+}
+
+/// ProductVariationsEnvelope Disposable Entity
+///
+/// `Load Product Variations` endpoint returns the requested objects in the `data` key. This entity
+/// allows us to parse all the things with JSONDecoder.
+///
+private struct ProductVariationsEnvelope: Decodable {
+    let productVariations: [ProductVariation]
+
+    private enum CodingKeys: String, CodingKey {
+        case productVariations = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ProductVariationListMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationListMapper.swift
@@ -15,7 +15,7 @@ struct ProductVariationListMapper: Mapper {
     /// We're injecting this field via `JSONDecoder.userInfo` because ProductID is not returned in any of the Product Variation Endpoints.
     ///
     let productID: Int64
-    
+
     /// (Attempts) to convert a dictionary into ProductVariation.
     ///
     func map(response: Data) throws -> [ProductVariation] {

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -1,0 +1,357 @@
+import Foundation
+
+/// Represents a Product Variation Entity.
+///
+public struct ProductVariation: Decodable {
+    public let siteID: Int64
+    public let productID: Int64
+
+    public let productVariationID: Int64
+
+    public let attributes: [ProductVariationAttribute]
+    public let image: ProductImage?
+
+    public let permalink: String
+
+    public let dateCreated: Date
+    public let dateModified: Date?
+    public let dateOnSaleStart: Date?
+    public let dateOnSaleEnd: Date?
+
+    public let statusKey: String        // draft, pending, private, published
+
+    public let description: String?
+    public let sku: String?
+
+    public let price: String
+    public let regularPrice: String?
+    public let salePrice: String?
+    public let onSale: Bool
+
+    public let purchasable: Bool
+    public let virtual: Bool
+
+    public let downloadable: Bool
+    public let downloads: [ProductDownload]
+    public let downloadLimit: Int64     // defaults to -1
+    public let downloadExpiry: Int64    // defaults to -1
+
+    public let taxStatusKey: String     // taxable, shipping, none
+    public let taxClass: String?
+
+    public let manageStock: Bool
+    public let stockQuantity: Int64?    // API reports Int or null
+    public let stockStatusKey: String   // instock, outofstock, backorder
+
+    public let backordersKey: String    // no, notify, yes
+    public let backordersAllowed: Bool
+    public let backordered: Bool
+
+    public let weight: String?
+    public let dimensions: ProductDimensions
+
+    public let shippingClass: String?
+    public let shippingClassID: Int64
+
+    public let menuOrder: Int64
+
+    /// Computed Properties
+    ///
+    public var status: ProductStatus {
+        return ProductStatus(rawValue: statusKey)
+    }
+
+    public var stockStatus: ProductStockStatus {
+        return ProductStockStatus(rawValue: stockStatusKey)
+    }
+
+    /// ProductVariation struct initializer.
+    ///
+    public init(siteID: Int64,
+                productID: Int64,
+                productVariationID: Int64,
+                attributes: [ProductVariationAttribute],
+                image: ProductImage?,
+                permalink: String,
+                dateCreated: Date,
+                dateModified: Date?,
+                dateOnSaleStart: Date?,
+                dateOnSaleEnd: Date?,
+                statusKey: String,
+                description: String?,
+                sku: String?,
+                price: String,
+                regularPrice: String?,
+                salePrice: String?,
+                onSale: Bool,
+                purchasable: Bool,
+                virtual: Bool,
+                downloadable: Bool,
+                downloads: [ProductDownload],
+                downloadLimit: Int64,
+                downloadExpiry: Int64,
+                taxStatusKey: String,
+                taxClass: String?,
+                manageStock: Bool,
+                stockQuantity: Int64?,
+                stockStatusKey: String,
+                backordersKey: String,
+                backordersAllowed: Bool,
+                backordered: Bool,
+                weight: String?,
+                dimensions: ProductDimensions,
+                shippingClass: String?,
+                shippingClassID: Int64,
+                menuOrder: Int64) {
+        self.siteID = siteID
+        self.productID = productID
+        self.productVariationID = productVariationID
+        self.attributes = attributes
+        self.image = image
+        self.permalink = permalink
+        self.dateCreated = dateCreated
+        self.dateModified = dateModified
+        self.dateOnSaleStart = dateOnSaleStart
+        self.dateOnSaleEnd = dateOnSaleEnd
+        self.statusKey = statusKey
+        self.description = description
+        self.sku = sku
+        self.price = price
+        self.regularPrice = regularPrice
+        self.salePrice = salePrice
+        self.onSale = onSale
+        self.purchasable = purchasable
+        self.virtual = virtual
+        self.downloadable = downloadable
+        self.downloads = downloads
+        self.downloadLimit = downloadLimit
+        self.downloadExpiry = downloadExpiry
+        self.taxStatusKey = taxStatusKey
+        self.taxClass = taxClass
+        self.manageStock = manageStock
+        self.stockQuantity = stockQuantity
+        self.stockStatusKey = stockStatusKey
+        self.backordersKey = backordersKey
+        self.backordersAllowed = backordersAllowed
+        self.backordered = backordered
+        self.weight = weight
+        self.dimensions = dimensions
+        self.shippingClass = shippingClass
+        self.shippingClassID = shippingClassID
+        self.menuOrder = menuOrder
+    }
+
+    /// The public initializer for ProductVariation.
+    ///
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ProductVariationDecodingError.missingSiteID
+        }
+
+        guard let productID = decoder.userInfo[.productID] as? Int64 else {
+            throw ProductVariationDecodingError.missingProductID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let productVariationID = try container.decode(Int64.self, forKey: .productVariationID)
+        let attributes = try container.decode([ProductVariationAttribute].self, forKey: .attributes)
+        let image = try container.decodeIfPresent(ProductImage.self, forKey: .image)
+        let permalink = try container.decode(String.self, forKey: .permalink)
+        let dateCreated = try container.decode(Date.self, forKey: .dateCreated)
+        let dateModified = try container.decodeIfPresent(Date.self, forKey: .dateModified)
+        let dateOnSaleStart = try container.decodeIfPresent(Date.self, forKey: .dateOnSaleStart)
+        let dateOnSaleEnd = try container.decodeIfPresent(Date.self, forKey: .dateOnSaleEnd)
+        let statusKey = try container.decode(String.self, forKey: .statusKey)
+        let description = try container.decodeIfPresent(String.self, forKey: .description)
+        let sku = try container.decodeIfPresent(String.self, forKey: .sku)
+        let price = try container.decode(String.self, forKey: .price)
+        let regularPrice = try container.decodeIfPresent(String.self, forKey: .regularPrice)
+        let salePrice = try container.decodeIfPresent(String.self, forKey: .salePrice)
+        let onSale = try container.decode(Bool.self, forKey: .onSale)
+        let purchasable = try container.decode(Bool.self, forKey: .purchasable)
+        let virtual = try container.decode(Bool.self, forKey: .virtual)
+        let downloadable = try container.decode(Bool.self, forKey: .downloadable)
+        let downloads = try container.decode([ProductDownload].self, forKey: .downloads)
+        let downloadLimit = try container.decode(Int64.self, forKey: .downloadLimit)
+        let downloadExpiry = try container.decode(Int64.self, forKey: .downloadExpiry)
+        let taxStatusKey = try container.decode(String.self, forKey: .taxStatusKey)
+        let taxClass = try container.decodeIfPresent(String.self, forKey: .taxClass)
+
+        // Even though the API docs claim `manageStock` is a bool, it's possible that `"parent"`
+        // could be returned as well (typically with variations) — we need to account for this.
+        // A "parent" value means that stock mgmt is turned on + managed at the parent product-level, therefore
+        // we need to set this var as `true` in this situation.
+        // See: https://github.com/woocommerce/woocommerce-ios/issues/884 for more deets
+        var manageStock = false
+        if let parsedBoolValue = container.failsafeDecodeIfPresent(booleanForKey: .manageStock) {
+            manageStock = parsedBoolValue
+        } else if let parsedStringValue = container.failsafeDecodeIfPresent(stringForKey: .manageStock) {
+            // A bool could not be parsed — check if "parent" is set, and if so, set manageStock to `true`
+            manageStock = parsedStringValue.lowercased() == Values.manageStockParent ? true : false
+        }
+
+        let stockQuantity = try container.decodeIfPresent(Int64.self, forKey: .stockQuantity)
+        let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
+        let backordersKey = try container.decode(String.self, forKey: .backordersKey)
+        let backordersAllowed = try container.decode(Bool.self, forKey: .backordersAllowed)
+        let backordered = try container.decode(Bool.self, forKey: .backordered)
+        let weight = try container.decodeIfPresent(String.self, forKey: .weight)
+        let dimensions = try container.decode(ProductDimensions.self, forKey: .dimensions)
+        let shippingClass = try container.decodeIfPresent(String.self, forKey: .shippingClass)
+        let shippingClassID = try container.decode(Int64.self, forKey: .shippingClassID)
+        let menuOrder = try container.decode(Int64.self, forKey: .menuOrder)
+
+        self.init(siteID: siteID,
+                  productID: productID,
+                  productVariationID: productVariationID,
+                  attributes: attributes,
+                  image: image,
+                  permalink: permalink,
+                  dateCreated: dateCreated,
+                  dateModified: dateModified,
+                  dateOnSaleStart: dateOnSaleStart,
+                  dateOnSaleEnd: dateOnSaleEnd,
+                  statusKey: statusKey,
+                  description: description,
+                  sku: sku,
+                  price: price,
+                  regularPrice: regularPrice,
+                  salePrice: salePrice,
+                  onSale: onSale,
+                  purchasable: purchasable,
+                  virtual: virtual,
+                  downloadable: downloadable,
+                  downloads: downloads,
+                  downloadLimit: downloadLimit,
+                  downloadExpiry: downloadExpiry,
+                  taxStatusKey: taxStatusKey,
+                  taxClass: taxClass,
+                  manageStock: manageStock,
+                  stockQuantity: stockQuantity,
+                  stockStatusKey: stockStatusKey,
+                  backordersKey: backordersKey,
+                  backordersAllowed: backordersAllowed,
+                  backordered: backordered,
+                  weight: weight,
+                  dimensions: dimensions,
+                  shippingClass: shippingClass,
+                  shippingClassID: shippingClassID,
+                  menuOrder: menuOrder)
+    }
+}
+
+/// Defines all of the ProductVariation CodingKeys
+///
+private extension ProductVariation {
+
+    enum CodingKeys: String, CodingKey {
+        case productVariationID = "id"
+        case permalink
+
+        case dateCreated = "date_created_gmt"
+        case dateModified = "date_modified_gmt"
+        case dateOnSaleStart  = "date_on_sale_from_gmt"
+        case dateOnSaleEnd = "date_on_sale_to_gmt"
+
+        case statusKey = "status"
+
+        case description
+
+        case sku
+        case price
+        case regularPrice   = "regular_price"
+        case salePrice      = "sale_price"
+        case onSale         = "on_sale"
+
+        case purchasable
+
+        case virtual
+
+        case downloadable
+        case downloads
+        case downloadLimit  = "download_limit"
+        case downloadExpiry = "download_expiry"
+
+        case taxStatusKey   = "tax_status"
+        case taxClass       = "tax_class"
+
+        case manageStock    = "manage_stock"
+        case stockQuantity  = "stock_quantity"
+        case stockStatusKey = "stock_status"
+
+        case backordersKey      = "backorders"
+        case backordersAllowed  = "backorders_allowed"
+        case backordered
+
+        case weight
+        case dimensions
+
+        case shippingClass      = "shipping_class"
+        case shippingClassID    = "shipping_class_id"
+
+        case image
+
+        case attributes
+        case menuOrder          = "menu_order"
+    }
+}
+
+
+// MARK: - Equatable Conformance
+//
+extension ProductVariation: Equatable {
+    public static func == (lhs: ProductVariation, rhs: ProductVariation) -> Bool {
+        return lhs.siteID == rhs.siteID &&
+            lhs.productID == rhs.productID &&
+            lhs.productVariationID == rhs.productVariationID &&
+            lhs.attributes == rhs.attributes &&
+            lhs.image == rhs.image &&
+            lhs.permalink == rhs.permalink &&
+            lhs.dateCreated == rhs.dateCreated &&
+            lhs.dateModified == rhs.dateModified &&
+            lhs.dateOnSaleStart == rhs.dateOnSaleStart &&
+            lhs.dateOnSaleEnd == rhs.dateOnSaleEnd &&
+            lhs.statusKey == rhs.statusKey &&
+            lhs.description == rhs.description &&
+            lhs.sku == rhs.sku &&
+            lhs.price == rhs.price &&
+            lhs.regularPrice == rhs.regularPrice &&
+            lhs.salePrice == rhs.salePrice &&
+            lhs.onSale == rhs.onSale &&
+            lhs.purchasable == rhs.purchasable &&
+            lhs.virtual == rhs.virtual &&
+            lhs.downloadable == rhs.downloadable &&
+            lhs.downloads == rhs.downloads &&
+            lhs.downloadLimit == rhs.downloadLimit &&
+            lhs.downloadExpiry == rhs.downloadExpiry &&
+            lhs.taxStatusKey == rhs.taxStatusKey &&
+            lhs.taxClass == rhs.taxClass &&
+            lhs.manageStock == rhs.manageStock &&
+            lhs.stockQuantity == rhs.stockQuantity &&
+            lhs.stockStatusKey == rhs.stockStatusKey &&
+            lhs.backordersKey == rhs.backordersKey &&
+            lhs.backordersAllowed == rhs.backordersAllowed &&
+            lhs.backordered == rhs.backordered &&
+            lhs.weight == rhs.weight &&
+            lhs.dimensions == rhs.dimensions &&
+            lhs.shippingClass == rhs.shippingClass &&
+            lhs.shippingClassID == rhs.shippingClassID &&
+            lhs.menuOrder == rhs.menuOrder
+    }
+}
+
+// MARK: - Constants!
+//
+private extension ProductVariation {
+    enum Values {
+        static let manageStockParent = "parent"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum ProductVariationDecodingError: Error {
+    case missingSiteID
+    case missingProductID
+}

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -18,7 +18,7 @@ public struct ProductVariation: Decodable {
     public let dateOnSaleStart: Date?
     public let dateOnSaleEnd: Date?
 
-    public var status: ProductStatus
+    public let status: ProductStatus
 
     public let description: String?
     public let sku: String?
@@ -41,7 +41,7 @@ public struct ProductVariation: Decodable {
 
     public let manageStock: Bool
     public let stockQuantity: Int64?    // API reports Int or null
-    public var stockStatus: ProductStockStatus
+    public let stockStatus: ProductStockStatus
 
     public let backordersKey: String    // no, notify, yes
     public let backordersAllowed: Bool

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -18,7 +18,7 @@ public struct ProductVariation: Decodable {
     public let dateOnSaleStart: Date?
     public let dateOnSaleEnd: Date?
 
-    public let statusKey: String        // draft, pending, private, published
+    public var status: ProductStatus
 
     public let description: String?
     public let sku: String?
@@ -41,7 +41,7 @@ public struct ProductVariation: Decodable {
 
     public let manageStock: Bool
     public let stockQuantity: Int64?    // API reports Int or null
-    public let stockStatusKey: String   // instock, outofstock, backorder
+    public var stockStatus: ProductStockStatus
 
     public let backordersKey: String    // no, notify, yes
     public let backordersAllowed: Bool
@@ -55,16 +55,6 @@ public struct ProductVariation: Decodable {
 
     public let menuOrder: Int64
 
-    /// Computed Properties
-    ///
-    public var status: ProductStatus {
-        return ProductStatus(rawValue: statusKey)
-    }
-
-    public var stockStatus: ProductStockStatus {
-        return ProductStockStatus(rawValue: stockStatusKey)
-    }
-
     /// ProductVariation struct initializer.
     ///
     public init(siteID: Int64,
@@ -77,7 +67,7 @@ public struct ProductVariation: Decodable {
                 dateModified: Date?,
                 dateOnSaleStart: Date?,
                 dateOnSaleEnd: Date?,
-                statusKey: String,
+                status: ProductStatus,
                 description: String?,
                 sku: String?,
                 price: String,
@@ -94,7 +84,7 @@ public struct ProductVariation: Decodable {
                 taxClass: String?,
                 manageStock: Bool,
                 stockQuantity: Int64?,
-                stockStatusKey: String,
+                stockStatus: ProductStockStatus,
                 backordersKey: String,
                 backordersAllowed: Bool,
                 backordered: Bool,
@@ -113,7 +103,7 @@ public struct ProductVariation: Decodable {
         self.dateModified = dateModified
         self.dateOnSaleStart = dateOnSaleStart
         self.dateOnSaleEnd = dateOnSaleEnd
-        self.statusKey = statusKey
+        self.status = status
         self.description = description
         self.sku = sku
         self.price = price
@@ -130,7 +120,7 @@ public struct ProductVariation: Decodable {
         self.taxClass = taxClass
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
-        self.stockStatusKey = stockStatusKey
+        self.stockStatus = stockStatus
         self.backordersKey = backordersKey
         self.backordersAllowed = backordersAllowed
         self.backordered = backordered
@@ -163,6 +153,7 @@ public struct ProductVariation: Decodable {
         let dateOnSaleStart = try container.decodeIfPresent(Date.self, forKey: .dateOnSaleStart)
         let dateOnSaleEnd = try container.decodeIfPresent(Date.self, forKey: .dateOnSaleEnd)
         let statusKey = try container.decode(String.self, forKey: .statusKey)
+        let status = ProductStatus(rawValue: statusKey)
         let description = try container.decodeIfPresent(String.self, forKey: .description)
         let sku = try container.decodeIfPresent(String.self, forKey: .sku)
         let price = try container.decode(String.self, forKey: .price)
@@ -193,6 +184,7 @@ public struct ProductVariation: Decodable {
 
         let stockQuantity = try container.decodeIfPresent(Int64.self, forKey: .stockQuantity)
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
+        let stockStatus = ProductStockStatus(rawValue: stockStatusKey)
         let backordersKey = try container.decode(String.self, forKey: .backordersKey)
         let backordersAllowed = try container.decode(Bool.self, forKey: .backordersAllowed)
         let backordered = try container.decode(Bool.self, forKey: .backordered)
@@ -212,7 +204,7 @@ public struct ProductVariation: Decodable {
                   dateModified: dateModified,
                   dateOnSaleStart: dateOnSaleStart,
                   dateOnSaleEnd: dateOnSaleEnd,
-                  statusKey: statusKey,
+                  status: status,
                   description: description,
                   sku: sku,
                   price: price,
@@ -229,7 +221,7 @@ public struct ProductVariation: Decodable {
                   taxClass: taxClass,
                   manageStock: manageStock,
                   stockQuantity: stockQuantity,
-                  stockStatusKey: stockStatusKey,
+                  stockStatus: stockStatus,
                   backordersKey: backordersKey,
                   backordersAllowed: backordersAllowed,
                   backordered: backordered,
@@ -312,7 +304,7 @@ extension ProductVariation: Equatable {
             lhs.dateModified == rhs.dateModified &&
             lhs.dateOnSaleStart == rhs.dateOnSaleStart &&
             lhs.dateOnSaleEnd == rhs.dateOnSaleEnd &&
-            lhs.statusKey == rhs.statusKey &&
+            lhs.status == rhs.status &&
             lhs.description == rhs.description &&
             lhs.sku == rhs.sku &&
             lhs.price == rhs.price &&
@@ -329,7 +321,7 @@ extension ProductVariation: Equatable {
             lhs.taxClass == rhs.taxClass &&
             lhs.manageStock == rhs.manageStock &&
             lhs.stockQuantity == rhs.stockQuantity &&
-            lhs.stockStatusKey == rhs.stockStatusKey &&
+            lhs.stockStatus == rhs.stockStatus &&
             lhs.backordersKey == rhs.backordersKey &&
             lhs.backordersAllowed == rhs.backordersAllowed &&
             lhs.backordered == rhs.backordered &&

--- a/Networking/Networking/Model/Product/ProductVariationAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductVariationAttribute.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Represents a Product Variation Attribute Entity.
+///
+public struct ProductVariationAttribute: Decodable {
+    public let id: Int64
+    public let name: String
+    public let option: String
+
+    public init(id: Int64, name: String, option: String) {
+        self.id = id
+        self.name = name
+        self.option = option
+    }
+}
+
+// MARK: - Equatable Conformance
+//
+extension ProductVariationAttribute: Equatable {
+    public static func == (lhs: ProductVariationAttribute, rhs: ProductVariationAttribute) -> Bool {
+        return lhs.id == rhs.id &&
+            lhs.name == rhs.name &&
+            lhs.option == rhs.option
+    }
+}

--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Alamofire
+
+
+/// ProductVariation: Remote Endpoints
+///
+public class ProductVariationsRemote: Remote {
+
+    /// Retrieves all of the `ProductVariation`s available.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote product variations.
+    ///     - productID: Product for which we'll fetch remote product variations.
+    ///     - context: view or edit. Scope under which the request is made;
+    ///                determines fields present in response. Default is view.
+    ///     - pageNumber: Number of page that should be retrieved.
+    ///     - pageSize: Number of product variations to be retrieved per page.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func loadAllProductVariations(for siteID: Int64,
+                                         productID: Int64,
+                                         context: String? = nil,
+                                         pageNumber: Int = Default.pageNumber,
+                                         pageSize: Int = Default.pageSize,
+                                         completion: @escaping ([ProductVariation]?, Error?) -> Void) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.contextKey: context ?? Default.context
+        ]
+
+        let path = "\(Path.products)/\(productID)/variations"
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int(siteID), path: path, parameters: parameters)
+        let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+
+// MARK: - Constants
+//
+public extension ProductVariationsRemote {
+    enum Default {
+        public static let pageSize: Int   = 25
+        public static let pageNumber: Int = 1
+        public static let context: String = "view"
+    }
+
+    private enum Path {
+        static let products   = "products"
+    }
+
+    private enum ParameterKey {
+        static let page: String       = "page"
+        static let perPage: String    = "per_page"
+        static let contextKey: String = "context"
+    }
+}

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+
+@testable import Networking
+
+final class ProductVariationsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockupNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID: Int64 = 1234
+
+    /// Dummy Product ID
+    ///
+    let sampleProductID: Int64 = 173
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        super.setUp()
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - Load all product variations tests
+
+    /// Verifies that loadAllProductVariations properly parses the `product-variations-load-all` sample response.
+    ///
+    func testLoadAllProductVariationsProperlyReturnsParsedData() {
+        let remote = ProductVariationsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Product Variations")
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+
+        remote.loadAllProductVariations(for: sampleSiteID, productID: sampleProductID) { productVariations, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(productVariations)
+            XCTAssertEqual(productVariations?.count, 8)
+
+            // Validates on Variation of ID 1275.
+            let expectedVariationID = 1275
+            guard let expectedVariation = productVariations?.first(where: { $0.productVariationID == expectedVariationID }) else {
+                XCTFail("Product variation with ID \(expectedVariationID) should exist")
+                return
+            }
+            XCTAssertEqual(expectedVariation.description, "<p>Nutty chocolate marble, 99% and organic.</p>\n")
+            XCTAssertEqual(expectedVariation.sku, "99%-nuts-marble")
+            XCTAssertEqual(expectedVariation.permalink, "https://chocolate.com/marble")
+
+            XCTAssertEqual(expectedVariation.dateCreated, self.dateFromGMT("2019-11-14T12:40:55"))
+            XCTAssertEqual(expectedVariation.dateModified, self.dateFromGMT("2019-11-14T13:06:42"))
+            XCTAssertEqual(expectedVariation.dateOnSaleStart, self.dateFromGMT("2019-10-15T21:30:00"))
+            XCTAssertEqual(expectedVariation.dateOnSaleEnd, self.dateFromGMT("2019-10-27T21:29:59"))
+
+            let expectedPrice = 12
+            XCTAssertEqual(expectedVariation.price, "\(expectedPrice)")
+            XCTAssertEqual(expectedVariation.regularPrice, "\(expectedPrice)")
+            XCTAssertEqual(expectedVariation.salePrice, "8")
+
+            XCTAssertEqual(expectedVariation.status, .publish)
+            XCTAssertEqual(expectedVariation.stockStatus, .inStock)
+
+            let expectedAttributes: [ProductVariationAttribute] = [
+                ProductVariationAttribute(id: 0, name: "Darkness", option: "99%"),
+                ProductVariationAttribute(id: 0, name: "Flavor", option: "nuts"),
+                ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
+            ]
+            XCTAssertEqual(expectedVariation.attributes, expectedAttributes)
+
+            XCTAssertEqual(expectedVariation.image?.imageID, 1063)
+
+            XCTAssertFalse(expectedVariation.onSale)
+            XCTAssertTrue(expectedVariation.purchasable)
+            XCTAssertFalse(expectedVariation.virtual)
+            XCTAssertTrue(expectedVariation.downloadable)
+
+            XCTAssertTrue(expectedVariation.manageStock)
+            XCTAssertEqual(expectedVariation.stockQuantity, 16)
+            XCTAssertEqual(expectedVariation.backordersKey, "notify")
+            XCTAssertTrue(expectedVariation.backordersAllowed)
+            XCTAssertFalse(expectedVariation.backordered)
+
+            XCTAssertEqual(expectedVariation.downloads.count, 0)
+            XCTAssertEqual(expectedVariation.downloadLimit, -1)
+            XCTAssertEqual(expectedVariation.downloadExpiry, 0)
+
+            XCTAssertEqual(expectedVariation.taxStatusKey, "taxable")
+            XCTAssertEqual(expectedVariation.taxClass, "")
+
+            XCTAssertEqual(expectedVariation.weight, "2.5")
+            XCTAssertEqual(expectedVariation.dimensions, ProductDimensions(length: "10", width: "2.5", height: ""))
+
+            XCTAssertEqual(expectedVariation.shippingClass, "")
+            XCTAssertEqual(expectedVariation.shippingClassID, 0)
+
+            XCTAssertEqual(expectedVariation.menuOrder, 8)
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that loadAllProductVariations properly relays Networking Layer errors.
+    ///
+    func testLoadAllProductVariationsProperlyRelaysNetwokingErrors() {
+        let remote = ProductVariationsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Product Variations returns error")
+
+        remote.loadAllProductVariations(for: sampleSiteID, productID: sampleProductID) { (productVariations, error) in
+            XCTAssertNil(productVariations)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+}
+
+private extension ProductVariationsRemoteTests {
+    func dateFromGMT(_ dateStringInGMT: String) -> Date {
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+        return dateFormatter.date(from: dateStringInGMT)!
+    }
+}

--- a/Networking/NetworkingTests/Responses/product-variations-load-all.json
+++ b/Networking/NetworkingTests/Responses/product-variations-load-all.json
@@ -1,0 +1,748 @@
+{
+    "data": [
+        {
+            "id": 1275,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+            "permalink": "https://chocolate.com/marble",
+            "sku": "99%-nuts-marble",
+            "price": "12",
+            "regular_price": "12",
+            "sale_price": "8",
+            "date_on_sale_from": "2019-10-16T00:00:00",
+            "date_on_sale_from_gmt": "2019-10-15T21:30:00",
+            "date_on_sale_to": "2019-10-27T23:59:59",
+            "date_on_sale_to_gmt": "2019-10-27T21:29:59",
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": true,
+            "virtual": false,
+            "downloadable": true,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": 0,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": true,
+            "stock_quantity": 16,
+            "stock_status": "instock",
+            "backorders": "notify",
+            "backorders_allowed": true,
+            "backordered": false,
+            "weight": "2.5",
+            "dimensions": {
+                "length": "10",
+                "width": "2.5",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 8,
+            "meta_data": [
+                {
+                    "id": 6767,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1275"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1274,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=99%25&attribute_flavor=nuts&attribute_shape=brick",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "brick"
+                }
+            ],
+            "menu_order": 7,
+            "meta_data": [
+                {
+                    "id": 6747,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1274"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1273,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=99%25&attribute_flavor=strawberry&attribute_shape=marble",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "strawberry"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 6,
+            "meta_data": [
+                {
+                    "id": 6727,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1273"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1272,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=99%25&attribute_flavor=strawberry&attribute_shape=brick",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "strawberry"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "brick"
+                }
+            ],
+            "menu_order": 5,
+            "meta_data": [
+                {
+                    "id": 6707,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1272"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1271,
+            "date_created": "2019-11-14T15:10:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=87%25&attribute_flavor=nuts&attribute_shape=marble",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "87%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 4,
+            "meta_data": [
+                {
+                    "id": 6687,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1271"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1270,
+            "date_created": "2019-11-14T15:10:54",
+            "date_created_gmt": "2019-11-14T12:40:54",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=87%25&attribute_flavor=nuts&attribute_shape=brick",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "87%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "brick"
+                }
+            ],
+            "menu_order": 3,
+            "meta_data": [
+                {
+                    "id": 6667,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1270"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1269,
+            "date_created": "2019-11-14T15:10:54",
+            "date_created_gmt": "2019-11-14T12:40:54",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=87%25&attribute_flavor=strawberry&attribute_shape=marble",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "87%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "strawberry"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 2,
+            "meta_data": [
+                {
+                    "id": 6647,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1269"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 1268,
+            "date_created": "2019-11-14T15:10:54",
+            "date_created_gmt": "2019-11-14T12:40:54",
+            "date_modified": "2019-11-14T15:36:42",
+            "date_modified_gmt": "2019-11-14T13:06:42",
+            "description": "",
+            "permalink": "https://funtestingusa.wpcomstaging.com/product/chocolate-2/?attribute_darkness=87%25&attribute_flavor=strawberry&attribute_shape=brick",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "image": {
+                "id": 1063,
+                "date_created": "2019-11-01T08:42:05",
+                "date_created_gmt": "2019-11-01T04:12:05",
+                "date_modified": "2019-11-01T08:42:05",
+                "date_modified_gmt": "2019-11-01T04:12:05",
+                "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                "name": "DSC_0010",
+                "alt": ""
+            },
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "87%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "strawberry"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "brick"
+                }
+            ],
+            "menu_order": 1,
+            "meta_data": [
+                {
+                    "id": 6627,
+                    "key": "_created_via",
+                    "value": "ajax-unknown"
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations/1268"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846/variations"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "https://funtestingusa.wpcomstaging.com/wp-json/wc/v3/products/846"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Networking layer for #1468 

## Changes
- Note: 748 diffs are on the JSON response for unit test, and many lines are on the ~35 properties of `ProductVariation` & equatable conformance 😛 
- Created `ProductVariation` and `ProductVariationAttribute` that represent the immutable entities in Networking layer
- Created `ProductVariationListMapper` that maps the API response (in the form of `{"data": { actual response }}` to an array of `ProductVariation`
- Created `ProductVariationsRemote` with a function `loadAllProductVariations` to retrieve all of the `ProductVariation`s available on the server

## Testing
CI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
