### PR TITLE
Update Ghost style beat end color to an opaque color

### DIFF
--- a/WooCommerce/Classes/Extensions/Ghost+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Ghost+Woo.swift
@@ -6,6 +6,6 @@ extension GhostStyle {
     static var wooDefaultGhostStyle: Self {
         return GhostStyle(beatDuration: Defaults.beatDuration,
                           beatStartColor: .listForeground,
-                          beatEndColor: .neutral(.shade10))
+                          beatEndColor: .ghostCellAnimationEndColor)
     }
 }

--- a/WooCommerce/Classes/Extensions/Ghost+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Ghost+Woo.swift
@@ -6,6 +6,6 @@ extension GhostStyle {
     static var wooDefaultGhostStyle: Self {
         return GhostStyle(beatDuration: Defaults.beatDuration,
                           beatStartColor: .listForeground,
-                          beatEndColor: .textQuaternary)
+                          beatEndColor: .neutral(.shade10))
     }
 }

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -217,6 +217,13 @@ extension UIColor {
         return UIColor(light: .white,
                        dark: .withColorStudio(.gray, shade: .shade90))
     }
+
+    /// Ghost cell animation end color. `Gray-5` (Light Mode) and Gray-10 (Dark Mode)
+    ///
+    static var ghostCellAnimationEndColor: UIColor {
+        return UIColor(light: neutral(.shade5),
+                       dark: neutral(.shade10))
+    }
 }
 
 

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -221,8 +221,14 @@ extension UIColor {
     /// Ghost cell animation end color. `Gray-5` (Light Mode) and Gray-10 (Dark Mode)
     ///
     static var ghostCellAnimationEndColor: UIColor {
-        return UIColor(light: neutral(.shade5),
-                       dark: neutral(.shade10))
+        if #available(iOS 13.0, *) {
+            return UIColor(light: .systemGray6,
+                           dark: .systemGray5)
+        } else {
+            return UIColor(light: neutral(.shade5),
+                           dark: neutral(.shade10))
+
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1541 

## Cause of the issue

As in the screenshot in #1541, the Ghost cells show the placeholder text from the xib after we updated the colors with Dark Mode support. Before the Dark Mode support, the ghost layer used to cover any placeholder text with a color animation between two opaque colors specified in https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Extensions/Ghost+Woo.swift#L8-L9. Since the animation end color became transparent with the Dark Mode color update (`quaternaryLabel` has 0.18 alpha in both Light and Dark modes), the placeholder text was shown through the transparent ghost layer.

## Changes

- Updated the beat animation end color to an opaque color, I picked `.neutral(.shade10)` but lemme know if there's a better color!

## Testing

- Log out of the app
- Log into the app
- Select a site with orders on the server to download
- Switch to the orders tab --> there should be no text in the ghost cells

## Example screenshots

before Dark Mode support | `develop` | PR branch - Light Mode | PR branch - Dark Mode
-- | -- | -- | --
![Simulator Screen Shot - iPhone SE - 2019-12-03 at 10 25 07](https://user-images.githubusercontent.com/1945542/70017399-ef89a900-15bd-11ea-8e18-f4ab87a70b42.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-03 at 10 12 11](https://user-images.githubusercontent.com/1945542/70017398-ef89a900-15bd-11ea-872b-c0fbdeebae04.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-04 at 16 01 25](https://user-images.githubusercontent.com/1945542/70124778-76b74980-16b0-11ea-9fdc-0a5e993369a0.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-04 at 16 01 46](https://user-images.githubusercontent.com/1945542/70124779-76b74980-16b0-11ea-956f-a68384a82415.png)






Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
