### PR TITLE
Products: delete stored Product's when syncing Products for the first page

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		023FA29523316A4D008C1769 /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29223316A4D008C1769 /* Product+CoreDataProperties.swift */; };
 		023FA29623316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */; };
 		023FA29723316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */; };
+		027D3E6E23A0EEA4007D91B0 /* StorageType+Deletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027D3E6D23A0EEA4007D91B0 /* StorageType+Deletions.swift */; };
 		028296F2237D404F00E84012 /* ProductVariation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */; };
 		028296F3237D404F00E84012 /* ProductVariation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296EF237D404F00E84012 /* ProductVariation+CoreDataProperties.swift */; };
 		028296F4237D404F00E84012 /* Attribute+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028296F0237D404F00E84012 /* Attribute+CoreDataClass.swift */; };
@@ -141,6 +142,7 @@
 		023FA29323316A4D008C1769 /* ProductSearchResults+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		023FA29423316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductSearchResults+CoreDataClass.swift"; sourceTree = "<group>"; };
 		026CF636237D9E84009563D4 /* Model 23.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 23.xcdatamodel"; sourceTree = "<group>"; };
+		027D3E6D23A0EEA4007D91B0 /* StorageType+Deletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StorageType+Deletions.swift"; sourceTree = "<group>"; };
 		028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataClass.swift"; sourceTree = "<group>"; };
 		028296EF237D404F00E84012 /* ProductVariation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		028296F0237D404F00E84012 /* Attribute+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attribute+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 			children = (
 				B505255320EE6914008090F5 /* StorageType+Extensions.swift */,
 				D87F61542265AA900031A13B /* PListFileStorage.swift */,
+				027D3E6D23A0EEA4007D91B0 /* StorageType+Deletions.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -822,6 +825,7 @@
 				D8FBFF5522D66A06006E3336 /* OrderStatsV4Interval+CoreDataClass.swift in Sources */,
 				D8FBFF5822D66A06006E3336 /* OrderStatsV4Totals+CoreDataProperties.swift in Sources */,
 				CE3B7AD22225E62C0050FE4B /* OrderStatus+CoreDataClass.swift in Sources */,
+				027D3E6E23A0EEA4007D91B0 /* StorageType+Deletions.swift in Sources */,
 				D8FBFF5922D66A06006E3336 /* OrderStatsV4+CoreDataClass.swift in Sources */,
 				74B7D6AE20F90CBB002667AC /* OrderNote+CoreDataProperties.swift in Sources */,
 				D87F614E22657C2F0031A13B /* PreselectedProvider.swift in Sources */,

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+
+// MARK: - StorageType DataModel Specific Extensions for Deletions
+//
+public extension StorageType {
+
+    // MARK: - Products
+
+    /// Deletes all of the stored Products for the provided siteID.
+    ///
+    func deleteProducts(siteID: Int) {
+        guard let products = loadProducts(siteID: siteID) else {
+            return
+        }
+        for product in products {
+            deleteObject(product)
+        }
+    }
+}

