### PR TITLE
Readonly Product Variations: Yosemite changes

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -336,17 +336,6 @@ public extension StorageType {
         return firstObject(ofType: ProductVariation.self, matching: predicate)
     }
 
-    /// Retrieves a stored Product Variation Attribute.
-    ///
-    /// Note: WC attribute ID's often have an ID of `0` (local Product attributes), so we need to
-    /// also look them up by key and value
-    ///
-    func loadProductVariationAttribute(attributeID: Int64, name: String, option: String) -> Attribute? {
-        let predicate = NSPredicate(format: "id = %lld AND key = %@ AND value = %@",
-                                    attributeID, name, option)
-        return firstObject(ofType: Attribute.self, matching: predicate)
-    }
-
     // MARK: - Refunds
 
     /// Retrieves a stored Refund for the provided siteID, orderID, and refundID.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */; };
 		0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */; };
 		0232372922F7DA6E00715FAB /* StatsTimeRangeV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */; };
+		026CF626237D8EFB009563D4 /* ProductVariationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF625237D8EFB009563D4 /* ProductVariationStore.swift */; };
+		026CF628237D8F30009563D4 /* ProductVariationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF627237D8F30009563D4 /* ProductVariationAction.swift */; };
+		026CF62A237D92C6009563D4 /* ProductVariation+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF629237D92C6009563D4 /* ProductVariation+ReadOnlyConvertible.swift */; };
+		026CF62C237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */; };
+		026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */; };
 		028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */; };
 		029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */; };
 		02BA23C222EEEABC009539E7 /* AvailabilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */; };
@@ -161,6 +166,11 @@
 		0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Date.swift"; sourceTree = "<group>"; };
 		0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+DateTests.swift"; sourceTree = "<group>"; };
 		0232372822F7DA6E00715FAB /* StatsTimeRangeV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeV4.swift; sourceTree = "<group>"; };
+		026CF625237D8EFB009563D4 /* ProductVariationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationStore.swift; sourceTree = "<group>"; };
+		026CF627237D8F30009563D4 /* ProductVariationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationAction.swift; sourceTree = "<group>"; };
+		026CF629237D92C6009563D4 /* ProductVariation+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariationAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationStoreTests.swift; sourceTree = "<group>"; };
 		028BCE2322DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsStoreErrorTests.swift; sourceTree = "<group>"; };
 		029B00A6230D64E800B0AE66 /* StatsTimeRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeTests.swift; sourceTree = "<group>"; };
 		02BA23C122EEEABC009539E7 /* AvailabilityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityStore.swift; sourceTree = "<group>"; };
@@ -422,6 +432,8 @@
 				744A3217216D55F80051439B /* SiteVisitStatsItem+ReadOnlyConvertible.swift */,
 				7455D4662141B57600FA8C1F /* TopEarnerStats+ReadOnlyConvertible.swift */,
 				7455D4682141B59E00FA8C1F /* TopEarnerStatsItem+ReadOnlyConvertible.swift */,
+				026CF629237D92C6009563D4 /* ProductVariation+ReadOnlyConvertible.swift */,
+				026CF62B237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -490,6 +502,7 @@
 				74D7FFF9221F01E90008CC0E /* ShipmentStore.swift */,
 				74A18C552113827E00DCF8A8 /* StatsStore.swift */,
 				D8C11A4F22DF2D9400D4A88D /* StatsStoreV4.swift */,
+				026CF625237D8EFB009563D4 /* ProductVariationStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -514,6 +527,7 @@
 				7495C5282114979D00CDD33B /* StatsStoreTests.swift */,
 				D8C11A5922DFC21600D4A88D /* StatsStoreV4Tests.swift */,
 				02BA23C522EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift */,
+				026D52BF238235930092AE05 /* ProductVariationStoreTests.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -649,6 +663,7 @@
 				74643EE0221F567E00EDC51A /* ShipmentAction.swift */,
 				74A18C57211382A000DCF8A8 /* StatsAction.swift */,
 				D8C11A5122DF2DA200D4A88D /* StatsActionV4.swift */,
