### PR TITLE
Stats v4 hotfix

### DIFF
--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -90,7 +90,7 @@ private extension OrderStatsV4Totals {
     enum CodingKeys: String, CodingKey {
         case ordersCount = "orders_count"
         case itemsSold = "num_items_sold"
-        case grossRevenue = "gross_revenue"
+        case grossRevenue = "total_sales"
         case couponDiscount = "coupons"
         case coupons = "coupons_count"
         case refunds

--- a/Networking/NetworkingTests/Responses/order-stats-v4-daily.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-daily.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 3,
             "num_items_sold": 5,
-            "gross_revenue": 800,
+            "total_sales": 800,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 3,
                     "num_items_sold": 5,
-                    "gross_revenue": 800,
+                    "total_sales": 800,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/Networking/NetworkingTests/Responses/order-stats-v4-defaults.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-defaults.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 3,
             "num_items_sold": 5,
-            "gross_revenue": 800,
+            "total_sales": 800,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 3,
                     "num_items_sold": 5,
-                    "gross_revenue": 800,
+                    "total_sales": 800,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -42,7 +42,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/Networking/NetworkingTests/Responses/order-stats-v4-hour.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-hour.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 3,
             "num_items_sold": 5,
-            "gross_revenue": 800,
+            "total_sales": 800,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -42,7 +42,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -61,7 +61,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -80,7 +80,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -99,7 +99,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -118,7 +118,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -137,7 +137,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -156,7 +156,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -175,7 +175,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -194,7 +194,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -213,7 +213,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -232,7 +232,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -251,7 +251,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -270,7 +270,7 @@
                 "subtotals": {
                     "orders_count": 2,
                     "num_items_sold": 2,
-                    "gross_revenue": 350,
+                    "total_sales": 350,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -289,7 +289,7 @@
                 "subtotals": {
                     "orders_count": 1,
                     "num_items_sold": 3,
-                    "gross_revenue": 450,
+                    "total_sales": 450,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -308,7 +308,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -327,7 +327,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -346,7 +346,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -365,7 +365,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -384,7 +384,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -403,7 +403,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -422,7 +422,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -441,7 +441,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,
@@ -460,7 +460,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/Networking/NetworkingTests/Responses/order-stats-v4-month.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-month.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 3,
             "num_items_sold": 5,
-            "gross_revenue": 800,
+            "total_sales": 800,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 3,
                     "num_items_sold": 5,
-                    "gross_revenue": 800,
+                    "total_sales": 800,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/Networking/NetworkingTests/Responses/order-stats-v4-wcadmin-activated.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-wcadmin-activated.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 1,
             "num_items_sold": 2,
-            "gross_revenue": 251,
+            "total_sales": 251,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 0,
                     "num_items_sold": 0,
-                    "gross_revenue": 0,
+                    "total_sales": 0,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/Networking/NetworkingTests/Responses/order-stats-v4-year-alt.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-year-alt.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 3,
             "num_items_sold": 5,
-            "gross_revenue": 800,
+            "total_sales": 800,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 3,
                     "num_items_sold": 5,
-                    "gross_revenue": 800,
+                    "total_sales": 800,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/Networking/NetworkingTests/Responses/order-stats-v4-year.json
+++ b/Networking/NetworkingTests/Responses/order-stats-v4-year.json
@@ -3,7 +3,7 @@
         "totals": {
             "orders_count": 3,
             "num_items_sold": 5,
-            "gross_revenue": 800,
+            "total_sales": 800,
             "coupons": 0,
             "coupons_count": 0,
             "refunds": 0,
@@ -23,7 +23,7 @@
                 "subtotals": {
                     "orders_count": 3,
                     "num_items_sold": 5,
-                    "gross_revenue": 800,
+                    "total_sales": 800,
                     "coupons": 0,
                     "coupons_count": 0,
                     "refunds": 0,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - Experimental: if a Product has variations, the variants info are shown on the Product Details that navigates to a list of variations with each price or visibility shown.
 - Enhancement: Support for dark mode
 - bugfix: Settings no longer convert to partial dark mode.
+- Experimental: Support the latest wc-admin plugin release, v0.23.0 and up
  
 3.1
 -----


### PR DESCRIPTION
Fixes #1608 

This hotfix does not refactor all of the code so that the model reflects the field names. Instead, it updateds the field names so that Stats v4 can be successfully decoded. More permanent changes (refactoring all `grossRevenue` property names to `totalSales`) will happen on `develop`.

This hotfix will break stats for any user that hasn't updated to v0.23.x. I think that's acceptable since we try to encourage users to keep the `wc-admin` plugin up-to-date.

## To test

Ensure your store has the new stats turned on in the app. 
Ensure your store has wc-admin v0.22.x plugin currently installed. 

0. Go to your store's site and update the wc-admin plugin to v0.23.0 or v0.23.1 (anything 0.23.+ will do)
1. Running the app on `develop` will display an error snackbar, reporting that order stats can't be loaded.
2. Check out this branch and run the app again.

Expected result: order stats load successfully and no error snackbar appears.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
