### PR TITLE
Fixed Orders badge which now is correctly refreshed after switching stores

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,8 @@
 - bugfix: add some padding to an order item image in the Fulfillment view, when no SKU exists
 - bugfix: View Billing Information > Contact Details: the email button wouldn't do anything if you don't have an email account configured in the Mail app. Now an option to copy the email address is presented instead of doing nothing.
 - bugfix: Fulfill Order screen now displays full customer provided note, instead of cutting it to a single line.
- 
 - bugfix: Fixed clipped content on section headings with larger font sizes
+- bugfix: the Orders badge on tab bar now is correctly refreshed after switching stores
 
 3.2
 -----

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -61,6 +61,10 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
 
         finalizeStoreSelection(storeID)
         presentStoreSwitchedNotice()
+        
+        // Reload orders badge
+        NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
+        
         onDismiss?()
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -61,10 +61,10 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
 
         finalizeStoreSelection(storeID)
         presentStoreSwitchedNotice()
-        
+
         // Reload orders badge
         NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
-        
+
         onDismiss?()
     }
 }


### PR DESCRIPTION
Fixes #1373 

## Description
The badge with the number of processing orders on the Orders tab does not refresh after switching stores. This PR fixes this issue firing a badge reload after switching a store.

## Testing
Prerequisites: having at least two stores, one with <= 9 orders with processing status, and the other with > 9 of them.

1) Launch the app logged in to one store, observe the Orders badge
2) Go to Settings and switch to the other store as in the prerequisites
3) Observe the Orders badge and make sure it was updated

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
