### PR TITLE
Disclosure indicators for each product in the list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -23,6 +23,7 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         configureNameLabel()
         configureDetailsLabel()
         configureProductImageView()
+        configureAccessoryType()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -106,5 +107,9 @@ private extension ProductsTabProductTableViewCell {
             productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1),
             productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor)
             ])
+    }
+
+    func configureAccessoryType() {
+        accessoryType = .disclosureIndicator
     }
 }


### PR DESCRIPTION
Fixes #1599

Now product list cells show the disclosure indicator.

## Testing
- Enable experimental feature products
- Go to the product list
- Check that every cell shows the disclosure indicator.

## Screenshot

![Simulator Screen Shot - iPhone 11 Pro - 2019-12-10 at 12 53 06](https://user-images.githubusercontent.com/495617/70527615-9f29c280-1b4c-11ea-8008-1566e146bd4d.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
