### PR TITLE
Dark Mode: update colors for Orders/Products search

### DIFF
--- a/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIButton+Helpers.swift
@@ -82,6 +82,15 @@ extension UIButton {
         setTitleColor(.accentDark, for: .highlighted)
     }
 
+    /// Applies the Modal Cancel Button Style
+    ///
+    func applyModalCancelButtonStyle() {
+        backgroundColor = .clear
+        titleLabel?.applyBodyStyle()
+        titleLabel?.textAlignment = .natural
+        setTitleColor(.modalCancelAction, for: .normal)
+    }
+
     /// Applies the Single-Color Icon Button Style: accent/accent dark tint color
     ///
     func applyIconButtonStyle(icon: UIImage) {

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -136,6 +136,13 @@ extension UIColor {
 
         return .gray(.shade30)
     }
+
+    /// Cancel Action Text Color.
+    ///
+    static var modalCancelAction: UIColor {
+        return UIColor(light: .accent,
+                       dark: .systemColor(.label))
+    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/FooterSpinnerView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/FooterSpinnerView.swift
@@ -28,7 +28,7 @@ class FooterSpinnerView: UIView {
     ///
     private func setupSubviews() {
         addSubview(activityIndicatorView)
-        activityIndicatorView.color = .systemColor(.label)
+        activityIndicatorView.color = .text
         activityIndicatorView.hidesWhenStopped = true
         activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/FooterSpinnerView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/FooterSpinnerView.swift
@@ -28,6 +28,7 @@ class FooterSpinnerView: UIView {
     ///
     private func setupSubviews() {
         addSubview(activityIndicatorView)
+        activityIndicatorView.color = .systemColor(.label)
         activityIndicatorView.hidesWhenStopped = true
         activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -26,6 +26,9 @@ where Cell.SearchModel == Command.CellViewModel {
     ///
     @IBOutlet private var tableView: UITableView!
 
+
+    @IBOutlet private weak var bordersView: BordersView!
+
     /// Footer "Loading More" Spinner.
     ///
     private lazy var footerSpinnerView = {
@@ -100,10 +103,12 @@ where Cell.SearchModel == Command.CellViewModel {
         registerTableViewCells()
 
         configureSyncingCoordinator()
+        configureCancelButton()
         configureActions()
         configureEmptyStateLabel()
         configureMainView()
         configureSearchBar()
+        configureSearchBarBordersView()
         configureTableView()
         configureResultsController()
 
@@ -210,12 +215,23 @@ private extension SearchViewController {
         searchBar.tintColor = .black
     }
 
+    /// Setup: Search Bar Borders
+    ///
+    func configureSearchBarBordersView() {
+        bordersView.bottomColor = .systemColor(.separator)
+    }
+
+    /// Setup: Cancel Button
+    ///
+    func configureCancelButton() {
+        cancelButton.applyModalCancelButtonStyle()
+    }
+
     /// Setup: Actions
     ///
     func configureActions() {
         let title = NSLocalizedString("Cancel", comment: "")
         cancelButton.setTitle(title, for: .normal)
-        cancelButton.titleLabel?.font = UIFont.body
     }
 
     /// Setup: No Results

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -122,6 +122,13 @@ where Cell.SearchModel == Command.CellViewModel {
         searchBar.becomeFirstResponder()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // Note: configuring the search bar text color does not work in `viewDidLoad` and `viewWillAppear`.
+        configureSearchBar()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -212,7 +219,7 @@ private extension SearchViewController {
     ///
     func configureSearchBar() {
         searchBar.placeholder = searchUICommand.searchBarPlaceholder
-        searchBar.tintColor = .black
+        searchBar.searchTextField.textColor = .systemColor(.label)
     }
 
     /// Setup: Search Bar Borders

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -219,7 +219,7 @@ private extension SearchViewController {
     ///
     func configureSearchBar() {
         searchBar.placeholder = searchUICommand.searchBarPlaceholder
-        searchBar.searchTextField.textColor = .systemColor(.label)
+        searchBar.searchTextField.textColor = .text
     }
 
     /// Setup: Search Bar Borders

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.xib
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SearchViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="bordersView" destination="Ncr-u2-zVd" id="S5W-h1-qR2"/>
                 <outlet property="cancelButton" destination="YBC-g3-0LP" id="rmu-WT-3G1"/>
                 <outlet property="emptyStateLabel" destination="aau-QM-41g" id="ii2-DV-AHM"/>
                 <outlet property="searchBar" destination="cOC-iR-MJr" id="usQ-SP-NSs"/>
@@ -25,21 +24,21 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ncr-u2-zVd" userLabel="Borders View" customClass="BordersView" customModule="WooCommerce" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="76"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="boolean" keyPath="bottomVisible" value="YES"/>
                     </userDefinedRuntimeAttributes>
                 </view>
                 <searchBar contentMode="redraw" searchBarStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="cOC-iR-MJr">
-                    <rect key="frame" x="8" y="20" width="297" height="56"/>
+                    <rect key="frame" x="8" y="0.0" width="297" height="56"/>
                     <textInputTraits key="textInputTraits"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="CeV-H5-n3x"/>
                     </connections>
                 </searchBar>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YBC-g3-0LP">
-                    <rect key="frame" x="308" y="30.5" width="51" height="33"/>
+                    <rect key="frame" x="308" y="10.5" width="51" height="33"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                     <state key="normal" title="Button"/>
                     <connections>
@@ -47,7 +46,7 @@
                     </connections>
                 </button>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="y9n-QI-xEB">
-                    <rect key="frame" x="0.0" y="76" width="375" height="591"/>
+                    <rect key="frame" x="0.0" y="56" width="375" height="611"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="qvh-01-20Z"/>
@@ -55,7 +54,7 @@
                     </connections>
                 </tableView>
                 <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[Empty State Legend]" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aau-QM-41g" userLabel="EmptyState Label">
-                    <rect key="frame" x="10" y="176" width="355" height="20.5"/>
+                    <rect key="frame" x="10" y="156" width="355" height="20.5"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
Search UI for #1555 

## Changes
- Added an outlet for search bar borders view from xib
- Updated colors for search UI

## Testing
- Launch the app
- Go to Orders tab
- Tap the search icon in the navigation bar --> the search bar should have the expected colors in Dark/Light modes
- Go to Products tab
- Tap the search icon in the navigation bar --> the search bar should have the expected colors in Dark/Light modes

## Example screenshots

Screen | Dark | Light
-- | -- | --
Order search | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 14 15 36](https://user-images.githubusercontent.com/1945542/70501196-6263c880-1b58-11ea-9351-c35504e88697.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 14 15 50](https://user-images.githubusercontent.com/1945542/70501198-6263c880-1b58-11ea-92f8-88d50bc23a42.png)
Product search | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 14 16 07](https://user-images.githubusercontent.com/1945542/70501200-62fc5f00-1b58-11ea-8aa2-901c5607612c.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-10 at 14 16 13](https://user-images.githubusercontent.com/1945542/70501201-62fc5f00-1b58-11ea-8660-da26858f7d21.png)
Search text and spinner | ![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 11 52 36](https://user-images.githubusercontent.com/1945542/70590163-d5c71200-1c0c-11ea-8477-bab680f4d609.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 11 52 50](https://user-images.githubusercontent.com/1945542/70590164-d5c71200-1c0c-11ea-9336-ce7d406ced0d.png)







Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