+				026CF627237D8F30009563D4 /* ProductVariationAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -862,6 +877,7 @@
 				CE4FD4562350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift in Sources */,
 				74FD596F216FB6ED00A5AE83 /* OrderStatsItem+ReadOnlyConvertible.swift in Sources */,
 				CE3B7AD92229C3570050FE4B /* OrderStatus+ReadOnlyType.swift in Sources */,
+				026CF62C237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift in Sources */,
 				74B7D6B020F910AF002667AC /* OrderNote+ReadOnlyConvertible.swift in Sources */,
 				74B2601F2188A92A0041793A /* Note+ReadOnlyConvertible.swift in Sources */,
 				CE179D57235F4E7500C24EB3 /* RefundStore.swift in Sources */,
@@ -915,8 +931,10 @@
 				CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */,
 				0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */,
 				74D7F29B20F6A7FB0058B2F0 /* Order+ReadOnlyConvertible.swift in Sources */,
+				026CF628237D8F30009563D4 /* ProductVariationAction.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
+				026CF626237D8EFB009563D4 /* ProductVariationStore.swift in Sources */,
 				B52E0034211A449600700FDE /* Site+ReadOnlyType.swift in Sources */,
 				D8C11A5822DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift in Sources */,
 				CE12FBDB221F406100C59248 /* OrderStatus+ReadOnlyConvertible.swift in Sources */,
@@ -948,6 +966,7 @@
 				7492FADB217FAE4D00ED2C69 /* SiteSetting+ReadOnlyType.swift in Sources */,
 				741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */,
 				74937502224968F8007D85D1 /* Product+ReadOnlyType.swift in Sources */,
+				026CF62A237D92C6009563D4 /* ProductVariation+ReadOnlyConvertible.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -961,6 +980,7 @@
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockupAcount.swift in Sources */,
 				02DA641B2313D6D200284168 /* AppSettingsStoreTests+StatsVersion.swift in Sources */,
+				026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */,
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,
 				0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Networking
