### PR TITLE
Create a generic list selector screen - paginated list - shipping class example

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -1,0 +1,352 @@
+import UIKit
+import WordPressUI
+import Yosemite
+
+protocol PaginatedListSelectorDataSource {
+    associatedtype StorageModel: ResultsControllerMutableType
+
+    var selected: StorageModel.ReadOnlyType? { get }
+
+    func createResultsController() -> ResultsController<StorageModel>
+
+    mutating func handleSelectedChange(selected: StorageModel.ReadOnlyType)
+
+    func configureCell(cell: BasicTableViewCell, model: StorageModel.ReadOnlyType)
+
+    func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?)
+}
+
+final class PaginatedListSelectorViewController<DataSource: PaginatedListSelectorDataSource, Model, StorageModel>:
+UIViewController, UITableViewDataSource, UITableViewDelegate, SyncingCoordinatorDelegate
+where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.ReadOnlyType, Model: Equatable {
+    private let viewProperties: PaginatedListSelectorViewProperties
+    private var dataSource: DataSource
+    private let onDismiss: (_ selected: Model?) -> Void
+
+    private let rowType = BasicTableViewCell.self
+
+    @IBOutlet private weak var tableView: UITableView!
+
+    /// Pull To Refresh Support.
+    ///
+    private lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(pullToRefresh(sender:)), for: .valueChanged)
+        return refreshControl
+    }()
+
+    /// Footer "Loading More" Spinner.
+    ///
+    private lazy var footerSpinnerView = {
+        return FooterSpinnerView(tableViewStyle: tableView.style)
+    }()
+
+    private lazy var footerEmptyView = {
+        return UIView(frame: .zero)
+    }()
+
+    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Product Variations in sync.
+    ///
+    private lazy var resultsController: ResultsController<StorageModel> = {
+        let resultsController = dataSource.createResultsController()
+        configureResultsController(resultsController) { [weak self] in
+            self?.tableView.reloadData()
+        }
+        return resultsController
+    }()
+
+    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    ///
+    private let syncingCoordinator = SyncingCoordinator()
+
+    private lazy var stateCoordinator: PaginatedListViewControllerStateCoordinator = {
+        let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: { [weak self] state in
+            self?.didLeave(state: state)
+            }, onEnteringState: { [weak self] state in
+                self?.didEnter(state: state)
+        })
+        return stateCoordinator
+    }()
+
+    /// Indicates if there are no results onscreen.
+    ///
+    private var isEmpty: Bool {
+        return resultsController.isEmpty
+    }
+
+    // MARK: - Constants
+    //
+    let placeholderRowsPerSection: [Int] = [3]
+
+    init(viewProperties: PaginatedListSelectorViewProperties,
+         dataSource: DataSource,
+         onDismiss: @escaping (_ selected: Model?) -> Void) {
+        self.viewProperties = viewProperties
+        self.dataSource = dataSource
+        self.onDismiss = onDismiss
+        super.init(nibName: "ListSelectorViewController", bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigation()
+        configureMainView()
+        configureTableView()
+        configureSyncingCoordinator()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        syncingCoordinator.synchronizeFirstPage()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        onDismiss(dataSource.selected)
+        super.viewWillDisappear(animated)
+    }
+
+    // MARK: UITableViewDataSource
+    //
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return resultsController.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return resultsController.sections[section].numberOfObjects
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: rowType.reuseIdentifier,
+                                                       for: indexPath) as? BasicTableViewCell else {
+                                                        fatalError()
+        }
+        let model = resultsController.object(at: indexPath)
+        dataSource.configureCell(cell: cell, model: model)
+
+        cell.accessoryType = model == dataSource.selected ? .checkmark: .none
+
+        return cell
+    }
+
+    // MARK: UITableViewDelegate
+    //
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let selected = resultsController.object(at: indexPath)
+        dataSource.handleSelectedChange(selected: selected)
+        tableView.reloadData()
+    }
+
+    // MARK: SyncingCoordinatorDelegate
+    //
+    func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+        transitionToSyncingState()
+        dataSource.sync(pageNumber: pageNumber, pageSize: pageSize) { [weak self] isCompleted in
+            guard let self = self else {
+                return
+            }
+
+            guard isCompleted else {
+                DDLogError("⛔️ Error synchronizing models")
+                self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
+                return
+            }
+
+            self.transitionToResultsUpdatedState()
+            onCompletion?(isCompleted)
+        }
+    }
+
+    // MARK: actions
+    //
+    @objc private func pullToRefresh(sender: UIRefreshControl) {
+        ServiceLocator.analytics.track(.productVariationListPulledToRefresh)
+
+        syncingCoordinator.synchronizeFirstPage {
+            sender.endRefreshing()
+        }
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension PaginatedListSelectorViewController {
+
+    func configureNavigation() {
+        title = viewProperties.navigationBarTitle
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        registerTableViewCells()
+    }
+
+    func registerTableViewCells() {
+        tableView.register(rowType.loadNib(), forCellReuseIdentifier: rowType.reuseIdentifier)
+    }
+
+    /// Setup: Sync'ing Coordinator
+    ///
+    func configureSyncingCoordinator() {
+        syncingCoordinator.delegate = self
+    }
+}
+
+// MARK: - Finite State Machine Management
+//
+private extension PaginatedListSelectorViewController {
+
+    func didEnter(state: PaginatedListViewControllerState) {
+        switch state {
+        case .noResultsPlaceholder:
+            displayNoResultsOverlay()
+        case .syncing(let withExistingData):
+            if withExistingData {
+                ensureFooterSpinnerIsStarted()
+            } else {
+                displayPlaceholderProducts()
+            }
+        case .results:
+            break
+        }
+    }
+
+    func didLeave(state: PaginatedListViewControllerState) {
+        switch state {
+        case .noResultsPlaceholder:
+            removeAllOverlays()
+        case .syncing:
+            ensureFooterSpinnerIsStopped()
+            removePlaceholderProducts()
+        case .results:
+            break
+        }
+    }
+
+    func transitionToSyncingState() {
+        stateCoordinator.transitionToSyncingState(withExistingData: !isEmpty)
+    }
+
+    func transitionToResultsUpdatedState() {
+        stateCoordinator.transitionToResultsUpdatedState(hasData: !isEmpty)
+    }
+}
+
+// MARK: - Placeholders
+//
+private extension PaginatedListSelectorViewController {
+
+    /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
+    ///
+    func displayPlaceholderProducts() {
+        let options = GhostOptions(reuseIdentifier: BasicTableViewCell.reuseIdentifier, rowsPerSection: placeholderRowsPerSection)
+        tableView.displayGhostContent(options: options,
+        style: .wooDefaultGhostStyle)
+
+        resultsController.stopForwardingEvents()
+    }
+
+    /// Removes the Placeholder Products (and restores the ResultsController <> UITableView link).
+    ///
+    func removePlaceholderProducts() {
+        tableView.removeGhostContent()
+        resultsController.startForwardingEvents(to: tableView)
+        tableView.reloadData()
+    }
+
+    /// Displays the Error Notice.
+    ///
+    func displaySyncingErrorNotice(pageNumber: Int, pageSize: Int) {
+        let message = NSLocalizedString("Unable to refresh list", comment: "Refresh Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
+        }
+
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Displays the overlay when there are no results.
+    ///
+    func displayNoResultsOverlay() {
+        let overlayView: OverlayMessageView = OverlayMessageView.instantiateFromNib()
+        overlayView.messageImage = nil
+        overlayView.messageText = viewProperties.noResultsPlaceholderText
+        overlayView.actionVisible = false
+        overlayView.attach(to: view)
+    }
+
+    /// Removes all of the the OverlayMessageView instances in the view hierarchy.
+    ///
+    func removeAllOverlays() {
+        for subview in view.subviews where subview is OverlayMessageView {
+            subview.removeFromSuperview()
+        }
+    }
+}
+
+// MARK: - Spinner Helpers
+//
+extension PaginatedListSelectorViewController {
+
+    /// Starts the Footer Spinner animation, whenever `mustStartFooterSpinner` returns *true*.
+    ///
+    private func ensureFooterSpinnerIsStarted() {
+        guard mustStartFooterSpinner() else {
+            return
+        }
+
+        tableView.tableFooterView = footerSpinnerView
+        footerSpinnerView.startAnimating()
+    }
+
+    /// Whenever we're sync'ing an Products Page that's beyond what we're currently displaying, this method will return *true*.
+    ///
+    private func mustStartFooterSpinner() -> Bool {
+        guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
+            return false
+        }
+
+        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > resultsController.numberOfObjects
+    }
+
+    /// Stops animating the Footer Spinner.
+    ///
+    private func ensureFooterSpinnerIsStopped() {
+        footerSpinnerView.stopAnimating()
+        tableView.tableFooterView = footerEmptyView
+    }
+}
+
+// MARK: - ResultsController
+//
+private extension PaginatedListSelectorViewController {
+
+    func configureResultsController(_ resultsController: ResultsController<StorageModel>, onReload: @escaping () -> Void) {
+        resultsController.onDidChangeContent = {
+            onReload()
+        }
+
+        resultsController.onDidResetContent = {
+            onReload()
+        }
+
+        try? resultsController.performFetch()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -26,8 +26,8 @@ protocol PaginatedListSelectorDataSource {
 
 /// Displays a paginated list (implemented by table view) for the user to select a generic model.
 ///
-final class PaginatedListSelectorViewController<DataSource: PaginatedListSelectorDataSource, Model, StorageModel, Cell>:
-    UIViewController, UITableViewDataSource, UITableViewDelegate, SyncingCoordinatorDelegate
+final class PaginatedListSelectorViewController<DataSource: PaginatedListSelectorDataSource, Model, StorageModel, Cell>: UIViewController,
+    UITableViewDataSource, UITableViewDelegate, SyncingCoordinatorDelegate
 where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.ReadOnlyType, Model: Equatable, DataSource.Cell == Cell {
     private let viewProperties: PaginatedListSelectorViewProperties
     private var dataSource: DataSource

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PaginatedListSelectorViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="iVE-H1-DkP" id="0az-sa-tpl"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="iVE-H1-DkP">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="iVE-H1-DkP" secondAttribute="bottom" id="H5y-MZ-5dX"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="iVE-H1-DkP" secondAttribute="trailing" id="lDa-EE-KPV"/>
+                <constraint firstItem="iVE-H1-DkP" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="wOy-cH-WWJ"/>
+                <constraint firstItem="iVE-H1-DkP" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="zou-uP-zyd"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="139" y="93"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewProperties.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewProperties.swift
@@ -1,0 +1,6 @@
+/// Properties for the list selector view.
+///
+struct PaginatedListSelectorViewProperties {
+    let navigationBarTitle: String?
+    let noResultsPlaceholderText: String
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
@@ -1,0 +1,49 @@
+import UIKit
+import Yosemite
+
+struct PaginatedProductShippingClassListSelectorDataSource: PaginatedListSelectorDataSource {
+
+    typealias StorageModel = StorageProductShippingClass
+
+    var selected: ProductShippingClass?
+
+    private let siteID: Int64
+
+    init(product: Product) {
+        self.siteID = Int64(product.siteID)
+        self.selected = product.productShippingClass
+    }
+
+    func createResultsController() -> ResultsController<StorageProductShippingClass> {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageProductShippingClass.name, ascending: true)
+
+        return ResultsController<StorageProductShippingClass>(storageManager: storageManager,
+                                                              matching: predicate,
+                                                              sortedBy: [descriptor])
+    }
+
+    mutating func handleSelectedChange(selected: ProductShippingClass) {
+        self.selected = selected == self.selected ? nil: selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: ProductShippingClass) {
+        cell.selectionStyle = .default
+
+        let bodyText = model.name
+        cell.textLabel?.text = bodyText
+    }
+
+    func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+        let action = ProductShippingClassAction
+            .synchronizeProductShippingClassModels(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { error in
+                if let error = error {
+                    DDLogError("⛔️ Error synchronizing product shipping classes: \(error)")
+                }
+                onCompletion?(error == nil)
+        }
+
+        ServiceLocator.stores.dispatch(action)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/PaginatedListViewControllerStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PaginatedListViewControllerStateCoordinator.swift
@@ -1,18 +1,18 @@
 import UIKit
 
-/// UI state of `ProductsViewController`.
+/// UI state of a view controller that displays a paginated list.
 ///
 /// - noResultsPlaceholder: a no results placeholder is displayed
 /// - syncing: syncing data UI with a parameter that indicates whether there is existing data
 /// - results: the results are shown
-enum ProductsViewControllerState {
+enum PaginatedListViewControllerState {
     case noResultsPlaceholder
     case syncing(withExistingData: Bool)
     case results
 }
 
-extension ProductsViewControllerState: Equatable {
-    static func ==(lhs: ProductsViewControllerState, rhs: ProductsViewControllerState) -> Bool {
+extension PaginatedListViewControllerState: Equatable {
+    static func ==(lhs: PaginatedListViewControllerState, rhs: PaginatedListViewControllerState) -> Bool {
             switch (lhs, rhs) {
             case let (.syncing(lhs), .syncing(rhs)):
                 return lhs == rhs
@@ -26,10 +26,10 @@ extension ProductsViewControllerState: Equatable {
     }
 }
 
-/// Keeps track of the Products view controller UI state, and allows the owning view controller to update UI when leaving and entering a state.
+/// Keeps track of the paginated list view controller UI state, and allows the owning view controller to update UI when leaving and entering a state.
 ///
-final class ProductsViewControllerStateCoordinator {
-    typealias State = ProductsViewControllerState
+final class PaginatedListViewControllerStateCoordinator {
+    typealias State = PaginatedListViewControllerState
 
     private let onLeavingState: (_ state: State) -> Void
     private let onEnteringState: (_ state: State) -> Void

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -62,8 +62,8 @@ final class ProductsViewController: UIViewController {
     ///
     private let syncingCoordinator = SyncingCoordinator()
 
-    private lazy var stateCoordinator: ProductsViewControllerStateCoordinator = {
-        let stateCoordinator = ProductsViewControllerStateCoordinator(onLeavingState: { [weak self] state in
+    private lazy var stateCoordinator: PaginatedListViewControllerStateCoordinator = {
+        let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: { [weak self] state in
             self?.didLeave(state: state)
             }, onEnteringState: { [weak self] state in
                 self?.didEnter(state: state)
@@ -462,7 +462,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
 //
 private extension ProductsViewController {
 
-    func didEnter(state: ProductsViewControllerState) {
+    func didEnter(state: PaginatedListViewControllerState) {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
@@ -477,7 +477,7 @@ private extension ProductsViewController {
         }
     }
 
-    func didLeave(state: ProductsViewControllerState) {
+    func didLeave(state: PaginatedListViewControllerState) {
         switch state {
         case .noResultsPlaceholder:
             removeAllOverlays()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -50,8 +50,8 @@ final class ProductVariationsViewController: UIViewController {
     ///
     private let syncingCoordinator = SyncingCoordinator()
 
-    private lazy var stateCoordinator: ProductsViewControllerStateCoordinator = {
-        let stateCoordinator = ProductsViewControllerStateCoordinator(onLeavingState: { [weak self] state in
+    private lazy var stateCoordinator: PaginatedListViewControllerStateCoordinator = {
+        let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: { [weak self] state in
             self?.didLeave(state: state)
             }, onEnteringState: { [weak self] state in
                 self?.didEnter(state: state)
@@ -329,7 +329,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
 //
 private extension ProductVariationsViewController {
 
-    func didEnter(state: ProductsViewControllerState) {
+    func didEnter(state: PaginatedListViewControllerState) {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
@@ -344,7 +344,7 @@ private extension ProductVariationsViewController {
         }
     }
 
-    func didLeave(state: ProductsViewControllerState) {
+    func didLeave(state: PaginatedListViewControllerState) {
         switch state {
         case .noResultsPlaceholder:
             removeAllOverlays()

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -38,6 +38,7 @@ class AuthenticatedState: StoresManagerState {
             OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             OrderStatusStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductReviewStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             RefundStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
 		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
+		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
@@ -651,6 +652,7 @@
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
 		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
+		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1340,6 +1342,7 @@
 			isa = PBXGroup;
 			children = (
 				0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift */,
+				02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */,
 			);
 			path = ListSelector;
 			sourceTree = "<group>";
@@ -3255,6 +3258,7 @@
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,
+				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,
 				45C8B25B231521510002FA77 /* CustomerNoteTableViewCellTests.swift in Sources */,
 				B5980A6721AC91AA00EBF596 /* BundleWooTests.swift in Sources */,
 				D88D5A3D230B5E85007B6E01 /* ServiceLocatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		02162727237963AF000208D2 /* ProductFormViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02162725237963AF000208D2 /* ProductFormViewController.xib */; };
 		02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02162728237965E8000208D2 /* ProductFormTableViewModel.swift */; };
 		0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */; };
+		0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */; };
 		021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */; };
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
 		02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */; };
@@ -572,6 +573,7 @@
 		02162725237963AF000208D2 /* ProductFormViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductFormViewController.xib; sourceTree = "<group>"; };
 		02162728237965E8000208D2 /* ProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModel.swift; sourceTree = "<group>"; };
+		0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxisTests.swift"; sourceTree = "<group>"; };
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
 		02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecUnorderedListFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -1404,6 +1406,7 @@
 			isa = PBXGroup;
 			children = (
 				02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorDataSource.swift */,
+				0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */,
 			);
 			path = "List Selector Data Source";
 			sourceTree = "<group>";
@@ -3083,6 +3086,7 @@
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
 				B5A8532220BDBFAF00FAAB4D /* CircularImageView.swift in Sources */,
 				CE1F51252064179A00C6C810 /* UILabel+Helpers.swift in Sources */,
+				0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */,
 				024DF31923742C3F006658FE /* AztecFormatBarFactory.swift in Sources */,
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
 		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
 		020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */; };
-		020DD49123239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */; };
+		020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */; };
 		020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E323163C0100776C4D /* TopBannerViewModel.swift */; };
 		020F41E623163C0100776C4D /* TopBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E423163C0100776C4D /* TopBannerView.swift */; };
 		020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F41E723176F8E00776C4D /* TopBannerPresenter.swift */; };
@@ -80,7 +80,7 @@
 		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
-		02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */; };
+		02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
 		0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */; };
 		02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */; };
@@ -560,7 +560,7 @@
 		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
 		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
 		020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AppReview.swift"; sourceTree = "<group>"; };
-		020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
+		020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinator.swift; sourceTree = "<group>"; };
 		020F41E323163C0100776C4D /* TopBannerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerViewModel.swift; sourceTree = "<group>"; };
 		020F41E423163C0100776C4D /* TopBannerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBannerView.swift; sourceTree = "<group>"; };
 		020F41E723176F8E00776C4D /* TopBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerPresenter.swift; sourceTree = "<group>"; };
@@ -613,7 +613,7 @@
 		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
-		02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
+		02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
 		0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserverTests.swift; sourceTree = "<group>"; };
 		0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecTextViewAttachmentHandler.swift; sourceTree = "<group>"; };
@@ -1260,7 +1260,7 @@
 			children = (
 				45FBDF29238BF87800127F77 /* Collection View Cells */,
 				0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */,
-				02691781232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift */,
+				02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */,
 				022A45ED237BADA6001417F0 /* Product+ProductFormTests.swift */,
 			);
 			path = Products;
@@ -1575,7 +1575,7 @@
 				74EC34A6225FE69C004BBC2E /* ProductDetailsViewController.swift */,
 				74EC34A7225FE69C004BBC2E /* ProductDetailsViewController.xib */,
 				0260F40023224E8100EDA10A /* ProductsViewController.swift */,
-				020DD49023239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift */,
+				020DD49023239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -3179,7 +3179,7 @@
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
-				020DD49123239DD6005822B1 /* ProductsViewControllerStateCoordinator.swift in Sources */,
+				020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */,
 				0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */,
 				024DF31423742B7A006658FE /* AztecUnderlineFormatBarCommand.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -105,11 +105,14 @@
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
 		0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */; };
 		0290E270238E3CE400B5C466 /* ListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0290E26E238E3CE400B5C466 /* ListSelectorViewController.xib */; };
+		0290E275238E4F8100B5C466 /* PaginatedListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */; };
+		0290E276238E4F8100B5C466 /* PaginatedListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0290E274238E4F8100B5C466 /* PaginatedListSelectorViewController.xib */; };
 		0290E27A238E590500B5C466 /* ListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E279238E590500B5C466 /* ListSelectorViewProperties.swift */; };
 		0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift */; };
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
 		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
+		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
@@ -638,11 +641,14 @@
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
 		0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectorViewController.swift; sourceTree = "<group>"; };
 		0290E26E238E3CE400B5C466 /* ListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ListSelectorViewController.xib; sourceTree = "<group>"; };
+		0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewController.swift; sourceTree = "<group>"; };
+		0290E274238E4F8100B5C466 /* PaginatedListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PaginatedListSelectorViewController.xib; sourceTree = "<group>"; };
 		0290E279238E590500B5C466 /* ListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
 		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
+		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1129,10 +1135,6 @@
 		021627232379637E000208D2 /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
-				02162724237963AF000208D2 /* ProductFormViewController.swift */,
-				02162725237963AF000208D2 /* ProductFormViewController.xib */,
-				02162728237965E8000208D2 /* ProductFormDataSource.swift */,
-				0216272A2379662C000208D2 /* DefaultProductFormDataSource.swift */,
 				02F4F50C237AFBB700E13A9C /* Cells */,
 				02E262CA238D0D0500B79588 /* List Selector Data Source */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
@@ -1391,6 +1393,9 @@
 				0290E279238E590500B5C466 /* ListSelectorViewProperties.swift */,
 				0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */,
 				0290E26E238E3CE400B5C466 /* ListSelectorViewController.xib */,
+				02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */,
+				0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */,
+				0290E274238E4F8100B5C466 /* PaginatedListSelectorViewController.xib */,
 			);
 			path = ListSelector;
 			sourceTree = "<group>";
@@ -2689,6 +2694,7 @@
 				0290E270238E3CE400B5C466 /* ListSelectorViewController.xib in Resources */,
 				B59D1EE821908A08009D1978 /* Noticons.ttf in Resources */,
 				D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */,
+				0290E276238E4F8100B5C466 /* PaginatedListSelectorViewController.xib in Resources */,
 				026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */,
 				B560D6882195BCC70027BB7E /* NoteDetailsHeaderTableViewCell.xib in Resources */,
 				CE27258021925AE8002B22EB /* ValueOneTableViewCell.xib in Resources */,
@@ -3122,6 +3128,7 @@
 				025FDD3223717D2900824006 /* EditorFactory.swift in Sources */,
 				453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */,
 				024DF30E23742A70006658FE /* AztecBoldFormatBarCommand.swift in Sources */,
+				0290E275238E4F8100B5C466 /* PaginatedListSelectorViewController.swift in Sources */,
 				020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */,
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
@@ -3190,6 +3197,7 @@
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,
 				CEEC9B5E21E79C330055EEF0 /* BuildConfiguration.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
+				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				748D34DF214828DD00E21A2F /* TopPerformersViewController.swift in Sources */,
@@ -3251,7 +3259,7 @@
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
 				B509FED521C052D1000076A9 /* MockupSupportManager.swift in Sources */,
-				02691782232605B9002AFC20 /* ProductsViewControllerStateCoordinatorTests.swift in Sources */,
+				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -8,6 +8,7 @@ final class MockProduct {
     let testProductID = 2020
 
     func product(name: String = "Hogsmeade",
+                 productShippingClass: ProductShippingClass? = nil,
                  stockQuantity: Int? = nil,
                  stockStatus: ProductStockStatus = .inStock,
                  variations: [Int] = [],
@@ -59,7 +60,7 @@ final class MockProduct {
                    shippingTaxable: false,
                    shippingClass: "",
                    shippingClassID: 0,
-                   productShippingClass: nil,
+                   productShippingClass: productShippingClass,
                    reviewsAllowed: true,
                    averageRating: "4.30",
                    ratingCount: 23,

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/PaginatedProductShippingClassListSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/PaginatedProductShippingClassListSelectorDataSourceTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+@testable import WooCommerce
+@testable import Yosemite
+
+final class PaginatedProductShippingClassListSelectorDataSourceTests: XCTestCase {
+    private let sampleSiteID: Int64 = 521
+
+    func testSelectedShippingClass() {
+        let shippingClassID = Int64(134)
+        let shippingClass = sampleProductShippingClass(remoteID: shippingClassID)
+        let product = MockProduct().product(productShippingClass: shippingClass)
+        var dataSource = PaginatedProductShippingClassListSelectorDataSource(product: product)
+        XCTAssertEqual(dataSource.selected, shippingClass)
+
+        let newShippingClass = sampleProductShippingClass(remoteID: 2019)
+        dataSource.handleSelectedChange(selected: newShippingClass)
+        XCTAssertEqual(dataSource.selected, newShippingClass)
+
+        // Select the same data twice should clear the selected data.
+        dataSource.handleSelectedChange(selected: newShippingClass)
+        XCTAssertNil(dataSource.selected)
+    }
+
+    func testCellConfiguration() {
+        let product = MockProduct().product()
+        let dataSource = PaginatedProductShippingClassListSelectorDataSource(product: product)
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        let shippingClass = sampleProductShippingClass(remoteID: 134)
+        dataSource.configureCell(cell: cell, model: shippingClass)
+
+        XCTAssertEqual(cell.textLabel?.text, shippingClass.name)
+    }
+
+}
+
+private extension PaginatedProductShippingClassListSelectorDataSourceTests {
+    func sampleProductShippingClass(remoteID: Int64) -> ProductShippingClass {
+        return ProductShippingClass(count: 3,
+                                    descriptionHTML: "Limited offer!",
+                                    name: "Free Shipping",
+                                    shippingClassID: remoteID,
+                                    siteID: sampleSiteID,
+                                    slug: "free-shipping")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/PaginatedListViewControllerStateCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/PaginatedListViewControllerStateCoordinatorTests.swift
@@ -2,25 +2,25 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-class ProductsViewControllerStateCoordinatorTests: XCTestCase {
+final class PaginatedListViewControllerStateCoordinatorTests: XCTestCase {
 
     func testTransitioningToSyncingState() {
         let hasExistingData = true
 
         let expectationForLeavingState = expectation(description: "Wait for leaving state")
         expectationForLeavingState.expectedFulfillmentCount = 1
-        let onLeavingState = { (state: ProductsViewControllerState) in
+        let onLeavingState = { (state: PaginatedListViewControllerState) in
             XCTAssertEqual(state, .results)
             expectationForLeavingState.fulfill()
         }
 
         let expectationForEnteringState = expectation(description: "Wait for entering state")
         expectationForEnteringState.expectedFulfillmentCount = 1
-        let onEnteringState = { (state: ProductsViewControllerState) in
+        let onEnteringState = { (state: PaginatedListViewControllerState) in
             XCTAssertEqual(state, .syncing(withExistingData: hasExistingData))
             expectationForEnteringState.fulfill()
         }
-        let stateCoordinator = ProductsViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+        let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
 
         stateCoordinator.transitionToSyncingState(withExistingData: hasExistingData)
         waitForExpectations(timeout: 0.1, handler: nil)
@@ -29,18 +29,18 @@ class ProductsViewControllerStateCoordinatorTests: XCTestCase {
     func testTransitioningToResultsUpdatedStateTwice() {
         let expectationForLeavingState = expectation(description: "Wait for leaving state")
         expectationForLeavingState.expectedFulfillmentCount = 1
-        let onLeavingState = { (state: ProductsViewControllerState) in
+        let onLeavingState = { (state: PaginatedListViewControllerState) in
             XCTAssertEqual(state, .results)
             expectationForLeavingState.fulfill()
         }
 
         let expectationForEnteringState = expectation(description: "Wait for entering state")
         expectationForEnteringState.expectedFulfillmentCount = 1
-        let onEnteringState = { (state: ProductsViewControllerState) in
+        let onEnteringState = { (state: PaginatedListViewControllerState) in
             XCTAssertEqual(state, .noResultsPlaceholder)
             expectationForEnteringState.fulfill()
         }
-        let stateCoordinator = ProductsViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
+        let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
 
         // .results --> .results (no state change)
         stateCoordinator.transitionToResultsUpdatedState(hasData: true)


### PR DESCRIPTION
Fixes #1526 (part 2: paginated list)

## Summary

This PR creates a paginated list selector view controller with a generic data source (could be any Storage model, and table view cell).

## Changes

- Renamed `ProductsViewControllerState*` to `PaginatedListViewControllerState*` since the use cases are all for a paginated list
- Created `PaginatedListSelectorViewController` as a generic paginated list selector view controller with data source protocol `PaginatedListSelectorDataSource`. The UI could be in one of such states:
  - no data - a placeholder label is displayed
  - a paginated list of data: when scrolling to the bottom, it will request another batch of data from the data source
  - syncing: when there are no data and it's fetching data from the server
- Created `PaginatedProductShippingClassListSelectorDataSource` that implements `PaginatedListSelectorDataSource` as the next use case in #1422 with basic unit tests

## Testing

Just CI, no user-facing changes in this PR

## Example screenshots

Example of shipping class

data | no data
-- | --
![Simulator Screen Shot - iPhone SE - 2019-12-04 at 14 47 52](https://user-images.githubusercontent.com/1945542/70121254-2be60380-16a9-11ea-9564-56ff2b1c29e4.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-04 at 14 48 17](https://user-images.githubusercontent.com/1945542/70121255-2be60380-16a9-11ea-9bc7-db0b844b2b6e.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
