### PR TITLE
Fixed footer overlapping bottom row with larger font size in Settings > About

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,8 @@
 - bugfix: add some padding to an order item image in the Fulfillment view, when no SKU exists
 - bugfix: View Billing Information > Contact Details: the email button wouldn't do anything if you don't have an email account configured in the Mail app. Now an option to copy the email address is presented instead of doing nothing.
 - bugfix: Fulfill Order screen now displays full customer provided note, instead of cutting it to a single line.
- 
 - bugfix: Fixed clipped content on section headings with larger font sizes
+- bugfix: Fixed footer overlapping the last row in Settings > About with larger font sizes
 
 3.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Dashboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z1L-hy-XB6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z1L-hy-XB6">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -395,9 +395,9 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="ibP-Y7-8cn" firstAttribute="trailing" secondItem="BsY-oa-k6u" secondAttribute="trailing" id="2ck-f3-BSs"/>
+                            <constraint firstItem="ibP-Y7-8cn" firstAttribute="bottom" secondItem="BsY-oa-k6u" secondAttribute="bottom" id="69q-a2-QAu"/>
                             <constraint firstItem="ibP-Y7-8cn" firstAttribute="leading" secondItem="BsY-oa-k6u" secondAttribute="leading" id="QKN-1I-cNm"/>
-                            <constraint firstAttribute="bottomMargin" secondItem="ibP-Y7-8cn" secondAttribute="bottom" id="XsC-5D-hY1"/>
-                            <constraint firstItem="ibP-Y7-8cn" firstAttribute="top" secondItem="ivz-5E-TEz" secondAttribute="topMargin" id="xJa-xJ-qrP"/>
+                            <constraint firstItem="ibP-Y7-8cn" firstAttribute="top" secondItem="BsY-oa-k6u" secondAttribute="top" id="qyY-cu-ksZ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="BsY-oa-k6u"/>
                     </view>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -42,7 +42,7 @@ class AboutViewController: UIViewController {
         configureTableViewFooter()
         registerTableViewCells()
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         tableView.updateFooterHeight()
@@ -79,6 +79,13 @@ private extension AboutViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
+
+        guard let tabBarHeight = tabBarController?.tabBar.frame.height else {
+            return
+        }
+        let adjustForTabbarInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: tabBarHeight, right: 0)
+        self.tableView.contentInset = adjustForTabbarInsets
+        self.tableView.scrollIndicatorInsets = adjustForTabbarInsets
     }
 
     /// Setup the tableview header.
@@ -198,7 +205,7 @@ extension AboutViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }
-    
+
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -42,6 +42,11 @@ class AboutViewController: UIViewController {
         configureTableViewFooter()
         registerTableViewCells()
     }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.updateFooterHeight()
+    }
 }
 
 
@@ -191,6 +196,10 @@ extension AboutViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -81,7 +81,7 @@ private extension AboutViewController {
         tableView.backgroundColor = .listBackground
         configureTableViewInsets()
     }
-    
+
     func configureTableViewInsets() {
         guard let tabBarHeight = tabBarController?.tabBar.frame.height else {
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -43,6 +43,12 @@ class AboutViewController: UIViewController {
         registerTableViewCells()
     }
 
+    /// Manage device rotation
+    ///
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        configureTableViewInsets()
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         tableView.updateFooterHeight()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -79,13 +79,16 @@ private extension AboutViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
-
+        configureTableViewInsets()
+    }
+    
+    func configureTableViewInsets() {
         guard let tabBarHeight = tabBarController?.tabBar.frame.height else {
             return
         }
         let adjustForTabbarInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: tabBarHeight, right: 0)
-        self.tableView.contentInset = adjustForTabbarInsets
-        self.tableView.scrollIndicatorInsets = adjustForTabbarInsets
+        tableView.contentInset = adjustForTabbarInsets
+        tableView.scrollIndicatorInsets = adjustForTabbarInsets
     }
 
     /// Setup the tableview header.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TableFooterView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,6 +34,7 @@
                 <constraint firstItem="qck-6N-xeW" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="20" id="3mL-e7-4IU"/>
                 <constraint firstItem="qck-6N-xeW" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="4mN-2A-P26"/>
                 <constraint firstItem="rC7-Y4-ujS" firstAttribute="top" secondItem="qck-6N-xeW" secondAttribute="bottom" constant="4" id="6QX-Rw-ukm"/>
+                <constraint firstItem="rC7-Y4-ujS" firstAttribute="top" relation="greaterThanOrEqual" secondItem="vUN-kp-3ea" secondAttribute="top" constant="20" id="G4n-zX-VFc"/>
                 <constraint firstItem="rC7-Y4-ujS" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="VCe-0w-MuS"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="rC7-Y4-ujS" secondAttribute="bottom" constant="20" id="Y7B-XW-EQ0"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="rC7-Y4-ujS" secondAttribute="trailing" constant="20" id="gR3-Ym-ZLn"/>


### PR DESCRIPTION
Fixes #1122 

## Description
When the device is on the larger font sizes, the app version footer text in Settings > About could overlap with other rows on certain screen sizes.

## Testing
1) Go in Device Settings > Accessibility > Display & Text Size > Larger Text
2) Turn Larger Accessibility Sizes to ON, and move the cursor to the largest text
3) Open the app, go to Settings
4) Tap under the section "About the app" the first cell "WooCommerce"
5) Check that the footer now is not overlapping the last cell

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2019-12-12 at 13 23 06](https://user-images.githubusercontent.com/495617/70724677-4fd5c480-1cfb-11ea-9d5f-2f2b58b2f99a.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2019-12-12 at 16 09 16](https://user-images.githubusercontent.com/495617/70724689-5401e200-1cfb-11ea-90ef-916764b3d363.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
