### PR TITLE
Updated open source licenses

### DIFF
--- a/WooCommerce/Resources/HTML/licenses.html
+++ b/WooCommerce/Resources/HTML/licenses.html
@@ -32,6 +32,8 @@
             <li><a href="https://github.com/Alamofire/Alamofire">Alamofire</a> by <a href="http://alamofire.org/">Alamofire Software Foundation</a></li>
             <li><a href="https://github.com/kishikawakatsumi/KeychainAccess">KeychainAccess</a> by <a href="https://github.com/kishikawakatsumi">Kishikawa Katsumi</a></li>
             <li><a href="https://github.com/xmartlabs/XLPagerTabStrip">XLPagerTabStrip</a> by <a href="https://xmartlabs.com/">XMARTLABS</a></li>
+            <li><a href="https://github.com/onevcat/Kingfisher">Kingfisher</a> by <a href="https://github.com/onevcat">Wei Wang</a></li>
+            <li><a href="https://github.com/pmusolino/Wormholy">Wormholy</a> by <a href="https://github.com/pmusolino">Paolo Musolino</a></li>
         </ul>
 
         <h4>The following libraries are licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">The Apache License, Version 2.0</a>:</h4>


### PR DESCRIPTION
After integrating Wormholy #1502 and Kingfisher #1551 I forgot to add them into the open source licenses file. This PR fixes this issue.

![Simulator Screen Shot - iPhone 11 Pro - 2019-12-04 at 17 37 00](https://user-images.githubusercontent.com/495617/70161861-0bc03f80-16bd-11ea-9e51-18fcaa678dbb.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
