### PR TITLE
Dark Mode: update colors for settings UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -192,7 +192,7 @@ private extension PrivacySettingsViewController {
         cell.imageView?.image = .invisibleImage
         cell.imageView?.tintColor = .listForeground
         cell.textLabel?.text = NSLocalizedString("Learn more", comment: "Settings > Privacy Settings. A text link to the cookie policy.")
-        cell.textLabel?.textColor = .primary
+        cell.textLabel?.textColor = .accent
     }
 
     func configurePrivacyInfo(cell: TopLeftImageTableViewCell) {
@@ -214,7 +214,7 @@ private extension PrivacySettingsViewController {
             "Read privacy policy",
             comment: "Settings > Privacy Settings > privacy policy info section. A text link to the privacy policy."
         )
-        cell.textLabel?.textColor = .primary
+        cell.textLabel?.textColor = .accent
     }
 
     func configureCookieInfo(cell: TopLeftImageTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwitchTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwitchTableViewCell.swift
@@ -80,7 +80,7 @@ private extension SwitchTableViewCell {
     }
 
     func setupSwitch() {
-        toggleSwitch.onTintColor = .listIcon
+        toggleSwitch.onTintColor = .primary
         toggleSwitch.addTarget(self, action: #selector(toggleSwitchWasPressed), for: .touchUpInside)
         accessoryView = toggleSwitch
     }


### PR DESCRIPTION
Settings for #1555 

## Changes
- Updated link cell title colors in `PrivacySettingsViewController`
- Updated the switch on tint color

## Testing

- Launch the app
- Go to Settings
- Go to "Experimental Features" --> the switches should have the expected colors
- Go back to Settings, then go to "Privacy Settings" --> the link titles should have the expected color

## Example screenshots

screen | Dark | Light
-- | -- | --
Privacy Settings | ![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 16 54 18](https://user-images.githubusercontent.com/1945542/70310021-b5ccd280-1849-11ea-948a-9362094c3429.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 16 54 09](https://user-images.githubusercontent.com/1945542/70310019-b5343c00-1849-11ea-9f7c-47f9cce2e651.png)
Experimental Features | ![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 16 54 24](https://user-images.githubusercontent.com/1945542/70310023-b5ccd280-1849-11ea-9709-cccd2d27b2a5.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-06 at 16 54 30](https://user-images.githubusercontent.com/1945542/70310024-b5ccd280-1849-11ea-8656-f87a2491da13.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
