### PR TITLE
Dark Mode: update colors for notice view

### DIFF
--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -7,7 +7,7 @@ class NoticeView: UIView {
     private let contentStackView = UIStackView()
 
     private let backgroundContainerView = UIView()
-    private let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight))
+    private let backgroundView: UIVisualEffectView
     private let actionBackgroundView = UIView()
     private let shadowLayer = CAShapeLayer()
     private let shadowMaskLayer = CAShapeLayer()
@@ -31,6 +31,12 @@ class NoticeView: UIView {
     ///
     init(notice: Notice) {
         self.notice = notice
+
+        if #available(iOS 13.0, *) {
+            self.backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThickMaterial))
+        } else {
+            self.backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight))
+        }
 
         super.init(frame: .zero)
 
@@ -209,10 +215,10 @@ private extension NoticeView {
     }
 
     enum Appearance {
-        static let actionBackgroundColor = UIColor.basicBackground.withAlphaComponent(0.5)
+        static let actionBackgroundColor = UIColor.systemColor(.secondarySystemGroupedBackground)
         static let actionColor: UIColor = .primaryButtonBackground
         static let shadowColor: UIColor = .black
-        static let shadowOpacity: Float = 0.25
+        static let shadowOpacity: Float = 0.2
         static let shadowRadius: CGFloat = 8.0
         static let shadowOffset = CGSize(width: 0.0, height: 2.0)
         static let titleColor: UIColor = .text


### PR DESCRIPTION
Notice view for #1555 

## Changes

- Updated colors for `NoticeView`

## Testing

- Launch the app
- Trigger a notice view (examples: Orders tab -> tap an Order -> edit the order status, going offline and pulling down to refresh a list) --> the notice snackbar should have the expected colors

## Example screenshots

Dark Mode | Light Mode
-- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 15 44 14](https://user-images.githubusercontent.com/1945542/70601844-fd7aa200-1c2d-11ea-8327-e3911aa1e3b8.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 15 43 59](https://user-images.githubusercontent.com/1945542/70601875-108d7200-1c2e-11ea-8d13-a99e8d68f712.png)
![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 15 44 17](https://user-images.githubusercontent.com/1945542/70601845-fd7aa200-1c2d-11ea-879e-65cc5bb49cfa.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 15 44 02](https://user-images.githubusercontent.com/1945542/70601877-108d7200-1c2e-11ea-97ac-3fff7b3589b1.png)
![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 15 48 49](https://user-images.githubusercontent.com/1945542/70601848-fe133880-1c2d-11ea-9887-6dd89d1de29e.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-11 at 15 51 29](https://user-images.githubusercontent.com/1945542/70601892-1c793400-1c2e-11ea-9a76-5b3dafce09de.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