+
+
+// MARK: - ProductVariationAction: Defines all of the Actions supported by the ProductVariationStore.
+//
+public enum ProductVariationAction: Action {
+
+    /// Synchronizes the ProductVariation's matching the specified criteria.
+    ///
+    case synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -48,6 +48,8 @@ public typealias ProductAttribute = Networking.ProductAttribute
 public typealias ProductDimensions = Networking.ProductDimensions
 public typealias ProductDefaultAttribute = Networking.ProductDefaultAttribute
 public typealias ProductDownload = Networking.ProductDownload
+public typealias ProductVariation = Networking.ProductVariation
+public typealias ProductVariationAttribute = Networking.ProductVariationAttribute
 public typealias Refund = Networking.Refund
 public typealias StatGranularity = Networking.StatGranularity
 public typealias StatsGranularityV4 = Networking.StatsGranularityV4
@@ -69,6 +71,7 @@ public typealias WooAPIVersion = Networking.WooAPIVersion
 // MARK: - Exported Storage Symbols
 
 public typealias StorageAccount = Storage.Account
+public typealias StorageAttribute = Storage.Attribute
 public typealias StorageNote = Storage.Note
 public typealias StorageOrder = Storage.Order
 public typealias StorageOrderNote = Storage.OrderNote
@@ -88,6 +91,7 @@ public typealias StorageProductDefaultAttribute = Storage.ProductDefaultAttribut
 public typealias StorageProductDownload = Storage.ProductDownload
 public typealias StorageProductReview = Storage.ProductReview
 public typealias StorageProductTag = Storage.ProductTag
+public typealias StorageProductVariation = Storage.ProductVariation
 public typealias StorageShipmentTracking = Storage.ShipmentTracking
 public typealias StorageShipmentTrackingProvider = Storage.ShipmentTrackingProvider
 public typealias StorageShipmentTrackingProviderGroup = Storage.ShipmentTrackingProviderGroup

--- a/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Storage
+
+extension Storage.ProductVariation {
+    var attributesArray: [Attribute] {
+        guard let attributes = attributes.array as? [Attribute] else {
+            return []
+        }
+        return attributes
+    }
+}
+
+// MARK: - Storage.ProductVariation: ReadOnlyConvertible
+//
+extension Storage.ProductVariation: ReadOnlyConvertible {
+
+    /// Updates the Storage.ProductVariation with the ReadOnly.
+    ///
+    public func update(with productVariation: Yosemite.ProductVariation) {
+        siteID = productVariation.siteID
+        productID = productVariation.productID
+        productVariationID = productVariation.productVariationID
+
+        permalink = productVariation.permalink
+
+        dateCreated = productVariation.dateCreated
+        dateModified = productVariation.dateModified
+        dateOnSaleStart = productVariation.dateOnSaleStart
+        dateOnSaleEnd = productVariation.dateOnSaleEnd
+
+        statusKey = productVariation.status.rawValue
+
+        fullDescription = productVariation.description
+        sku = productVariation.sku
+
+        price = productVariation.price
+        regularPrice = productVariation.regularPrice
+        salePrice = productVariation.salePrice
+        onSale = productVariation.onSale
+
+        purchasable = productVariation.purchasable
+        virtual = productVariation.virtual
+
+        downloadable = productVariation.downloadable
+        downloadLimit = productVariation.downloadLimit
+        downloadExpiry = productVariation.downloadExpiry
+
+        taxStatusKey = productVariation.taxStatusKey
+        taxClass = productVariation.taxClass
+
+        manageStock = productVariation.manageStock
+        stockQuantity = productVariation.stockQuantity ?? 0
+        stockStatusKey = productVariation.stockStatus.rawValue
+
+        backordersKey = productVariation.backordersKey
+        backordersAllowed = productVariation.backordersAllowed
+        backordered = productVariation.backordered
+
+        weight = productVariation.weight
+
+        shippingClass = productVariation.shippingClass
+        shippingClassID = productVariation.shippingClassID
+
+        menuOrder = productVariation.menuOrder
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.ProductVariation {
+        let productDownloads = downloads?.map { $0.toReadOnly() } ?? [Yosemite.ProductDownload]()
+        let productImage = image?.toReadOnly()
+        let productAttributes = attributesArray.map { $0.toReadOnly() }
+        let productDimensions = createReadOnlyDimensions()
+
+        return ProductVariation(siteID: siteID,
+                                productID: productID,
+                                productVariationID: productVariationID,
+                                attributes: productAttributes,
+                                image: productImage,
+                                permalink: permalink,
+                                dateCreated: dateCreated,
+                                dateModified: dateModified,
+                                dateOnSaleStart: dateOnSaleStart,
+                                dateOnSaleEnd: dateOnSaleEnd,
+                                status: ProductStatus(rawValue: statusKey),
+                                description: fullDescription,
+                                sku: sku,
+                                price: price,
+                                regularPrice: regularPrice,
+                                salePrice: salePrice,
+                                onSale: onSale,
+                                purchasable: purchasable,
+                                virtual: virtual,
+                                downloadable: downloadable,
+                                downloads: productDownloads,
+                                downloadLimit: downloadLimit,
+                                downloadExpiry: downloadExpiry,
+                                taxStatusKey: taxStatusKey,
+                                taxClass: taxClass,
+                                manageStock: manageStock,
+                                stockQuantity: stockQuantity,
+                                stockStatus: ProductStockStatus(rawValue: stockStatusKey),
+                                backordersKey: backordersKey,
+                                backordersAllowed: backordersAllowed,
+                                backordered: backordered,
+                                weight: weight,
+                                dimensions: productDimensions,
+                                shippingClass: shippingClass,
+                                shippingClassID: shippingClassID,
+                                menuOrder: menuOrder)
+    }
+}
+
+// MARK: - Private Helpers
+//
+private extension Storage.ProductVariation {
+    func createReadOnlyDimensions() -> Yosemite.ProductDimensions {
+        guard let dimensions = dimensions else {
+            return ProductDimensions(length: "", width: "", height: "")
+        }
+
+        return ProductDimensions(length: dimensions.length, width: dimensions.width, height: dimensions.height)
+    }
+}

--- a/Yosemite/Yosemite/Model/Storage/ProductVariationAttribute+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductVariationAttribute+ReadOnlyConvertible.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Storage
+
+// Storage.Attribute: ReadOnlyConvertible Conformance.
+//
+extension Storage.Attribute: ReadOnlyConvertible {
+
+    /// Updates the Storage.Attribute with the a ReadOnly ProductVariationAttribute.
+    ///
+    public func update(with attribute: Yosemite.ProductVariationAttribute) {
+        id = attribute.id
+        key = attribute.name
+        value = attribute.option
+    }
+
+    /// Returns a ReadOnly version of the receiver.
+    ///
+    public func toReadOnly() -> Yosemite.ProductVariationAttribute {
+        return ProductVariationAttribute(id: id,
+                                         name: key,
+                                         option: value)
+    }
+}

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Networking
+import Storage
+
+// MARK: - ProductVariationStore
+//
+public final class ProductVariationStore: Store {
+
+    private lazy var sharedDerivedStorage: StorageType = {
+        return storageManager.newDerivedStorage()
+    }()
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: ProductVariationAction.self)
+    }
+
+    /// Receives and executes Actions.
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? ProductVariationAction else {
+            assertionFailure("ProductReviewStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case .synchronizeProductVariations(let siteID, let productID, let pageNumber, let pageSize, let onCompletion):
+            synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        }
+    }
+}
+
+
+// MARK: - Services!
+//
+private extension ProductVariationStore {
+
+    /// Synchronizes the product reviews associated with a given Site ID (if any!).
+    ///
+    func synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+        let remote = ProductVariationsRemote(network: network)
+
+        remote.loadAllProductVariations(for: siteID, productID: productID) { [weak self] (productVariations, error) in
+            guard let productVariations = productVariations else {
+                onCompletion(error)
+                return
+            }
+
+            self?.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations, siteID: siteID, productID: productID) {
+                onCompletion(nil)
+            }
+        }
+    }
+}
+
+
+// MARK: - Storage: ProductReview
+//
+private extension ProductVariationStore {
+
+    /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities *in a background thread*. onCompletion will be called
+    /// on the main thread!
+    ///
+    func upsertStoredProductVariationsInBackground(readOnlyProductVariations: [Networking.ProductVariation], siteID: Int64, productID: Int64, onCompletion: @escaping () -> Void) {
+        let derivedStorage = sharedDerivedStorage
+        derivedStorage.perform { [weak self] in
+            self?.upsertStoredProductVariations(readOnlyProductVariations: readOnlyProductVariations, in: derivedStorage, siteID: siteID, productID: productID)
+        }
+
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+}
+
+
+private extension ProductVariationStore {
+    /// Updates (OR Inserts) the specified ReadOnly ProductVariation Entities into the Storage Layer.
+    ///
+    /// - Parameters:
+    ///     - readOnlyProductVariations: Remote ProductVariation's to be persisted.
+    ///     - storage: Where we should save all the things!
+    ///     - siteID: site ID for looking up the Product.
+    ///     - productID: product ID for looking up the Product.
+    ///
+    func upsertStoredProductVariations(readOnlyProductVariations: [Networking.ProductVariation],
+                                       in storage: StorageType,
+                                       siteID: Int64,
+                                       productID: Int64) {
+        let product = storage.loadProduct(siteID: Int(siteID), productID: Int(productID))
+
+        // Upserts the Product Variations from the read-only version
+        for readOnlyProductVariation in readOnlyProductVariations {
+            let storageProductVariation = storage.loadProductVariation(siteID: siteID, productVariationID: readOnlyProductVariation.productVariationID) ?? storage.insertNewObject(ofType: Storage.ProductVariation.self)
+            storageProductVariation.update(with: readOnlyProductVariation)
+            storageProductVariation.product = product
+            handleProductDimensions(readOnlyProductVariation, storageProductVariation, storage)
+            handleProductVariationAttributes(readOnlyProductVariation, storageProductVariation, storage)
+            handleProductImage(readOnlyProductVariation, storageProductVariation, storage)
+        }
+    }
+
+    /// Updates or inserts the provided StorageProductVariation's dimensions using the provided read-only ProductVariation's dimensions
+    ///
+    func handleProductDimensions(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+        if let existingStorageDimensions = storageVariation.dimensions {
+            existingStorageDimensions.update(with: readOnlyVariation.dimensions)
+        } else {
+            let newStorageDimensions = storage.insertNewObject(ofType: Storage.ProductDimensions.self)
+            newStorageDimensions.update(with: readOnlyVariation.dimensions)
+            storageVariation.dimensions = newStorageDimensions
+        }
+    }
+
+    /// Replaces the provided StorageProductVariation's attributes with the provided read-only
+    /// ProductVariation's attributes.
+    /// Because all local Product attributes have ID = 0, they are not unique in Storage and we always replace the whole
+    /// attribute array.
+    ///
+    func handleProductVariationAttributes(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+
+        // Removes all the attributes first.
+        storageVariation.attributesArray.forEach { existingStorageAttribute in
+            storage.deleteObject(existingStorageAttribute)
+        }
+
+        // Inserts the attributes from the read-only product variation.
+        var storageAttributes = [StorageAttribute]()
+        for readOnlyAttribute in readOnlyVariation.attributes {
+            let newStorageAttribute = storage.insertNewObject(ofType: Storage.Attribute.self)
+            newStorageAttribute.update(with: readOnlyAttribute)
+            storageAttributes.append(newStorageAttribute)
+        }
+        storageVariation.attributes = NSOrderedSet(array: storageAttributes)
+    }
+
+    /// Updates, inserts, or prunes the provided StorageProductVariation's image using the provided read-only ProductVariation's image
+    ///
+    func handleProductImage(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
+        guard let readOnlyImage = readOnlyVariation.image else {
+            if let existingStorageImage = storageVariation.image {
+                storage.deleteObject(existingStorageImage)
+            }
+            return
+        }
+
+        if let existingStorageImage = storageVariation.image {
+            existingStorageImage.update(with: readOnlyImage)
+        } else {
+            let newStorageImage = storage.insertNewObject(ofType: Storage.ProductImage.self)
+            newStorageImage.update(with: readOnlyImage)
+            storageVariation.image = newStorageImage
+        }
+    }
+}

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -47,7 +47,9 @@ private extension ProductVariationStore {
                 return
             }
 
-            self?.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations, siteID: siteID, productID: productID) {
+            self?.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
+                                                            siteID: siteID,
+                                                            productID: productID) {
                 onCompletion(nil)
             }
         }
