### PR TITLE
Add/Edit Product main screen: show price/inventory/shipping settings rows

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -143,6 +143,12 @@ extension UIImage {
         return Gridicon.iconOfType(.heartOutline)
     }
 
+    /// Inventory Icon
+    ///
+    static var inventoryImage: UIImage {
+        return Gridicon.iconOfType(.listCheckmark, withSize: CGSize(width: 24, height: 24))
+    }
+
     /// Jetpack Logo Image
     ///
     static var jetpackLogoImage: UIImage {
@@ -176,6 +182,12 @@ extension UIImage {
     static var moreImage: UIImage {
         let tintColor = StyleManager.wooCommerceBrandColor
         return ellipsisImage.imageWithTintColor(tintColor)!
+    }
+
+    /// Price Icon
+    ///
+    static var priceImage: UIImage {
+        return Gridicon.iconOfType(.money, withSize: CGSize(width: 24, height: 24))
     }
 
     /// Product Placeholder Image
@@ -227,6 +239,12 @@ extension UIImage {
     static var searchImage: UIImage {
         return Gridicon.iconOfType(.search)
             .imageFlippedForRightToLeftLayoutDirection()
+    }
+
+    /// Shipping Icon
+    ///
+    static var shippingImage: UIImage {
+        return Gridicon.iconOfType(.shipping, withSize: CGSize(width: 24, height: 24))
     }
 
     /// Spam Icon

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -4,14 +4,16 @@ import UIKit
 ///
 final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     struct ViewModel {
-        let title: String
-        let text: String
+        let title: String?
+        let text: String?
         let image: UIImage?
+        let numberOfLinesForText: Int
 
-        init(title: String, text: String, image: UIImage? = nil) {
+        init(title: String?, text: String?, image: UIImage? = nil, numberOfLinesForText: Int = 1) {
             self.title = title
             self.text = text
             self.image = image
+            self.numberOfLinesForText = numberOfLinesForText
         }
     }
 
@@ -35,7 +37,11 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
 extension ImageAndTitleAndTextTableViewCell {
     func updateUI(viewModel: ViewModel) {
         titleLabel.text = viewModel.title
+        titleLabel.isHidden = viewModel.title == nil || viewModel.title?.isEmpty == true
+        titleLabel.textColor = viewModel.text?.isEmpty == false ? .text: .textSubtle
         descriptionLabel.text = viewModel.text
+        descriptionLabel.isHidden = viewModel.text == nil || viewModel.text?.isEmpty == true
+        descriptionLabel.numberOfLines = viewModel.numberOfLinesForText
         contentImageView.image = viewModel.image
         contentImageView.isHidden = viewModel.image == nil
     }
@@ -63,6 +69,6 @@ private extension ImageAndTitleAndTextTableViewCell {
     }
 
     func configureTitleAndTextStackView() {
-        titleAndTextStackView.spacing = 6
+        titleAndTextStackView.spacing = 2
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -5,8 +5,12 @@ import Yosemite
 struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
 
     private(set) var sections: [ProductFormSection] = []
+    private let currency: String
+    private let currencyFormatter: CurrencyFormatter
 
-    init(product: Product) {
+    init(product: Product, currency: String, currencyFormatter: CurrencyFormatter = CurrencyFormatter()) {
+        self.currency = currency
+        self.currencyFormatter = currencyFormatter
         configureSections(product: product)
     }
 }
@@ -15,7 +19,7 @@ private extension DefaultProductFormTableViewModel {
     mutating func configureSections(product: Product) {
         sections = [.images,
                     .primaryFields(rows: primaryFieldRows(product: product)),
-                    .details(rows: [])]
+                    .settings(rows: settingsRows(product: product))]
     }
 
     func primaryFieldRows(product: Product) -> [ProductFormSection.PrimaryFieldRow] {
@@ -23,5 +27,102 @@ private extension DefaultProductFormTableViewModel {
             .name(name: product.name),
             .description(description: product.trimmedFullDescription)
         ]
+    }
+
+    func settingsRows(product: Product) -> [ProductFormSection.SettingsRow] {
+        return [
+            .price(viewModel: priceSettingsRow(product: product)),
+            .shipping(viewModel: shippingSettingsRow(product: product)),
+            .inventory(viewModel: inventorySettingsRow(product: product))
+        ]
+    }
+}
+
+private extension DefaultProductFormTableViewModel {
+    func priceSettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.priceImage.applyProductFormSettingsStyle()
+        let title = Constants.priceSettingsTitle
+
+        var priceDetails = [String]()
+
+        // Regular price and sale price are both available only when a sale price is set.
+        if let regularPrice = product.regularPrice, !regularPrice.isEmpty,
+            let salePrice = product.salePrice, !salePrice.isEmpty {
+            let formattedRegularPrice = currencyFormatter.formatAmount(regularPrice, with: currency) ?? ""
+            let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
+            priceDetails.append(String.localizedStringWithFormat(Constants.regularPriceFormat, formattedRegularPrice))
+            priceDetails.append(String.localizedStringWithFormat(Constants.salePriceFormat, formattedSalePrice))
+
+            // TODO-1505: show sale period
+        } else if product.price.isEmpty == false {
+            let formattedPrice = currencyFormatter.formatAmount(product.price, with: currency) ?? ""
+            priceDetails.append(String.localizedStringWithFormat(Constants.regularPriceFormat, formattedPrice))
+        }
+
+        let details = priceDetails.isEmpty ? nil: priceDetails.joined(separator: "\n")
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details)
+    }
+
+    func inventorySettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.inventoryImage.applyProductFormSettingsStyle()
+        let title = Constants.inventorySettingsTitle
+
+        var inventoryDetails = [String]()
+
+        if let sku = product.sku, !sku.isEmpty {
+            inventoryDetails.append(String.localizedStringWithFormat(Constants.skuFormat, sku))
+        }
+
+        if let stockQuantity = product.stockQuantity {
+            inventoryDetails.append(String.localizedStringWithFormat(Constants.stockQuantityFormat, stockQuantity))
+        } else {
+            let stockStatus = product.productStockStatus
+            inventoryDetails.append(String.localizedStringWithFormat(Constants.stockStatusFormat, stockStatus.description))
+        }
+
+        let details = inventoryDetails.isEmpty ? nil: inventoryDetails.joined(separator: "\n")
+
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details)
+    }
+
+    func shippingSettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.shippingImage.applyProductFormSettingsStyle()
+        let title = Constants.shippingSettingsTitle
+        // TODO-1507: show shipping details after the weight and dimension units are available
+        let details: String? = nil
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details)
+    }
+}
+
+private extension DefaultProductFormTableViewModel {
+    enum Constants {
+        static let priceSettingsTitle = NSLocalizedString("Price",
+                                                          comment: "Title of the Price Settings row on Product main screen")
+        static let inventorySettingsTitle = NSLocalizedString("Inventory",
+                                                              comment: "Title of the Inventory Settings row on Product main screen")
+        static let shippingSettingsTitle = NSLocalizedString("Shipping",
+                                                             comment: "Title of the Shipping Settings row on Product main screen")
+
+        // Price
+        static let regularPriceFormat = NSLocalizedString("Regular price: %@",
+                                                          comment: "Format of the regular price on the Price Settings row")
+        static let salePriceFormat = NSLocalizedString("Sale price: %@",
+                                                       comment: "Format of the sale price on the Price Settings row")
+        static let saleDatesFormat = NSLocalizedString("Sale dates: %1$@-%2$@",
+                                                       comment: "Format of the sale period on the Price Settings row")
+
+        // Inventory
+        static let skuFormat = NSLocalizedString("SKU: %@",
+                                                 comment: "Format of the SKU on the Inventory Settings row")
+        static let stockQuantityFormat = NSLocalizedString("Quantity: %ld",
+                                                           comment: "Format of the stock quantity on the Inventory Settings row")
+        static let stockStatusFormat = NSLocalizedString("Stock status: %@",
+                                                         comment: "Format of the stock status on the Inventory Settings row")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -6,8 +6,11 @@ extension ProductFormSection {
         case .primaryFields(let rows):
             let row = rows[rowIndex]
             return row.reuseIdentifier
-        default:
-            fatalError("Not implemented yet")
+        case .settings(let rows):
+            let row = rows[rowIndex]
+            return row.reuseIdentifier
+        case .images:
+            fatalError()
         }
     }
 }
