### PR TITLE
Mention git-lfs requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Jetpack-powered companion app for WooCommerce.
 
 - Download Xcode
   - At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 10.2 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
+- Install [git-lfs](https://github.com/git-lfs/git-lfs)
 - Clone project by `git clone https://github.com/woocommerce/woocommerce-ios.git` in the folder of your preference
 - Enter the project directory by `cd woocommerce-ios`
 - Install the third party dependencies and tools required to run the project


### PR DESCRIPTION
When trying to clone the project, I received this error: 

```
Cloning into 'woocommerce-ios'...
remote: Enumerating objects: 399, done.
remote: Counting objects: 100% (399/399), done.
remote: Compressing objects: 100% (300/300), done.
remote: Total 58097 (delta 198), reused 218 (delta 98), pack-reused 57698
Receiving objects: 100% (58097/58097), 19.30 MiB | 1.16 MiB/s, done.
Resolving deltas: 100% (42571/42571), done.
git-lfs filter-process: git-lfs: command not found
fatal: the remote end hung up unexpectedly
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'
```

Embarrassingly, it took me a while to figure out. 😅 

## Changes 

This mentions `git-lfs` as a requirement in the build instructions. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 
