### PR TITLE
Product update error handling (SKU for now)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -87,6 +87,7 @@ private extension ProductFormViewController {
             guard let product = product, error == nil else {
                 let errorDescription = error?.localizedDescription ?? "No error specified"
                 DDLogError("⛔️ Error updating Product: \(errorDescription)")
+                self?.displayError(error: error)
                 return
             }
             self?.product = product
@@ -95,6 +96,34 @@ private extension ProductFormViewController {
             self?.dismiss(animated: true)
         }
         ServiceLocator.stores.dispatch(action)
+    }
+
+    func displayError(error: ProductUpdateError?) {
+        let title = NSLocalizedString("Cannot update Product", comment: "The title of the alert when there is an error updating the product")
+
+        let message: String?
+        switch error {
+        case .invalidSKU:
+            message = NSLocalizedString("The SKU is used for another product or invalid. Please check the inventory settings.",
+                                        comment: "The message of the alert when there is an error updating the product SKU")
+        default:
+            message = nil
+        }
+
+        displayErrorAlert(title: title, message: message)
+    }
+
+    func displayErrorAlert(title: String?, message: String?) {
+        let alert = UIAlertController(title: title,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let cancel = UIAlertAction(title: NSLocalizedString(
+            "OK",
+            comment: "Dismiss button on the alert when there is an error updating the product"
+        ), style: .cancel, handler: nil)
+        alert.addAction(cancel)
+
+        present(alert, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -104,7 +104,7 @@ private extension ProductFormViewController {
         let message: String?
         switch error {
         case .invalidSKU:
-            message = NSLocalizedString("The SKU is used for another product or invalid. Please check the inventory settings.",
+            message = NSLocalizedString("The SKU is used for another product or is invalid. Please check the inventory settings.",
                                         comment: "The message of the alert when there is an error updating the product SKU")
         default:
             message = nil

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -32,5 +32,5 @@ public enum ProductAction: Action {
 
     /// Updates a specified Product.
     ///
-    case updateProduct(product: Product, onCompletion: (Product?, Error?) -> Void)
+    case updateProduct(product: Product, onCompletion: (Product?, ProductUpdateError?) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -478,7 +478,7 @@ public extension ProductStore {
 
 /// An error that occurs while updating a Product.
 ///
-/// - invalidSKU: the user has no permission to view site stats.
+/// - invalidSKU: the SKU is invalid or duplicated.
 /// - unknown: other error cases.
 ///
 public enum ProductUpdateError: Error {

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -176,12 +176,12 @@ private extension ProductStore {
 
     /// Updates the product.
     ///
-    func updateProduct(product: Product, onCompletion: @escaping (Product?, Error?) -> Void) {
+    func updateProduct(product: Product, onCompletion: @escaping (Product?, ProductUpdateError?) -> Void) {
         let remote = ProductsRemote(network: network)
 
         remote.updateProduct(product: product) { [weak self] (product, error) in
             guard let product = product else {
-                onCompletion(nil, error)
+                onCompletion(nil, error.map({ ProductUpdateError(error: $0) }))
                 return
             }
 
@@ -473,5 +473,43 @@ public extension ProductStore {
 
     enum Constants {
         public static let firstPageNumber: Int = ProductsRemote.Default.pageNumber
+    }
+}
+
+/// An error that occurs while updating a Product.
+///
+/// - invalidSKU: the user has no permission to view site stats.
+/// - unknown: other error cases.
+///
+public enum ProductUpdateError: Error {
+    case invalidSKU
+    case unknown
+
+    init(error: Error) {
+        guard let dotcomError = error as? DotcomError else {
+            self = .unknown
+            return
+        }
+        switch dotcomError {
+        case .unknown(let code, _):
+            guard let errorCode = ErrorCode(rawValue: code) else {
+                self = .unknown
+                return
+            }
+            self = errorCode.error
+        default:
+            self = .unknown
+        }
+    }
+
+    private enum ErrorCode: String {
+        case invalidSKU = "product_invalid_sku"
+
+        var error: ProductUpdateError {
+            switch self {
+            case .invalidSKU:
+                return .invalidSKU
+            }
+        }
     }
 }


### PR DESCRIPTION
Error handling for #1424 

## Summary

When the user tries updating the Product SKU to an existing SKU or an invalid format (determined by the backend), the update fails with an error. This PR processes the error and displays an alert about the SKU error to the user

## Changes

- Created a `ProductUpdateError` enum that corresponds to the error while updating a Product based on the dotcom error code. Passed this error in `ProductStore`'s `updateProduct` action
  - Right now SKU is the only error returned by the server that I can think of. As we encounter more error types, we can add them to the enum
- In `ProductFormViewController`, displayed an alert based on `ProductUpdateError`

## Testing

Not available yet until the inventory settings are on `develop`, just the screenshots and CI for now

## Example screenshots

Note: I came up with the copy myself (not a copy expert for sure), please lemme know if there's a better messaging!

<img src="https://user-images.githubusercontent.com/1945542/71183945-d9fdca00-22b3-11ea-98a0-b5b1d107009f.png" width=320/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
