### PR TITLE
Dark Mode: color updates for Fulfill Order, Review Details, Stats chart lines, Nav/Tab Bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 3.4
 -----
 - bugfix: on the Order Details screen, the product quantity title in the 2-column header view aligns to the right now
+- Dark mode: colors are updated up to design for the navigation bar, tab bar, Fulfill Order > add tracking icon, Review Details > product link icon.
 
 3.3
 -----

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -8,7 +8,7 @@ extension UITabBar {
     ///
     class func applyWooAppearance() {
         let appearance = Self.appearance()
-        appearance.barTintColor = .basicBackground
+        appearance.barTintColor = .appTabBar
         appearance.tintColor = .text
     }
 }

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -158,7 +158,7 @@ extension UIColor {
         return .white
     }
 
-    /// App Bar. WooCommercePurple-60 (< iOS 13 and Light Mode) and `UIColor.systemThickMaterial` (Dark Mode)
+    /// App Navigation Bar. WooCommercePurple-60 (< iOS 13 and Light Mode) and `UIColor.systemThickMaterial` (Dark Mode)
     ///
     static var appBar: UIColor {
         if #available(iOS 13, *) {
@@ -168,6 +168,13 @@ extension UIColor {
 
 
         return .withColorStudio(.wooCommercePurple, shade: .shade60)
+    }
+
+    /// App Tab Bar.
+    ///
+    static var appTabBar: UIColor {
+        return UIColor(light: .basicBackground,
+        dark: .systemColor(.secondarySystemGroupedBackground))
     }
 
     /// Tab Unselected. Gray-20 (< iOS 13 and Light Mode) and Gray-60 (Dark Mode)

--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -163,7 +163,7 @@ extension UIColor {
     static var appBar: UIColor {
         if #available(iOS 13, *) {
             return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60),
-                           dark: .systemBackground)
+                           dark: .systemColor(.secondarySystemGroupedBackground))
         }
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/PeriodDataViewController.swift
@@ -280,8 +280,8 @@ private extension PeriodDataViewController {
         xAxis.setLabelCount(2, force: true)
         xAxis.labelFont = StyleManager.chartLabelFont
         xAxis.labelTextColor = .textSubtle
-        xAxis.axisLineColor = .listSmallIcon
-        xAxis.gridColor = .listSmallIcon
+        xAxis.axisLineColor = .systemColor(.separator)
+        xAxis.gridColor = .systemColor(.separator)
         xAxis.drawLabelsEnabled = true
         xAxis.drawGridLinesEnabled = false
         xAxis.drawAxisLineEnabled = false
@@ -292,9 +292,9 @@ private extension PeriodDataViewController {
         let yAxis = barChartView.leftAxis
         yAxis.labelFont = StyleManager.chartLabelFont
         yAxis.labelTextColor = .textSubtle
-        yAxis.axisLineColor = .listSmallIcon
-        yAxis.gridColor = .listSmallIcon
-        yAxis.zeroLineColor = .listSmallIcon
+        yAxis.axisLineColor = .systemColor(.separator)
+        yAxis.gridColor = .systemColor(.separator)
+        yAxis.zeroLineColor = .systemColor(.separator)
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
         yAxis.drawAxisLineEnabled = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -143,7 +143,7 @@ private extension TopPerformerDataViewController {
 
     func configureTableView() {
         tableView.backgroundColor = .basicBackground
-        tableView.separatorColor = .divider
+        tableView.separatorColor = .systemColor(.separator)
         tableView.allowsSelection = false
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -150,7 +150,7 @@ private extension TopPerformersViewController {
     func configureView() {
         view.backgroundColor = .listBackground
         topBorder.backgroundColor = .systemColor(.separator)
-        middleBorder.backgroundColor = .divider
+        middleBorder.backgroundColor = .systemColor(.separator)
         buttonBarView.backgroundColor = .listForeground
         headingLabel.applyFootnoteStyle()
         headingLabel.textColor = .listIcon

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -319,8 +319,8 @@ private extension StoreStatsV4PeriodViewController {
         xAxis.labelPosition = .bottom
         xAxis.labelFont = StyleManager.chartLabelFont
         xAxis.labelTextColor = .textSubtle
-        xAxis.axisLineColor = .listSmallIcon
-        xAxis.gridColor = .listSmallIcon
+        xAxis.axisLineColor = .systemColor(.separator)
+        xAxis.gridColor = .systemColor(.separator)
         xAxis.drawLabelsEnabled = true
         xAxis.drawGridLinesEnabled = false
         xAxis.drawAxisLineEnabled = false
@@ -332,9 +332,9 @@ private extension StoreStatsV4PeriodViewController {
         let yAxis = barChartView.leftAxis
         yAxis.labelFont = StyleManager.chartLabelFont
         yAxis.labelTextColor = .textSubtle
-        yAxis.axisLineColor = .listSmallIcon
-        yAxis.gridColor = .listSmallIcon
-        yAxis.zeroLineColor = .listSmallIcon
+        yAxis.axisLineColor = .systemColor(.separator)
+        yAxis.gridColor = .systemColor(.separator)
+        yAxis.zeroLineColor = .systemColor(.separator)
         yAxis.drawLabelsEnabled = true
         yAxis.drawGridLinesEnabled = true
         yAxis.drawAxisLineEnabled = false

--- a/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/Cells/NoteDetailsHeaderPlainTableViewCell.swift
@@ -69,7 +69,7 @@ private extension NoteDetailsHeaderPlainTableViewCell {
     ///
     func configureImages() {
         imageView?.tintColor = .textSubtle
-        accessoryImageView.tintColor = .primary
+        accessoryImageView.tintColor = .accent
         accessoryView = accessoryImageView
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -430,6 +430,7 @@ private extension FulfillViewController {
 
         let cellTextContent = NSLocalizedString("Add Tracking", comment: "Add Tracking row label")
         cell.leftImage = .addOutlineImage
+        cell.imageView?.tintColor = .accent
         cell.labelText = cellTextContent
 
         cell.isAccessibilityElement = true


### PR DESCRIPTION
Orders, General, Reviews, Stats for #1638 

## Changes

- Stats/Dashboard ("My store" tab): updated all chart and top performers separator colors to `systemColor(.secondarySystemGroupedBackground)`
- Reviews > Review Details: updated the color to `accent` in `NoteDetailsHeaderPlainTableViewCell`
- Orders > Fulfill Order: updated the color of "Add Tracking" icon to `accent`
- Navigation bar tint color: updated the bar color in Dark mode to `systemColor(.secondarySystemGroupedBackground)`

## Testing

Prerequisite: the store has the shipment tracking extension

- Launch the app
- Go to all 4 tabs --> the navigation and tab bar color should look as expected
- Go to Orders tab
- Tap on an Order with status processing
- Tap "Begin fulfillment" --> the "Add Tracking" icon should have the expected color
- Go to Reviews tab
- Tap on a Review --> the Product icon link icon at the top should have the expected color

## Example screenshots

Screen | Dark | Light
-- | -- | --
Fulfill Order > Add Tracking icon | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 26](https://user-images.githubusercontent.com/1945542/71393250-cac9a400-2646-11ea-862d-bfac86ef980e.png) | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 13 02](https://user-images.githubusercontent.com/1945542/71393254-cac9a400-2646-11ea-9b44-1147c6a1a7d6.png)
Reviews > Product link icon | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 37](https://user-images.githubusercontent.com/1945542/71393253-cac9a400-2646-11ea-8643-72e52f1a2be0.png) | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 13 07](https://user-images.githubusercontent.com/1945542/71393256-cb623a80-2646-11ea-8e45-3e5a032fe2fd.png)


### Navigation bar / tab bar

@kyleaparker I checked how WPiOS set up the navigation bar color, and they just used a muriel gray color shade 100. I checked the design and it looks like the navigation bar has the same color as the stats background `secondarySystemGroupedBackground`, which is what I used for this PR

Screen | Dark | Light
-- | -- | --
My store | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 05](https://user-images.githubusercontent.com/1945542/71393265-d4530c00-2646-11ea-81ab-02e02fc0a9f3.png) | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 48](https://user-images.githubusercontent.com/1945542/71393270-d4eba280-2646-11ea-84fa-ee9f07326339.png)
Orders | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 07](https://user-images.githubusercontent.com/1945542/71393266-d4530c00-2646-11ea-963b-2fa1a5debefd.png) | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 52](https://user-images.githubusercontent.com/1945542/71393273-d5843900-2646-11ea-9f12-c3f46daa3dfe.png)
Products | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 10](https://user-images.githubusercontent.com/1945542/71393267-d4eba280-2646-11ea-957e-763f4a5aad1d.png) | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 54](https://user-images.githubusercontent.com/1945542/71393274-d5843900-2646-11ea-91c2-c297290beb01.png)
Reviews | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 12](https://user-images.githubusercontent.com/1945542/71393268-d4eba280-2646-11ea-916c-ff480e7bac52.png) | ![Simulator Screen Shot - iPhone 11 - 2019-12-24 at 12 12 56](https://user-images.githubusercontent.com/1945542/71393275-d5843900-2646-11ea-9cef-24bb220acc6e.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
