### PR TITLE
Order Details: fix product quantity title in the 2-column header view isn't aligning to the trailing edge

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+3.4
+-----
+- bugfix: on the Order Details screen, the product quantity title in the 2-column header view aligns to the right now
+
 3.3
 -----
 - bugfix: add some padding to an order item image in the Fulfillment view, when no SKU exists

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -25,7 +23,7 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nAe-82-c1s">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nAe-82-c1s">
                             <rect key="frame" x="310" y="0.0" width="33" height="28"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                             <nil key="textColor"/>


### PR DESCRIPTION
Fixes #1647 

## Cause of the issue

In release 3.3, we added multiline support to the right column label in https://github.com/woocommerce/woocommerce-ios/commit/ee05079abbea76f7163099420a9027ae31de62ca#diff-84d8ec864e2cbd59a2a0be78e3263aab. Without clear documentation from Apple, setting `numberOfLines = 0` to a label also changes its intrinsic width so that the label takes half of the stack view width as a side effect

## Changes

- Updated the horizontal content hugging priority of the right column label from 251 to 1000 (`required`) so that the right column has its width that fits the content

## Testing

- Launch the app
- Go to Orders tab
- Tap on an Order --> the "QTY" label in the product list section header should align to the trailing edge, on portrait or landscape

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-19 at 23 49 52](https://user-images.githubusercontent.com/1945542/71187564-42e84080-22ba-11ea-814e-7e33404bf1f1.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-19 at 23 33 34](https://user-images.githubusercontent.com/1945542/71187562-424faa00-22ba-11ea-8df8-a7259f1ec4cc.png)



Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
