### PR TITLE
Edit Product: inventory settings UI

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */ = {isa = PBXBuildFile; fileRef = 020220E123966CD900290165 /* product-shipping-classes-load-one.json */; };
 		0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */; };
 		021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */; };
+		021E2A1423A9FC5900B1DE07 /* ProductBackordersSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */; };
 		022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 022902D122E2436300059692 /* stats_module_disabled_error.json */; };
 		022902D622E2436400059692 /* no_stats_permission_error.json in Resources */ = {isa = PBXBuildFile; fileRef = 022902D322E2436400059692 /* no_stats_permission_error.json */; };
 		025CA2C0238EB8CB00B05C81 /* ProductShippingClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */; };
@@ -306,6 +307,7 @@
 		020220E123966CD900290165 /* product-shipping-classes-load-one.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-one.json"; sourceTree = "<group>"; };
 		0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductShippingClassMapper.swift; sourceTree = "<group>"; };
 		021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Serialization.swift"; sourceTree = "<group>"; };
+		021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSetting.swift; sourceTree = "<group>"; };
 		022902D122E2436300059692 /* stats_module_disabled_error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = stats_module_disabled_error.json; sourceTree = "<group>"; };
 		022902D322E2436400059692 /* no_stats_permission_error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = no_stats_permission_error.json; sourceTree = "<group>"; };
 		025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductShippingClass.swift; sourceTree = "<group>"; };
@@ -1129,6 +1131,7 @@
 				028296F6237D588700E84012 /* ProductVariation.swift */,
 				026CF619237D607A009563D4 /* ProductVariationAttribute.swift */,
 				025CA2BF238EB8CB00B05C81 /* ProductShippingClass.swift */,
+				021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";
@@ -1507,6 +1510,7 @@
 				CE43066A23465F340073CBFF /* Refund.swift in Sources */,
 				B524194121AC60A700D6FC0A /* DotcomDevice.swift in Sources */,
 				D823D90D2237784A00C90817 /* ShipmentTrackingProvider.swift in Sources */,
+				021E2A1423A9FC5900B1DE07 /* ProductBackordersSetting.swift in Sources */,
 				CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */,
 				B557DA0420975500005962F4 /* OrdersRemote.swift in Sources */,
 				CE43066C2347C5F90073CBFF /* OrderItemRefund.swift in Sources */,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -95,6 +95,10 @@ public struct Product: Codable {
         return ProductType(rawValue: productTypeKey)
     }
 
