### PR TITLE
Hotfix: crash when you try to open a push notification for a product review with app inactive

### DIFF
--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -18,4 +18,16 @@ extension UINavigationController {
 
         scrollView.setContentOffset(.zero, animated: animated)
     }
+
+    /// Completion block for popToRootViewController
+    /// UINavigationController API doesn't offer any options for this.
+    /// However by using the CoreAnimation framework it's possible to add a completion block to the underlying animation
+    ///
+    func popToRootViewController(animated: Bool, handler: @escaping ()->()) {
+        CATransaction.begin()
+        CATransaction.setCompletionBlock(handler)
+        popToRootViewController(animated: animated)
+        CATransaction.commit()
+    }
+
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -261,6 +261,7 @@ extension MainTabBarController {
         guard let tabBar = AppDelegate.shared.tabBarController else {
             return
         }
+
         tabBar.navigateTo(tab, animated: animated, completion: completion)
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -143,10 +143,12 @@ final class MainTabBarController: UITabBarController {
 
     /// Switches the TabBarcController to the specified Tab
     ///
-    func navigateTo(_ tab: WooTab, animated: Bool = false) {
+    func navigateTo(_ tab: WooTab, animated: Bool = false, completion: (() -> Void)? = nil) {
         selectedIndex = tab.visibleIndex()
         if let navController = selectedViewController as? UINavigationController {
-            navController.popToRootViewController(animated: animated)
+            navController.popToRootViewController(animated: animated) {
+                completion?()
+            }
         }
     }
 }
@@ -249,18 +251,17 @@ extension MainTabBarController {
 
     /// Switches to the Reviews tab and pops to the root view controller
     ///
-    static func switchToReviewsTab() {
-        navigateTo(.reviews)
+    static func switchToReviewsTab(completion: (() -> Void)? = nil) {
+        navigateTo(.reviews, completion: completion)
     }
 
     /// Switches the TabBarController to the specified Tab
     ///
-    private static func navigateTo(_ tab: WooTab, animated: Bool = false) {
+    private static func navigateTo(_ tab: WooTab, animated: Bool = false, completion: (() -> Void)? = nil) {
         guard let tabBar = AppDelegate.shared.tabBarController else {
             return
         }
-
-        tabBar.navigateTo(tab, animated: animated)
+        tabBar.navigateTo(tab, animated: animated, completion: completion)
     }
 
     /// Returns the "Top Visible Child" of the specified type
@@ -295,13 +296,12 @@ extension MainTabBarController {
     /// Switches to the Notifications Tab, and displays the details for the specified Notification ID.
     ///
     static func presentNotificationDetails(for noteID: Int) {
-        switchToReviewsTab()
-
-        guard let reviewsViewController: ReviewsViewController = childViewController() else {
-            return
+        switchToReviewsTab {
+            guard let reviewsViewController: ReviewsViewController = childViewController() else {
+                return
+            }
+            reviewsViewController.presentDetails(for: noteID)
         }
-
-        reviewsViewController.presentDetails(for: noteID)
     }
 
     /// Switches to the My Store Tab, and presents the Settings .


### PR DESCRIPTION
[Public crash report](https://sentry.io/share/issue/24814f8f61b941f7926d360eba018e0c/). Please log into Sentry to see full details.

## How to generate the crash
Receive a new product review on your store when the app is closed. When you try to open it, the app crash.

![crash push review](https://user-images.githubusercontent.com/495617/69893252-0787d100-130f-11ea-9901-3de882b69df4.gif)

## Description
This PR fixes a crash into frozen release 3.1. 
The crash was generated from `SyncingCoordinator` since `ReviewsViewController` was not initialized before being shown.
There was a problem of priority, as it was assumed that the view controller was immediately visible on the screen, instead, we have to consider the animations during the `popToRootViewController()`.
I implemented a completion handler on some methods, and the `popToRootViewController()` method now returns when the animation has actually been completed.

## Testing
Receive a new product review on your store (e.g. use a test account to post a review) when the app is closed. Confirm you get a push notification for the review, and you can open the review from that push notification.

## New product review payload for testing purpose
I advise you to change the data with a review actually present in your test store.
```
{
  "comment_id": 1204,
  "note_id": 4323986173,
  "type": "comment",
  "blog_id": 165135189,
  "aps": {
    "alert": "The user left a new review!",
    "badge": 1,
    "category": "approve-comment",
    "content-available": 1,
    "mutable-content": 1,
    "sound": "default",
    "thread-id": "comment-157"
  },
  "blog": 165135189,
  "post_id": 157
}
```

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
