### PR TITLE
Fixed issues on Order Detail refresh

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,11 @@
 3.3
 -----
  
+ 3.2.1
+ -----
+ - bugfix: the order detail status and "Begin fulfillment" button now are correctly updated when the order status changes
+ - bugfix: after adding a new order note, now it appear correctly inside the order detail
+ 
 3.2
 -----
 - Experimental: a Products feature switch is visible in Settings > Experimental Features that shows/hides the Products tab with a Work In Progress banner at the top.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -68,6 +68,11 @@ class NewNoteViewController: UIViewController {
                 self?.configureForEditingNote()
                 return
             }
+
+                                                    if let orderNote = orderNote {
+                                                                  self?.viewModel.orderNotes.insert(orderNote, at: 0)
+                                                              }
+
             ServiceLocator.analytics.track(.orderNoteAddSuccess)
             self?.dismiss(animated: true, completion: nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -63,8 +63,7 @@ final class OrderDetailsViewController: UIViewController {
                 self?.viewModel.trackingIsReachable = true
             }
 
-            self?.reloadSections()
-            self?.tableView.reloadData()
+            self?.reloadTableViewSectionsAndData()
         }
     }
 }
@@ -104,7 +103,7 @@ private extension OrderDetailsViewController {
                 return
             }
             self.viewModel.updateOrderStatus(order: order)
-            self.tableView.reloadData()
+            self.reloadTableViewSectionsAndData()
         }
         entityListener.onDelete = { [weak self] in
             guard let self = self else {


### PR DESCRIPTION
Fixes #1615 
Fixes #1614 

This is a good fix to have in the 3.2.1 release.

## Description
This PR fixes two problems of refresh on Order Detail.
The first one #1615 if you add a new order note in the app, it doesn't appear in the Order Notes section until you pull to refresh the screen. It was solved by updating the `orderNotes` array in the view model. I think it stopped working since the introduction of iOS 13, since we expected a refresh of the notes in the `viewWillAppear`.
The second one #1614 if you fulfill an order and then undo it, the status changes from Completed to Processing immediately, but the "Begin Fulfillment" button doesn't reappear until you pull to refresh the screen. This problem was solved refreshing not only the order status and the table view, but also the datasource section array.

## Testing

### Case 1
1) Open an order in the app.
2) Scroll down to "Order Notes" and select "Add a note."
3) Enter some text in the note and tap "Add" to finish.
4) Notice that the note appears in the Order Notes section.

### Case 2
1) Open an order in the app.
2) Select "Begin Fulfillment."
3) Select "Mark Order Complete."
4) On the "Order marked as fulfilled" notice, select "Undo."
5) Notice that the status changes from Completed to Processing and notice that the "Begin Fulfillment" button reappears.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
