### PR TITLE
Bumps Authenticator pod to 1.10.5 release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -26,7 +26,7 @@ target 'WooCommerce' do
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
-  pod 'WordPressAuthenticator', '~> 1.10.5-beta'
+  pod 'WordPressAuthenticator', '~> 1.10.5'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
   pod 'WordPressShared', '~> 1.8.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,7 +47,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.10.5-beta.2):
+  - WordPressAuthenticator (1.10.5):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -56,10 +56,10 @@ PODS:
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.5.4)
+    - WordPressKit (~> 4.5.5)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.5.4):
+  - WordPressKit (4.5.5):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -93,7 +93,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.10.5-beta)
+  - WordPressAuthenticator (~> 1.10.5)
   - WordPressShared (~> 1.8.2)
   - WordPressUI (~> 1.4)
   - Wormholy (~> 1.5.1)
@@ -154,8 +154,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 8ae7f6973b4aaae551d1ba985c0194ed40692224
-  WordPressKit: 1d365775fac17903a76ad5723bc146ab1739ec82
+  WordPressAuthenticator: c07d36f36ce73f77f468db665973faab6392ff43
+  WordPressKit: 8029cb93a89de79442254c346523da11c2706d7b
   WordPressShared: 914ec1f855d74755e42d76e83c98b2d2d0e66218
   WordPressUI: 4a4adafd2b052e94e4846c0a0203761773dc4fd5
   Wormholy: f01b096b449a9fcab864a10f7e5b5693b1225c88
@@ -163,6 +163,6 @@ SPEC CHECKSUMS:
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
 
-PODFILE CHECKSUM: e63c90f8731bc4f2191aa389836880db13097af0
+PODFILE CHECKSUM: a9a49f6751af290016b65aba1145692984a7ef56
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.8.9):
+  - WordPressShared (1.8.10):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.0)
@@ -156,7 +156,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: c07d36f36ce73f77f468db665973faab6392ff43
   WordPressKit: 8029cb93a89de79442254c346523da11c2706d7b
-  WordPressShared: 914ec1f855d74755e42d76e83c98b2d2d0e66218
+  WordPressShared: 5561910e9b6635874abeb10e450b7d2a29f23838
   WordPressUI: 4a4adafd2b052e94e4846c0a0203761773dc4fd5
   Wormholy: f01b096b449a9fcab864a10f7e5b5693b1225c88
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -242,10 +242,10 @@ private extension AppDelegate {
     ///
     func setupLogLevel(_ level: DDLogLevel) {
         let rawLevel = Int32(level.rawValue)
-
         WPSharedSetLoggingLevel(rawLevel)
-        WPAuthenticatorSetLoggingLevel(rawLevel)
-        WPKitSetLoggingLevel(rawLevel)
+
+        WPAuthenticatorSetLoggingLevel(level)
+        WPKitSetLoggingLevel(level)
     }
 
     /// Setup: Notice Presenter

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -241,9 +241,7 @@ private extension AppDelegate {
     /// Sets up the current Log Leve.
     ///
     func setupLogLevel(_ level: DDLogLevel) {
-        let rawLevel = Int32(level.rawValue)
-        WPSharedSetLoggingLevel(rawLevel)
-
+        WPSharedSetLoggingLevel(level)
         WPAuthenticatorSetLoggingLevel(level)
         WPKitSetLoggingLevel(level)
     }


### PR DESCRIPTION
In preparation for the 3.3 release, bump the WordPressAuthenticator pod to 1.10.5, dropping the beta suffix.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
