### PR TITLE
Stats v4 hotfix: update min WC Admin version for the stats v4->v3 banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -41,7 +41,7 @@ private extension DashboardTopBannerFactory {
     enum V4ToV3BannerConstants {
         static let title: String? = nil
         static let info = NSLocalizedString(
-            "We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.22 or higher",
+            "We have reverted to the old stats. To use the beta stats, please activate the WooCommerce Admin plugin with version 0.23 or higher",
             comment: "The info of the top banner on Dashboard that indicates new stats is unavailable")
         static let icon = UIImage.infoImage
         static let actionTitle = NSLocalizedString("Learn more",


### PR DESCRIPTION
Fixes #1608 

## Changes

- Updated the min WC Admin version for the user to update their site to in the stats v4->v3 banner

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
