### PR TITLE
Product Search: update empty search results placeholder copy

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -8,7 +8,7 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let searchBarPlaceholder = NSLocalizedString("Search all products", comment: "Products Search Placeholder")
 
-    let emptyStateText = NSLocalizedString("No products yet", comment: "Search Products (Empty State)")
+    let emptyStateText = NSLocalizedString("No products found", comment: "Search Products (Empty State)")
 
     private let siteID: Int
 


### PR DESCRIPTION
Fixes #1583 

## Changes

- Updated the copy of the placeholder when there are no Product search results from "No products yet" to "No products found"

## Testing

- Go to the Products tab
- Tap the search icon in the navigation bar
- Search with a query that generates no results --> the placeholder should say "No products found" 

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 21 47 20](https://user-images.githubusercontent.com/1945542/70440856-18ce9b80-1ace-11ea-9b00-af07310b8e03.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-09 at 21 48 43](https://user-images.githubusercontent.com/1945542/70440857-19673200-1ace-11ea-8a8c-4051cf79e705.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
