### PR TITLE
Fixed product experimental feature after a logout and login

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -111,8 +111,6 @@ final class MainTabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setNeedsStatusBarAppearanceUpdate() // call this to refresh status bar changes happening at runtime
-
-        reloadProductListVisibility()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -125,6 +123,8 @@ final class MainTabBarController: UITabBarController {
         startListeningToBadgeUpdatesIfNeeded()
         startListeningToOrdersBadge()
         startListeningToProductsVisibilityChanges()
+
+        reloadProductListVisibility()
     }
 
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {


### PR DESCRIPTION
Fixes #1532 

## Description
In App Settings, enabling the product experimental features after logout generates a wrong status.

## Testing
1) Go in settings, and enable an experimental feature, like Products.
2) Logout from the app.
3) Close the app
4) Reopen the app
5) Go into settings -> Experimental features
6) You will see the toggle which is still ON, and the feature is enabled.
7) Close the app. Relaunch it. You will see the toggle ON, and the feature enabled.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
