### PR TITLE
Feature Flag: delete dead code

### DIFF
--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -25,19 +25,4 @@ enum FeatureFlag: Int {
     /// Refunds
     ///
     case refunds
-
-    /// Returns a boolean indicating if the feature is enabled
-    ///
-    var enabled: Bool {
-        switch self {
-        case .stats:
-            return BuildConfiguration.current == .localDeveloper
-        case .reviews:
-            return true
-        case .refunds:
-            return BuildConfiguration.current == .localDeveloper
-        default:
-            return true
-        }
-    }
 }


### PR DESCRIPTION
Fixes #1515 

This PR removes the `enabled` property found in the Feature Flag enum. This isn't the correct code for flagging a feature and caused enough confusion that I updated this property instead of the `isFeatureFlagEnabled` method. If it had not been caught during code review, the Refunds feature would have been prematurely exposed to users.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
