### PR TITLE
Crash: Orders table row count in section zero is invalid during a refresh

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -16,7 +16,7 @@ class OrdersViewController: UIViewController {
 
     /// Ghostable TableView.
     ///
-    private(set) var ghostableTableView = UITableView()
+    private(set) let ghostableTableView = UITableView()
 
     /// Pull To Refresh Support.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -14,6 +14,10 @@ class OrdersViewController: UIViewController {
     ///
     @IBOutlet private var tableView: UITableView!
 
+    /// Ghostable TableView.
+    ///
+    private(set) var ghostableTableView = UITableView()
+
     /// Pull To Refresh Support.
     ///
     private lazy var refreshControl: UIRefreshControl = {
@@ -126,6 +130,7 @@ class OrdersViewController: UIViewController {
         configureSyncingCoordinator()
         configureNavigation()
         configureTableView()
+        configureGhostableTableView()
         configureResultsControllers()
 
         startListeningToNotifications()
@@ -275,6 +280,25 @@ private extension OrdersViewController {
         tableView.tableFooterView = footerSpinnerView
     }
 
+    /// Setup: Ghostable TableView
+    ///
+    func configureGhostableTableView() {
+        view.addSubview(ghostableTableView)
+        ghostableTableView.isHidden = true
+
+        ghostableTableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ghostableTableView.widthAnchor.constraint(equalTo: tableView.widthAnchor),
+            ghostableTableView.heightAnchor.constraint(equalTo: tableView.heightAnchor),
+            ghostableTableView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            ghostableTableView.topAnchor.constraint(equalTo: tableView.topAnchor)
+        ])
+
+        view.backgroundColor = .listBackground
+        ghostableTableView.backgroundColor = .listBackground
+        ghostableTableView.isScrollEnabled = false
+    }
+
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
@@ -282,6 +306,7 @@ private extension OrdersViewController {
 
         for cell in cells {
             tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+            ghostableTableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
         }
     }
 }
@@ -520,17 +545,24 @@ private extension OrdersViewController {
     /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
     ///
     func displayPlaceholderOrders() {
-        let options = GhostOptions(reuseIdentifier: OrderTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
-        tableView.displayGhostContent(options: options,
-                                      style: .wooDefaultGhostStyle)
-
         resultsController.stopForwardingEvents()
+
+        let options = GhostOptions(reuseIdentifier: OrderTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
+
+        ghostableTableView.removeGhostContent()
+        ghostableTableView.displayGhostContent(options: options,
+                                               style: .wooDefaultGhostStyle)
+        ghostableTableView.startGhostAnimation()
+        ghostableTableView.isHidden = false
     }
 
     /// Removes the Placeholder Orders (and restores the ResultsController <> UITableView link).
     ///
     func removePlaceholderOrders() {
-        tableView.removeGhostContent()
+        ghostableTableView.isHidden = true
+        ghostableTableView.stopGhostAnimation()
+        ghostableTableView.removeGhostContent()
+        
         resultsController.startForwardingEvents(to: self.tableView)
         tableView.reloadData()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -538,7 +538,7 @@ extension OrdersViewController {
 }
 
 
-// MARK: - Placeholders
+// MARK: - Placeholders & Ghostable Table
 //
 private extension OrdersViewController {
 
@@ -549,6 +549,8 @@ private extension OrdersViewController {
 
         let options = GhostOptions(reuseIdentifier: OrderTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
 
+        // If the ghostable table view gets stuck for any reason,
+        // let's reset the state before using it again
         ghostableTableView.removeGhostContent()
         ghostableTableView.displayGhostContent(options: options,
                                                style: .wooDefaultGhostStyle)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -562,7 +562,7 @@ private extension OrdersViewController {
         ghostableTableView.isHidden = true
         ghostableTableView.stopGhostAnimation()
         ghostableTableView.removeGhostContent()
-        
+
         resultsController.startForwardingEvents(to: self.tableView)
         tableView.reloadData()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -542,11 +542,9 @@ extension OrdersViewController {
 //
 private extension OrdersViewController {
 
-    /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
+    /// Renders the Placeholder Orders
     ///
     func displayPlaceholderOrders() {
-        resultsController.stopForwardingEvents()
-
         let options = GhostOptions(reuseIdentifier: OrderTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
 
         // If the ghostable table view gets stuck for any reason,
@@ -564,8 +562,6 @@ private extension OrdersViewController {
         ghostableTableView.isHidden = true
         ghostableTableView.stopGhostAnimation()
         ghostableTableView.removeGhostContent()
-
-        resultsController.startForwardingEvents(to: self.tableView)
         tableView.reloadData()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -16,7 +16,7 @@ class OrdersViewController: UIViewController {
 
     /// Ghostable TableView.
     ///
-    private(set) let ghostableTableView = UITableView()
+    private(set) var ghostableTableView = UITableView()
 
     /// Pull To Refresh Support.
     ///


### PR DESCRIPTION
Fixes #1543.

There are no steps to reproduce. I tried to follow the steps in [WPiOS fix](https://github.com/wordpress-mobile/WordPress-iOS/pull/12974) but it never successfully caused a crash for me. 

**Steps I tried:**
1. Delete the app from the sim
2. Build and run the app
3. Upon login, quickly switch to the Orders tab and pull-to-refresh while the ghostable table view is visible. 

Also tried Steps 1&2, followed by 3. Quickly tapping the filters button while the ghostable table view was visible.

From the crashes reported in Sentry, the fetchedResultsController appears to send inconsistent data to the Orders table view. Many of our Sentry reports for this issue mirror the problems WPiOS had experienced with ghostable tables. (See also: https://github.com/wordpress-mobile/WordPress-iOS/pull/12974)

My main concern is that changing from the main table to adding a ghostable table blindly (as in, no exact steps to reproduce on our app) could cause new bugs.

### Changes
- make ghostable its own table instead of 1 table doing 2 things
- don't allow ghostable table to pull-to-refresh

### To test
- try to break the Order list view controller

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
