### PR TITLE
Edit Product: shipping settings UI

### DIFF
--- a/WooCommerce/Classes/Tools/UnitInputFormatter/DecimalInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/DecimalInputFormatter.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// `UnitInputFormatter` implementation for decimal number input.
+///
+struct DecimalInputFormatter: UnitInputFormatter {
+    private let numberFormatter: NumberFormatter = {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter
+    }()
+
+    func isValid(input: String) -> Bool {
+        guard input.isEmpty == false else {
+            // Allows empty input to be replaced by 0.
+            return true
+        }
+        return numberFormatter.number(from: input) != nil
+    }
+
+    func format(input text: String?) -> String {
+        guard let text = text, text.isEmpty == false else {
+            return "0"
+        }
+
+        let formattedText = text.replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
+        return formattedText
+    }
+}

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/UnitInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/UnitInputFormatter.swift
@@ -1,0 +1,11 @@
+/// Determines formatting requirements for numerical input string with a unit.
+///
+protocol UnitInputFormatter {
+    /// Determines if the input is valid for the unit.
+    ///
+    func isValid(input: String) -> Bool
+
+    /// Applies formatting to the given input string.
+    ///
+    func format(input: String?) -> String
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -114,11 +114,18 @@ extension ProductFormViewController: UITableViewDelegate {
             case .description:
                 editProductDescription()
             }
-        case .settings:
-            // TODO-1422: Shipping Settings
-            // TODO-1423: Price Settings
-            // TODO-1424: Inventory Settings
-            return
+        case .settings(let rows):
+            let row = rows[indexPath.row]
+            switch row {
+            case .shipping:
+                editShippingSettings()
+            case .price:
+                // TODO-1423: Price Settings
+                return
+            case .inventory:
+                // TODO-1424: Inventory Settings
+                return
+            }
         }
     }
 
@@ -190,6 +197,11 @@ private extension ProductFormViewController {
             return
         }
         self.product = productUpdater.descriptionUpdated(description: newDescription)
