### PR TITLE
Remove Xcode warnings

### DIFF
--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 24.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 24.xcdatamodel/contents
@@ -480,7 +480,7 @@
         <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats"/>
     </entity>
-    <entity name="TaxClass" representedClassName="TaxClass" syncable="YES" codeGenerationType="class">
+    <entity name="TaxClass" representedClassName="TaxClass" syncable="YES">
         <attribute name="name" attributeType="String"/>
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="slug" attributeType="String"/>


### PR DESCRIPTION
I forgot to mention a "gotcha" in Core Data. Mea Culpa.

<img width="381" alt="Screen Shot 2019-12-19 at 2 27 17 PM" src="https://user-images.githubusercontent.com/1062444/71213778-17456600-227a-11ea-85c3-b9eda9bc290f.png">

ref: p99K0U-2hm-p2 to prevent this from happening in the future

### To test
Check out and run this branch. Xcode should no longer show the 3 warnings about Copy Bundle Resources.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
