### PR TITLE
Paginated List: show placeholder state when fetching for the first page of data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -157,7 +157,7 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
     // MARK: SyncingCoordinatorDelegate
     //
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
-        transitionToSyncingState()
+        transitionToSyncingState(pageNumber: pageNumber)
         dataSource.sync(pageNumber: pageNumber, pageSize: pageSize) { [weak self] isCompleted in
             guard let self = self else {
                 return
@@ -228,11 +228,11 @@ private extension PaginatedListSelectorViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
-        case .syncing(let withExistingData):
-            if withExistingData {
-                ensureFooterSpinnerIsStarted()
-            } else {
+        case .syncing(let pageNumber):
+            if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
                 displayPlaceholderProducts()
+            } else {
+                ensureFooterSpinnerIsStarted()
             }
         case .results:
             break
@@ -251,8 +251,8 @@ private extension PaginatedListSelectorViewController {
         }
     }
 
-    func transitionToSyncingState() {
-        stateCoordinator.transitionToSyncingState(withExistingData: !isEmpty)
+    func transitionToSyncingState(pageNumber: Int) {
+        stateCoordinator.transitionToSyncingState(pageNumber: pageNumber)
     }
 
     func transitionToResultsUpdatedState() {

--- a/WooCommerce/Classes/ViewRelated/Products/PaginatedListViewControllerStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PaginatedListViewControllerStateCoordinator.swift
@@ -7,7 +7,7 @@ import UIKit
 /// - results: the results are shown
 enum PaginatedListViewControllerState {
     case noResultsPlaceholder
-    case syncing(withExistingData: Bool)
+    case syncing(pageNumber: Int)
     case results
 }
 
@@ -53,11 +53,10 @@ final class PaginatedListViewControllerStateCoordinator {
         }
     }
 
-    /// Should be called before Sync'ing. Transitions to either `results` or `placeholder` state, depending on whether if
-    /// we've got cached results, or not.
+    /// Should be called before Sync'ing.
     ///
-    func transitionToSyncingState(withExistingData: Bool) {
-        state = .syncing(withExistingData: withExistingData)
+    func transitionToSyncingState(pageNumber: Int) {
+        state = .syncing(pageNumber: pageNumber)
     }
 
     /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -466,12 +466,8 @@ private extension ProductsViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
-        case .syncing(let withExistingData):
-            if withExistingData {
-                ensureFooterSpinnerIsStarted()
-            } else {
-                displayPlaceholderProducts()
-            }
+        case .syncing:
+            displayPlaceholderProducts()
         case .results:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -140,6 +140,7 @@ private extension ProductsViewController {
         }
         updateResultsController(siteID: siteID)
         tableView.reloadData()
+        syncingCoordinator.resynchronize()
     }
 }
 
@@ -432,7 +433,7 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
             return
         }
 
-        transitionToSyncingState()
+        transitionToSyncingState(pageNumber: pageNumber)
 
         let action = ProductAction
             .synchronizeProducts(siteID: siteID,
@@ -466,8 +467,12 @@ private extension ProductsViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
-        case .syncing:
-            displayPlaceholderProducts()
+        case .syncing(let pageNumber):
+            if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
+                displayPlaceholderProducts()
+            } else {
+                ensureFooterSpinnerIsStarted()
+            }
         case .results:
             break
         }
@@ -485,8 +490,8 @@ private extension ProductsViewController {
         }
     }
 
-    func transitionToSyncingState() {
-        stateCoordinator.transitionToSyncingState(withExistingData: !isEmpty)
+    func transitionToSyncingState(pageNumber: Int) {
+        stateCoordinator.transitionToSyncingState(pageNumber: pageNumber)
     }
 
     func transitionToResultsUpdatedState() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -300,7 +300,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
     /// Synchronizes the Product Variations for the Default Store (if any).
     ///
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)? = nil) {
-        transitionToSyncingState()
+        transitionToSyncingState(pageNumber: pageNumber)
 
         let action = ProductVariationAction
             .synchronizeProductVariations(siteID: Int64(siteID), productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
@@ -333,11 +333,11 @@ private extension ProductVariationsViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
-        case .syncing(let withExistingData):
-            if withExistingData {
-                ensureFooterSpinnerIsStarted()
-            } else {
+        case .syncing(let pageNumber):
+            if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
                 displayPlaceholderProducts()
+            } else {
+                ensureFooterSpinnerIsStarted()
             }
         case .results:
             break
@@ -356,8 +356,8 @@ private extension ProductVariationsViewController {
         }
     }
 
-    func transitionToSyncingState() {
-        stateCoordinator.transitionToSyncingState(withExistingData: !isEmpty)
+    func transitionToSyncingState(pageNumber: Int) {
+        stateCoordinator.transitionToSyncingState(pageNumber: pageNumber)
     }
 
     func transitionToResultsUpdatedState() {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -195,6 +195,7 @@ extension ProductVariationsViewController: UITableViewDataSource {
                                                     currency: currency)
         cell.update(viewModel: viewModel)
         cell.selectionStyle = .none
+        cell.accessoryType = .none
 
         return cell
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/PaginatedListViewControllerStateCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/PaginatedListViewControllerStateCoordinatorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class PaginatedListViewControllerStateCoordinatorTests: XCTestCase {
 
     func testTransitioningToSyncingState() {
-        let hasExistingData = true
+        let pageNumber = 3
 
         let expectationForLeavingState = expectation(description: "Wait for leaving state")
         expectationForLeavingState.expectedFulfillmentCount = 1
@@ -17,12 +17,12 @@ final class PaginatedListViewControllerStateCoordinatorTests: XCTestCase {
         let expectationForEnteringState = expectation(description: "Wait for entering state")
         expectationForEnteringState.expectedFulfillmentCount = 1
         let onEnteringState = { (state: PaginatedListViewControllerState) in
-            XCTAssertEqual(state, .syncing(withExistingData: hasExistingData))
+            XCTAssertEqual(state, .syncing(pageNumber: pageNumber))
             expectationForEnteringState.fulfill()
         }
         let stateCoordinator = PaginatedListViewControllerStateCoordinator(onLeavingState: onLeavingState, onEnteringState: onEnteringState)
 
-        stateCoordinator.transitionToSyncingState(withExistingData: hasExistingData)
+        stateCoordinator.transitionToSyncingState(pageNumber: pageNumber)
         waitForExpectations(timeout: 0.1, handler: nil)
     }
 


### PR DESCRIPTION
Fixes #1634 
Fixes #1658 

## Changes

- Updated `PaginatedListViewControllerState`'s syncing case to take `pageNumber: Int` parameter instead of `withExistingData: Bool`
- In `PaginatedListSelectorViewController`, `ProductsViewController`, and `ProductVariationsViewController`:
  - Placeholder is displayed when syncing the first page of data (so that older data aren't visible and interactable)
  - Footer spinner is displayed when syncing beyond the first page
- This PR also fixed the disclosure indicator on the Product Variations screen

## Testing

Prerequisite:
- make sure some Products are available on the Products tab before launching the app
- the store has non-zero shipping classes
---
- Launch the app
- Go to the Products tab --> should see the placeholder flashing state, then the Product list becomes visible
- Tap on a Product with Variations
- Tap on the Variations row --> the Variations should start with the placeholder flashing state, then the Variation list becomes visible; each Variation row should not have a disclosure indicator
- Go back to the Products tab
- Tap on a simple Product
- Tap "Edit" in the navigation bar
- Tap on the shipping settings row
- Tap on the Shipping class row --> the Shipping Classes screen should start with the placeholder flashing state, then the shipping class list becomes visible

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