@@ -62,7 +64,10 @@ private extension ProductVariationStore {
     /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities *in a background thread*. onCompletion will be called
     /// on the main thread!
     ///
-    func upsertStoredProductVariationsInBackground(readOnlyProductVariations: [Networking.ProductVariation], siteID: Int64, productID: Int64, onCompletion: @escaping () -> Void) {
+    func upsertStoredProductVariationsInBackground(readOnlyProductVariations: [Networking.ProductVariation],
+                                                   siteID: Int64,
+                                                   productID: Int64,
+                                                   onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform { [weak self] in
             self?.upsertStoredProductVariations(readOnlyProductVariations: readOnlyProductVariations, in: derivedStorage, siteID: siteID, productID: productID)
@@ -92,7 +97,9 @@ private extension ProductVariationStore {
 
         // Upserts the Product Variations from the read-only version
         for readOnlyProductVariation in readOnlyProductVariations {
-            let storageProductVariation = storage.loadProductVariation(siteID: siteID, productVariationID: readOnlyProductVariation.productVariationID) ?? storage.insertNewObject(ofType: Storage.ProductVariation.self)
+            let storageProductVariation = storage.loadProductVariation(siteID: siteID,
+                                                                       productVariationID: readOnlyProductVariation.productVariationID)
+                ?? storage.insertNewObject(ofType: Storage.ProductVariation.self)
             storageProductVariation.update(with: readOnlyProductVariation)
             storageProductVariation.product = product
             handleProductDimensions(readOnlyProductVariation, storageProductVariation, storage)
@@ -118,8 +125,9 @@ private extension ProductVariationStore {
     /// Because all local Product attributes have ID = 0, they are not unique in Storage and we always replace the whole
     /// attribute array.
     ///
-    func handleProductVariationAttributes(_ readOnlyVariation: Networking.ProductVariation, _ storageVariation: Storage.ProductVariation, _ storage: StorageType) {
-
+    func handleProductVariationAttributes(_ readOnlyVariation: Networking.ProductVariation,
+                                          _ storageVariation: Storage.ProductVariation,
+                                          _ storage: StorageType) {
         // Removes all the attributes first.
         storageVariation.attributesArray.forEach { existingStorageAttribute in
             storage.deleteObject(existingStorageAttribute)

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -57,7 +57,10 @@ final class ProductVariationStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
 
-        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID,
+                                                                         productID: sampleProductID,
+                                                                         pageNumber: defaultPageNumber,
+                                                                         pageSize: defaultPageSize) { error in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 8)
             XCTAssertNil(error)
 
@@ -84,7 +87,10 @@ final class ProductVariationStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
 
-        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID,
+                                                                         productID: sampleProductID,
+                                                                         pageNumber: defaultPageNumber,
+                                                                         pageSize: defaultPageSize) { error in
             XCTAssertNil(error)
 
             let storedProductVariations = self.viewStorage.loadProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID)
@@ -94,7 +100,10 @@ final class ProductVariationStoreTests: XCTestCase {
             let storedProductVariation = self.viewStorage.loadProductVariation(siteID: self.sampleSiteID, productVariationID: sampleProductVariationID)
             XCTAssertEqual(storedProductVariation?.toReadOnly(), self.sampleProductVariation(id: sampleProductVariationID))
 
-            let action = ProductVariationAction.synchronizeProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID, pageNumber: self.defaultPageNumber, pageSize: self.defaultPageSize) { error in
+            let action = ProductVariationAction.synchronizeProductVariations(siteID: self.sampleSiteID,
+                                                                             productID: self.sampleProductID,
+                                                                             pageNumber: self.defaultPageNumber,
+                                                                             pageSize: self.defaultPageSize) { error in
                 XCTAssertNil(error)
 
                 let storedProductVariations = self.viewStorage.loadProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID)
@@ -122,7 +131,10 @@ final class ProductVariationStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "generic_error")
 
-        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID,
+                                                                         productID: sampleProductID,
+                                                                         pageNumber: defaultPageNumber,
+                                                                         pageSize: defaultPageSize) { error in
             XCTAssertNotNil(error)
 
             expectation.fulfill()
@@ -138,7 +150,10 @@ final class ProductVariationStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve product variations empty response")
         let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID,
+                                                                         productID: sampleProductID,
+                                                                         pageNumber: defaultPageNumber,
+                                                                         pageSize: defaultPageSize) { error in
             XCTAssertNotNil(error)
 
             expectation.fulfill()
@@ -160,6 +175,7 @@ private extension ProductVariationStoreTests {
     }
 
     func sampleProductVariation(id: Int64) -> Yosemite.ProductVariation {
+        let imageSource = "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1"
         return ProductVariation(siteID: sampleSiteID,
                                 productID: sampleProductID,
                                 productVariationID: id,
@@ -167,7 +183,7 @@ private extension ProductVariationStoreTests {
                                 image: ProductImage(imageID: 1063,
                                                     dateCreated: dateFromGMT("2019-11-01T04:12:05"),
                                                     dateModified: dateFromGMT("2019-11-01T04:12:05"),
-                                                    src: "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                                                    src: imageSource,
                                                     name: "DSC_0010",
                                                     alt: ""),
                                 permalink: "https://chocolate.com/marble",

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+
+@testable import Networking
+@testable import Storage
+@testable import Yosemite
+
+final class ProductVariationStoreTests: XCTestCase {
+    /// Mockup Dispatcher!
+    ///
+    private var dispatcher: Dispatcher!
+
+    /// Mockup Storage: InMemory
+    ///
+    private var storageManager: MockupStorageManager!
+
+    /// Mockup Network: Allows us to inject predefined responses!
+    ///
+    private var network: MockupNetwork!
+
+    /// Convenience Property: Returns the StorageType associated with the main thread.
+    ///
+    private var viewStorage: StorageType {
+        return storageManager.viewStorage
+    }
+
+    /// Testing SiteID
+    ///
+    private let sampleSiteID: Int64 = 123
+
+    /// Testing ProductID
+    ///
+    private let sampleProductID: Int64 = 282
+
+    /// Testing Page Number
+    ///
+    private let defaultPageNumber = 1
+
+    /// Testing Page Size
+    ///
+    private let defaultPageSize = 75
+
+    override func setUp() {
+        super.setUp()
+        dispatcher = Dispatcher()
+        storageManager = MockupStorageManager()
+        network = MockupNetwork()
+    }
+
+    // MARK: - ProductVariationAction.synchronizeProductVariations
+
+    /// Verifies that `ProductVariationAction.synchronizeProductVariations` effectively persists any retrieved product variations.
+    ///
+    func testRetrieveProductVariationsEffectivelyPersisted() {
+        let expectation = self.expectation(description: "Retrieve product variation list")
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
+
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 8)
+            XCTAssertNil(error)
+
+            let sampleProductVariationID: Int64 = 1275
+            let storedProductVariation = self.viewStorage.loadProductVariation(siteID: self.sampleSiteID, productVariationID: sampleProductVariationID)
+            let readOnlyStoredProductVariation = storedProductVariation?.toReadOnly()
+            XCTAssertNotNil(storedProductVariation)
+            XCTAssertNotNil(readOnlyStoredProductVariation)
+            XCTAssertEqual(readOnlyStoredProductVariation, self.sampleProductVariation(id: sampleProductVariationID))
+
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductVariationAction.synchronizeProductVariations` multiple times does not create duplicated objects.
+    ///
+    func testRetrieveProductVariationsCreateNoDuplicates() {
+        let expectation = self.expectation(description: "Retrieve product variation list")
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "product-variations-load-all")
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductVariation.self), 0)
+
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+            XCTAssertNil(error)
+
+            let storedProductVariations = self.viewStorage.loadProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID)
+            XCTAssertEqual(storedProductVariations?.count, 8)
+
+            let sampleProductVariationID: Int64 = 1275
+            let storedProductVariation = self.viewStorage.loadProductVariation(siteID: self.sampleSiteID, productVariationID: sampleProductVariationID)
+            XCTAssertEqual(storedProductVariation?.toReadOnly(), self.sampleProductVariation(id: sampleProductVariationID))
+
+            let action = ProductVariationAction.synchronizeProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID, pageNumber: self.defaultPageNumber, pageSize: self.defaultPageSize) { error in
+                XCTAssertNil(error)
+
+                let storedProductVariations = self.viewStorage.loadProductVariations(siteID: self.sampleSiteID, productID: self.sampleProductID)
+                XCTAssertEqual(storedProductVariations?.count, 8)
+
+                // Verifies the expected Product Variation is still correct.
+                let sampleProductVariationID: Int64 = 1275
+                let storedProductVariation = self.viewStorage.loadProductVariation(siteID: self.sampleSiteID, productVariationID: sampleProductVariationID)
+                XCTAssertEqual(storedProductVariation?.toReadOnly(), self.sampleProductVariation(id: sampleProductVariationID))
+
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductVariationAction.synchronizeProductVariations` returns an error whenever there is an error response from the backend.
+    ///
+    func testRetrieveProductVariationsReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve product variations error response")
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations", filename: "generic_error")
+
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+            XCTAssertNotNil(error)
+
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `ProductVariationAction.synchronizeProductVariations` returns an error whenever there is no backend response.
+    ///
+    func testRetrieveProductVariationsReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve product variations empty response")
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        let action = ProductVariationAction.synchronizeProductVariations(siteID: sampleSiteID, productID: sampleProductID, pageNumber: defaultPageNumber, pageSize: defaultPageSize) { error in
+            XCTAssertNotNil(error)
+
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}
+
+
+private extension ProductVariationStoreTests {
+    func sampleProductVariationAttributes() -> [Yosemite.ProductVariationAttribute] {
+        return [
+            ProductVariationAttribute(id: 0, name: "Darkness", option: "99%"),
+            ProductVariationAttribute(id: 0, name: "Flavor", option: "nuts"),
+            ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
+        ]
+    }
+
+    func sampleProductVariation(id: Int64) -> Yosemite.ProductVariation {
+        return ProductVariation(siteID: sampleSiteID,
+                                productID: sampleProductID,
+                                productVariationID: id,
+                                attributes: sampleProductVariationAttributes(),
+                                image: ProductImage(imageID: 1063,
+                                                    dateCreated: dateFromGMT("2019-11-01T04:12:05"),
+                                                    dateModified: dateFromGMT("2019-11-01T04:12:05"),
+                                                    src: "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+                                                    name: "DSC_0010",
+                                                    alt: ""),
+                                permalink: "https://chocolate.com/marble",
+                                dateCreated: dateFromGMT("2019-11-14T12:40:55"),
+                                dateModified: dateFromGMT("2019-11-14T13:06:42"),
+                                dateOnSaleStart: dateFromGMT("2019-10-15T21:30:00"),
+                                dateOnSaleEnd: dateFromGMT("2019-10-27T21:29:59"),
+                                status: .publish,
+                                description: "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+                                sku: "99%-nuts-marble",
+                                price: "12",
+                                regularPrice: "12",
+                                salePrice: "8",
+                                onSale: false,
+                                purchasable: true,
+                                virtual: false,
+                                downloadable: true,
+                                downloads: [],
+                                downloadLimit: -1,
+                                downloadExpiry: 0,
+                                taxStatusKey: "taxable",
+                                taxClass: "",
+                                manageStock: true,
+                                stockQuantity: 16,
+                                stockStatus: .inStock,
+                                backordersKey: "notify",
+                                backordersAllowed: true,
+                                backordered: false,
+                                weight: "2.5",
+                                dimensions: ProductDimensions(length: "10",
+                                                              width: "2.5",
+                                                              height: ""),
+                                shippingClass: "",
+                                shippingClassID: 0,
+                                menuOrder: 8)
+    }
+
+    func dateFromGMT(_ dateStringInGMT: String) -> Date {
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+        return dateFormatter.date(from: dateStringInGMT)!
+    }
+}


### PR DESCRIPTION
Fixes #1468 

## Changes

- Added an extension to convert `Storage.ProductVariation` <--> readonly `Networking.ProductVariation`
  - Added an extension to `Storage.ProductVariation` to convert its attributes property (`NSOrderedSet` type in Core Data) to an array of `Storage.Attribute`s
- Added an extension to convert `Storage.Attribute` <--> readonly `Networking.ProductVariationAttribute` (`Storage.Attribute` is a generic attribute)
- Created `ProductVariationAction` and `ProductVariationStore` to retrieve Product Variations from the server + tests
  - Because `Storage.Attribute` is a generic entity that can be used for different purposes (p99K0U-1Za-p2), the ID might not be unique. For this reason, a Product Variation's attributes are always replaced instead of checking if any of the attributes already exist in the storage

## Testing

No UI yet (coming next), so just CI for this one!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