--- a/WooCommerce/Classes/Tools/SyncCoordinator.swift
+++ b/WooCommerce/Classes/Tools/SyncCoordinator.swift
@@ -92,9 +92,9 @@ class SyncingCoordinator {
 
     /// Resets Internal State + (RE)synchronizes the first page in the collection.
     ///
-    func resynchronize() {
+    func resynchronize(onCompletion: (() -> Void)? = nil) {
         resetInternalState()
-        synchronizeFirstPage()
+        synchronizeFirstPage(onCompletion: onCompletion)
     }
 
     /// Synchronizes the First Page in the collection.

--- a/WooCommerce/Classes/Tools/SyncCoordinator.swift
+++ b/WooCommerce/Classes/Tools/SyncCoordinator.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+import Yosemite
 
 
 /// SyncingCoordinatorDelegate: Delegate that's expected to provide Sync'ing Services per Page.
@@ -24,7 +24,7 @@ class SyncingCoordinator {
     /// Default Settings
     ///
     enum Defaults {
-        static let pageFirstIndex = 1
+        static let pageFirstIndex = ProductStore.Constants.firstPageNumber
         static let pageSize = 25
         static let pageTTLInSeconds = TimeInterval(3 * 60)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -83,6 +83,7 @@ final class ProductsViewController: UIViewController {
         registerTableViewCells()
 
         startListeningToNotifications()
+        syncingCoordinator.resynchronize()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -93,7 +94,6 @@ final class ProductsViewController: UIViewController {
             return
         }
         updateResultsController(siteID: siteID)
-        syncingCoordinator.resynchronize()
 
         if AppRatingManager.shared.shouldPromptForAppReview() {
             displayRatingPrompt()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -93,7 +93,7 @@ final class ProductsViewController: UIViewController {
             return
         }
         updateResultsController(siteID: siteID)
-        syncingCoordinator.synchronizeFirstPage()
+        syncingCoordinator.resynchronize()
 
         if AppRatingManager.shared.shouldPromptForAppReview() {
             displayRatingPrompt()
@@ -360,7 +360,7 @@ private extension ProductsViewController {
     @objc private func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.productListPulledToRefresh)
 
-        syncingCoordinator.synchronizeFirstPage {
+        syncingCoordinator.resynchronize {
             sender.endRefreshing()
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -96,6 +96,10 @@ private extension ProductStore {
                 return
             }
 
+            if pageNumber == 1 {
+                self?.deleteStoredProducts(siteID: siteID)
+            }
+
             self?.upsertStoredProductsInBackground(readOnlyProducts: products) {
                 onCompletion(nil)
             }
@@ -202,6 +206,14 @@ private extension ProductStore {
         }
 
         storage.deleteObject(product)
+        storage.saveIfNeeded()
+    }
+
+    /// Deletes any Storage.Product with the specified `siteID`
+    ///
+    func deleteStoredProducts(siteID: Int) {
+        let storage = storageManager.viewStorage
+        storage.deleteProducts(siteID: siteID)
         storage.saveIfNeeded()
     }
 
@@ -440,5 +452,14 @@ extension ProductStore {
     ///
     func upsertStoredProduct(readOnlyProduct: Networking.Product, in storage: StorageType) {
         upsertStoredProducts(readOnlyProducts: [readOnlyProduct], in: storage)
+    }
+}
+
+// MARK: - Constants!
+//
+public extension ProductStore {
+
+    enum Constants {
+        public static let firstPageNumber: Int = ProductsRemote.Default.pageNumber
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -128,7 +128,9 @@ class ProductStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 2)
 
-        let action = ProductAction.synchronizeProducts(siteID: siteID1, pageNumber: ProductStore.Constants.firstPageNumber, pageSize: defaultPageSize) { error in
+        let action = ProductAction.synchronizeProducts(siteID: siteID1,
+                                                       pageNumber: ProductStore.Constants.firstPageNumber,
+                                                       pageSize: defaultPageSize) { error in
             XCTAssertNil(error)
 
             // The previously upserted Product for siteID1 should be deleted.


### PR DESCRIPTION
Fixes #1574 

## Changes

- Deleted all stored `Product`s for a given site ID after successfully loading the first page of `Product`s from the API and before inserting the data from the API to the storage
- Added 3 test cases for `ProductStore` for this change

## Testing

Prerequisite: the logged in account has at least stores, and one of them has at least 25 Products (feel free to change the `pageSize` param in `ProductsRemote` to a smaller number)

- Log in to the store with a lower number of Products
- Go to Products tab and wait until some Products are loaded
- Go to My Store tab and switch to another store with at least 25/`pageSize` Products
- Go to Products tab
- Scroll down the Product list to at least another page
- On `wp-admin`, delete some Products
- Back on the app, refresh the Product list by either pulling down to refresh or going to another tab and back --> the previously deleted Products should not show up anymore
- Go to My Store tab and switch to the first store 
- Go to Products tab --> the previously loaded Products should remain

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