+    public var backordersSetting: ProductBackordersSetting {
+        return ProductBackordersSetting(rawValue: backordersKey)
+    }
+
     /// Product struct initializer.
     ///
     public init(siteID: Int,

--- a/Networking/Networking/Model/Product/ProductBackordersSetting.swift
+++ b/Networking/Networking/Model/Product/ProductBackordersSetting.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Represents a ProductBackordersSetting Entity.
+///
+public enum ProductBackordersSetting: Decodable, Hashable {
+    case allowed
+    case allowedAndNotifyCustomer
+    case notAllowed
+    case custom(String) // in case there are extensions modifying backorders setting
+}
+
+/// RawRepresentable Conformance
+///
+extension ProductBackordersSetting: RawRepresentable {
+
+    /// Designated Initializer.
+    ///
+    public init(rawValue: String) {
+        switch rawValue {
+        case Keys.allowed:
+            self = .allowed
+        case Keys.allowedAndNotifyCustomer:
+            self = .allowedAndNotifyCustomer
+        case Keys.notAllowed:
+            self = .notAllowed
+        default:
+            self = .custom(rawValue)
+        }
+    }
+
+    /// Returns the current Enum Case's Raw Value
+    ///
+    public var rawValue: String {
+        switch self {
+        case .allowed: return Keys.allowed
+        case .allowedAndNotifyCustomer: return Keys.allowedAndNotifyCustomer
+        case .notAllowed: return Keys.notAllowed
+        case .custom(let payload):  return payload
+        }
+    }
+}
+
+extension ProductBackordersSetting {
+    /// Returns the localized text version of the Enum
+    ///
+    public var description: String {
+        switch self {
+        case .allowed:
+            return NSLocalizedString("Allow", comment: "Display label for the product's inventory backorders setting option")
+        case .allowedAndNotifyCustomer:
+            return NSLocalizedString("Allow, but notify customer", comment: "Display label for the product's inventory backorders setting option")
+        case .notAllowed:
+            return NSLocalizedString("Do not allow", comment: "Display label for the product's inventory backorders setting option")
+        case .custom(let payload):
+            return payload // unable to localize at runtime.
+        }
+    }
+}
+
+/// Enum containing the 'Known' ProductBackordersSetting Keys
+///
+private enum Keys {
+    static let allowed = "yes"
+    static let allowedAndNotifyCustomer = "notify"
+    static let notAllowed = "no"
+}

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -72,6 +72,7 @@ class ProductMapperTests: XCTestCase {
         XCTAssertEqual(product.stockStatusKey, "instock")
 
         XCTAssertEqual(product.backordersKey, "no")
+        XCTAssertEqual(product.backordersSetting, .notAllowed)
         XCTAssertFalse(product.backordersAllowed)
         XCTAssertFalse(product.backordered)
 

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -11,4 +11,10 @@ extension UIViewController {
     class var nibName: String {
         return classNameWithoutNamespaces
     }
+
+    /// Removes the text of the navigation bar back button in the next view controller of the navigation stack.
+    ///
+    func removeNavigationBackBarButtonText() {
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+    }
 }

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/StringInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/StringInputFormatter.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// `UnitInputFormatter` implementation for string input.
+///
+struct StringInputFormatter: UnitInputFormatter {
+    func isValid(input: String) -> Bool {
+        return true
+    }
+
+    func format(input text: String?) -> String {
+        return text ?? ""
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -1,0 +1,23 @@
+import Yosemite
+
+extension Product {
+    static func createSKUViewModel(sku: String?, onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let title = NSLocalizedString("SKU", comment: "Title of the cell in Product Inventory Settings > SKU")
+        return UnitInputViewModel(title: title,
+                                  unit: "",
+                                  value: sku,
+                                  keyboardType: .default,
+                                  inputFormatter: StringInputFormatter(),
+                                  onInputChange: onInputChange)
+    }
+
+    static func createStockQuantityViewModel(stockQuantity: Int?, onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+        let title = NSLocalizedString("Quantity", comment: "Title of the cell in Product Inventory Settings > Quantity")
+        return UnitInputViewModel(title: title,
+                                  unit: "",
+                                  value: "\(stockQuantity ?? 0)",
+                                  keyboardType: .numberPad,
+                                  inputFormatter: DecimalInputFormatter(),
+                                  onInputChange: onInputChange)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -1,0 +1,299 @@
+import UIKit
+import Networking
+import Yosemite
+
+final class ProductInventorySettingsViewController: UIViewController {
+
+    @IBOutlet private weak var tableView: UITableView!
+
+    // Editable data - shared.
+    //
+    private var sku: String?
+    private var manageStockEnabled: Bool
+    private var soldIndividually: Bool
+
+    // Editable data - manage stock enabled.
+    private var stockQuantity: Int?
+    private var backordersSetting: ProductBackordersSetting?
+
+    // Editable data - manage stock disabled.
+    private var stockStatus: ProductStockStatus?
+
+    /// Table Sections to be rendered
+    ///
+    private var sections: [Section] = []
+
+    init(product: Product) {
+        self.sku = product.sku
+        self.manageStockEnabled = product.manageStock
+        self.soldIndividually = product.soldIndividually
+
+        if manageStockEnabled {
+            self.stockQuantity = product.stockQuantity
+            self.backordersSetting = product.backordersSetting
+        } else {
+            self.stockStatus = product.productStockStatus
+        }
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigationBar()
+        configureMainView()
+        configureTableView()
+        reloadSections()
+    }
+}
+
+// MARK: - View Updates
+//
+private extension ProductInventorySettingsViewController {
+    func reloadSections() {
+        let stockSection: Section
+        if manageStockEnabled {
+            stockSection = Section(rows: [.manageStock, .stockQuantity, .backorders])
+        } else {
+            stockSection = Section(rows: [.manageStock, .stockStatus])
+        }
+
+        sections = [
+            Section(rows: [.sku]),
+            stockSection,
+            Section(rows: [.limitOnePerOrder])
+        ]
+
+        tableView.reloadData()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ProductInventorySettingsViewController {
+
+    func configureNavigationBar() {
+        title = NSLocalizedString("Inventory", comment: "Product Inventory Settings navigation title")
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        registerTableViewCells()
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+        }
+    }
+}
+
+// MARK: - Navigation actions handling
+//
+private extension ProductInventorySettingsViewController {
+    @objc func completeUpdating() {
+        // TODO-1424: update shipping settings
+    }
+}
+
+// MARK: - Input changes handling
+//
+private extension ProductInventorySettingsViewController {
+    func handleSKUChange(sku: String?) {
+        self.sku = sku
+    }
+
+    func handleStockQuantityChange(stockQuantity: String?) {
+        guard let stockQuantity = stockQuantity else {
+            return
+        }
+        self.stockQuantity = Int(stockQuantity)
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductInventorySettingsViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductInventorySettingsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch rowAtIndexPath(indexPath) {
+        case .stockStatus:
+            let title = NSLocalizedString("Stock status", comment: "Product stock status list selector navigation title")
+            let viewProperties = ListSelectorViewProperties(navigationBarTitle: title)
+            let dataSource = ProductStockStatusListSelectorDataSource(selected: stockStatus)
+            let listSelectorViewController = ListSelectorViewController(viewProperties: viewProperties,
+                                                                        dataSource: dataSource) { [weak self] selected in
+                                                                            self?.stockStatus = selected
+                                                                            self?.tableView.reloadData()
+            }
+            navigationController?.pushViewController(listSelectorViewController, animated: true)
+        case .backorders:
+            let title = NSLocalizedString("Allow backorders?", comment: "Product backorders setting list selector navigation title")
+            let viewProperties = ListSelectorViewProperties(navigationBarTitle: title)
+            let dataSource = ProductBackordersSettingListSelectorDataSource(selected: backordersSetting)
+            let listSelectorViewController = ListSelectorViewController(viewProperties: viewProperties,
+                                                                        dataSource: dataSource) { [weak self] selected in
+                                                                            self?.backordersSetting = selected
+                                                                            self?.tableView.reloadData()
+            }
+            navigationController?.pushViewController(listSelectorViewController, animated: true)
+        default:
+            return
+        }
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension ProductInventorySettingsViewController {
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as UnitInputTableViewCell where row == .sku:
+            configureSKU(cell: cell)
+        case let cell as SwitchTableViewCell where row == .manageStock:
+            configureManageStock(cell: cell)
+        case let cell as SwitchTableViewCell where row == .limitOnePerOrder:
+            configureLimitOnePerOrder(cell: cell)
+        case let cell as UnitInputTableViewCell where row == .stockQuantity:
+            configureStockQuantity(cell: cell)
+        case let cell as SettingTitleAndValueTableViewCell where row == .backorders:
+            configureBackordersSetting(cell: cell)
+        case let cell as SettingTitleAndValueTableViewCell where row == .stockStatus:
+            configureStockStatus(cell: cell)
+        default:
+            fatalError()
+        }
+    }
+
+    func configureSKU(cell: UnitInputTableViewCell) {
+        let viewModel = Product.createSKUViewModel(sku: sku) { [weak self] value in
+            self?.handleSKUChange(sku: value)
+        }
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureManageStock(cell: SwitchTableViewCell) {
+        cell.title = NSLocalizedString("Manage stock", comment: "Title of the cell in Product Inventory Settings > Manage stock")
+        cell.isOn = manageStockEnabled
+        cell.onChange = { [weak self] value in
+            self?.manageStockEnabled = value
+            self?.reloadSections()
+        }
+    }
+
+    func configureLimitOnePerOrder(cell: SwitchTableViewCell) {
+        cell.title = NSLocalizedString("Limit one per order", comment: "Title of the cell in Product Inventory Settings > Limit one per order")
+        cell.isOn = soldIndividually
+        cell.onChange = { [weak self] value in
+            self?.soldIndividually = value
+        }
+    }
+
+    // Manage stock enabled.
+
+    func configureStockQuantity(cell: UnitInputTableViewCell) {
+        let viewModel = Product.createStockQuantityViewModel(stockQuantity: stockQuantity) { [weak self] value in
+            self?.handleStockQuantityChange(stockQuantity: value)
+        }
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureBackordersSetting(cell: SettingTitleAndValueTableViewCell) {
+        let title = NSLocalizedString("Backorders", comment: "Title of the cell in Product Inventory Settings > Backorders")
+        cell.updateUI(title: title, value: backordersSetting?.description)
+        cell.accessoryType = .disclosureIndicator
+    }
+
+    // Manage stock disabled.
+
+    func configureStockStatus(cell: SettingTitleAndValueTableViewCell) {
+        let title = NSLocalizedString("Stock status", comment: "Title of the cell in Product Inventory Settings > Stock status")
+        cell.updateUI(title: title, value: stockStatus?.description)
+        cell.accessoryType = .disclosureIndicator
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension ProductInventorySettingsViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+}
+
+private extension ProductInventorySettingsViewController {
+
+    struct Section {
+        let rows: [Row]
+    }
+
+    enum Row: CaseIterable {
+        case sku
+        case manageStock
+        case limitOnePerOrder
+        // Manage stock is enabled.
+        case stockQuantity
+        case backorders
+        // Manage stock is disabled.
+        case stockStatus
+
+        var type: UITableViewCell.Type {
+            switch self {
+            case .sku:
+                // TODO-1424: update with a input cell without a unit
+                return UnitInputTableViewCell.self
+            case .manageStock, .limitOnePerOrder:
+                return SwitchTableViewCell.self
+            case .stockQuantity:
+                return UnitInputTableViewCell.self
+            case .stockStatus, .backorders:
+                return SettingTitleAndValueTableViewCell.self
+            }
+        }
+
+        var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -27,12 +27,9 @@ final class ProductInventorySettingsViewController: UIViewController {
         self.manageStockEnabled = product.manageStock
         self.soldIndividually = product.soldIndividually
 
-        if manageStockEnabled {
-            self.stockQuantity = product.stockQuantity
-            self.backordersSetting = product.backordersSetting
-        } else {
-            self.stockStatus = product.productStockStatus
-        }
+        self.stockQuantity = product.stockQuantity
+        self.backordersSetting = product.backordersSetting
+        self.stockStatus = product.productStockStatus
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -107,7 +104,7 @@ private extension ProductInventorySettingsViewController {
 //
 private extension ProductInventorySettingsViewController {
     @objc func completeUpdating() {
-        // TODO-1424: update shipping settings
+        // TODO-1424: update inventory settings
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Networking
 import Yosemite
 
 final class ProductInventorySettingsViewController: UIViewController {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -111,11 +111,11 @@ private extension ProductInventorySettingsViewController {
 // MARK: - Input changes handling
 //
 private extension ProductInventorySettingsViewController {
-    func handleSKUChange(sku: String?) {
+    func handleSKUChange(_ sku: String?) {
         self.sku = sku
     }
 
-    func handleStockQuantityChange(stockQuantity: String?) {
+    func handleStockQuantityChange(_ stockQuantity: String?) {
         guard let stockQuantity = stockQuantity else {
             return
         }
@@ -203,7 +203,7 @@ private extension ProductInventorySettingsViewController {
 
     func configureSKU(cell: UnitInputTableViewCell) {
         let viewModel = Product.createSKUViewModel(sku: sku) { [weak self] value in
-            self?.handleSKUChange(sku: value)
+            self?.handleSKUChange(value)
         }
         cell.configure(viewModel: viewModel)
     }
@@ -229,7 +229,7 @@ private extension ProductInventorySettingsViewController {
 
     func configureStockQuantity(cell: UnitInputTableViewCell) {
         let viewModel = Product.createStockQuantityViewModel(stockQuantity: stockQuantity) { [weak self] value in
-            self?.handleStockQuantityChange(stockQuantity: value)
+            self?.handleStockQuantityChange(value)
         }
         cell.configure(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -162,7 +162,7 @@ extension ProductInventorySettingsViewController: UITableViewDelegate {
             }
             navigationController?.pushViewController(listSelectorViewController, animated: true)
         case .backorders:
-            let title = NSLocalizedString("Allow backorders?", comment: "Product backorders setting list selector navigation title")
+            let title = NSLocalizedString("Backorders", comment: "Product backorders setting list selector navigation title")
             let viewProperties = ListSelectorViewProperties(navigationBarTitle: title)
             let dataSource = ProductBackordersSettingListSelectorDataSource(selected: backordersSetting)
             let listSelectorViewController = ListSelectorViewController(viewProperties: viewProperties,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductInventorySettingsViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="ve6-T3-4xp" id="say-7k-jZf"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="ve6-T3-4xp">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="ve6-T3-4xp" secondAttribute="trailing" id="dzk-Sr-7eF"/>
+                <constraint firstItem="ve6-T3-4xp" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="goy-iA-65I"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="ve6-T3-4xp" secondAttribute="bottom" id="p1P-sl-pmM"/>
+                <constraint firstItem="ve6-T3-4xp" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="uhw-zT-fGm"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="139" y="89"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductBackordersSettingListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductBackordersSettingListSelectorDataSource.swift
@@ -1,0 +1,31 @@
+import UIKit
+import Networking
+import Yosemite
+
+/// `ListSelectorDataSource` for selecting a Product Backorders Setting.
+///
+struct ProductBackordersSettingListSelectorDataSource: ListSelectorDataSource {
+    typealias Model = ProductBackordersSetting
+    typealias Cell = BasicTableViewCell
+
+    let data: [ProductBackordersSetting] = [
+        .notAllowed,
+        .allowedAndNotifyCustomer,
+        .allowed
+    ]
+
+    var selected: ProductBackordersSetting?
+
+    init(selected: ProductBackordersSetting?) {
+        self.selected = selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: ProductBackordersSetting) {
+        cell.selectionStyle = .default
+        cell.textLabel?.text = model.description
+    }
+
+    mutating func handleSelectedChange(selected: ProductBackordersSetting) {
+        self.selected = selected
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductBackordersSettingListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductBackordersSettingListSelectorDataSource.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Networking
 import Yosemite
 
 /// `ListSelectorDataSource` for selecting a Product Backorders Setting.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductStockStatusListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductStockStatusListSelectorDataSource.swift
@@ -15,8 +15,8 @@ struct ProductStockStatusListSelectorDataSource: ListSelectorDataSource {
 
     var selected: ProductStockStatus?
 
-    init(product: Product) {
-        selected = product.productStockStatus
+    init(selected: ProductStockStatus?) {
+        self.selected = selected
     }
 
     func configureCell(cell: BasicTableViewCell, model: ProductStockStatus) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -47,6 +47,7 @@ final class ProductFormViewController: UIViewController {
 private extension ProductFormViewController {
     func configureNavigationBar() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(updateProduct))
+        removeNavigationBackBarButtonText()
     }
 
     func configureTableView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -123,8 +123,7 @@ extension ProductFormViewController: UITableViewDelegate {
                 // TODO-1423: Price Settings
                 return
             case .inventory:
-                // TODO-1424: Inventory Settings
-                return
+                editInventorySettings()
             }
         }
     }
@@ -202,6 +201,15 @@ private extension ProductFormViewController {
     func editShippingSettings() {
         let shippingSettingsViewController = ProductShippingSettingsViewController(product: product)
         navigationController?.pushViewController(shippingSettingsViewController, animated: true)
+    }
+}
+
+// MARK: Action - Edit Product Inventory Settings
+//
+private extension ProductFormViewController {
+    func editInventorySettings() {
+        let inventorySettingsViewController = ProductInventorySettingsViewController(product: product)
+        navigationController?.pushViewController(inventorySettingsViewController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -9,6 +9,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  keyboardType: .decimalPad,
                                   inputFormatter: DecimalInputFormatter(),
                                   onInputChange: onInputChange)
     }
@@ -20,6 +21,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: dimensions.length.isEmpty ? "0": dimensions.length,
+                                  keyboardType: .decimalPad,
                                   inputFormatter: DecimalInputFormatter(),
                                   onInputChange: onInputChange)
     }
@@ -31,6 +33,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: dimensions.width.isEmpty ? "0": dimensions.width,
+                                  keyboardType: .decimalPad,
                                   inputFormatter: DecimalInputFormatter(),
                                   onInputChange: onInputChange)
     }
@@ -42,6 +45,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: dimensions.height.isEmpty ? "0": dimensions.height,
+                                  keyboardType: .decimalPad,
                                   inputFormatter: DecimalInputFormatter(),
                                   onInputChange: onInputChange)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -4,6 +4,7 @@ struct UnitInputViewModel {
     let title: String
     let unit: String
     let value: String?
+    let keyboardType: UIKeyboardType
     let inputFormatter: UnitInputFormatter
     let onInputChange: ((_ input: String?) -> Void)?
 }
@@ -32,7 +33,9 @@ final class UnitInputTableViewCell: UITableViewCell {
     func configure(viewModel: UnitInputViewModel) {
         titleLabel.text = viewModel.title
         unitLabel.text = viewModel.unit
+        unitLabel.isHidden = viewModel.unit.isEmpty
         inputTextField.text = viewModel.value
+        inputTextField.keyboardType = viewModel.keyboardType
         inputFormatter = viewModel.inputFormatter
         onInputChange = viewModel.onInputChange
     }
@@ -59,7 +62,6 @@ private extension UnitInputTableViewCell {
             inputTextField.textAlignment = .right
             // swiftlint:enable:next inverse_text_alignment
         }
-        inputTextField.keyboardType = .decimalPad
         inputTextField.delegate = self
         inputTextField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */; };
 		021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift */; };
 		021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */; };
+		021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift */; };
 		021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */; };
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
 		02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */; };
@@ -590,6 +591,7 @@
 		021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+InventorySettingsViewModels.swift"; sourceTree = "<group>"; };
 		021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorDataSource.swift; sourceTree = "<group>"; };
 		021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringInputFormatter.swift; sourceTree = "<group>"; };
+		021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
 		021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxisTests.swift"; sourceTree = "<group>"; };
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
 		02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecUnorderedListFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -1385,6 +1387,7 @@
 			children = (
 				0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift */,
 				02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */,
+				021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift */,
 			);
 			path = ListSelector;
 			sourceTree = "<group>";
@@ -3307,6 +3310,7 @@
 				CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */,
 				02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */,
 				B555531121B57E6F00449E71 /* MockupApplicationAdapter.swift in Sources */,
+				021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -37,6 +37,11 @@
 		02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02162728237965E8000208D2 /* ProductFormTableViewModel.swift */; };
 		0216272B2379662C000208D2 /* DefaultProductFormTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */; };
 		0219B03723964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */; };
+		021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */; };
+		021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */; };
+		021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */; };
+		021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift */; };
+		021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */; };
 		021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */; };
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
 		02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */; };
@@ -580,6 +585,11 @@
 		02162728237965E8000208D2 /* ProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModel.swift; sourceTree = "<group>"; };
 		0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSource.swift; sourceTree = "<group>"; };
+		021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewController.swift; sourceTree = "<group>"; };
+		021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductInventorySettingsViewController.xib; sourceTree = "<group>"; };
+		021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+InventorySettingsViewModels.swift"; sourceTree = "<group>"; };
+		021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorDataSource.swift; sourceTree = "<group>"; };
+		021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringInputFormatter.swift; sourceTree = "<group>"; };
 		021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxisTests.swift"; sourceTree = "<group>"; };
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
 		02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecUnorderedListFormatBarCommand.swift; sourceTree = "<group>"; };
@@ -1150,6 +1160,7 @@
 			isa = PBXGroup;
 			children = (
 				02F4F50C237AFBB700E13A9C /* Cells */,
+				021E2A1223A9FBF200B1DE07 /* Inventory Settings */,
 				02E262CA238D0D0500B79588 /* List Selector Data Source */,
 				0262DA5523A23AA40029AF30 /* Shipping Settings */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
@@ -1162,6 +1173,16 @@
 				02784A04238BA85500BDD6A8 /* UIImage+ProductForm.swift */,
 			);
 			path = "Edit Product";
+			sourceTree = "<group>";
+		};
+		021E2A1223A9FBF200B1DE07 /* Inventory Settings */ = {
+			isa = PBXGroup;
+			children = (
+				021E2A1523A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift */,
+				021E2A1623A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib */,
+				021E2A1923AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift */,
+			);
+			path = "Inventory Settings";
 			sourceTree = "<group>";
 		};
 		0227958E237A5D5200787C63 /* Editor */ = {
@@ -1373,6 +1394,7 @@
 			children = (
 				02913E9423A774C500707A0C /* UnitInputFormatter.swift */,
 				02913E9623A774E600707A0C /* DecimalInputFormatter.swift */,
+				021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */,
 			);
 			path = UnitInputFormatter;
 			sourceTree = "<group>";
@@ -1440,6 +1462,7 @@
 			children = (
 				02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorDataSource.swift */,
 				0219B03623964527007DCD5E /* PaginatedProductShippingClassListSelectorDataSource.swift */,
+				021E2A1B23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift */,
 			);
 			path = "List Selector Data Source";
 			sourceTree = "<group>";
@@ -2721,6 +2744,7 @@
 				B5FD110E21D3CB8500560344 /* OrderTableViewCell.xib in Resources */,
 				D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */,
 				B59D1EE121907304009D1978 /* ProductReviewTableViewCell.xib in Resources */,
+				021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */,
 				0290E270238E3CE400B5C466 /* ListSelectorViewController.xib in Resources */,
 				B59D1EE821908A08009D1978 /* Noticons.ttf in Resources */,
 				D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */,
@@ -2986,6 +3010,7 @@
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
+				021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */,
 				02E4FD7A230688BA0049610C /* OrderStatsV4Interval+Chart.swift in Sources */,
 				0262DA5823A23AC80029AF30 /* ProductShippingSettingsViewController.swift in Sources */,
 				748C7782211E294000814F2C /* Double+Woo.swift in Sources */,
@@ -3023,6 +3048,7 @@
 				747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */,
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,
+				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */,
 				02F4F50B237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift in Sources */,
 				B57C5C9621B80E5500FF82B2 /* Dictionary+Woo.swift in Sources */,
@@ -3036,6 +3062,7 @@
 				CE1EC8F120B8A408009762BF /* OrderNoteTableViewCell.swift in Sources */,
 				D8C11A5E22E2440400D4A88D /* OrderPaymentDetailsViewModel.swift in Sources */,
 				0282DD9A233CA32D006A5FDB /* OrderSearchCellViewModel.swift in Sources */,
+				021E2A1E23AA24C600B1DE07 /* StringInputFormatter.swift in Sources */,
 				D8D15F83230A17A000D48B3F /* ServiceLocator.swift in Sources */,
 				CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */,
 				02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */,
@@ -3146,6 +3173,7 @@
 				CE1F51272064345B00C6C810 /* UIColor+Helpers.swift in Sources */,
 				934CB123224EAB150005CCB9 /* main.swift in Sources */,
 				02F4F50F237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.swift in Sources */,
+				021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,
 				7493BB8E2149852A003071A9 /* TopPerformersHeaderView.swift in Sources */,
 				D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -9,6 +9,7 @@ final class MockProduct {
 
     func product(name: String = "Hogsmeade",
                  productShippingClass: ProductShippingClass? = nil,
+                 backordersSetting: ProductBackordersSetting = .notAllowed,
                  stockQuantity: Int? = nil,
                  stockStatus: ProductStockStatus = .inStock,
                  variations: [Int] = [],
@@ -52,7 +53,7 @@ final class MockProduct {
                    manageStock: false,
                    stockQuantity: stockQuantity,
                    stockStatusKey: stockStatus.rawValue,
-                   backordersKey: "no",
+                   backordersKey: backordersSetting.rawValue,
                    backordersAllowed: false,
                    backordered: false,
                    soldIndividually: true,

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductBackordersSettingListSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductBackordersSettingListSelectorDataSourceTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import Networking
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ProductBackordersSettingListSelectorDataSourceTests: XCTestCase {
+
+    func testSelectedSetting() {
+        let expectedSetting = ProductBackordersSetting.notAllowed
+        let product = MockProduct().product(backordersSetting: expectedSetting)
+        var dataSource = ProductBackordersSettingListSelectorDataSource(selected: product.backordersSetting)
+        XCTAssertEqual(dataSource.selected, expectedSetting)
+
+        let newSetting = ProductBackordersSetting.allowedAndNotifyCustomer
+        dataSource.handleSelectedChange(selected: newSetting)
+        XCTAssertEqual(dataSource.selected, newSetting)
+    }
+
+    func testSettingListData() {
+        let dataSource = ProductBackordersSettingListSelectorDataSource(selected: nil)
+        XCTAssertEqual(dataSource.data.count, 3)
+    }
+
+    func testCellConfiguration() {
+        let product = MockProduct().product()
+        let dataSource = ProductBackordersSettingListSelectorDataSource(selected: product.backordersSetting)
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        dataSource.configureCell(cell: cell, model: product.backordersSetting)
+
+        XCTAssertEqual(cell.textLabel?.text, product.backordersSetting.description)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductBackordersSettingListSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductBackordersSettingListSelectorDataSourceTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 
-@testable import Networking
 @testable import WooCommerce
 @testable import Yosemite
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductStockStatusListSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductStockStatusListSelectorDataSourceTests.swift
@@ -8,7 +8,7 @@ final class ProductStockStatusListSelectorDataSourceTests: XCTestCase {
     func testSelectedStatus() {
         let expectedStockStatus = ProductStockStatus.outOfStock
         let product = MockProduct().product(stockStatus: expectedStockStatus)
-        var dataSource = ProductStockStatusListSelectorDataSource(product: product)
+        var dataSource = ProductStockStatusListSelectorDataSource(selected: product.productStockStatus)
         XCTAssertEqual(dataSource.selected, expectedStockStatus)
 
         let newStockStatus = ProductStockStatus.inStock
@@ -18,13 +18,13 @@ final class ProductStockStatusListSelectorDataSourceTests: XCTestCase {
 
     func testStockStatusListData() {
         let product = MockProduct().product()
-        let dataSource = ProductStockStatusListSelectorDataSource(product: product)
+        let dataSource = ProductStockStatusListSelectorDataSource(selected: product.productStockStatus)
         XCTAssertEqual(dataSource.data.count, 3)
     }
 
     func testCellConfiguration() {
         let product = MockProduct().product()
-        let dataSource = ProductStockStatusListSelectorDataSource(product: product)
+        let dataSource = ProductStockStatusListSelectorDataSource(selected: product.productStockStatus)
         let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
         guard let cell = nib?.first as? BasicTableViewCell else {
             XCTFail()

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -36,6 +36,7 @@ public typealias OrderStatsV4Interval = Networking.OrderStatsV4Interval
 public typealias OrderStatsV4Totals = Networking.OrderStatsV4Totals
 public typealias OrderStatus = Networking.OrderStatus
 public typealias Product = Networking.Product
+public typealias ProductBackordersSetting = Networking.ProductBackordersSetting
 public typealias ProductReview = Networking.ProductReview
 public typealias ProductReviewStatus = Networking.ProductReviewStatus
 public typealias ProductShippingClass = Networking.ProductShippingClass


### PR DESCRIPTION
UI part for #1424 

## Summary

This PR implements the UI for the Product Inventory Settings without the remote update functionality (the next task).

## Changes

- Created a new enum `ProductBackordersSetting` based on `Product`'s `backordersKey` as the raw value. Added a calculated property `backordersSetting: ProductBackordersSetting` for `Product`
- Added `StringInputFormatter: UnitInputFormatter` for temporary SKU input view model
- Created 2 functions for `Product` extension to create view models for SKU and stock quantity
- Created `ProductBackordersSettingListSelectorDataSource` for backorders setting list selector + basic unit tests
- Created `ProductInventorySettingsViewController` with a table view that shows 3 sections of inventory settings. Implemented cell did select actions
- Added `keyboardType: UIKeyboardType` to `UnitInputViewModel` and hid the unit label if empty

## Testing

Prerequisite: at least 2 Products, one with Manage Stock enabled and the other disabled

- Launch the app
- Go to the Products tab
- Tap on a Product
- Tap "Edit" in the navigation bar
- Tap the inventory settings row --> should see 3 sections of data: SKU, Manage Stock and its corresponding fields when it's enabled/disabled, and whether a Product can only be sold once per order
- Toggle the "Manage Stock" switch --> the fields should change
- Repeat the above for Products with Manage Stock enabled and disabled

## Example screenshots

@kyleaparker I'm not sure about the navigation bar title of the Backorders allowed selector screen, I used what's on wp-admin for the first pass

manage stock disabled | manage stock enabled | stock status selector | backorders selector
-- | -- | -- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-18 at 17 59 40](https://user-images.githubusercontent.com/1945542/71076529-d89fa500-21c0-11ea-8643-77f08611355a.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-18 at 18 05 19](https://user-images.githubusercontent.com/1945542/71076611-fa992780-21c0-11ea-981f-1ed0f2b8f342.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-18 at 18 00 10](https://user-images.githubusercontent.com/1945542/71076531-d9383b80-21c0-11ea-8b02-4cc5a9e856be.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-18 at 18 03 13](https://user-images.githubusercontent.com/1945542/71076532-d9383b80-21c0-11ea-812e-55f7631117a3.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
