### PR TITLE
Product Details: handled support rotation on product images collection view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -40,7 +40,7 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
         viewModel.registerCollectionViewCells(collectionView)
     }
 
-    /// Manage rotation
+    /// Rotation management
     ///
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -40,6 +40,15 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
         viewModel.registerCollectionViewCells(collectionView)
     }
 
+    /// Manage rotation
+    ///
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection != previousTraitCollection {
+            collectionView.collectionViewLayout.invalidateLayout()
+            collectionView.reloadData()
+        }
+    }
 }
 
 // MARK: - Collection View Delegate


### PR DESCRIPTION
Fixes #1531 

Initially, when you rotate the screen, the cell inside the collection view of product images would not resize after frame changes or rotation.
This PR fixes this issue.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![69716590-9d9eda00-110a-11ea-865e-fb3c63437382](https://user-images.githubusercontent.com/495617/69735798-9d660500-1131-11ea-9267-a753e8ad9c6f.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-11-27 at 16 10 06](https://user-images.githubusercontent.com/495617/69735803-9f2fc880-1131-11ea-837f-7711deddcb50.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
