### PR TITLE
Dark Mode: update colors for badge on Orders and Reviews tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/OrdersBadgeController.swift
+++ b/WooCommerce/Classes/ViewRelated/OrdersBadgeController.swift
@@ -80,6 +80,7 @@ private extension OrdersBadgeController {
 
     enum Constants {
         static let borderWidth  = CGFloat(1)
+        static let borderColor  = UIColor.basicBackground
         static let cornerRadius = CGFloat(8)
 
         static let width = CGFloat(18)
@@ -116,7 +117,9 @@ private extension OrdersBadgeController {
             horizontalPadding = Constants.horizontalPadding
         }
 
-        let returnValue = BadgeLabel(frame: CGRect(x: Constants.xOffset,
+        let returnValue = BadgeLabel(borderWidth: Constants.borderWidth,
+                                     borderColor: Constants.borderColor,
+                                     frame: CGRect(x: Constants.xOffset,
                                                    y: Constants.yOffset,
                                                    width: width,
                                                    height: Constants.height))
@@ -124,8 +127,6 @@ private extension OrdersBadgeController {
         returnValue.tag = badgeTag(for: tab)
         returnValue.text = text
         returnValue.font = StyleManager.badgeFont
-        returnValue.borderColor = UIColor.basicBackground
-        returnValue.borderWidth = Constants.borderWidth
         returnValue.textColor = .textInverted
         returnValue.horizontalPadding = horizontalPadding
         returnValue.cornerRadius = Constants.cornerRadius
@@ -133,7 +134,7 @@ private extension OrdersBadgeController {
         // BUGFIX: Don't add the backgroundColor property, use this!
         // Labels with rounded borders and a background color will end
         // up with a fuzzy shadow / outline outside of the border color.
-        returnValue.fillColor = .accent
+        returnValue.fillColor = .primary
 
         returnValue.isHidden = true
         returnValue.adjustsFontForContentSizeCategory = false

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BadgeLabel.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BadgeLabel.swift
@@ -11,16 +11,20 @@ final class BadgeLabel: UILabel {
 
     @IBInspectable var fillColor: UIColor = .primary
 
+    private let borderWidth: CGFloat
+    private let borderColor: UIColor
+
     // MARK: Initialization
 
-    override init(frame: CGRect) {
+    init(borderWidth: CGFloat, borderColor: UIColor, frame: CGRect) {
+        self.borderWidth = borderWidth
+        self.borderColor = borderColor
         super.init(frame: frame)
         setupView()
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        setupView()
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func setupView() {
@@ -41,6 +45,10 @@ final class BadgeLabel: UILabel {
         fillColor.setFill()
         path.fill()
 
+        path.lineWidth = borderWidth
+        borderColor.setStroke()
+        path.stroke()
+
         let insets = UIEdgeInsets.init(top: 0, left: horizontalPadding, bottom: 0, right: horizontalPadding)
         super.drawText(in: rect.inset(by: insets))
     }
@@ -52,24 +60,6 @@ final class BadgeLabel: UILabel {
     }
 
     // MARK: Computed Properties
-
-    @IBInspectable var borderColor: UIColor {
-        get {
-            return UIColor(cgColor: layer.borderColor!)
-        }
-        set {
-            layer.borderColor = newValue.cgColor
-        }
-    }
-
-    @IBInspectable var borderWidth: CGFloat {
-        get {
-            return layer.borderWidth
-        }
-        set {
-            layer.borderWidth = newValue
-        }
-    }
 
     @IBInspectable var cornerRadius: CGFloat {
         get {


### PR DESCRIPTION
Orders/Reviews badge for #1555 

## Changes

- There seems to be some weird gap setting `cornerRadius` and `borderWidth` at the same time. This PR moved the border width/color setup to `BadgeLabel` which responds to Dark/Light mode changes automatically.
- Updated the color of the Orders badge

## Testing

To show the Reviews tab badge, you can hard code the count in this line to a value > 0: https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/MainTabBarController.swift#L360

- Launch the app --> the badge on the Orders and Reviews tabs should look as expected in both Light and Dark modes
- Go to Orders tab --> the badge on the Orders and Reviews tabs should look as expected in both Light and Dark modes
- Go to Reviews tab --> the badge on the Orders and Reviews tabs should look as expected in both Light and Dark modes

## Example screenshots

State | Dark | Light
-- | -- | --
Other tab selected | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 11 51 43](https://user-images.githubusercontent.com/1945542/70494062-ddbb7f00-1b44-11ea-8d4e-db1aae264ce6.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 11 52 20](https://user-images.githubusercontent.com/1945542/70494066-de541580-1b44-11ea-8580-bc852e151c6a.png)
Orders tab selected | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 11 51 50](https://user-images.githubusercontent.com/1945542/70494063-ddbb7f00-1b44-11ea-8b6c-6901c5397ee3.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 11 52 22](https://user-images.githubusercontent.com/1945542/70494068-de541580-1b44-11ea-8e08-e973ca7009dc.png)
Reviews tab selected | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 11 51 57](https://user-images.githubusercontent.com/1945542/70494065-de541580-1b44-11ea-8afb-c78e4b73c78b.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 11 52 24](https://user-images.githubusercontent.com/1945542/70494069-deecac00-1b44-11ea-9af4-29fc2e2d66b5.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