+    }
+
+    func editShippingSettings() {
+        let shippingSettingsViewController = ProductShippingSettingsViewController(product: product)
+        navigationController?.pushViewController(shippingSettingsViewController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,0 +1,48 @@
+import Yosemite
+
+extension Product {
+    func createShippingWeightCellViewModel(shippingSettingsService: ShippingSettingsService,
+                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let title = NSLocalizedString("Weight", comment: "Title of the cell in Product Shipping Settings > Weight")
+        let unit = shippingSettingsService.weightUnit ?? ""
+        let value = weight == nil || weight?.isEmpty == true ? "0": weight
+        return UnitInputViewModel(title: title,
+                                  unit: unit,
+                                  value: value,
+                                  inputFormatter: DecimalInputFormatter(),
+                                  onInputChange: onInputChange)
+    }
+
+    func createShippingLengthCellViewModel(shippingSettingsService: ShippingSettingsService,
+                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let title = NSLocalizedString("Length", comment: "Title of the cell in Product Shipping Settings > Length")
+        let unit = shippingSettingsService.dimensionUnit ?? ""
+        return UnitInputViewModel(title: title,
+                                  unit: unit,
+                                  value: dimensions.length.isEmpty ? "0": dimensions.length,
+                                  inputFormatter: DecimalInputFormatter(),
+                                  onInputChange: onInputChange)
+    }
+
+    func createShippingWidthCellViewModel(shippingSettingsService: ShippingSettingsService,
+                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let title = NSLocalizedString("Width", comment: "Title of the cell in Product Shipping Settings > Width")
+        let unit = shippingSettingsService.dimensionUnit ?? ""
+        return UnitInputViewModel(title: title,
+                                  unit: unit,
+                                  value: dimensions.width.isEmpty ? "0": dimensions.width,
+                                  inputFormatter: DecimalInputFormatter(),
+                                  onInputChange: onInputChange)
+    }
+
+    func createShippingHeightCellViewModel(shippingSettingsService: ShippingSettingsService,
+                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let title = NSLocalizedString("Height", comment: "Title of the cell in Product Shipping Settings > Height")
+        let unit = shippingSettingsService.dimensionUnit ?? ""
+        return UnitInputViewModel(title: title,
+                                  unit: unit,
+                                  value: dimensions.height.isEmpty ? "0": dimensions.height,
+                                  inputFormatter: DecimalInputFormatter(),
+                                  onInputChange: onInputChange)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,8 +1,8 @@
 import Yosemite
 
 extension Product {
-    func createShippingWeightCellViewModel(shippingSettingsService: ShippingSettingsService,
-                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+    func createShippingWeightViewModel(using shippingSettingsService: ShippingSettingsService,
+                                       onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Weight", comment: "Title of the cell in Product Shipping Settings > Weight")
         let unit = shippingSettingsService.weightUnit ?? ""
         let value = weight == nil || weight?.isEmpty == true ? "0": weight
@@ -13,8 +13,8 @@ extension Product {
                                   onInputChange: onInputChange)
     }
 
-    func createShippingLengthCellViewModel(shippingSettingsService: ShippingSettingsService,
-                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+    func createShippingLengthViewModel(using shippingSettingsService: ShippingSettingsService,
+                                       onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Length", comment: "Title of the cell in Product Shipping Settings > Length")
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
@@ -24,8 +24,8 @@ extension Product {
                                   onInputChange: onInputChange)
     }
 
-    func createShippingWidthCellViewModel(shippingSettingsService: ShippingSettingsService,
-                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+    func createShippingWidthViewModel(using shippingSettingsService: ShippingSettingsService,
+                                      onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Width", comment: "Title of the cell in Product Shipping Settings > Width")
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
@@ -35,8 +35,8 @@ extension Product {
                                   onInputChange: onInputChange)
     }
 
-    func createShippingHeightCellViewModel(shippingSettingsService: ShippingSettingsService,
-                                           onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+    func createShippingHeightViewModel(using shippingSettingsService: ShippingSettingsService,
+                                       onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Height", comment: "Title of the cell in Product Shipping Settings > Height")
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -126,7 +126,7 @@ extension ProductShippingSettingsViewController: UITableViewDataSource {
 //
 extension ProductShippingSettingsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
+        // TODO-1422: navigate to shipping class selector.
     }
 }
 
@@ -215,7 +215,6 @@ private extension ProductShippingSettingsViewController {
             case .weight, .length, .width, .height:
                 return UnitInputTableViewCell.self
             case .shippingClass:
-                // TODO-1422: update cell type after the reusable cell is built
                 return SettingTitleAndValueTableViewCell.self
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -1,0 +1,227 @@
+import UIKit
+import Yosemite
+
+// MARK: - ProductShippingSettingsViewController
+//
+final class ProductShippingSettingsViewController: UIViewController {
+
+    @IBOutlet private weak var tableView: UITableView!
+
+    // Editable data
+    //
+    private var weight: String?
+    private var length: String?
+    private var width: String?
+    private var height: String?
+    private var shippingClassSlug: String?
+
+    /// Table Sections to be rendered
+    ///
+    private let sections: [Section] = [
+        Section(rows: [.weight, .length, .width, .height]),
+        Section(rows: [.shippingClass])
+    ]
+
+    private let product: Product
+    private let shippingSettingsService: ShippingSettingsService
+
+    init(product: Product,
+         shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService) {
+        self.product = product
+        self.shippingSettingsService = shippingSettingsService
+
+        self.weight = product.weight
+        self.length = product.dimensions.length
+        self.width = product.dimensions.width
+        self.height = product.dimensions.height
+        self.shippingClassSlug = product.shippingClass
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBar()
+        configureMainView()
+        configureTableView()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ProductShippingSettingsViewController {
+
+    func configureNavigationBar() {
+        title = NSLocalizedString("Shipping", comment: "Product Shipping Settings navigation title")
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        registerTableViewCells()
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+        }
+    }
+}
+
+// MARK: - Input changes handling
+//
+private extension ProductShippingSettingsViewController {
+    func handleWeightChange(weight: String?) {
+        self.weight = weight
+    }
+
+    func handleLengthChange(weight: String?) {
+        self.length = weight
+    }
+
+    func handleWidthChange(weight: String?) {
+        self.width = weight
+    }
+
+    func handleHeightChange(weight: String?) {
+        self.height = weight
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductShippingSettingsViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductShippingSettingsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension ProductShippingSettingsViewController {
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as UnitInputTableViewCell where row == .weight:
+            configureWeight(cell: cell)
+        case let cell as UnitInputTableViewCell where row == .length:
+            configureLength(cell: cell)
+        case let cell as UnitInputTableViewCell where row == .width:
+            configureWidth(cell: cell)
+        case let cell as UnitInputTableViewCell where row == .height:
+            configureHeight(cell: cell)
+        case let cell as SettingTitleAndValueTableViewCell where row == .shippingClass:
+            configureShippingClass(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    func configureWeight(cell: UnitInputTableViewCell) {
+        let viewModel = product.createShippingWeightCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
+            self?.handleWeightChange(weight: value)
+        }
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureLength(cell: UnitInputTableViewCell) {
+        let viewModel = product.createShippingLengthCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
+            self?.handleLengthChange(weight: value)
+        }
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureWidth(cell: UnitInputTableViewCell) {
+        let viewModel = product.createShippingWidthCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
+            self?.handleWidthChange(weight: value)
+        }
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureHeight(cell: UnitInputTableViewCell) {
+        let viewModel = product.createShippingHeightCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
+            self?.handleHeightChange(weight: value)
+        }
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureShippingClass(cell: SettingTitleAndValueTableViewCell) {
+        let title = NSLocalizedString("Shipping class", comment: "Title of the cell in Product Shipping Settings > Shipping class")
+        // TODO-1422: update slug to name once the model is fetched
+        cell.updateUI(title: title, value: product.shippingClass)
+        cell.accessoryType = .disclosureIndicator
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension ProductShippingSettingsViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+private extension ProductShippingSettingsViewController {
+
+    struct Section {
+        let rows: [Row]
+    }
+
+    enum Row: CaseIterable {
+        case weight
+        case length
+        case width
+        case height
+        case shippingClass
+
+        var type: UITableViewCell.Type {
+            switch self {
+            case .weight, .length, .width, .height:
+                return UnitInputTableViewCell.self
+            case .shippingClass:
+                // TODO-1422: update cell type after the reusable cell is built
+                return SettingTitleAndValueTableViewCell.self
+            }
+        }
+
+        var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -98,16 +98,16 @@ private extension ProductShippingSettingsViewController {
         self.weight = weight
     }
 
-    func handleLengthChange(weight: String?) {
-        self.length = weight
+    func handleLengthChange(length: String?) {
+        self.length = length
     }
 
-    func handleWidthChange(weight: String?) {
-        self.width = weight
+    func handleWidthChange(width: String?) {
+        self.width = width
     }
 
-    func handleHeightChange(weight: String?) {
-        self.height = weight
+    func handleHeightChange(height: String?) {
+        self.height = height
     }
 }
 
@@ -136,6 +136,8 @@ extension ProductShippingSettingsViewController: UITableViewDataSource {
 //
 extension ProductShippingSettingsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
         // TODO-1422: navigate to shipping class selector.
     }
 }
@@ -163,29 +165,29 @@ private extension ProductShippingSettingsViewController {
     }
 
     func configureWeight(cell: UnitInputTableViewCell) {
-        let viewModel = product.createShippingWeightCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
+        let viewModel = product.createShippingWeightViewModel(using: shippingSettingsService) { [weak self] value in
             self?.handleWeightChange(weight: value)
         }
         cell.configure(viewModel: viewModel)
     }
 
     func configureLength(cell: UnitInputTableViewCell) {
-        let viewModel = product.createShippingLengthCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
-            self?.handleLengthChange(weight: value)
+        let viewModel = product.createShippingLengthViewModel(using: shippingSettingsService) { [weak self] value in
+            self?.handleLengthChange(length: value)
         }
         cell.configure(viewModel: viewModel)
     }
 
     func configureWidth(cell: UnitInputTableViewCell) {
-        let viewModel = product.createShippingWidthCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
-            self?.handleWidthChange(weight: value)
+        let viewModel = product.createShippingWidthViewModel(using: shippingSettingsService) { [weak self] value in
+            self?.handleWidthChange(width: value)
         }
         cell.configure(viewModel: viewModel)
     }
 
     func configureHeight(cell: UnitInputTableViewCell) {
-        let viewModel = product.createShippingHeightCellViewModel(shippingSettingsService: shippingSettingsService) { [weak self] value in
-            self?.handleHeightChange(weight: value)
+        let viewModel = product.createShippingHeightViewModel(using: shippingSettingsService) { [weak self] value in
+            self?.handleHeightChange(height: value)
         }
         cell.configure(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -58,6 +58,8 @@ private extension ProductShippingSettingsViewController {
 
     func configureNavigationBar() {
         title = NSLocalizedString("Shipping", comment: "Product Shipping Settings navigation title")
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
     }
 
     func configureMainView() {
@@ -78,6 +80,14 @@ private extension ProductShippingSettingsViewController {
         for row in Row.allCases {
             tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
         }
+    }
+}
+
+// MARK: - Navigation actions handling
+//
+private extension ProductShippingSettingsViewController {
+    @objc func completeUpdating() {
+        // TODO-1422: update shipping settings
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductShippingSettingsViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="Ruw-LK-REo" id="yhW-0w-HZj"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="Ruw-LK-REo">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="Ruw-LK-REo" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="KRw-Qy-TT7"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Ruw-LK-REo" secondAttribute="trailing" id="MB2-9M-8kv"/>
+                <constraint firstItem="Ruw-LK-REo" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="rV4-P1-9YN"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Ruw-LK-REo" secondAttribute="bottom" id="uPJ-wr-71h"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="139" y="125"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -1,35 +1,5 @@
 import UIKit
 
-struct DecimalInputFormatter: UnitInputFormatter {
-    private let numberFormatter: NumberFormatter = {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimal
-        return numberFormatter
-    }()
-
-    func isValid(input: String) -> Bool {
-        guard input.isEmpty == false else {
-            // Allows empty input to be replaced by 0.
-            return true
-        }
-        return numberFormatter.number(from: input) != nil
-    }
-
-    func format(input text: String?) -> String {
-        guard let text = text, text.isEmpty == false else {
-            return "0"
-        }
-
-        let formattedText = text.replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
-        return formattedText
-    }
-}
-
-protocol UnitInputFormatter {
-    func isValid(input: String) -> Bool
-    func format(input: String?) -> String
-}
-
 struct UnitInputViewModel {
     let title: String
     let unit: String
@@ -38,6 +8,8 @@ struct UnitInputViewModel {
     let onInputChange: ((_ input: String?) -> Void)?
 }
 
+/// Displays a title, an editable text field for user input and the unit of the text field value.
+///
 final class UnitInputTableViewCell: UITableViewCell {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var inputAndUnitStackView: UIStackView!

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -1,0 +1,110 @@
+import UIKit
+
+struct DecimalInputFormatter: UnitInputFormatter {
+    private let numberFormatter: NumberFormatter = {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter
+    }()
+
+    func isValid(input: String) -> Bool {
+        guard input.isEmpty == false else {
+            // Allows empty input to be replaced by 0.
+            return true
+        }
+        return numberFormatter.number(from: input) != nil
+    }
+
+    func format(input text: String?) -> String {
+        guard let text = text, text.isEmpty == false else {
+            return "0"
+        }
+
+        let formattedText = text.replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
+        return formattedText
+    }
+}
+
+protocol UnitInputFormatter {
+    func isValid(input: String) -> Bool
+    func format(input: String?) -> String
+}
+
+struct UnitInputViewModel {
+    let title: String
+    let unit: String
+    let value: String?
+    let inputFormatter: UnitInputFormatter
+    let onInputChange: ((_ input: String?) -> Void)?
+}
+
+final class UnitInputTableViewCell: UITableViewCell {
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var inputAndUnitStackView: UIStackView!
+    @IBOutlet private weak var inputTextField: UITextField!
+    @IBOutlet private weak var unitLabel: UILabel!
+
+    private var inputFormatter: UnitInputFormatter?
+    private var onInputChange: ((_ input: String?) -> Void)?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureTitleLabel()
+        configureInputAndUnitStackView()
+        configureInputTextField()
+        configureUnitLabel()
+        applyDefaultBackgroundStyle()
+    }
+
+    func configure(viewModel: UnitInputViewModel) {
+        titleLabel.text = viewModel.title
+        unitLabel.text = viewModel.unit
+        inputTextField.text = viewModel.value
+        inputFormatter = viewModel.inputFormatter
+        onInputChange = viewModel.onInputChange
+    }
+}
+
+private extension UnitInputTableViewCell {
+    func configureTitleLabel() {
+        titleLabel.applyBodyStyle()
+    }
+
+    func configureInputAndUnitStackView() {
+        inputAndUnitStackView.spacing = 6
+    }
+
+    func configureInputTextField() {
+        inputTextField.borderStyle = .none
+        inputTextField.applyBodyStyle()
+        inputTextField.textAlignment = .right
+        inputTextField.keyboardType = .decimalPad
+        inputTextField.delegate = self
+        inputTextField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
+    }
+
+    func configureUnitLabel() {
+        unitLabel.applyBodyStyle()
+    }
+}
+
+extension UnitInputTableViewCell: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text,
+            let textRange = Range(range, in: text) else {
+                                                        return false
+        }
+        let updatedText = text.replacingCharacters(in: textRange,
+                                                   with: string)
+        return inputFormatter?.isValid(input: updatedText) == true
+    }
+}
+
+private extension UnitInputTableViewCell {
+    @objc func textFieldDidChange(textField: UITextField) {
+        let formattedText = inputFormatter?.format(input: textField.text)
+        textField.text = inputFormatter?.format(input: formattedText)
+        onInputChange?(formattedText)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -50,7 +50,15 @@ private extension UnitInputTableViewCell {
     func configureInputTextField() {
         inputTextField.borderStyle = .none
         inputTextField.applyBodyStyle()
-        inputTextField.textAlignment = .right
+        if traitCollection.layoutDirection == .rightToLeft {
+            // swiftlint:disable:next natural_text_alignment
+            inputTextField.textAlignment = .left
+            // swiftlint:enable:next natural_text_alignment
+        } else {
+            // swiftlint:disable:next inverse_text_alignment
+            inputTextField.textAlignment = .right
+            // swiftlint:enable:next inverse_text_alignment
+        }
         inputTextField.keyboardType = .decimalPad
         inputTextField.delegate = self
         inputTextField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.xib
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="UnitInputTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="USm-hW-Nqm">
+                        <rect key="frame" x="16" y="16" width="42" height="12"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ob4-NO-lKK">
+                        <rect key="frame" x="74" y="11" width="230" height="22"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Egc-4I-j1K">
+                                <rect key="frame" x="0.0" y="0.0" width="188" height="22"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zeq-2u-wuX">
+                                <rect key="frame" x="188" y="0.0" width="42" height="22"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Ob4-NO-lKK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="11" id="1SP-Ip-tgf"/>
+                    <constraint firstItem="USm-hW-Nqm" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="94h-Pu-yw9"/>
+                    <constraint firstAttribute="trailing" secondItem="Ob4-NO-lKK" secondAttribute="trailing" constant="16" id="Cgk-BX-4Tt"/>
+                    <constraint firstAttribute="bottom" secondItem="Ob4-NO-lKK" secondAttribute="bottom" constant="11" id="L3s-mF-7Se"/>
+                    <constraint firstItem="USm-hW-Nqm" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="NaZ-l9-qgY"/>
+                    <constraint firstAttribute="bottom" secondItem="USm-hW-Nqm" secondAttribute="bottom" constant="16" id="jA4-Ga-8ge"/>
+                    <constraint firstItem="Ob4-NO-lKK" firstAttribute="leading" secondItem="USm-hW-Nqm" secondAttribute="trailing" constant="16" id="ohO-Vo-Z9g"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="inputAndUnitStackView" destination="Ob4-NO-lKK" id="ENb-Cm-KUp"/>
+                <outlet property="inputTextField" destination="Egc-4I-j1K" id="ABz-lR-XQG"/>
+                <outlet property="titleLabel" destination="USm-hW-Nqm" id="z1x-su-ObU"/>
+                <outlet property="unitLabel" destination="Zeq-2u-wuX" id="GWc-C1-ftr"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="125"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -117,12 +117,14 @@
 		0290E276238E4F8100B5C466 /* PaginatedListSelectorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0290E274238E4F8100B5C466 /* PaginatedListSelectorViewController.xib */; };
 		0290E27A238E590500B5C466 /* ListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E279238E590500B5C466 /* ListSelectorViewProperties.swift */; };
 		0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift */; };
+		02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9423A774C500707A0C /* UnitInputFormatter.swift */; };
+		02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9623A774E600707A0C /* DecimalInputFormatter.swift */; };
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
 		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
-		02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
+		02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */; };
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
@@ -659,12 +661,14 @@
 		0290E274238E4F8100B5C466 /* PaginatedListSelectorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PaginatedListSelectorViewController.xib; sourceTree = "<group>"; };
 		0290E279238E590500B5C466 /* ListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
+		02913E9423A774C500707A0C /* UnitInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitInputFormatter.swift; sourceTree = "<group>"; };
+		02913E9623A774E600707A0C /* DecimalInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatter.swift; sourceTree = "<group>"; };
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
 		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
-		02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SystemColors.swift"; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
+		02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SystemColors.swift"; sourceTree = "<group>"; };
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1366,6 +1370,15 @@
 			path = ListSelector;
 			sourceTree = "<group>";
 		};
+		02913E9323A774B000707A0C /* UnitInputFormatter */ = {
+			isa = PBXGroup;
+			children = (
+				02913E9423A774C500707A0C /* UnitInputFormatter.swift */,
+				02913E9623A774E600707A0C /* DecimalInputFormatter.swift */,
+			);
+			path = UnitInputFormatter;
+			sourceTree = "<group>";
+		};
 		029B0F58234197C90010C1F3 /* Order */ = {
 			isa = PBXGroup;
 			children = (
@@ -1745,6 +1758,7 @@
 				B5A03699214C0E7000774E2C /* Logging */,
 				B58B4ABC2108F7F800076FDD /* Notices */,
 				B541B2182189F387008FE7C1 /* StringFormatter */,
+				02913E9323A774B000707A0C /* UnitInputFormatter */,
 				CE14452C2188C0EC00A991D8 /* Zendesk */,
 				0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */,
 				74460D3F22289B7600D7316A /* Coordinator.swift */,
@@ -2944,6 +2958,7 @@
 				74460D4222289C7A00D7316A /* StorePickerCoordinator.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
+				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
@@ -3208,6 +3223,7 @@
 				02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */,
 				B5980A6321AC879F00EBF596 /* Bundle+Woo.swift in Sources */,
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
+				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
 				020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		02404EE2231501E000FF1170 /* StatsVersionStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EE1231501E000FF1170 /* StatsVersionStateCoordinatorTests.swift */; };
 		02404EE42315151400FF1170 /* MockupStatsVersionStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EE32315151400FF1170 /* MockupStatsVersionStoresManager.swift */; };
 		0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */; };
+		0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */; };
 		02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */; };
 		02482A8C237BE8C7007E73ED /* LinkSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */; };
 		02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */; };
@@ -81,6 +82,11 @@
 		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
 		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
+		0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0262DA5123A238460029AF30 /* UnitInputTableViewCell.swift */; };
+		0262DA5423A238460029AF30 /* UnitInputTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0262DA5223A238460029AF30 /* UnitInputTableViewCell.xib */; };
+		0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0262DA5623A23AC80029AF30 /* ProductShippingSettingsViewController.swift */; };
+		0262DA5923A23AC80029AF30 /* ProductShippingSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0262DA5723A23AC80029AF30 /* ProductShippingSettingsViewController.xib */; };
+		0262DA5B23A244830029AF30 /* Product+ShippingSettingsViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0262DA5A23A244830029AF30 /* Product+ShippingSettingsViewModels.swift */; };
 		02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */; };
 		02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */; };
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
@@ -593,6 +599,7 @@
 		02404EE1231501E000FF1170 /* StatsVersionStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		02404EE32315151400FF1170 /* MockupStatsVersionStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockupStatsVersionStoresManager.swift; sourceTree = "<group>"; };
 		0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelper.swift; sourceTree = "<group>"; };
+		0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatterTests.swift; sourceTree = "<group>"; };
 		02482A89237BE8C7007E73ED /* LinkSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSettingsViewController.swift; sourceTree = "<group>"; };
 		02482A8A237BE8C7007E73ED /* LinkSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LinkSettingsViewController.xib; sourceTree = "<group>"; };
 		02482A8D237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecLinkFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -617,6 +624,11 @@
 		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
 		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
+		0262DA5123A238460029AF30 /* UnitInputTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitInputTableViewCell.swift; sourceTree = "<group>"; };
+		0262DA5223A238460029AF30 /* UnitInputTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UnitInputTableViewCell.xib; sourceTree = "<group>"; };
+		0262DA5623A23AC80029AF30 /* ProductShippingSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingSettingsViewController.swift; sourceTree = "<group>"; };
+		0262DA5723A23AC80029AF30 /* ProductShippingSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductShippingSettingsViewController.xib; sourceTree = "<group>"; };
+		0262DA5A23A244830029AF30 /* Product+ShippingSettingsViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingSettingsViewModels.swift"; sourceTree = "<group>"; };
 		0269177F232600A6002AFC20 /* ProductsTabProductViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModelTests.swift; sourceTree = "<group>"; };
 		02691781232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListViewControllerStateCoordinatorTests.swift; sourceTree = "<group>"; };
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
@@ -1137,6 +1149,7 @@
 			children = (
 				02F4F50C237AFBB700E13A9C /* Cells */,
 				02E262CA238D0D0500B79588 /* List Selector Data Source */,
+				0262DA5523A23AA40029AF30 /* Shipping Settings */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
 				02162725237963AF000208D2 /* ProductFormViewController.xib */,
 				02162728237965E8000208D2 /* ProductFormTableViewModel.swift */,
@@ -1255,6 +1268,16 @@
 				024DF3082372CA00006658FE /* EditorViewProperties.swift */,
 			);
 			path = Editor;
+			sourceTree = "<group>";
+		};
+		0262DA5523A23AA40029AF30 /* Shipping Settings */ = {
+			isa = PBXGroup;
+			children = (
+				0262DA5623A23AC80029AF30 /* ProductShippingSettingsViewController.swift */,
+				0262DA5723A23AC80029AF30 /* ProductShippingSettingsViewController.xib */,
+				0262DA5A23A244830029AF30 /* Product+ShippingSettingsViewModels.swift */,
+			);
+			path = "Shipping Settings";
 			sourceTree = "<group>";
 		};
 		0269177E23260090002AFC20 /* Products */ = {
@@ -1653,6 +1676,7 @@
 				D8AB131D225DC25F002BB5D1 /* MockOrders.swift */,
 				024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */,
 				02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */,
+				0247AAA123A3C5A6007F967E /* DecimalInputFormatterTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -2405,6 +2429,8 @@
 				D81F2D34225F0CF70084BF9C /* EmptyListMessageWithActionView.xib */,
 				CE227096228F152400C0626C /* WooBasicTableViewCell.swift */,
 				CE227098228F180B00C0626C /* WooBasicTableViewCell.xib */,
+				0262DA5123A238460029AF30 /* UnitInputTableViewCell.swift */,
+				0262DA5223A238460029AF30 /* UnitInputTableViewCell.xib */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -2629,6 +2655,7 @@
 				CE0F17D022A8105800964A63 /* ReadMoreTableViewCell.xib in Resources */,
 				CE1D5A5A228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib in Resources */,
 				B5A8F8AF20B88DCC00D211DE /* LoginPrologueViewController.xib in Resources */,
+				0262DA5923A23AC80029AF30 /* ProductShippingSettingsViewController.xib in Resources */,
 				74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */,
 				B5F571B021BF149D0010D1B8 /* o.caf in Resources */,
 				45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */,
@@ -2667,6 +2694,7 @@
 				CE1EC8F020B8A408009762BF /* OrderNoteTableViewCell.xib in Resources */,
 				B55D4BFD20B5CDE700D7A50F /* replace_secrets.rb in Resources */,
 				74A95B5821C403EA00FEE953 /* pure-min.css in Resources */,
+				0262DA5423A238460029AF30 /* UnitInputTableViewCell.xib in Resources */,
 				B5BE75DD213F1D3D00909A14 /* OverlayMessageView.xib in Resources */,
 				02F4F510237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib in Resources */,
 				45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */,
@@ -2947,6 +2975,7 @@
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
 				02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */,
+				0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */,
 				748C7782211E294000814F2C /* Double+Woo.swift in Sources */,
 				D8915DC32372C9EF00F63762 /* UIColor+ColorStudio.swift in Sources */,
 				024DF31623742BB6006658FE /* AztecStrikethroughFormatBarCommand.swift in Sources */,
@@ -3036,9 +3065,11 @@
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
+				0262DA5B23A244830029AF30 /* Product+ShippingSettingsViewModels.swift in Sources */,
 				0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */,
 				D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */,
 				B5F8B7E02194759100DAB7E2 /* ReviewDetailsViewController.swift in Sources */,
+				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
@@ -3252,6 +3283,7 @@
 				02279594237A60FD00787C63 /* AztecHeaderFormatBarCommandTests.swift in Sources */,
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
+				0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */,
 				B509FED521C052D1000076A9 /* MockupSupportManager.swift in Sources */,
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/DecimalInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DecimalInputFormatterTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import WooCommerce
+
+final class DecimalInputFormatterTests: XCTestCase {
+    private let formatter = DecimalInputFormatter()
+
+    // MARK: test cases for `isValid(input:)`
+
+    func testEmptyInputIsValid() {
+        let input = ""
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testAlphanumericInputIsNotValid() {
+        let input = "06two"
+        XCTAssertFalse(formatter.isValid(input: input))
+    }
+
+    func testDecimalInputIsValid() {
+        let input = "9990.52"
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testTrailingPointInputIsValid() {
+        let input = "9990."
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testLeadingPointInputIsInvalid() {
+        let input = "."
+        XCTAssertFalse(formatter.isValid(input: input))
+    }
+
+    // MARK: test cases for `format(input:)`
+
+    func testFormattingEmptyInput() {
+        let input = ""
+        XCTAssertEqual(formatter.format(input: input), "0")
+    }
+
+    func testFormattingInputWithLeadingZeros() {
+        let input = "00123.91"
+        XCTAssertEqual(formatter.format(input: input), "123.91")
+    }
+
+    func testFormattingDecimalInput() {
+        let input = "0.314"
+        XCTAssertEqual(formatter.format(input: input), "0.314")
+    }
+
+    func testFormattingIntegerInput() {
+        let input = "314200"
+        XCTAssertEqual(formatter.format(input: input), "314200")
+    }
+}


### PR DESCRIPTION
Shipping Settings UI for #1422 

## Summary

This PR implements the UI for the Product Shipping Settings. These are the TODO tasks after this PR:
- Fetch the product's shipping class model so that we can display the shipping class name on the Shipping Settings screen
- Navigate to the Shipping Class list selector from the Shipping Settings screen
- Functionality to update the Shipping Settings

## Changes

Note: I will request design review after the shipping class name is displayed

- Created `UnitInputTableViewCell` that has a title, editable text field, and a unit. The UI is configured by `UnitInputViewModel` that contains a protocol `UnitInputFormatter` that formats and validates the unit input
  - Please lemme know if you have a better naming!
- Added some extension helpers to `Product` to create `UnitInputViewModel` for each shipping setting field
- Created `ProductShippingSettingsViewController` that configures 2 sections of 5 fields as in the screenshot below
- In `ProductFormViewController`, added navigation to `ProductShippingSettingsViewController`

## Testing

- Launch the app
- Go to Products tab
- Tap on a Product with non-empty shipping settings
- Tap "Edit"
- Tap "Shiping" row --> the weight, length, width, height, and shipping class slug (if any) should be displayed
- Go back to the Products tab and repeat the above 2 steps with different shipping settings (e.g. empty settings)

## Example screenshots

LTR | RTL
-- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-16 at 16 31 50](https://user-images.githubusercontent.com/1945542/70895362-c4756f80-2029-11ea-9e77-b146ccbb4510.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-16 at 16 38 40](https://user-images.githubusercontent.com/1945542/70895363-c50e0600-2029-11ea-8b1a-9508bc71aac2.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
