### PR TITLE
Dark Mode: update colors for Orders tab

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -82,6 +82,16 @@ extension UIButton {
         setTitleColor(.accentDark, for: .highlighted)
     }
 
+    /// Applies the single-color Icon Button Style: accent/accent dark tint color
+    ///
+    func applyIconButtonStyle(icon: UIImage) {
+        let normalImage = icon.applyTintColor(.accent)
+        let highlightedImage = icon.applyTintColor(.accentDark)
+        setImage(normalImage, for: .normal)
+        setImage(highlightedImage, for: .highlighted)
+        tintColor = .accent
+    }
+
     /// Supports title of multiple lines, either from longer text than allocated width or text with line breaks.
     private func enableMultipleLines() {
         titleLabel?.lineBreakMode = .byWordWrapping

--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -82,7 +82,7 @@ extension UIButton {
         setTitleColor(.accentDark, for: .highlighted)
     }
 
-    /// Applies the single-color Icon Button Style: accent/accent dark tint color
+    /// Applies the Single-Color Icon Button Style: accent/accent dark tint color
     ///
     func applyIconButtonStyle(icon: UIImage) {
         let normalImage = icon.applyTintColor(.accent)

--- a/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+OrderStatus.swift
@@ -27,22 +27,14 @@ extension UILabel {
     ///
     private func applyBackground(for statusEnum: OrderStatusEnum) {
         switch statusEnum {
-        case .cancelled:
-            fallthrough
-        case .completed:
-            fallthrough
-        case .custom:
-            fallthrough
-        case .onHold:
-            fallthrough
-        case .pending:
-            fallthrough
-        case .processing:
+        case .pending, .completed, .cancelled, .refunded, .custom:
             backgroundColor = .gray(.shade5)
+        case .onHold:
+            backgroundColor = .withColorStudio(.orange, shade: .shade5)
+        case .processing:
+            backgroundColor = .withColorStudio(.green, shade: .shade5)
         case .failed:
-            fallthrough
-        case .refunded:
-            backgroundColor = .error
+            backgroundColor = .withColorStudio(.red, shade: .shade5)
         }
 
         textColor = .black

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
@@ -261,6 +261,7 @@ private extension OrderDetailsDataSource {
             "This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.",
             comment: "Shipping notice row label when there is more than one shipping method")
         cell.imageView?.image = Icons.shippingNoticeIcon
+        cell.imageView?.tintColor = .accent
         cell.textLabel?.text = cellTextContent
         cell.selectionStyle = .none
 
@@ -274,6 +275,7 @@ private extension OrderDetailsDataSource {
 
     private func configureNewNote(cell: LeftImageTableViewCell) {
         cell.leftImage = Icons.addNoteIcon
+        cell.imageView?.tintColor = .accent
         cell.labelText = Titles.addNoteText
 
         cell.accessibilityTraits = .button
@@ -387,6 +389,7 @@ private extension OrderDetailsDataSource {
     private func configureNewTracking(cell: LeftImageTableViewCell) {
         let cellTextContent = NSLocalizedString("Add Tracking", comment: "Add Tracking row label")
         cell.leftImage = .addOutlineImage
+        cell.imageView?.tintColor = .accent
         cell.labelText = cellTextContent
 
         cell.accessibilityTraits = .button

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -112,7 +112,7 @@ private extension BillingInformationViewController {
         }
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .primary
+        actionSheet.view.tintColor = .text
 
         actionSheet.addCancelActionWithTitle(ContactAction.dismiss)
         actionSheet.addDefaultActionWithTitle(ContactAction.call) { [weak self] _ in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -119,7 +119,7 @@ private extension SummaryTableViewCell {
     }
 
     func configureIcon() {
-        updateStatusButton.setImage(.pencilImage, for: .normal)
+        updateStatusButton.applyIconButtonStyle(icon: .pencilImage)
 
         updateStatusButton.addTarget(self, action: #selector(editWasTapped), for: .touchUpInside)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,29 +14,29 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="108"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="107.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="108"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="#00 Jane Doe" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VuR-wG-Bbc">
-                        <rect key="frame" x="16" y="19" width="288" height="26"/>
+                        <rect key="frame" x="15" y="19" width="290" height="26"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Created eons ago at 9:51" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kz9-1h-fRY">
-                        <rect key="frame" x="16" y="53" width="288" height="16"/>
+                        <rect key="frame" x="15" y="53" width="290" height="16"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="740" text="Processing" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uIV-Sn-Yeh" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                        <rect key="frame" x="16" y="77" width="67" height="16"/>
+                        <rect key="frame" x="15" y="77" width="67" height="16"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0jq-dU-DSt">
-                        <rect key="frame" x="284" y="75" width="20" height="20"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0jq-dU-DSt">
+                        <rect key="frame" x="285" y="75" width="20" height="20"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="0jq-dU-DSt" secondAttribute="height" multiplier="1:1" id="JlF-NG-SGG"/>
                             <constraint firstAttribute="width" constant="20" id="weV-me-Oj4"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -416,7 +416,7 @@ private extension OrderDetailsViewController {
         }
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .primary
+        actionSheet.view.tintColor = .text
 
         actionSheet.addCancelActionWithTitle(TrackingAction.dismiss)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -491,7 +491,7 @@ private extension FulfillViewController {
         }
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .primary
+        actionSheet.view.tintColor = .text
         actionSheet.addCancelActionWithTitle(DeleteAction.cancel)
         actionSheet.addDestructiveActionWithTitle(DeleteAction.delete) { [weak self] _ in
             ServiceLocator.analytics.track(.orderFulfillmentDeleteTrackingButtonTapped)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/OrderTrackingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/OrderTrackingTableViewCell.swift
@@ -70,11 +70,10 @@ final class OrderTrackingTableViewCell: UITableViewCell {
     }
 
     private func configureActionButton() {
-        let deleteIcon = UIImage.moreImage
+        let moreIcon = UIImage.moreImage
             .imageFlippedForRightToLeftLayoutDirection()
-            .imageWithTintColor(.primary)
 
-        ellipsisButton.setImage(deleteIcon!, for: .normal)
+        ellipsisButton.applyIconButtonStyle(icon: moreIcon)
         ellipsisButton.addTarget(self, action: #selector(iconTapped), for: .touchUpInside)
 
         self.accessoryView = ellipsisButton

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -53,5 +53,6 @@ private extension TextViewTableViewCell {
 
     func configureTextView() {
         noteTextView.delegate = self
+        noteTextView.backgroundColor = .listForeground
     }
 }


### PR DESCRIPTION
Orders UI for #1555 

- [x] ⚠️ update PR base to `release/3.2` after https://github.com/woocommerce/woocommerce-ios/pull/1571 is merged ⚠️ 

## Changes
- Added a `UIButton` extension helper for styling a single-color icon button
- Updated colors for Order status badge, action sheet color, note text view background color, icon button color

## Testing

Prerequisite: the store can add tracking number
- Launch the app
- Go to Orders tab --> each order status badge should have the expected color
- Tap on an Order --> the pencil icon button should have the expected color (pink), and the "Add tracking" and "Add a note" cells should have the icon with the expected color (pink)
- Tap "Add a note" --> the text view background should have the same background color as the space to the left
- Go back to the Order Details
- Tap "Add Tracking" and create a tracking number
- Go back to the Order Details --> should see the new tracking number cell
- Tap the "..." on the tracking number cell accessory --> the "..." icon should be pink, and the action sheet default style labels should have the expected color


## Example screenshots

Screen | Dark | Light
-- | -- | --
Order status badge - page 1 | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 01 31](https://user-images.githubusercontent.com/1945542/70415208-1735b100-1a97-11ea-80b8-4c8f48995c44.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 01 08](https://user-images.githubusercontent.com/1945542/70415206-1735b100-1a97-11ea-8d76-10b1c0fe2322.png)
Order status badge - page 2 | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 01 39](https://user-images.githubusercontent.com/1945542/70415210-17ce4780-1a97-11ea-8e2c-f27eb6e2ca88.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 01 13](https://user-images.githubusercontent.com/1945542/70415207-1735b100-1a97-11ea-9c89-dc20cd989a43.png)
Order Details - top | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 19 37](https://user-images.githubusercontent.com/1945542/70415518-bc508980-1a97-11ea-9218-9836ca29fb55.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 21 06](https://user-images.githubusercontent.com/1945542/70415522-bce92000-1a97-11ea-86aa-478d7f5a3561.png)
Order Details - bottom | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 20 01](https://user-images.githubusercontent.com/1945542/70415519-bc508980-1a97-11ea-9db6-0a864def35bf.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 21 29](https://user-images.githubusercontent.com/1945542/70415524-bce92000-1a97-11ea-8d69-3d5c45d17621.png)
Order Details - action sheet | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 20 03](https://user-images.githubusercontent.com/1945542/70415520-bc508980-1a97-11ea-8b8d-270467d7a7f5.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 21 33](https://user-images.githubusercontent.com/1945542/70415525-bd81b680-1a97-11ea-8a12-060881cb8594.png)
Order Details > Add note | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 20 45](https://user-images.githubusercontent.com/1945542/70415521-bce92000-1a97-11ea-9a62-13c9adeadf6b.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 15 22 16](https://user-images.githubusercontent.com/1945542/70415527-bd81b680-1a97-11ea-9503-45b4a64460f8.png)




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
