### PR TITLE
Readonly Product Variations: analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -115,6 +115,7 @@ public enum WooAnalyticsStat: String {
 
     case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
     case settingsBetaFeaturesNewStatsUIToggled  = "settings_beta_features_new_stats_ui_toggled"
+    case settingsBetaFeaturesProductsToggled    = "settings_beta_features_products_toggled"
 
     case settingsPrivacySettingsTapped          = "settings_privacy_settings_button_tapped"
     case settingsCollectInfoToggled             = "privacy_settings_collect_info_toggled"
@@ -247,6 +248,13 @@ public enum WooAnalyticsStat: String {
     case productListPulledToRefresh             = "product_list_pulled_to_refresh"
     case productListSearched                    = "product_list_searched"
     case productListMenuSearchTapped            = "product_list_menu_search_tapped"
+
+    // Readonly Product Variations Events
+    //
+    case productDetailsProductVariantsTapped    = "product_detail_view_product_variants_tapped"
+    case productVariationListLoaded             = "product_variants_loaded"
+    case productVariationListLoadError          = "product_variants_load_error"
+    case productVariationListPulledToRefresh    = "product_variants_pulled_to_refresh"
 
     // Jetpack Tunnel Events
     //

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -756,6 +756,7 @@ extension ProductDetailsViewModel {
         case .affiliateLink:
             WebviewHelper.launch(product.externalURL, with: sender)
         case .productVariants:
+            ServiceLocator.analytics.track(.productDetailsProductVariantsTapped)
             let variationsViewController = ProductVariationsViewController(siteID: Int64(product.siteID),
                                                                            productID: Int64(product.productID))
             sender.navigationController?.pushViewController(variationsViewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -191,7 +191,7 @@ private extension BetaFeaturesViewController {
         ServiceLocator.stores.dispatch(action)
 
         cell.onChange = { isSwitchOn in
-            // TODO-1464: analytics
+            ServiceLocator.analytics.track(.settingsBetaFeaturesProductsToggled)
 
             let action = AppSettingsAction.setProductsVisibility(isVisible: isSwitchOn) {
                 NotificationCenter.default.post(name: .ProductsVisibilityDidChange, object: self)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -232,7 +232,7 @@ extension ProductVariationsViewController: UITableViewDelegate {
 
 private extension ProductVariationsViewController {
     @objc private func pullToRefresh(sender: UIRefreshControl) {
-        ServiceLocator.analytics.track(.productListPulledToRefresh)
+        ServiceLocator.analytics.track(.productVariationListPulledToRefresh)
 
         syncingCoordinator.synchronizeFirstPage {
             sender.endRefreshing()
@@ -309,11 +309,12 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
                                     }
 
                                     if let error = error {
-                                        // TODO-1464: analytics
+                                        ServiceLocator.analytics.track(.productVariationListLoadError, withError: error)
+
                                         DDLogError("⛔️ Error synchronizing product variations: \(error)")
                                         self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
                                     } else {
-                                        // TODO-1464: analytics
+                                        ServiceLocator.analytics.track(.productVariationListLoaded)
                                     }
 
                                     self.transitionToResultsUpdatedState()


### PR DESCRIPTION
Fixes #1464 

## Changes

Based on the events in #1464 :
- Added new events
- Recorded the new events

## Testing

- Launch the app
- Tap Settings > Experimental Features
- Switch on Products feature on and off --> every time it's toggled, should see `🔵 Tracked settings_beta_features_products_toggled` in the console
- Make sure the Products switch is on --> should see the Products tab
- Go to the Products tab
- Tap on a Variable Product with variations --> should see the variants info on the Product page
- Tap on the variants info row --> should see `🔵 Tracked product_detail_view_product_variants_tapped` in the console
- When the variations are loaded --> should see `🔵 Tracked product_variants_loaded` in the console
- Turn off the internet or some other way to generate an error, then pull down to refresh --> should see `🔵 Tracked product_variants_pulled_to_refresh` followed by `🔵 Tracked product_variants_load_error, properties: [AnyHashable("error_description"): "Error Domain=...]` in the console


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
