### PR TITLE
Design updates for the Products teaser release

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -365,7 +365,7 @@ extension ProductDetailsViewModel {
     /// Product variants cell.
     ///
     func configureProductVariants(_ cell: TitleBodyTableViewCell) {
-        cell.titleLabel?.text = NSLocalizedString("Variants", comment: "Product Details > descriptive label for the Product Variants cell.")
+        cell.titleLabel?.text = NSLocalizedString("Variations", comment: "Product Details > descriptive label for the Product Variants cell.")
 
         let attributes = product.attributes
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -194,7 +194,7 @@ private extension ProductsViewController {
     /// Apply Woo styles.
     ///
     func configureMainView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = StyleManager.tableViewBackgroundColor
     }
 
     /// Configure common table properties.
@@ -215,8 +215,8 @@ private extension ProductsViewController {
         tableView.estimatedSectionHeaderHeight = 0
         tableView.sectionHeaderHeight = 0
 
-        tableView.backgroundColor = .listBackground
-        tableView.separatorColor = .divider
+        tableView.backgroundColor = StyleManager.tableViewBackgroundColor
+        tableView.separatorColor = StyleManager.cellSeparatorColor
         tableView.refreshControl = refreshControl
         tableView.tableFooterView = footerSpinnerView
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -240,7 +240,9 @@ private extension ProductsViewController {
                                          comment: "The info of the Work In Progress top banner on the Products tab")
         let viewModel = TopBannerViewModel(title: title,
                                            infoText: infoText,
-                                           icon: .workInProgressBanner)
+                                           icon: .workInProgressBanner) { [weak self] in
+                                            self?.tableView.updateHeaderHeight()
+        }
         let topBannerView = TopBannerView(viewModel: viewModel)
         topBannerView.translatesAutoresizingMaskIntoConstraints = false
         return topBannerView

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -88,7 +88,7 @@ private extension TopBannerView {
             actionButton.applyLinkButtonStyle()
             actionButton.addTarget(self, action: #selector(onActionButtonTapped), for: .touchUpInside)
         } else {
-            expandCollapseButton.setImage(.chevronDownImage, for: .normal)
+            updateExpandCollapseState(isExpanded: isExpanded)
             expandCollapseButton.tintColor = StyleManager.wooGreyTextMin
             expandCollapseButton.addTarget(self, action: #selector(onExpandCollapseButtonTapped), for: .touchUpInside)
         }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -9,18 +9,21 @@ struct TopBannerViewModel {
     let actionButtonTitle: String?
     let actionHandler: (() -> Void)?
     let dismissHandler: (() -> Void)?
+    let expandedStateChangeHandler: (() -> Void)?
 
     /// Used when the top banner is not actionable.
     ///
     init(title: String?,
          infoText: String?,
-         icon: UIImage?) {
+         icon: UIImage?,
+         expandedStateChangeHandler: (() -> Void)?) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
         self.actionButtonTitle = nil
         self.actionHandler = nil
         self.dismissHandler = nil
+        self.expandedStateChangeHandler = expandedStateChangeHandler
     }
 
     /// Used when the top banner is actionable.
@@ -37,5 +40,6 @@ struct TopBannerViewModel {
         self.actionButtonTitle = actionButtonTitle
         self.actionHandler = actionHandler
         self.dismissHandler = dismissHandler
+        self.expandedStateChangeHandler = nil
     }
 }


### PR DESCRIPTION
Fixes #1529 

## Changes

- Updated the variants info row title on Product Details screen from "Variants" to "Variations"
- Reverted new semantic colors to `StyleManager` colors before Dark Mode is released
- Made `TopBannerView` expandable when it is not actionable

## Testing

- Launch the app
- Go to Products tab --> the WIP banner should be expandable as in the screenshots

## Example screenshots

Notes: the stats banner still has the dismiss button since it is actionable

expanded | collapsed | Product Details > Variations
-- | -- | --
![Simulator Screen Shot - iPhone 8 - 2019-11-27 at 12 55 49](https://user-images.githubusercontent.com/1945542/69692413-4f430880-1115-11ea-98ad-756b420f699f.png) | ![Simulator Screen Shot - iPhone 8 - 2019-11-27 at 12 55 51](https://user-images.githubusercontent.com/1945542/69692414-4fdb9f00-1115-11ea-8402-b9f3bc448734.png) | ![Simulator Screen Shot - iPhone 8 - 2019-11-27 at 12 59 39](https://user-images.githubusercontent.com/1945542/69692577-c9738d00-1115-11ea-8aaf-0f29138fa24a.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
