### PR TITLE
Settings: switching store now update correctly the screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -60,12 +60,7 @@ class SettingsViewController: UIViewController {
         configureTableView()
         configureTableViewFooter()
         registerTableViewCells()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configureSections()
-        tableView.reloadData()
+        refreshViewContent()
     }
 
     override func viewDidLayoutSubviews() {
@@ -121,6 +116,11 @@ private extension SettingsViewController {
         footerContainer.addSubview(footerView)
     }
 
+    func refreshViewContent() {
+        configureSections()
+        tableView.reloadData()
+    }
+    
     func configureSections() {
         let selectedStoreTitle = NSLocalizedString(
             "Selected Store",
@@ -314,6 +314,12 @@ private extension SettingsViewController {
         if let navigationController = navigationController {
             storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
             storePickerCoordinator?.start()
+            storePickerCoordinator?.onDismiss = { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                self.refreshViewContent()
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -120,7 +120,7 @@ private extension SettingsViewController {
         configureSections()
         tableView.reloadData()
     }
-    
+
     func configureSections() {
         let selectedStoreTitle = NSLocalizedString(
             "Selected Store",


### PR DESCRIPTION
Fixes partially #1466
Fixes #1480 

Tapping on a store, change the store selected inside the app (also without touching continue or dismiss button). It seems the right behavior. So this PR fixes only the refresh of the settings screen.

## Testing
1) Go to settings
2) Tap switch store
3) Switch to a different store
4) Check that the settings screen now shows the correct store.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
