### PR TITLE
Fixed clipped content on section headings with larger font sizes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 3.3
 -----
- 
+- bugfix: Fixed clipped content on section headings with larger font sizes
+
 3.2
 -----
 - Experimental: a Products feature switch is visible in Settings > Experimental Features that shows/hides the Products tab with a Work In Progress banner at the top.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
@@ -42,10 +42,19 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
 
         tintColor = .clear
 
-        leftColumn.applyFootnoteStyle()
-        rightColumn.applyFootnoteStyle()
+        configureLabels()
+    }
+}
 
+/// Private methods
+///
+private extension TwoColumnSectionHeaderView {
+    func configureLabels() {
+        leftColumn.applyFootnoteStyle()
+        leftColumn.numberOfLines = 0
         leftColumn.textColor = .listIcon
+        rightColumn.numberOfLines = 0
         rightColumn.textColor = .listIcon
+        rightColumn.applyFootnoteStyle()
     }
 }


### PR DESCRIPTION
Fixes #1575 

## Description
This PR fixes a problem with large titles on section header, which truncates the content.
This problem affects not only the Product details but also every point of the app where `TwoColumnSectionHeaderView` was used.

| Before             |  After |
:-------------------------:|:-------------------------:
![70340204-3be81980-1848-11ea-8077-5af0f9a12a3e](https://user-images.githubusercontent.com/495617/70434792-738fd500-1a85-11ea-88e2-86739b719137.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-12-09 at 13 11 34](https://user-images.githubusercontent.com/495617/70434821-8bffef80-1a85-11ea-87f5-7f4197959313.png)

## Testing
1) Go to the Settings app > Accessibility > Display & Text Size > Larger Text.
2) Enable "Larger Accessibility Sizes" and set the text size to the largest possible size.
3) Open the Woo app and go to Settings > Experimental Features to enable the Products section if needed.
4) Open the Products tab.
5) Select a product to open the product details and scroll through the section.
6) Check also that every cell section of the app now is multiline.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
