### PR TITLE
Turn on feature flags for teaser release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,8 @@
  
 3.2
 -----
-- Experimental: if the Products feature flag is on, a Products feature switch is visible in Settings > Experimental Features that shows/hides the Products tab with a Work In Progress banner at the top.
-- If the Readonly Product variants feature flag is on and the Product has variations, the variants info are shown on the Product Details that navigates to a list of variations with each price or visibility shown.
+- Experimental: a Products feature switch is visible in Settings > Experimental Features that shows/hides the Products tab with a Work In Progress banner at the top.
+- Experimental: if a Product has variations, the variants info are shown on the Product Details that navigates to a list of variations with each price or visibility shown.
 - Enhancement: Support for dark mode
 - bugfix: Settings no longer convert to partial dark mode.
  

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -2,11 +2,11 @@ struct DefaultFeatureFlagService: FeatureFlagService {
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
         case .productList:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .editProducts:
             return BuildConfiguration.current == .localDeveloper
         case .readonlyProductVariants:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .stats:
             return true
         case .refunds:


### PR DESCRIPTION
Fixes #1558 

## Changes

- Turned on these two feature flags:
  - `productList`
  - `readonlyProductVariants`

## Testing

- In Xcode, edit WooCommerce scheme > update Build configuration to a non-debug one
- Build the app --> should see the Experimental Features in Settings, and on Products tab > Variable Product can see the variants info

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
