### PR TITLE
Add unit tests for all Aztec format bar commands

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -24,6 +24,15 @@
 		0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */; };
 		0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */; };
 		0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */; };
+		020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76623B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift */; };
+		020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76823B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift */; };
+		020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76A23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift */; };
+		020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76C23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift */; };
+		020BE76F23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76E23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift */; };
+		020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77023B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift */; };
+		020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77223B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift */; };
+		020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77423B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift */; };
+		020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77623B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift */; };
 		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
 		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
 		020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */; };
@@ -578,6 +587,15 @@
 		0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsTabProductViewModel+ProductVariation.swift"; sourceTree = "<group>"; };
 		0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooTab+Tag.swift"; sourceTree = "<group>"; };
 		0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Order.swift"; sourceTree = "<group>"; };
+		020BE76623B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecBoldFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE76823B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecItalicFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE76A23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUnderlineFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE76C23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecStrikethroughFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE76E23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecBlockquoteFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE77023B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecHorizontalRulerFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE77223B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecInsertMoreFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE77423B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecSourceCodeFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020BE77623B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecLinkFormatBarCommandTests.swift; sourceTree = "<group>"; };
 		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
 		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
 		020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AppReview.swift"; sourceTree = "<group>"; };
@@ -1219,6 +1237,15 @@
 			children = (
 				0227958F237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift */,
 				02279593237A60FD00787C63 /* AztecHeaderFormatBarCommandTests.swift */,
+				020BE76623B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift */,
+				020BE76823B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift */,
+				020BE76A23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift */,
+				020BE76C23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift */,
+				020BE76E23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift */,
+				020BE77023B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift */,
+				020BE77223B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift */,
+				020BE77423B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift */,
+				020BE77623B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift */,
 			);
 			path = Command;
 			sourceTree = "<group>";
@@ -3338,10 +3365,13 @@
 				02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */,
 				B555531121B57E6F00449E71 /* MockupApplicationAdapter.swift in Sources */,
 				021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift in Sources */,
+				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,
 				D83A6A782379097A00419D48 /* MurielColorTests.swift in Sources */,
+				020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */,
+				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,
 				B53A569D21123EEB000776C9 /* MockupStorage.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
@@ -3353,6 +3383,7 @@
 				CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */,
 				02279594237A60FD00787C63 /* AztecHeaderFormatBarCommandTests.swift in Sources */,
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
+				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
 				0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */,
 				B509FED521C052D1000076A9 /* MockupSupportManager.swift in Sources */,
@@ -3364,6 +3395,7 @@
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
+				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,
 				02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */,
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
@@ -3378,6 +3410,7 @@
 				02404EE2231501E000FF1170 /* StatsVersionStateCoordinatorTests.swift in Sources */,
 				D83F5939225B424B00626E75 /* AddManualTrackingViewModelTests.swift in Sources */,
 				0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */,
+				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
 				D83F5937225B402E00626E75 /* EditableValueOneTableViewCellTests.swift in Sources */,
 				9379E1A6225537D0006A6BE4 /* TestingAppDelegate.swift in Sources */,
 				B56C721421B5BBC000E5E85B /* MockupStoresManager.swift in Sources */,
@@ -3385,12 +3418,15 @@
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
+				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,
 				CE50345A21B1F8F7007573C6 /* ZendeskManagerTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
+				020BE76F23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift in Sources */,
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
+				020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */,
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,
 				B53A56A22112470C000776C9 /* MockupStorage+Sample.swift in Sources */,
 				D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecBlockquoteFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecBlockquoteFormatBarCommandTests.swift
@@ -1,0 +1,42 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecBlockquoteFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecBlockquoteFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .blockquote)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecBlockquoteFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+        let formattedHTML = "<blockquote>test</blockquote>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        editorView.richTextView.selectedRange = NSRange(location: 0, length: editorView.richTextView.text.count)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), formattedHTML)
+
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecBoldFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecBoldFormatBarCommandTests.swift
@@ -1,0 +1,42 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecBoldFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecBoldFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .bold)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecBoldFormatBarCommand()
+
+        let text = "test"
+        let unboldedHTML = "<p>test</p>"
+        let boldedHTML = "<p><strong>test</strong></p>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        editorView.richTextView.selectedRange = NSRange(location: 0, length: editorView.richTextView.text.count)
+        XCTAssertEqual(editorView.getHTML(), unboldedHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), boldedHTML)
+
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), unboldedHTML)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecHorizontalRulerFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecHorizontalRulerFormatBarCommandTests.swift
@@ -1,0 +1,40 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecHorizontalRulerFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecHorizontalRulerFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .horizontalruler)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecHorizontalRulerFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+        let formattedHTML = """
+        <p>test
+          <hr>
+        </p>
+        """
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), formattedHTML)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecInsertMoreFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecInsertMoreFormatBarCommandTests.swift
@@ -1,0 +1,47 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecInsertMoreFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecInsertMoreFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .more)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecInsertMoreFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+        let formattedHTML = "<p>test<!--more--></p>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+
+        // "Insert more" formatting requires at least one `TextViewAttachmentImageProvider`.
+        let providers: [TextViewAttachmentImageProvider] = [
+            SpecialTagAttachmentRenderer(),
+        ]
+
+        for provider in providers {
+            editorView.richTextView.registerAttachmentImageProvider(provider)
+        }
+
+
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), formattedHTML)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecItalicFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecItalicFormatBarCommandTests.swift
@@ -1,0 +1,42 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecItalicFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecItalicFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .italic)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecItalicFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+        let italicizedHTML = "<p><em>test</em></p>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        editorView.richTextView.selectedRange = NSRange(location: 0, length: editorView.richTextView.text.count)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), italicizedHTML)
+
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecLinkFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecLinkFormatBarCommandTests.swift
@@ -1,0 +1,38 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecLinkFormatBarCommandTests: XCTestCase {
+
+    private let viewController = UIViewController()
+
+    func testFormattingIdentifier() {
+        let command = AztecLinkFormatBarCommand(linkDialogPresenter: viewController)
+        XCTAssertEqual(command.formattingIdentifier, .link)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecLinkFormatBarCommand(linkDialogPresenter: viewController)
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = "test"
+        editorView.richTextView.selectedRange = NSRange(location: 0, length: editorView.richTextView.text.count)
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        let presentedViewController = (viewController.presentedViewController as? UINavigationController)?.viewControllers.first
+        XCTAssertTrue(presentedViewController is LinkSettingsViewController)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecSourceCodeFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecSourceCodeFormatBarCommandTests.swift
@@ -1,0 +1,42 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecSourceCodeFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecSourceCodeFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .sourcecode)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecSourceCodeFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.editingMode, .html)
+        XCTAssertFalse(formatBar.enabled)
+
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.editingMode, .richText)
+        XCTAssertTrue(formatBar.enabled)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecStrikethroughFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecStrikethroughFormatBarCommandTests.swift
@@ -1,0 +1,42 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecStrikethroughFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecStrikethroughFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .strikethrough)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecStrikethroughFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+        let formattedHTML = "<p><s>test</s></p>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        editorView.richTextView.selectedRange = NSRange(location: 0, length: editorView.richTextView.text.count)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), formattedHTML)
+
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecUnderlineFormatBarCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Editor/FormatBar/Command/AztecUnderlineFormatBarCommandTests.swift
@@ -1,0 +1,42 @@
+import Aztec
+import WordPressEditor
+import XCTest
+
+@testable import WooCommerce
+
+final class AztecUnderlineFormatBarCommandTests: XCTestCase {
+
+    func testFormattingIdentifier() {
+        let command = AztecUnderlineFormatBarCommand()
+        XCTAssertEqual(command.formattingIdentifier, .underline)
+    }
+
+    func testTogglingCommand() {
+        let command = AztecUnderlineFormatBarCommand()
+
+        let text = "test"
+        let originalHTML = "<p>test</p>"
+        let formattedHTML = "<p><span style=\"text-decoration: underline\">test</span></p>"
+
+        let editorView = EditorView(defaultFont: .body,
+                                    defaultHTMLFont: .body,
+                                    defaultParagraphStyle: .default,
+                                    defaultMissingImage: .asideImage)
+        editorView.richTextView.text = text
+        editorView.richTextView.selectedRange = NSRange(location: 0, length: editorView.richTextView.text.count)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+
+        let formatBarItem = FormatBarItem(image: .bellImage)
+        let formatBar = FormatBar()
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), formattedHTML)
+
+        command.handleAction(editorView: editorView,
+                             formatBarItem: formatBarItem,
+                             formatBar: formatBar)
+        XCTAssertEqual(editorView.getHTML(), originalHTML)
+    }
+
+}


### PR DESCRIPTION
Fixes #1421 
(The last step)

## Changes

- Added unit tests for all the Aztec format bar commands

## Testing

All changes are in the tests, just CI!


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
