### PR TITLE
iOS 12: fix crash on Orders/Products search action

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -219,7 +219,9 @@ private extension SearchViewController {
     ///
     func configureSearchBar() {
         searchBar.placeholder = searchUICommand.searchBarPlaceholder
-        searchBar.searchTextField.textColor = .text
+        if #available(iOS 13.0, *) {
+            searchBar.searchTextField.textColor = .text
+        }
     }
 
     /// Setup: Search Bar Borders


### PR DESCRIPTION
Crash fix for search color updates in #1555 

## Steps to repro on `release/3.2`

On an iOS 12 simulator or device:
- Launch the app
- Go to Orders or Products tab
- Tap on the search icon in the navigation bar --> the app crashed because [`UISearchBar`'s `searchTextField` is iOS 13+](https://developer.apple.com/documentation/uikit/uisearchbar/3175433-searchtextfield) (but there was no build warning for this one 😞)

## Changes

- Added an iOS 13+ check for configuring the search bar text field text color

## Testing

On an iOS 12 simulator or device:
- Launch the app
- Go to Orders or Products tab
- Tap on the search icon in the navigation bar --> the app should not crash, and the search works normally

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