@@ -40,6 +43,26 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
             return name?.isEmpty == false ? ImageAndTitleAndTextTableViewCell.self: BasicTableViewCell.self
         case .description(let description):
             return description?.isEmpty == false ? ImageAndTitleAndTextTableViewCell.self: BasicTableViewCell.self
+        }
+    }
+}
+
+extension ProductFormSection.SettingsRow: ReusableTableRow {
+    var cellTypes: [UITableViewCell.Type] {
+        switch self {
+        case .price, .inventory, .shipping:
+            return [ImageAndTitleAndTextTableViewCell.self]
+        }
+    }
+
+    var reuseIdentifier: String {
+        return cellType.reuseIdentifier
+    }
+
+    private var cellType: UITableViewCell.Type {
+        switch self {
+        case .price, .inventory, .shipping:
+            return ImageAndTitleAndTextTableViewCell.self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -1,5 +1,14 @@
 import UIKit
 
+private extension ProductFormSection.SettingsRow.ViewModel {
+    func toCellViewModel() -> ImageAndTitleAndTextTableViewCell.ViewModel {
+        return ImageAndTitleAndTextTableViewCell.ViewModel(title: title,
+                                                           text: details,
+                                                           image: icon,
+                                                           numberOfLinesForText: 0)
+    }
+}
+
 /// Configures the sections and rows of Product form table view based on the view model.
 ///
 final class ProductFormTableViewDataSource: NSObject {
@@ -23,7 +32,7 @@ extension ProductFormTableViewDataSource: UITableViewDataSource {
             return 0
         case .primaryFields(let rows):
             return rows.count
-        case .details(let rows):
+        case .settings(let rows):
             return rows.count
         }
     }
@@ -42,6 +51,8 @@ private extension ProductFormTableViewDataSource {
         switch section {
         case .primaryFields(let rows):
             configureCellInPrimaryFieldsSection(cell, row: rows[indexPath.row])
+        case .settings(let rows):
+            configureCellInSettingsFieldsSection(cell, row: rows[indexPath.row])
         default:
             fatalError("Not implemented yet")
         }
@@ -99,6 +110,25 @@ private extension ProductFormTableViewDataSource {
             cell.textLabel?.applyBodyStyle()
             cell.textLabel?.textColor = .textSubtle
         }
+        cell.accessoryType = .disclosureIndicator
+    }
+}
+
+// MARK: Configure rows in Settings Fields Section
+//
+private extension ProductFormTableViewDataSource {
+    func configureCellInSettingsFieldsSection(_ cell: UITableViewCell, row: ProductFormSection.SettingsRow) {
+        guard let cell = cell as? ImageAndTitleAndTextTableViewCell else {
+            fatalError()
+        }
+        switch row {
+        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel):
+            configureSettings(cell: cell, viewModel: viewModel)
+        }
+    }
+
+    func configureSettings(cell: ImageAndTitleAndTextTableViewCell, viewModel: ProductFormSection.SettingsRow.ViewModel) {
+        cell.updateUI(viewModel: viewModel.toCellViewModel())
         cell.accessoryType = .disclosureIndicator
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -3,17 +3,23 @@ import UIKit
 enum ProductFormSection {
     case images
     case primaryFields(rows: [PrimaryFieldRow])
-    case details(rows: [DetailRow])
+    case settings(rows: [SettingsRow])
 
     enum PrimaryFieldRow {
         case name(name: String?)
         case description(description: String?)
     }
 
-    enum DetailRow {
-        case price
-        case shipping
-        case inventory
+    enum SettingsRow {
+        case price(viewModel: ViewModel)
+        case shipping(viewModel: ViewModel)
+        case inventory(viewModel: ViewModel)
+
+        struct ViewModel {
+            let icon: UIImage
+            let title: String?
+            let details: String?
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -8,7 +8,7 @@ final class ProductFormViewController: UIViewController {
 
     private var product: Product {
         didSet {
-            viewModel = DefaultProductFormTableViewModel(product: product)
+            viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
             tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel)
             tableView.dataSource = tableViewDataSource
             tableView.reloadData()
@@ -22,9 +22,12 @@ final class ProductFormViewController: UIViewController {
     private var viewModel: ProductFormTableViewModel
     private var tableViewDataSource: ProductFormTableViewDataSource
 
-    init(product: Product) {
+    private let currency: String
+
+    init(product: Product, currency: String) {
+        self.currency = currency
         self.product = product
-        self.viewModel = DefaultProductFormTableViewModel(product: product)
+        self.viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
         self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel)
         super.init(nibName: nil, bundle: nil)
     }
@@ -51,6 +54,9 @@ private extension ProductFormViewController {
 
         tableView.dataSource = tableViewDataSource
         tableView.delegate = self
+
+        tableView.backgroundColor = .listBackground
+        tableView.tableFooterView = UIView()
 
         tableView.reloadData()
     }
@@ -108,8 +114,33 @@ extension ProductFormViewController: UITableViewDelegate {
             case .description:
                 editProductDescription()
             }
-        case .details:
-            fatalError()
+        case .settings:
+            // TODO-1422: Shipping Settings
+            // TODO-1423: Price Settings
+            // TODO-1424: Inventory Settings
+            return
+        }
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        let section = viewModel.sections[section]
+        switch section {
+        case .settings:
+            return Constants.settingsHeaderHeight
+        default:
+            return 0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let section = viewModel.sections[section]
+        switch section {
+        case .settings:
+            let clearView = UIView(frame: .zero)
+            clearView.backgroundColor = .clear
+            return clearView
+        default:
+            return nil
         }
     }
 }
@@ -159,5 +190,13 @@ private extension ProductFormViewController {
             return
         }
         self.product = productUpdater.descriptionUpdated(description: newDescription)
+    }
+}
+
+// MARK: Action - Edit Product Description
+//
+private extension ProductFormViewController {
+    enum Constants {
+        static let settingsHeaderHeight = CGFloat(16)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/UIImage+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/UIImage+ProductForm.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+extension UIImage {
+    func applyProductFormSettingsStyle() -> UIImage {
+        let color = UIColor.textSubtle
+        return imageWithTintColor(color)!
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -203,7 +203,9 @@ private extension ProductDetailsViewController {
 
     @objc func editProduct() {
         let product = viewModel.product
-        let productForm = ProductFormViewController(product: product)
+        let currencyCode = CurrencySettings.shared.currencyCode
+        let currency = CurrencySettings.shared.symbol(from: currencyCode)
+        let productForm = ProductFormViewController(product: product, currency: currency)
         let navController = WooNavigationController(rootViewController: productForm)
         navigationController?.present(navController, animated: true)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */; };
+		02784A05238BA85500BDD6A8 /* UIImage+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02784A04238BA85500BDD6A8 /* UIImage+ProductForm.swift */; };
 		02820F3422C257B700DE0D37 /* UITableView+FooterHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */; };
 		028296EC237D28B600E84012 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EA237D28B600E84012 /* TextViewViewController.swift */; };
 		028296ED237D28B600E84012 /* TextViewViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 028296EB237D28B600E84012 /* TextViewViewController.xib */; };
@@ -596,6 +597,7 @@
 		026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVariationsViewController.xib; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0274C25323162FB200EF1E40 /* DashboardTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopBannerFactory.swift; sourceTree = "<group>"; };
+		02784A04238BA85500BDD6A8 /* UIImage+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+ProductForm.swift"; sourceTree = "<group>"; };
 		02820F3322C257B700DE0D37 /* UITableView+FooterHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+FooterHelpers.swift"; sourceTree = "<group>"; };
 		028296EA237D28B600E84012 /* TextViewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
 		028296EB237D28B600E84012 /* TextViewViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextViewViewController.xib; sourceTree = "<group>"; };
@@ -1087,6 +1089,7 @@
 				02F4F50A237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift */,
 				025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */,
 				025B1749237AA49D00C780B4 /* Product+ProductForm.swift */,
+				02784A04238BA85500BDD6A8 /* UIImage+ProductForm.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -2827,6 +2830,7 @@
 				B59D1EE321907C7B009D1978 /* NSAttributedString+Helpers.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
 				D8149F532251CFE60006A245 /* EditableOrderTrackingTableViewCell.swift in Sources */,
+				02784A05238BA85500BDD6A8 /* UIImage+ProductForm.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -90,12 +90,20 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.invisibleImage)
     }
 
+    func testInventoryImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.inventoryImage)
+    }
+
     func testMailImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.mailImage)
     }
 
     func testMoreImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.moreImage)
+    }
+
+    func testPriceImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.priceImage)
     }
 
     func testProductPlaceholderImageIconIsNotNil() {
@@ -120,6 +128,10 @@ final class IconsTests: XCTestCase {
 
     func testSearchImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.searchImage)
+    }
+
+    func testShippingImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.shippingImage)
     }
 
     func testSpamImageIconIsNotNil() {


### PR DESCRIPTION
Fixes #1506 

## Changes
- Added 3 icons from `Gridicons`: `inventoryImage`, `priceImage, `shippingImage` as icons for each Product settings on the Product form screen
- Updated `ImageAndTitleAndTextTableViewCell` for more style configurations and UI states base on title/description empty states
- In `ProductFormSection`, renamed the details section to settings section. Added a `SettingsRow`
- In `DefaultProductFormTableViewModel`, added 3 rows under the settings section: 
  - price
  - inventory
  - shipping
- In `ProductFormTableViewDataSource`, implemented the cell configuration for the Settings row
  - Added a private extension to convert `ProductFormSection.SettingsRow.ViewModel` to `ImageAndTitleAndTextTableViewCell.ViewModel`
- In `ProductFormViewController`, added a clear view of 16px height as the header view of the Settings section

## Testing
- Launch the app
- Go to Products tab
- Tap on a Simple Product row
- Tap "Edit" in the navigation bar --> should see the price/inventory/shipping rows below the section of title/description (the shipping row data aren't available #1507, and the sale price period isn't available #1505)

## Example screenshots

![Simulator Screen Shot - iPhone 8 - 2019-11-25 at 15 10 47](https://user-images.githubusercontent.com/1945542/69517487-39f49f80-0f98-11ea-8a7a-a4b0e87e2e0b.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
