### PR TITLE
Create a system color wrapper to support iOS 12 and update default button colors

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -8,29 +8,47 @@ extension UIButton {
     /// Applies the Primary Button Style: Solid BG!
     ///
     func applyPrimaryButtonStyle() {
-        backgroundColor = .primary
+        backgroundColor = .primaryButtonBackground
         contentEdgeInsets = Style.defaultEdgeInsets
-        tintColor = .primaryButtonBackground
         layer.borderColor = UIColor.primary.cgColor
         layer.borderWidth = Style.defaultBorderWidth
         layer.cornerRadius = Style.defaultCornerRadius
         titleLabel?.applyHeadlineStyle()
         enableMultipleLines()
         titleLabel?.textAlignment = .center
+
+        setTitleColor(.primaryButtonTitle, for: .normal)
+        setTitleColor(.primaryButtonTitle, for: .highlighted)
+        setTitleColor(.buttonDisabledTitle, for: .disabled)
+        setBackgroundImage(UIImage.renderBackgroundImage(fill: .primaryButtonDownBackground,
+                                                         border: .primaryButtonDownBorder),
+                           for: .highlighted)
+        setBackgroundImage(UIImage.renderBackgroundImage(fill: .buttonDisabledBackground,
+                                                         border: .buttonDisabledBorder),
+                           for: .disabled)
     }
 
     /// Applies the Secondary Button Style: Clear BG / Bordered Outline
     ///
     func applySecondaryButtonStyle() {
-        backgroundColor = .clear
+        backgroundColor = .secondaryButtonBackground
         contentEdgeInsets = Style.defaultEdgeInsets
-        tintColor = .primary
-        layer.borderColor = UIColor.primary.cgColor
+        layer.borderColor = UIColor.secondaryButtonBorder.cgColor
         layer.borderWidth = Style.defaultBorderWidth
         layer.cornerRadius = Style.defaultCornerRadius
         titleLabel?.applyHeadlineStyle()
         enableMultipleLines()
         titleLabel?.textAlignment = .center
+
+        setTitleColor(.secondaryButtonTitle, for: .normal)
+        setTitleColor(.secondaryButtonTitle, for: .highlighted)
+        setTitleColor(.buttonDisabledTitle, for: .disabled)
+        setBackgroundImage(UIImage.renderBackgroundImage(fill: .secondaryButtonDownBackground,
+                                                         border: .secondaryButtonDownBorder),
+                           for: .highlighted)
+        setBackgroundImage(UIImage.renderBackgroundImage(fill: .buttonDisabledBackground,
+                                                         border: .buttonDisabledBorder),
+                           for: .disabled)
     }
 
     /// Applies the Tertiary Button Style: Clear BG / Top Outline

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -10,7 +10,7 @@ extension UIButton {
     func applyPrimaryButtonStyle() {
         backgroundColor = .primaryButtonBackground
         contentEdgeInsets = Style.defaultEdgeInsets
-        layer.borderColor = UIColor.primary.cgColor
+        layer.borderColor = UIColor.primaryButtonBorder.cgColor
         layer.borderWidth = Style.defaultBorderWidth
         layer.cornerRadius = Style.defaultCornerRadius
         titleLabel?.applyHeadlineStyle()

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -44,10 +44,10 @@ extension UIButton {
         setTitleColor(.secondaryButtonTitle, for: .highlighted)
         setTitleColor(.buttonDisabledTitle, for: .disabled)
         setBackgroundImage(UIImage.renderBackgroundImage(fill: .secondaryButtonDownBackground,
-                                                         border: .secondaryButtonDownBorder),
+                                                         border: .clear),
                            for: .highlighted)
         setBackgroundImage(UIImage.renderBackgroundImage(fill: .buttonDisabledBackground,
-                                                         border: .buttonDisabledBorder),
+                                                         border: .clear),
                            for: .disabled)
     }
 

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -190,17 +190,17 @@ extension UIColor {
         return .white
     }
 
+    /// Primary Button Border.
+    ///
+    static var primaryButtonBorder = UIColor.clear
+
     /// Primary Button Highlighted Background.
     ///
     static var primaryButtonDownBackground = accentDark
 
     /// Primary Button Highlighted Border.
     ///
-    static var primaryButtonDownBorder = primaryButtonDownBackground
-
-    /// Primary Button Border.
-    ///
-    static var primaryButtonBorder = primaryButtonBackground
+    static var primaryButtonDownBorder = accentDark
 
     /// Secondary Button Background.
     ///

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -196,11 +196,11 @@ extension UIColor {
 
     /// Primary Button Highlighted Border.
     ///
-    static var primaryButtonDownBorder = UIColor.clear
+    static var primaryButtonDownBorder = primaryButtonDownBackground
 
     /// Primary Button Border.
     ///
-    static var primaryButtonBorder = UIColor.clear
+    static var primaryButtonBorder = primaryButtonBackground
 
     /// Secondary Button Background.
     ///

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -184,20 +184,72 @@ extension UIColor {
     ///
     static var primaryButtonBackground = accent
 
+    /// Primary Button Title.
+    ///
+    static var primaryButtonTitle: UIColor {
+        return .white
+    }
+
+    /// Primary Button Highlighted Background.
+    ///
+    static var primaryButtonDownBackground = accentDark
+
+    /// Primary Button Highlighted Border.
+    ///
+    static var primaryButtonDownBorder = UIColor.clear
+
     /// Primary Button Border. Resolves to `accent`
     ///
     static var primaryButtonBorder = accent
 
-    /// Primary Button Down Background. Pink-80 (< iOS 13 and Light Mode) and Pink-50 (Dark Mode)
+    /// Secondary Button Background.
     ///
-    static var primaryButtonDownBackground: UIColor {
-        return UIColor(light: .withColorStudio(.pink, shade: .shade80),
-                       dark: .withColorStudio(.pink, shade: .shade50))
+    static var secondaryButtonBackground: UIColor {
+        return UIColor(light: .white,
+                       dark: .systemColor(.systemGray5))
     }
 
-    /// Primary Button Down Border. Resolves to `primaryButtonDownBackground`
+    /// Secondary Button Title.
     ///
-    static var primaryButtonDownBorder = primaryButtonDownBackground
+    static var secondaryButtonTitle: UIColor {
+        return .systemColor(.label)
+    }
+
+    /// Secondary Button Border.
+    ///
+    static var secondaryButtonBorder: UIColor {
+        return .systemColor(.systemGray3)
+    }
+
+    /// Secondary Button Highlighted Background.
+    ///
+    static var secondaryButtonDownBackground: UIColor {
+        return .systemColor(.systemGray3)
+    }
+
+    /// Secondary Button Highlighted Border.
+    ///
+    static var secondaryButtonDownBorder: UIColor {
+        return .systemColor(.systemGray3)
+    }
+
+    /// Button Disabled Background.
+    ///
+    static var buttonDisabledBackground: UIColor {
+        return .clear
+    }
+
+    /// Button Disabled Title.
+    ///
+    static var buttonDisabledTitle: UIColor {
+        return .systemColor(.quaternaryLabel)
+    }
+
+    /// Button Disabled Border.
+    ///
+    static var buttonDisabledBorder: UIColor {
+        return .systemColor(.systemGray3)
+    }
 
     /// Filter Bar Selected. `primary` (< iOS 13 and Light Mode) and `UIColor.label` (Dark Mode)
     ///
@@ -221,14 +273,8 @@ extension UIColor {
     /// Ghost cell animation end color. `Gray-5` (Light Mode) and Gray-10 (Dark Mode)
     ///
     static var ghostCellAnimationEndColor: UIColor {
-        if #available(iOS 13.0, *) {
-            return UIColor(light: .systemGray6,
-                           dark: .systemGray5)
-        } else {
-            return UIColor(light: neutral(.shade5),
-                           dark: neutral(.shade10))
-
-        }
+        return UIColor(light: .systemColor(.systemGray6),
+                       dark: .systemColor(.systemGray5))
     }
 }
 

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -198,9 +198,9 @@ extension UIColor {
     ///
     static var primaryButtonDownBorder = UIColor.clear
 
-    /// Primary Button Border. Resolves to `accent`
+    /// Primary Button Border.
     ///
-    static var primaryButtonBorder = accent
+    static var primaryButtonBorder = UIColor.clear
 
     /// Secondary Button Background.
     ///

--- a/WooCommerce/Classes/Styles/UIColor+SystemColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SystemColors.swift
@@ -1,0 +1,169 @@
+import UIKit
+
+/// Represents each iOS system color, available in iOS 13+.
+enum SystemColor {
+    case label
+    case secondaryLabel
+    case tertiaryLabel
+    case quaternaryLabel
+    case systemFill
+    case secondarySystemFill
+    case tertiarySystemFill
+    case quaternarySystemFill
+    case placeholderText
+    case systemBackground
+    case secondarySystemBackground
+    case tertiarySystemBackground
+    case systemGroupedBackground
+    case secondarySystemGroupedBackground
+    case tertiarySystemGroupedBackground
+    case separator
+    case opaqueSeparator
+    case link
+    case darkText
+    case lightText
+    case systemBlue
+    case systemGreen
+    case systemIndigo
+    case systemOrange
+    case systemPink
+    case systemPurple
+    case systemRed
+    case systemTeal
+    case systemYellow
+    case systemGray
+    case systemGray2
+    case systemGray3
+    case systemGray4
+    case systemGray5
+    case systemGray6
+}
+
+private extension SystemColor {
+    var color: UIColor {
+        if #available(iOS 13, *) {
+            switch self {
+            case .label: return .label
+            case .secondaryLabel: return .secondaryLabel
+            case .tertiaryLabel: return .tertiaryLabel
+            case .quaternaryLabel: return .quaternaryLabel
+            case .systemFill: return .systemFill
+            case .secondarySystemFill: return .secondarySystemFill
+            case .tertiarySystemFill: return .tertiarySystemFill
+            case .quaternarySystemFill: return .quaternarySystemFill
+            case .placeholderText: return .placeholderText
+            case .systemBackground: return .systemBackground
+            case .secondarySystemBackground: return .secondarySystemBackground
+            case .tertiarySystemBackground: return .tertiarySystemBackground
+            case .systemGroupedBackground: return .systemGroupedBackground
+            case .secondarySystemGroupedBackground: return .secondarySystemGroupedBackground
+            case .tertiarySystemGroupedBackground: return .tertiarySystemGroupedBackground
+            case .separator: return .separator
+            case .opaqueSeparator: return .opaqueSeparator
+            case .link: return .link
+            case .darkText: return .darkText
+            case .lightText: return .lightText
+            case .systemBlue: return .systemBlue
+            case .systemGreen: return .systemGreen
+            case .systemIndigo: return .systemIndigo
+            case .systemOrange: return .systemOrange
+            case .systemPink: return .systemPink
+            case .systemPurple: return .systemPurple
+            case .systemRed: return .systemRed
+            case .systemTeal: return .systemTeal
+            case .systemYellow: return .systemYellow
+            case .systemGray: return .systemGray
+            case .systemGray2: return .systemGray2
+            case .systemGray3: return .systemGray3
+            case .systemGray4: return .systemGray4
+            case .systemGray5: return .systemGray5
+            case .systemGray6: return .systemGray6
+            }
+        }
+
+        switch self {
+        case .label: // rgba(0.0, 0.0, 0.0, 1.0)
+            return .init(red: 0, green: 0, blue: 0, alpha: 1)
+        case .secondaryLabel: // #3c3c4399    rgba(60.0, 60.0, 67.0, 0.6)
+            return .init(red: 60, green: 60, blue: 67, alpha: 0.6)
+        case .tertiaryLabel: // #3c3c434c    rgba(60.0, 60.0, 67.0, 0.3)
+            return .init(red: 60, green: 60, blue: 67, alpha: 0.3)
+        case .quaternaryLabel: // #3c3c432d    rgba(60.0, 60.0, 67.0, 0.18)
+            return .init(red: 60, green: 60, blue: 67, alpha: 0.18)
+        case .systemFill: // #78788033    rgba(120.0, 120.0, 128.0, 0.2)
+            return .init(red: 120, green: 120, blue: 128, alpha: 0.2)
+        case .secondarySystemFill: // #78788028    rgba(120.0, 120.0, 128.0, 0.16)
+            return .init(red: 120, green: 120, blue: 128, alpha: 0.16)
+        case .tertiarySystemFill: // #7676801e    rgba(118.0, 118.0, 128.0, 0.12)
+            return .init(red: 118, green: 118, blue: 128, alpha: 0.12)
+        case .quaternarySystemFill: // #74748014    rgba(116.0, 116.0, 128.0, 0.08)
+            return .init(red: 116, green: 116, blue: 128, alpha: 0.08)
+        case .placeholderText: // #3c3c434c    rgba(60.0, 60.0, 67.0, 0.3)
+            return .init(red: 60, green: 60, blue: 67, alpha: 0.3)
+        case .systemBackground: // #ffffffff    rgba(255.0, 255.0, 255.0, 1.0)
+            return .init(red: 255, green: 255, blue: 255, alpha: 1)
+        case .secondarySystemBackground: // #f2f2f7ff    rgba(242.0, 242.0, 247.0, 1.0)
+            return .init(red: 242, green: 242, blue: 247, alpha: 1)
+        case .tertiarySystemBackground: // #ffffffff    rgba(255.0, 255.0, 255.0, 1.0)
+            return .init(red: 255, green: 255, blue: 255, alpha: 1)
+        case .systemGroupedBackground: // #f2f2f7ff    rgba(242.0, 242.0, 247.0, 1.0)
+            return .init(red: 242, green: 242, blue: 247, alpha: 1)
+        case .secondarySystemGroupedBackground: // #ffffffff    rgba(255.0, 255.0, 255.0, 1.0)
+            return .init(red: 255, green: 255, blue: 255, alpha: 1)
+        case .tertiarySystemGroupedBackground: // #f2f2f7ff    rgba(242.0, 242.0, 247.0, 1.0)
+            return .init(red: 242, green: 242, blue: 247, alpha: 1)
+        case .separator: // #3c3c4349    rgba(60.0, 60.0, 67.0, 0.29)
+            return .init(red: 60, green: 60, blue: 67, alpha: 0.29)
+        case .opaqueSeparator: // #c6c6c8ff    rgba(198.0, 198.0, 200.0, 1.0)
+            return .init(red: 198, green: 198, blue: 200, alpha: 1)
+        case .link: // #007affff    rgba(0.0, 122.0, 255.0, 1.0)
+            return .init(red: 0, green: 122, blue: 255, alpha: 1)
+        case .darkText: // #000000ff    rgba(0.0, 0.0, 0.0, 1.0)
+            return .init(red: 0, green: 0, blue: 0, alpha: 1)
+        case .lightText: // #ffffff99    rgba(255.0, 255.0, 255.0, 0.6)
+            return .init(red: 255, green: 255, blue: 255, alpha: 0.6)
+        case .systemBlue: // #007affff    rgba(0.0, 122.0, 255.0, 1.0)
+            return .init(red: 0, green: 122, blue: 255, alpha: 1)
+        case .systemGreen: // #34c759ff    rgba(52.0, 199.0, 89.0, 1.0)
+            return .init(red: 52, green: 199, blue: 89, alpha: 1)
+        case .systemIndigo: // #5856d6ff    rgba(88.0, 86.0, 214.0, 1.0)
+            return .init(red: 88, green: 86, blue: 214, alpha: 1)
+        case .systemOrange: // #ff9500ff    rgba(255.0, 149.0, 0.0, 1.0)
+            return .init(red: 255, green: 149, blue: 0, alpha: 1)
+        case .systemPink: // #ff2d55ff    rgba(255.0, 45.0, 85.0, 1.0)
+            return .init(red: 255, green: 45, blue: 85, alpha: 1)
+        case .systemPurple: // #af52deff    rgba(175.0, 82.0, 222.0, 1.0)
+            return .init(red: 175, green: 82, blue: 222, alpha: 1)
+        case .systemRed: // #ff3b30ff    rgba(255.0, 59.0, 48.0, 1.0)
+            return .init(red: 255, green: 59, blue: 48, alpha: 1)
+        case .systemTeal: // #5ac8faff    rgba(90.0, 200.0, 250.0, 1.0)
+            return .init(red: 90, green: 200, blue: 250, alpha: 1)
+        case .systemYellow: // #ffcc00ff    rgba(255.0, 204.0, 0.0, 1.0)
+            return .init(red: 255, green: 204, blue: 0, alpha: 1)
+        case .systemGray: // #8e8e93ff    rgba(142.0, 142.0, 147.0, 1.0)
+            return .init(red: 142, green: 142, blue: 147, alpha: 1)
+        case .systemGray2: // #aeaeb2ff    rgba(174.0, 174.0, 178.0, 1.0)
+            return .init(red: 174, green: 174, blue: 178, alpha: 1)
+        case .systemGray3: // #c7c7ccff    rgba(199.0, 199.0, 204.0, 1.0)
+            return .init(red: 199, green: 199, blue: 204, alpha: 1)
+        case .systemGray4: // #d1d1d6ff    rgba(209.0, 209.0, 214.0, 1.0)
+            return .init(red: 209, green: 209, blue: 214, alpha: 1)
+        case .systemGray5: // #e5e5eaff    rgba(229.0, 229.0, 234.0, 1.0)
+            return .init(red: 229, green: 229, blue: 234, alpha: 1)
+        case .systemGray6: // #f2f2f7ff    rgba(242.0, 242.0, 247.0, 1.0)
+            return .init(red: 242, green: 242, blue: 247, alpha: 1)
+        }
+    }
+}
+
+extension UIColor {
+
+    /// Get a system color.
+    ///
+    /// - Parameters:
+    ///   - systemColor: a system color enum
+    /// - Returns: UIColor for each system color
+    class func systemColor(_ systemColor: SystemColor) -> UIColor {
+        return systemColor.color
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/FulfillButtonTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/FulfillButtonTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="331" height="74.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-8C-l5l">
-                        <rect key="frame" x="16" y="19" width="299" height="37"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rng-8C-l5l">
+                        <rect key="frame" x="15" y="19" width="301" height="37"/>
                         <state key="normal" title="Button"/>
                         <connections>
                             <action selector="fulfillWasPressed" destination="KGk-i7-Jjw" eventType="touchUpInside" id="N5x-ry-GxY"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,7 +22,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="44" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="TsO-Qh-HeU">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="Yv6-Rf-W4s"/>
@@ -47,7 +45,7 @@
             <rect key="frame" x="0.0" y="0.0" width="390" height="133"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aEY-5S-3tb">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aEY-5S-3tb">
                     <rect key="frame" x="16" y="16" width="358" height="53"/>
                     <color key="backgroundColor" red="0.58823529409999997" green="0.34509803919999998" blue="0.54117647059999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" title="Button"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/OverlayMessageView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +15,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="2w1-dg-Nr4">
-                    <rect key="frame" x="0.0" y="213.5" width="375" height="240.5"/>
+                    <rect key="frame" x="0.0" y="211.5" width="375" height="244.5"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3Ng-em-fRz">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="140"/>
@@ -28,8 +26,8 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JeL-xN-0dT">
-                            <rect key="frame" x="172.5" y="210.5" width="30" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JeL-xN-0dT">
+                            <rect key="frame" x="172.5" y="210.5" width="30" height="34"/>
                             <connections>
                                 <action selector="buttonWasPressed" destination="Rnv-rx-naA" eventType="touchUpInside" id="wVH-WX-WDl"/>
                             </connections>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
 		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
+		02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */; };
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
@@ -643,6 +644,7 @@
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
 		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
+		02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SystemColors.swift"; sourceTree = "<group>"; };
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1129,10 +1131,6 @@
 		021627232379637E000208D2 /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
-				02162724237963AF000208D2 /* ProductFormViewController.swift */,
-				02162725237963AF000208D2 /* ProductFormViewController.xib */,
-				02162728237965E8000208D2 /* ProductFormDataSource.swift */,
-				0216272A2379662C000208D2 /* DefaultProductFormDataSource.swift */,
 				02F4F50C237AFBB700E13A9C /* Cells */,
 				02E262CA238D0D0500B79588 /* List Selector Data Source */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
@@ -2067,6 +2065,7 @@
 				D8915DC02372C8AC00F63762 /* ColorStudio.swift */,
 				D8915DC22372C9EF00F63762 /* UIColor+ColorStudio.swift */,
 				D8CD710E237A49DB007148B9 /* UIColor+SemanticColors.swift */,
+				02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */,
 			);
 			path = Styles;
 			sourceTree = "<group>";
@@ -3139,6 +3138,7 @@
 				743EDD9F214B05350039071B /* TopEarnerStatsItem+Woo.swift in Sources */,
 				B5BBD6DE21B1703700E3207E /* PushNotificationsManager.swift in Sources */,
 				CE1EC8EC20B8A3FF009762BF /* LeftImageTableViewCell.swift in Sources */,
+				02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */,
 				CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */,
 				B5C3876421C41B9F006CE970 /* UIApplication+Woo.swift in Sources */,
 				D85136B9231CED5800DD0539 /* ReviewAge.swift in Sources */,


### PR DESCRIPTION
Prerequisite for #1555 

cc @jkmassel : I'm planning on making a series of PRs targeting `release/3.2` that update the colors for the Dark Mode support. after all the color fixes are done, we can make another beta.

## Summary
We use system colors in the Dark/Light mode design, but these system colors are iOS 13+. This PR added iOS 12 support for these iOS 13+ system colors for the followup color updates. In addition, this PR updated the default button styles, used in many instances in the app.

## Changes
- Created `SystemColor` enum for all iOS 13+ system colors
- Added a `UIColor` extension to get the system color that is backward compatible
- Updated semantic colors for the primary, secondary, and disabled button state
- Updated default colors for primary and secondary buttons

## Testing
- Run the app and play around --> all buttons that use primary/secondary style should have the expected colors

## Example screenshots
button | Light | Dark
-- | -- | --
Primary button | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 16 58 15](https://user-images.githubusercontent.com/1945542/70221449-5906e480-1783-11ea-8347-57bc57fdd726.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 16 58 34](https://user-images.githubusercontent.com/1945542/70221450-599f7b00-1783-11ea-92f4-1f5b8a1bd491.png)
Primary button - Highlighted | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 16 58 17](https://user-images.githubusercontent.com/1945542/70221588-9b302600-1783-11ea-8aed-023aede428b4.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 17 08 28](https://user-images.githubusercontent.com/1945542/70221589-9bc8bc80-1783-11ea-9317-ab1245efda4d.png)
Secondary button | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 16 47 49](https://user-images.githubusercontent.com/1945542/70219075-2824b080-177f-11ea-8c7f-2951002ee040.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 16 48 00](https://user-images.githubusercontent.com/1945542/70219076-28bd4700-177f-11ea-8541-30b85e976eca.png)
Secondary button - Highlighted | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 17 19 58](https://user-images.githubusercontent.com/1945542/70221638-b26f1380-1783-11ea-9507-4782d462e0f3.png) | ![Simulator Screen Shot - iPhone SE - 2019-12-05 at 17 20 15](https://user-images.githubusercontent.com/1945542/70221640-b26f1380-1783-11ea-8e15-9f9a3d3f7312.png)




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
