### PR TITLE
Product List: make the Products API request ordered by ascending name

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -15,17 +15,23 @@ public class ProductsRemote: Remote {
     ///                determines fields present in response. Default is view.
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of products to be retrieved per page.
+    ///     - orderBy: the key to order the remote products. Default to product name.
+    ///     - order: ascending or descending order. Default to ascending.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadAllProducts(for siteID: Int,
                                 context: String? = nil,
                                 pageNumber: Int = Default.pageNumber,
                                 pageSize: Int = Default.pageSize,
+                                orderBy: OrderKey = .name,
+                                order: Order = .ascending,
                                 completion: @escaping ([Product]?, Error?) -> Void) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.contextKey: context ?? Default.context
+            ParameterKey.contextKey: context ?? Default.context,
+            ParameterKey.orderBy: orderBy.value,
+            ParameterKey.order: order.value
         ]
 
         let path = Path.products
@@ -126,6 +132,15 @@ public class ProductsRemote: Remote {
 // MARK: - Constants
 //
 public extension ProductsRemote {
+    enum OrderKey {
+        case name
+    }
+
+    enum Order {
+        case ascending
+        case descending
+    }
+
     enum Default {
         public static let pageSize: Int   = 25
         public static let pageNumber: Int = 1
@@ -142,5 +157,27 @@ public extension ProductsRemote {
         static let contextKey: String = "context"
         static let include: String    = "include"
         static let search: String     = "search"
+        static let orderBy: String    = "orderby"
+        static let order: String      = "order"
+    }
+}
+
+private extension ProductsRemote.OrderKey {
+    var value: String {
+        switch self {
+        case .name:
+            return "title"
+        }
+    }
+}
+
+private extension ProductsRemote.Order {
+    var value: String {
+        switch self {
+        case .ascending:
+            return "asc"
+        case .descending:
+            return "desc"
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -272,7 +272,7 @@ private extension ProductsViewController {
     func createResultsController(siteID: Int) -> ResultsController<StorageProduct> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(key: "name", ascending: true)
+        let descriptor = NSSortDescriptor(key: "name", ascending: true, selector: #selector(NSString.localizedCompare(_:)))
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -81,12 +81,16 @@ private extension ProductStore {
         }
     }
 
-    /// Synchronizes the products associated with a given Site ID (if any!).
+    /// Synchronizes the products associated with a given Site ID, sorted by ascending name.
     ///
     func synchronizeProducts(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductsRemote(network: network)
 
-        remote.loadAllProducts(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (products, error) in
+        remote.loadAllProducts(for: siteID,
+                               pageNumber: pageNumber,
+                               pageSize: pageSize,
+                               orderBy: .name,
+                               order: .ascending) { [weak self] (products, error) in
             guard let products = products else {
                 onCompletion(error)
                 return


### PR DESCRIPTION
Fixes #1569 

## Summary

Since we sort the Products by name on the Products tab, we should also make the API request to fetch a page of Products ordered by ascending name so that the paging is continuous.

## Changes

- Added 2 params to `ProductsRemote`: `orderBy` and `order`
- Updated the API call in `ProductStore`

## Testing

Note: it'd be easier to test for a store with more than 30 Products.

- Log out and in (so that there are no Products on the Products tab to begin with)
- Go to the Products tab and scroll down the Product list --> the Products for each page should be ordered by ascending Product name (e.g. the first page should start from "a"/"A", --> "b"/"B" etc. if any)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
