### PR TITLE
Update Networking model remote ID type from `Int` to `Int64`

### DIFF
--- a/Networking/Networking/Extensions/Array+Woo.swift
+++ b/Networking/Networking/Extensions/Array+Woo.swift
@@ -3,12 +3,12 @@ import Foundation
 
 // MARK: - Array Helpers
 //
-extension Array where Element == Int {
+extension Array where Element == Int64 {
 
     /// Returns a sorted, de-duplicated array of integer values as a comma-separated String.
     ///
     func sortedUniqueIntToString() -> String {
-        let uniqued: Array = Array(Set<Int>(self))
+        let uniqued: Array = Array(Set<Int64>(self))
 
         let items = uniqued.sorted()
         .map { String($0) }

--- a/Networking/Networking/Mapper/AccountSettingsMapper.swift
+++ b/Networking/Networking/Mapper/AccountSettingsMapper.swift
@@ -9,7 +9,7 @@ struct AccountSettingsMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because UserID is not returned in the /me/settings endpoint.
     ///
-    let userID: Int
+    let userID: Int64
 
     /// (Attempts) to convert a dictionary into an AccountSettings entity.
     ///

--- a/Networking/Networking/Mapper/NewShipmentTrackingMapper.swift
+++ b/Networking/Networking/Mapper/NewShipmentTrackingMapper.swift
@@ -5,13 +5,13 @@ struct NewShipmentTrackingMapper: Mapper {
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
     /// really return the siteID for the shipment tracking endpoint
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Order Identifier associated to the shipment trackings that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
     /// really return the orderID for the shipment tracking endpoint
     ///
-    let orderID: Int
+    let orderID: Int64
 
     /// (Attempts) to convert a dictionary into an ShipmentTracking entity.
     ///

--- a/Networking/Networking/Mapper/OrderCountMapper.swift
+++ b/Networking/Networking/Mapper/OrderCountMapper.swift
@@ -9,7 +9,7 @@ struct OrderCountMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into OrderCount.
     ///

--- a/Networking/Networking/Mapper/OrderListMapper.swift
+++ b/Networking/Networking/Mapper/OrderListMapper.swift
@@ -9,7 +9,7 @@ struct OrderListMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
 
     /// (Attempts) to convert a dictionary into [Order].

--- a/Networking/Networking/Mapper/OrderMapper.swift
+++ b/Networking/Networking/Mapper/OrderMapper.swift
@@ -9,7 +9,7 @@ struct OrderMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
 
     /// (Attempts) to convert a dictionary into [Order].

--- a/Networking/Networking/Mapper/OrderStatsV4Mapper.swift
+++ b/Networking/Networking/Mapper/OrderStatsV4Mapper.swift
@@ -8,7 +8,7 @@ struct OrderStatsV4Mapper: Mapper {
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
     /// really return the siteID for the stats v4 endpoint
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Granularity associated to the stats that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't

--- a/Networking/Networking/Mapper/ProductListMapper.swift
+++ b/Networking/Networking/Mapper/ProductListMapper.swift
@@ -8,7 +8,7 @@ struct ProductListMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into [Product].
     ///

--- a/Networking/Networking/Mapper/ProductMapper.swift
+++ b/Networking/Networking/Mapper/ProductMapper.swift
@@ -9,7 +9,7 @@ struct ProductMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
 
     /// (Attempts) to convert a dictionary into Product.

--- a/Networking/Networking/Mapper/ProductReviewListMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewListMapper.swift
@@ -7,7 +7,7 @@ struct ProductReviewListMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into [Product].
     ///

--- a/Networking/Networking/Mapper/ProductReviewMapper.swift
+++ b/Networking/Networking/Mapper/ProductReviewMapper.swift
@@ -9,7 +9,7 @@ struct ProductReviewMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
 
     /// (Attempts) to convert a dictionary into ProductReview.

--- a/Networking/Networking/Mapper/RefundListMapper.swift
+++ b/Networking/Networking/Mapper/RefundListMapper.swift
@@ -9,12 +9,12 @@ struct RefundListMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Refund Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Order Identifier associated with the refund that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the orderID is not returned in any of the Refund Endpoints.
     ///
-    let orderID: Int
+    let orderID: Int64
 
 
     /// (Attempts) to convert a dictionary into [Refund].

--- a/Networking/Networking/Mapper/RefundMapper.swift
+++ b/Networking/Networking/Mapper/RefundMapper.swift
@@ -9,12 +9,12 @@ struct RefundMapper: Mapper {
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Refund Endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Order Identifier associated with the refund that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the orderID is not returned in any of the Refund Endpoints.
     ///
-    let orderID: Int
+    let orderID: Int64
 
 
     /// (Attempts) to convert a dictionary into a single Refund.

--- a/Networking/Networking/Mapper/ReportOrderTotalsMapper.swift
+++ b/Networking/Networking/Mapper/ReportOrderTotalsMapper.swift
@@ -10,7 +10,7 @@ struct ReportOrderTotalsMapper: Mapper {
     /// the remote endpoints don't really return the SiteID in any of the
     /// settings endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// (Attempts) to extract order totals report from a given JSON Encoded response.
     ///

--- a/Networking/Networking/Mapper/ShipmentTrackingListMapper.swift
+++ b/Networking/Networking/Mapper/ShipmentTrackingListMapper.swift
@@ -9,13 +9,13 @@ struct ShipmentTrackingListMapper: Mapper {
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
     /// really return the siteID for the shipment tracking endpoint
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Order Identifier associated to the shipment trackings that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
     /// really return the orderID for the shipment tracking endpoint
     ///
-    let orderID: Int
+    let orderID: Int64
 
     /// (Attempts) to convert a dictionary into [ShipmentTracking]
     ///

--- a/Networking/Networking/Mapper/ShipmentTrackingProviderListMapper.swift
+++ b/Networking/Networking/Mapper/ShipmentTrackingProviderListMapper.swift
@@ -3,9 +3,9 @@ import Foundation
 /// (Attempts) to convert a dictionary into an ShipmentTrackingProviderGroup entity.
 ///
 struct ShipmentTrackingProviderListMapper: Mapper {
-    private let siteID: Int
+    private let siteID: Int64
 
-    public init(siteID: Int) {
+    public init(siteID: Int64) {
         self.siteID = siteID
     }
 

--- a/Networking/Networking/Mapper/SiteAPIMapper.swift
+++ b/Networking/Networking/Mapper/SiteAPIMapper.swift
@@ -8,7 +8,7 @@ struct SiteAPIMapper: Mapper {
     /// Site Identifier associated to the API information that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into [SiteSetting].
     ///

--- a/Networking/Networking/Mapper/SiteSettingsMapper.swift
+++ b/Networking/Networking/Mapper/SiteSettingsMapper.swift
@@ -9,7 +9,7 @@ struct SiteSettingsMapper: Mapper {
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't really return the SiteID in any of the
     /// settings endpoints.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Group name associated to the settings that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the group in any of the setting endpoints.

--- a/Networking/Networking/Mapper/TaxClassListMapper.swift
+++ b/Networking/Networking/Mapper/TaxClassListMapper.swift
@@ -8,7 +8,7 @@ struct TaxClassListMapper: Mapper {
     /// Site Identifier associated to the API information that will be parsed.
     /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't return the SiteID.
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// (Attempts) to convert a dictionary into [TaxClass].
     ///

--- a/Networking/Networking/Model/Account.swift
+++ b/Networking/Networking/Model/Account.swift
@@ -7,7 +7,7 @@ public struct Account: Decodable {
 
     /// Dotcom UserID
     ///
-    public let userID: Int
+    public let userID: Int64
 
     /// Display Name
     ///
@@ -28,7 +28,7 @@ public struct Account: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(userID: Int, displayName: String, email: String, username: String, gravatarUrl: String?) {
+    public init(userID: Int64, displayName: String, email: String, username: String, gravatarUrl: String?) {
         self.userID = userID
         self.displayName = displayName
         self.email = email

--- a/Networking/Networking/Model/AccountSettings.swift
+++ b/Networking/Networking/Model/AccountSettings.swift
@@ -6,7 +6,7 @@ public struct AccountSettings: Decodable {
 
     /// Dotcom UserID
     ///
-    public let userID: Int
+    public let userID: Int64
 
     /// Tracks analytics opt out dotcom setting
     ///
@@ -15,7 +15,7 @@ public struct AccountSettings: Decodable {
 
     /// Default initializer for AccountSettings.
     ///
-    public init(userID: Int, tracksOptOut: Bool) {
+    public init(userID: Int64, tracksOptOut: Bool) {
         self.userID = userID
         self.tracksOptOut = tracksOptOut
     }
@@ -24,7 +24,7 @@ public struct AccountSettings: Decodable {
     /// The public initializer for AccountSettings.
     ///
     public init(from decoder: Decoder) throws {
-        guard let userID = decoder.userInfo[.userID] as? Int else {
+        guard let userID = decoder.userInfo[.userID] as? Int64 else {
             throw AccountSettingsDecodingError.missingUserID
         }
 

--- a/Networking/Networking/Model/MetaContainer.swift
+++ b/Networking/Networking/Model/MetaContainer.swift
@@ -19,8 +19,8 @@ public struct MetaContainer {
 
     /// Returns the Meta ID associated with the specified key (if any).
     ///
-    public func identifier(forKey key: Keys) -> Int64? {
-        let identifiers = container(ofType: [String: Int64].self, forKey: .ids)
+    public func identifier(forKey key: Keys) -> Int? {
+        let identifiers = container(ofType: [String: Int].self, forKey: .ids)
         return identifiers?[key.rawValue]
     }
 

--- a/Networking/Networking/Model/MetaContainer.swift
+++ b/Networking/Networking/Model/MetaContainer.swift
@@ -19,8 +19,8 @@ public struct MetaContainer {
 
     /// Returns the Meta ID associated with the specified key (if any).
     ///
-    public func identifier(forKey key: Keys) -> Int? {
-        let identifiers = container(ofType: [String: Int].self, forKey: .ids)
+    public func identifier(forKey key: Keys) -> Int64? {
+        let identifiers = container(ofType: [String: Int64].self, forKey: .ids)
         return identifiers?[key.rawValue]
     }
 

--- a/Networking/Networking/Model/Note.swift
+++ b/Networking/Networking/Model/Note.swift
@@ -8,7 +8,7 @@ public struct Note {
 
     /// Notification's Primary Key.
     ///
-    public let noteId: Int64
+    public let noteID: Int64
 
     /// Notification's Hash.
     ///
@@ -97,7 +97,7 @@ public struct Note {
 
     /// Designed Initializer.
     ///
-    public init(noteId: Int64,
+    public init(noteID: Int64,
                 hash: Int64,
                 read: Bool,
                 icon: String?,
@@ -112,7 +112,7 @@ public struct Note {
                 body: Data,
                 meta: Data) {
 
-        self.noteId = noteId
+        self.noteID = noteID
         self.hash = hash
         self.read = read
         self.icon = icon
@@ -175,7 +175,7 @@ extension Note: Decodable {
         let rawMetaAsData = container.failsafeDecodeIfPresent([String: AnyCodable].self, forKey: .meta) ?? [:]
         let metaAsData = try JSONEncoder().encode(rawMetaAsData)
 
-        self.init(noteId: noteID,
+        self.init(noteID: noteID,
                   hash: hash,
                   read: read,
                   icon: icon,

--- a/Networking/Networking/Model/NoteRange.swift
+++ b/Networking/Networking/Model/NoteRange.swift
@@ -23,19 +23,19 @@ public struct NoteRange: Equatable {
 
     /// Comment ID, if any.
     ///
-    private(set) public var commentID: Int?
+    private(set) public var commentID: Int64?
 
     /// Post ID, if any.
     ///
-    private(set) public var postID: Int?
+    private(set) public var postID: Int64?
 
     /// Site ID, if any.
     ///
-    private(set) public var siteID: Int?
+    private(set) public var siteID: Int64?
 
     /// User ID, if any.
     ///
-    private(set) public var userID: Int?
+    private(set) public var userID: Int64?
 
     /// String Payload, if any.
     ///
@@ -45,7 +45,7 @@ public struct NoteRange: Equatable {
 
     /// Designated Initializer.
     ///
-    init(type: String?, range: NSRange, url: URL?, identifier: Int?, postID: Int?, siteID: Int?, value: String?) {
+    init(type: String?, range: NSRange, url: URL?, identifier: Int64?, postID: Int64?, siteID: Int64?, value: String?) {
         self.kind = NoteRange.kind(forType: type, siteID: siteID, url: url)
         self.type = type
         self.range = range
@@ -86,9 +86,9 @@ extension NoteRange: Decodable {
         let type = try container.decodeIfPresent(String.self, forKey: .type)
         let range = try container.decode(arrayEncodedRangeForKey: .indices)
         let url = try container.decodeIfPresent(URL.self, forKey: .url)
-        let identifier = try container.decodeIfPresent(Int.self, forKey: .id)
-        let postID = try container.decodeIfPresent(Int.self, forKey: .postId)
-        let siteID = try container.decodeIfPresent(Int.self, forKey: .siteId)
+        let identifier = try container.decodeIfPresent(Int64.self, forKey: .id)
+        let postID = try container.decodeIfPresent(Int64.self, forKey: .postId)
+        let siteID = try container.decodeIfPresent(Int64.self, forKey: .siteId)
         let value = try container.decodeIfPresent(String.self, forKey: .value)
 
         self.init(type: type, range: range, url: url, identifier: identifier, postID: postID, siteID: siteID, value: value)
@@ -102,7 +102,7 @@ private extension NoteRange {
 
     /// Parses the NoteRange.Type field into a Swift Native enum. Returns .unknown on failure.
     ///
-    static func kind(forType type: String?, siteID: Int?, url: URL?) -> Kind {
+    static func kind(forType type: String?, siteID: Int64?, url: URL?) -> Kind {
         if let type = type, let kind = Kind(rawValue: type) {
             return kind
         }

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -4,10 +4,10 @@ import Foundation
 /// Represents an Order Entity.
 ///
 public struct Order: Decodable {
-    public let siteID: Int
-    public let orderID: Int
-    public let parentID: Int
-    public let customerID: Int
+    public let siteID: Int64
+    public let orderID: Int64
+    public let parentID: Int64
+    public let customerID: Int64
 
     public let number: String
     public let statusKey: String
@@ -35,10 +35,10 @@ public struct Order: Decodable {
 
     /// Order struct initializer.
     ///
-    public init(siteID: Int,
-                orderID: Int,
-                parentID: Int,
-                customerID: Int,
+    public init(siteID: Int64,
+                orderID: Int64,
+                parentID: Int64,
+                customerID: Int64,
                 number: String,
                 statusKey: String,
                 currency: String,
@@ -94,15 +94,15 @@ public struct Order: Decodable {
     /// The public initializer for Order.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw OrderDecodingError.missingSiteID
         }
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let orderID = try container.decode(Int.self, forKey: .orderID)
-        let parentID = try container.decode(Int.self, forKey: .parentID)
-        let customerID = try container.decode(Int.self, forKey: .customerID)
+        let orderID = try container.decode(Int64.self, forKey: .orderID)
+        let parentID = try container.decode(Int64.self, forKey: .parentID)
+        let customerID = try container.decode(Int64.self, forKey: .customerID)
 
         let number = try container.decode(String.self, forKey: .number)
         let statusKey = try container.decode(String.self, forKey: .status)

--- a/Networking/Networking/Model/OrderCount.swift
+++ b/Networking/Networking/Model/OrderCount.swift
@@ -5,10 +5,10 @@ import Foundation
 /// Each OrderCountItem represents the number of Orders for a given status
 ///
 public struct OrderCount {
-    public let siteID: Int
+    public let siteID: Int64
     public let items: [OrderCountItem]
 
-    public init(siteID: Int, items: [OrderCountItem]) {
+    public init(siteID: Int64, items: [OrderCountItem]) {
         self.siteID = siteID
         self.items = items
     }

--- a/Networking/Networking/Model/OrderCouponLine.swift
+++ b/Networking/Networking/Model/OrderCouponLine.swift
@@ -4,14 +4,14 @@ import Foundation
 /// Represents a CouponLine Entity within an Order.
 ///
 public struct OrderCouponLine: Decodable {
-    public let couponID: Int
+    public let couponID: Int64
     public let code: String
     public let discount: String
     public let discountTax: String
 
     /// OrderCouponLine struct initializer.
     ///
-    public init(couponID: Int, code: String, discount: String, discountTax: String) {
+    public init(couponID: Int64, code: String, discount: String, discountTax: String) {
         self.couponID = couponID
         self.code = code
         self.discount = discount

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -4,10 +4,10 @@ import Foundation
 /// Represents an Order's Item Entity.
 ///
 public struct OrderItem: Decodable {
-    public let itemID: Int
+    public let itemID: Int64
     public let name: String
-    public let productID: Int
-    public let variationID: Int
+    public let productID: Int64
+    public let variationID: Int64
     public let quantity: Decimal
 
     /// Price is a currency.
@@ -26,10 +26,10 @@ public struct OrderItem: Decodable {
 
     /// OrderItem struct initializer.
     ///
-    public init(itemID: Int,
+    public init(itemID: Int64,
                 name: String,
-                productID: Int,
-                variationID: Int,
+                productID: Int64,
+                variationID: Int64,
                 quantity: Decimal,
                 price: NSDecimalNumber,
                 sku: String?,
@@ -58,10 +58,10 @@ public struct OrderItem: Decodable {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let itemID = try container.decode(Int.self, forKey: .itemID)
+        let itemID = try container.decode(Int64.self, forKey: .itemID)
         let name = try container.decode(String.self, forKey: .name)
-        let productID = try container.decode(Int.self, forKey: .productID)
-        let variationID = try container.decode(Int.self, forKey: .variationID)
+        let productID = try container.decode(Int64.self, forKey: .productID)
+        let variationID = try container.decode(Int64.self, forKey: .variationID)
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
         let decimalPrice = try container.decodeIfPresent(Decimal.self, forKey: .price) ?? Decimal(0)

--- a/Networking/Networking/Model/OrderItemTax.swift
+++ b/Networking/Networking/Model/OrderItemTax.swift
@@ -7,7 +7,7 @@ public struct OrderItemTax: Codable {
 
     /// Tax ID for line item
     ///
-    public let taxID: Int
+    public let taxID: Int64
 
     /// Tax subtotal
     ///
@@ -19,7 +19,7 @@ public struct OrderItemTax: Codable {
 
     /// OrderItemTax struct initializer
     ///
-    public init(taxID: Int, subtotal: String, total: String) {
+    public init(taxID: Int64, subtotal: String, total: String) {
         self.taxID = taxID
         self.subtotal = subtotal
         self.total = total
@@ -30,7 +30,7 @@ public struct OrderItemTax: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let taxID = try container.decode(Int.self, forKey: .taxID)
+        let taxID = try container.decode(Int64.self, forKey: .taxID)
         let subtotal = try container.decode(String.self, forKey: .subtotal)
         let total = try container.decode(String.self, forKey: .total)
 

--- a/Networking/Networking/Model/OrderNote.swift
+++ b/Networking/Networking/Model/OrderNote.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Represents an Order's Note Entity.
 ///
 public struct OrderNote: Decodable {
-    public let noteID: Int
+    public let noteID: Int64
     public let dateCreated: Date
     public let note: String
     public let isCustomerNote: Bool
@@ -12,8 +12,8 @@ public struct OrderNote: Decodable {
 
     /// OrderNote struct initializer.
     ///
-    public init(noteId: Int, dateCreated: Date, note: String, isCustomerNote: Bool, author: String) {
-        self.noteID = noteId
+    public init(noteID: Int64, dateCreated: Date, note: String, isCustomerNote: Bool, author: String) {
+        self.noteID = noteID
         self.dateCreated = dateCreated
         self.note = note
         self.isCustomerNote = isCustomerNote
@@ -24,13 +24,13 @@ public struct OrderNote: Decodable {
     ///
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let noteId = try container.decode(Int.self, forKey: .noteId)
+        let noteID = try container.decode(Int64.self, forKey: .noteID)
         let dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? Date()
         let note = try container.decode(String.self, forKey: .note)
         let isCustomerNote = try container.decode(Bool.self, forKey: .isCustomerNote)
         let author = try container.decode(String.self, forKey: .author)
 
-        self.init(noteId: noteId, dateCreated: dateCreated, note: note, isCustomerNote: isCustomerNote, author: author) // initialize the struct
+        self.init(noteID: noteID, dateCreated: dateCreated, note: note, isCustomerNote: isCustomerNote, author: author) // initialize the struct
     }
 }
 
@@ -40,7 +40,7 @@ public struct OrderNote: Decodable {
 private extension OrderNote {
 
     enum CodingKeys: String, CodingKey {
-        case noteId         = "id"
+        case noteID         = "id"
         case dateCreated    = "date_created_gmt"
         case note           = "note"
         case isCustomerNote = "customer_note"

--- a/Networking/Networking/Model/OrderRefundCondensed.swift
+++ b/Networking/Networking/Model/OrderRefundCondensed.swift
@@ -4,13 +4,13 @@ import Foundation
 /// Represents an Order Refund Entity.
 ///
 public struct OrderRefundCondensed: Decodable {
-    public let refundID: Int
+    public let refundID: Int64
     public let reason: String?
     public let total: String
 
     /// OrderRefundCondensed struct initializer
     ///
-    public init(refundID: Int, reason: String?, total: String) {
+    public init(refundID: Int64, reason: String?, total: String) {
         self.refundID = refundID
         self.reason = reason
         self.total = total
@@ -21,7 +21,7 @@ public struct OrderRefundCondensed: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let refundID = try container.decode(Int.self, forKey: .refundID)
+        let refundID = try container.decode(Int64.self, forKey: .refundID)
         let reason = try container.decodeIfPresent(String.self, forKey: .reason)
         let total = try container.decode(String.self, forKey: .total)
 

--- a/Networking/Networking/Model/OrderStatus.swift
+++ b/Networking/Networking/Model/OrderStatus.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 public struct OrderStatus: Decodable {
     public let name: String?
-    public let siteID: Int
+    public let siteID: Int64
     public let slug: String
     public let total: Int
 
@@ -15,7 +15,7 @@ public struct OrderStatus: Decodable {
 
     /// OrderStatus struct initializer.
     ///
-    public init(name: String?, siteID: Int, slug: String, total: Int) {
+    public init(name: String?, siteID: Int64, slug: String, total: Int) {
         self.name = name
         self.siteID = siteID
         self.slug = slug
@@ -25,7 +25,7 @@ public struct OrderStatus: Decodable {
     /// The public initializer for OrderStatus.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw OrderStatusError.missingSiteID
         }
 

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -4,8 +4,8 @@ import Foundation
 /// Represents a Product Entity.
 ///
 public struct Product: Codable {
-    public let siteID: Int
-    public let productID: Int
+    public let siteID: Int64
+    public let productID: Int64
     public let name: String
     public let slug: String
     public let permalink: String
@@ -57,17 +57,17 @@ public struct Product: Codable {
     public let shippingRequired: Bool
     public let shippingTaxable: Bool
     public let shippingClass: String?
-    public let shippingClassID: Int
+    public let shippingClassID: Int64
     public let productShippingClass: ProductShippingClass?
 
     public let reviewsAllowed: Bool
     public let averageRating: String
     public let ratingCount: Int
 
-    public let relatedIDs: [Int]
-    public let upsellIDs: [Int]
-    public let crossSellIDs: [Int]
-    public let parentID: Int
+    public let relatedIDs: [Int64]
+    public let upsellIDs: [Int64]
+    public let crossSellIDs: [Int64]
+    public let parentID: Int64
 
     public let purchaseNote: String?
     public let categories: [ProductCategory]
@@ -76,8 +76,8 @@ public struct Product: Codable {
 
     public let attributes: [ProductAttribute]
     public let defaultAttributes: [ProductDefaultAttribute]
-    public let variations: [Int]
-    public let groupedProducts: [Int]
+    public let variations: [Int64]
+    public let groupedProducts: [Int64]
 
     public let menuOrder: Int
 
@@ -101,8 +101,8 @@ public struct Product: Codable {
 
     /// Product struct initializer.
     ///
-    public init(siteID: Int,
-                productID: Int,
+    public init(siteID: Int64,
+                productID: Int64,
                 name: String,
                 slug: String,
                 permalink: String,
@@ -143,23 +143,23 @@ public struct Product: Codable {
                 shippingRequired: Bool,
                 shippingTaxable: Bool,
                 shippingClass: String?,
-                shippingClassID: Int,
+                shippingClassID: Int64,
                 productShippingClass: ProductShippingClass?,
                 reviewsAllowed: Bool,
                 averageRating: String,
                 ratingCount: Int,
-                relatedIDs: [Int],
-                upsellIDs: [Int],
-                crossSellIDs: [Int],
-                parentID: Int,
+                relatedIDs: [Int64],
+                upsellIDs: [Int64],
+                crossSellIDs: [Int64],
+                parentID: Int64,
                 purchaseNote: String?,
                 categories: [ProductCategory],
                 tags: [ProductTag],
                 images: [ProductImage],
                 attributes: [ProductAttribute],
                 defaultAttributes: [ProductDefaultAttribute],
-                variations: [Int],
-                groupedProducts: [Int],
+                variations: [Int64],
+                groupedProducts: [Int64],
                 menuOrder: Int) {
         self.siteID = siteID
         self.productID = productID
@@ -226,13 +226,13 @@ public struct Product: Codable {
     /// The public initializer for Product.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw ProductDecodingError.missingSiteID
         }
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let productID = try container.decode(Int.self, forKey: .productID)
+        let productID = try container.decode(Int64.self, forKey: .productID)
         let name = try container.decode(String.self, forKey: .name)
         let slug = try container.decode(String.self, forKey: .slug)
         let permalink = try container.decode(String.self, forKey: .permalink)
@@ -313,16 +313,16 @@ public struct Product: Codable {
         let shippingRequired = try container.decode(Bool.self, forKey: .shippingRequired)
         let shippingTaxable = try container.decode(Bool.self, forKey: .shippingTaxable)
         let shippingClass = try container.decodeIfPresent(String.self, forKey: .shippingClass)
-        let shippingClassID = try container.decode(Int.self, forKey: .shippingClassID)
+        let shippingClassID = try container.decode(Int64.self, forKey: .shippingClassID)
 
         let reviewsAllowed = try container.decode(Bool.self, forKey: .reviewsAllowed)
         let averageRating = try container.decode(String.self, forKey: .averageRating)
         let ratingCount = try container.decode(Int.self, forKey: .ratingCount)
 
-        let relatedIDs = try container.decode([Int].self, forKey: .relatedIDs)
-        let upsellIDs = try container.decode([Int].self, forKey: .upsellIDs)
-        let crossSellIDs = try container.decode([Int].self, forKey: .crossSellIDs)
-        let parentID = try container.decode(Int.self, forKey: .parentID)
+        let relatedIDs = try container.decode([Int64].self, forKey: .relatedIDs)
+        let upsellIDs = try container.decode([Int64].self, forKey: .upsellIDs)
+        let crossSellIDs = try container.decode([Int64].self, forKey: .crossSellIDs)
+        let parentID = try container.decode(Int64.self, forKey: .parentID)
 
         let purchaseNote = try container.decodeIfPresent(String.self, forKey: .purchaseNote)
         let categories = try container.decode([ProductCategory].self, forKey: .categories)
@@ -331,8 +331,8 @@ public struct Product: Codable {
 
         let attributes = try container.decode([ProductAttribute].self, forKey: .attributes)
         let defaultAttributes = try container.decode([ProductDefaultAttribute].self, forKey: .defaultAttributes)
-        let variations = try container.decode([Int].self, forKey: .variations)
-        let groupedProducts = try container.decode([Int].self, forKey: .groupedProducts)
+        let variations = try container.decode([Int64].self, forKey: .variations)
+        let groupedProducts = try container.decode([Int64].self, forKey: .groupedProducts)
 
         let menuOrder = try container.decode(Int.self, forKey: .menuOrder)
 

--- a/Networking/Networking/Model/Product/ProductAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductAttribute.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Represents a ProductAttribute entity.
 ///
 public struct ProductAttribute: Decodable {
-    public let attributeID: Int
+    public let attributeID: Int64
     public let name: String
     public let position: Int
     public let visible: Bool
@@ -19,7 +19,7 @@ public struct ProductAttribute: Decodable {
 
     /// ProductAttribute initializer.
     ///
-    public init(attributeID: Int,
+    public init(attributeID: Int64,
                 name: String,
                 position: Int,
                 visible: Bool,
@@ -39,7 +39,7 @@ public struct ProductAttribute: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let attributeID = container.failsafeDecodeIfPresent(Int.self, forKey: .attributeID) ?? 0
+        let attributeID = container.failsafeDecodeIfPresent(Int64.self, forKey: .attributeID) ?? 0
         let name = container.failsafeDecodeIfPresent(String.self, forKey: .name) ?? String()
         let position = container.failsafeDecodeIfPresent(Int.self, forKey: .position) ?? 0
         let visible = container.failsafeDecodeIfPresent(Bool.self, forKey: .visible) ?? true

--- a/Networking/Networking/Model/Product/ProductCategory.swift
+++ b/Networking/Networking/Model/Product/ProductCategory.swift
@@ -4,13 +4,13 @@ import Foundation
 /// Represents a ProductCategory entity.
 ///
 public struct ProductCategory: Decodable {
-    public let categoryID: Int
+    public let categoryID: Int64
     public let name: String
     public let slug: String
 
     /// ProductCategory initializer.
     ///
-    public init(categoryID: Int,
+    public init(categoryID: Int64,
                 name: String,
                 slug: String) {
         self.categoryID = categoryID
@@ -23,7 +23,7 @@ public struct ProductCategory: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let categoryID = try container.decode(Int.self, forKey: .categoryID)
+        let categoryID = try container.decode(Int64.self, forKey: .categoryID)
         let name = try container.decode(String.self, forKey: .name)
         let slug = try container.decode(String.self, forKey: .slug)
 

--- a/Networking/Networking/Model/Product/ProductDefaultAttribute.swift
+++ b/Networking/Networking/Model/Product/ProductDefaultAttribute.swift
@@ -4,13 +4,13 @@ import Foundation
 /// Represents a ProductDefaultAttribute entity.
 ///
 public struct ProductDefaultAttribute: Decodable {
-    public let attributeID: Int
+    public let attributeID: Int64
     public let name: String?
     public let option: String?
 
     /// ProductAttribute initializer.
     ///
-    public init(attributeID: Int,
+    public init(attributeID: Int64,
                 name: String?,
                 option: String?) {
         self.attributeID = attributeID
@@ -23,7 +23,7 @@ public struct ProductDefaultAttribute: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let attributeID = try container.decode(Int.self, forKey: .attributeID)
+        let attributeID = try container.decode(Int64.self, forKey: .attributeID)
         let name = try container.decodeIfPresent(String.self, forKey: .name)
         let option = try container.decodeIfPresent(String.self, forKey: .option)
 

--- a/Networking/Networking/Model/Product/ProductImage.swift
+++ b/Networking/Networking/Model/Product/ProductImage.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Represents a ProductImage entity.
 ///
 public struct ProductImage: Decodable {
-    public let imageID: Int
+    public let imageID: Int64
     public let dateCreated: Date    // gmt
     public let dateModified: Date?  // gmt
     public let src: String
@@ -13,7 +13,7 @@ public struct ProductImage: Decodable {
 
     /// ProductImage initializer.
     ///
-    public init(imageID: Int,
+    public init(imageID: Int64,
                 dateCreated: Date,
                 dateModified: Date?,
                 src: String,
@@ -32,7 +32,7 @@ public struct ProductImage: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let imageID = try container.decode(Int.self, forKey: .imageID)
+        let imageID = try container.decode(Int64.self, forKey: .imageID)
         let dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? Date()
         let dateModified = try container.decodeIfPresent(Date.self, forKey: .dateModified)
         let src = try container.decode(String.self, forKey: .src)

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Represents a ProductReview Entity.
 ///
 public struct ProductReview: Decodable {
-    public let siteID: Int
-    public let reviewID: Int
-    public let productID: Int
+    public let siteID: Int64
+    public let reviewID: Int64
+    public let productID: Int64
 
     public let dateCreated: Date        // gmt
 
@@ -26,9 +26,9 @@ public struct ProductReview: Decodable {
 
     /// ProductReview struct initializer.
     ///
-    public init(siteID: Int,
-                reviewID: Int,
-                productID: Int,
+    public init(siteID: Int64,
+                reviewID: Int64,
+                productID: Int64,
                 dateCreated: Date,
                 statusKey: String,
                 reviewer: String,
@@ -53,14 +53,14 @@ public struct ProductReview: Decodable {
     /// The public initializer for ProductReview.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw ProductReviewDecodingError.missingSiteID
         }
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let reviewID = try container.decode(Int.self, forKey: .reviewID)
-        let productID = try container.decode(Int.self, forKey: .productID)
+        let reviewID = try container.decode(Int64.self, forKey: .reviewID)
+        let productID = try container.decode(Int64.self, forKey: .productID)
         let dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? Date()
         let statusKey = try container.decode(String.self, forKey: .status)
         let reviewer = try container.decode(String.self, forKey: .reviewer)

--- a/Networking/Networking/Model/Product/ProductTag.swift
+++ b/Networking/Networking/Model/Product/ProductTag.swift
@@ -4,13 +4,13 @@ import Foundation
 /// Represents a ProductTag entity.
 ///
 public struct ProductTag: Decodable {
-    public let tagID: Int
+    public let tagID: Int64
     public let name: String
     public let slug: String
 
     /// ProductTag initializer.
     ///
-    public init(tagID: Int,
+    public init(tagID: Int64,
                 name: String,
                 slug: String) {
         self.tagID = tagID
@@ -23,7 +23,7 @@ public struct ProductTag: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let tagID = try container.decode(Int.self, forKey: .tagID)
+        let tagID = try container.decode(Int64.self, forKey: .tagID)
         let name = try container.decode(String.self, forKey: .name)
         let slug = try container.decode(String.self, forKey: .slug)
 

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -4,10 +4,10 @@ import Foundation
 /// Represents an Order Item to be Refunded
 ///
 public struct OrderItemRefund: Codable {
-    public let itemID: Int
+    public let itemID: Int64
     public let name: String
-    public let productID: Int
-    public let variationID: Int
+    public let productID: Int64
+    public let variationID: Int64
     public let quantity: Decimal
 
     /// Price is a currency.
@@ -26,10 +26,10 @@ public struct OrderItemRefund: Codable {
 
     /// OrderItemRefund struct initializer.
     ///
-    public init(itemID: Int,
+    public init(itemID: Int64,
                 name: String,
-                productID: Int,
-                variationID: Int,
+                productID: Int64,
+                variationID: Int64,
                 quantity: Decimal,
                 price: NSDecimalNumber,
                 sku: String?,
@@ -59,10 +59,10 @@ public struct OrderItemRefund: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let itemID = try container.decode(Int.self, forKey: .itemID)
+        let itemID = try container.decode(Int64.self, forKey: .itemID)
         let name = try container.decode(String.self, forKey: .name)
-        let productID = try container.decode(Int.self, forKey: .productID)
-        let variationID = try container.decode(Int.self, forKey: .variationID)
+        let productID = try container.decode(Int64.self, forKey: .productID)
+        let variationID = try container.decode(Int64.self, forKey: .variationID)
 
         let quantity = try container.decode(Decimal.self, forKey: .quantity)
         let decimalPrice = try container.decodeIfPresent(Decimal.self, forKey: .price) ?? Decimal(0)

--- a/Networking/Networking/Model/Refund/OrderItemTaxRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemTaxRefund.swift
@@ -7,7 +7,7 @@ public struct OrderItemTaxRefund: Codable {
 
     /// Tax ID for line item
     ///
-    public let taxID: Int
+    public let taxID: Int64
 
     /// Tax subtotal
     ///
@@ -19,7 +19,7 @@ public struct OrderItemTaxRefund: Codable {
 
     /// OrderItemTaxRefund struct initializer
     ///
-    public init(taxID: Int, subtotal: String, total: String) {
+    public init(taxID: Int64, subtotal: String, total: String) {
         self.taxID = taxID
         self.subtotal = subtotal
         self.total = total
@@ -30,7 +30,7 @@ public struct OrderItemTaxRefund: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let taxID = try container.decode(Int.self, forKey: .taxID)
+        let taxID = try container.decode(Int64.self, forKey: .taxID)
         let subtotal = try container.decode(String.self, forKey: .subtotal)
         let total = try container.decode(String.self, forKey: .total)
 

--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -4,13 +4,13 @@ import Foundation
 /// Represents a decoded Refund entity.
 ///
 public struct Refund: Codable {
-    public let refundID: Int
-    public let orderID: Int
-    public let siteID: Int
+    public let refundID: Int64
+    public let orderID: Int64
+    public let siteID: Int64
     public let dateCreated: Date // gmt
     public let amount: String
     public let reason: String
-    public let refundedByUserID: Int
+    public let refundedByUserID: Int64
 
     /// If true, the automatic refund is used.
     /// When false, manual refund process is used.
@@ -26,13 +26,13 @@ public struct Refund: Codable {
 
     /// Refund struct initializer
     ///
-    public init(refundID: Int,
-                orderID: Int,
-                siteID: Int,
+    public init(refundID: Int64,
+                orderID: Int64,
+                siteID: Int64,
                 dateCreated: Date,
                 amount: String,
                 reason: String,
-                refundedByUserID: Int,
+                refundedByUserID: Int64,
                 isAutomated: Bool?,
                 createAutomated: Bool?,
                 items: [OrderItemRefund]) {
@@ -51,21 +51,21 @@ public struct Refund: Codable {
     // The public initializer for a Refund
     ///
     public init(from decoder: Decoder) throws {
-        guard let orderID = decoder.userInfo[.orderID] as? Int else {
+        guard let orderID = decoder.userInfo[.orderID] as? Int64 else {
             throw RefundDecodingError.missingOrderID
         }
 
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw RefundDecodingError.missingSiteID
         }
 
         let container = try decoder.container(keyedBy: DecodingKeys.self)
 
-        let refundID = try container.decode(Int.self, forKey: .refundID)
+        let refundID = try container.decode(Int64.self, forKey: .refundID)
         let dateCreated = try container.decodeIfPresent(Date.self, forKey: .dateCreated) ?? Date()
         let amount = try container.decode(String.self, forKey: .amount)
         let reason = try container.decode(String.self, forKey: .reason)
-        let refundedByUserID = try container.decode(Int.self, forKey: .refundedByUserID)
+        let refundedByUserID = try container.decode(Int64.self, forKey: .refundedByUserID)
         let isAutomated = try container.decode(Bool.self, forKey: .automatedRefund)
         let items = try container.decode([OrderItemRefund].self, forKey: .items)
 

--- a/Networking/Networking/Model/ShipmentTracking.swift
+++ b/Networking/Networking/Model/ShipmentTracking.swift
@@ -36,7 +36,13 @@ public struct ShipmentTracking: Decodable {
 
     /// ShipmentTracking struct initializer.
     ///
-    public init(siteID: Int64, orderID: Int64, trackingID: String, trackingNumber: String, trackingProvider: String?, trackingURL: String?, dateShipped: Date?) {
+    public init(siteID: Int64,
+                orderID: Int64,
+                trackingID: String,
+                trackingNumber: String,
+                trackingProvider: String?,
+                trackingURL: String?,
+                dateShipped: Date?) {
         self.siteID = siteID
         self.orderID = orderID
         self.trackingID = trackingID

--- a/Networking/Networking/Model/ShipmentTracking.swift
+++ b/Networking/Networking/Model/ShipmentTracking.swift
@@ -7,11 +7,11 @@ public struct ShipmentTracking: Decodable {
 
     /// Site Identifier.
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Order Identifier.
     ///
-    public let orderID: Int
+    public let orderID: Int64
 
     /// Unique identifier for shipment tracking
     ///
@@ -36,7 +36,7 @@ public struct ShipmentTracking: Decodable {
 
     /// ShipmentTracking struct initializer.
     ///
-    public init(siteID: Int, orderID: Int, trackingID: String, trackingNumber: String, trackingProvider: String?, trackingURL: String?, dateShipped: Date?) {
+    public init(siteID: Int64, orderID: Int64, trackingID: String, trackingNumber: String, trackingProvider: String?, trackingURL: String?, dateShipped: Date?) {
         self.siteID = siteID
         self.orderID = orderID
         self.trackingID = trackingID
@@ -49,10 +49,10 @@ public struct ShipmentTracking: Decodable {
     /// The public initializer for ShipmentTracking.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw ShipmentTrackingAPIError.missingSiteID
         }
-        guard let orderID = decoder.userInfo[.orderID] as? Int else {
+        guard let orderID = decoder.userInfo[.orderID] as? Int64 else {
             throw ShipmentTrackingAPIError.missingOrderID
         }
 

--- a/Networking/Networking/Model/ShipmentTrackingProvider.swift
+++ b/Networking/Networking/Model/ShipmentTrackingProvider.swift
@@ -9,7 +9,7 @@ public struct ShipmentTrackingProvider {
 
     /// Site Identifier
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Tracking provider url
     ///
@@ -17,7 +17,7 @@ public struct ShipmentTrackingProvider {
 
     /// Shipment Tracking Provider struct initializer
     ///
-    public init(siteID: Int, name: String, url: String) {
+    public init(siteID: Int64, name: String, url: String) {
         self.siteID = siteID
         self.name = name
         self.url = url

--- a/Networking/Networking/Model/ShipmentTrackingProviderGroup.swift
+++ b/Networking/Networking/Model/ShipmentTrackingProviderGroup.swift
@@ -9,19 +9,19 @@ public struct ShipmentTrackingProviderGroup {
 
     /// Site Identifier
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Tracking providers belonging to the group
     ///
     public let providers: [ShipmentTrackingProvider]
 
-    public init(name: String, siteID: Int, providers: [ShipmentTrackingProvider]) {
+    public init(name: String, siteID: Int64, providers: [ShipmentTrackingProvider]) {
         self.name = name
         self.siteID = siteID
         self.providers = providers
     }
 
-    public init(name: String, siteID: Int, dictionary: [String: String]?) {
+    public init(name: String, siteID: Int64, dictionary: [String: String]?) {
         let providers = dictionary?.map({ ShipmentTrackingProvider(siteID: siteID, name: $0.key, url: $0.value) }) ?? []
         self.init(name: name, siteID: siteID, providers: providers)
     }

--- a/Networking/Networking/Model/ShippingLine.swift
+++ b/Networking/Networking/Model/ShippingLine.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Represents a Shipping Line Entity.
 ///
 public struct ShippingLine: Decodable {
-    public let shippingID: Int
+    public let shippingID: Int64
     public let methodTitle: String
     public let methodID: String
     public let total: String
@@ -12,7 +12,7 @@ public struct ShippingLine: Decodable {
 
     /// Shipping Method struct initializer.
     ///
-    public init(shippingID: Int,
+    public init(shippingID: Int64,
                 methodTitle: String,
                 methodID: String,
                 total: String,
@@ -31,7 +31,7 @@ public struct ShippingLine: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        let shippingID = try container.decode(Int.self, forKey: .shippingID)
+        let shippingID = try container.decode(Int64.self, forKey: .shippingID)
         let methodTitle = try container.decode(String.self, forKey: .methodTitle)
         let methodID = try container.decode(String.self, forKey: .methodID)
         let total = try container.decode(String.self, forKey: .total)

--- a/Networking/Networking/Model/Site.swift
+++ b/Networking/Networking/Model/Site.swift
@@ -7,7 +7,7 @@ public struct Site: Decodable {
 
     /// WordPress.com Site Identifier.
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Site's Name.
     ///
@@ -42,7 +42,7 @@ public struct Site: Decodable {
     public init(from decoder: Decoder) throws {
         let siteContainer = try decoder.container(keyedBy: SiteKeys.self)
 
-        let siteID = try siteContainer.decode(Int.self, forKey: .siteID)
+        let siteID = try siteContainer.decode(Int64.self, forKey: .siteID)
         let name = try siteContainer.decode(String.self, forKey: .name)
         let description = try siteContainer.decode(String.self, forKey: .description)
         let url = try siteContainer.decode(String.self, forKey: .url)
@@ -64,7 +64,7 @@ public struct Site: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int,
+    public init(siteID: Int64,
                 name: String,
                 description: String,
                 url: String,

--- a/Networking/Networking/Model/SiteAPI.swift
+++ b/Networking/Networking/Model/SiteAPI.swift
@@ -7,7 +7,7 @@ public struct SiteAPI: Decodable {
 
     /// Site Identifier.
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Available API namespaces
     ///
@@ -30,7 +30,7 @@ public struct SiteAPI: Decodable {
     /// Decodable Conformance.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw SiteAPIError.missingSiteID
         }
 
@@ -42,7 +42,7 @@ public struct SiteAPI: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int, namespaces: [String]) {
+    public init(siteID: Int64, namespaces: [String]) {
         self.siteID = siteID
         self.namespaces = namespaces
     }

--- a/Networking/Networking/Model/SitePlan.swift
+++ b/Networking/Networking/Model/SitePlan.swift
@@ -7,7 +7,7 @@ public struct SitePlan: Decodable {
 
     /// WordPress.com Site Identifier.
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Short name for the site's plan.
     ///
@@ -18,7 +18,7 @@ public struct SitePlan: Decodable {
     ///
     public init(from decoder: Decoder) throws {
         let sitePlanContainer = try decoder.container(keyedBy: PlanKeys.self)
-        let siteID = try sitePlanContainer.decode(Int.self, forKey: .siteID)
+        let siteID = try sitePlanContainer.decode(Int64.self, forKey: .siteID)
 
         let planContainer = try sitePlanContainer.nestedContainer(keyedBy: PlanKeys.self, forKey: .plan)
         let shortName = try planContainer.decode(String.self, forKey: .shortName)
@@ -29,7 +29,7 @@ public struct SitePlan: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int, shortName: String) {
+    public init(siteID: Int64, shortName: String) {
         self.siteID = siteID
         self.shortName = shortName
     }

--- a/Networking/Networking/Model/SiteSetting.swift
+++ b/Networking/Networking/Model/SiteSetting.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Represents a specific setting entity for a specific site.
 ///
 public struct SiteSetting: Decodable {
-    public let siteID: Int
+    public let siteID: Int64
     public let settingID: String
     public let label: String
     public let settingDescription: String
@@ -19,7 +19,7 @@ public struct SiteSetting: Decodable {
 
     /// OrderNote struct initializer.
     ///
-    public init(siteID: Int, settingID: String, label: String, description: String, value: String, settingGroupKey: String) {
+    public init(siteID: Int64, settingID: String, label: String, description: String, value: String, settingGroupKey: String) {
         self.siteID = siteID
         self.settingID = settingID
         self.label = label
@@ -31,7 +31,7 @@ public struct SiteSetting: Decodable {
     /// The public initializer for SiteSetting.
     ///
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw SiteSettingError.missingSiteID
         }
         guard let settingGroupKey = decoder.userInfo[.settingGroupKey] as? String else {

--- a/Networking/Networking/Model/Stats/OrderStatsV4.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4.swift
@@ -3,12 +3,12 @@ import Foundation
 /// Represents order stats over a specific period.
 /// v4 API
 public struct OrderStatsV4: Decodable {
-    public let siteID: Int
+    public let siteID: Int64
     public let granularity: StatsGranularityV4
     public let totals: OrderStatsV4Totals
     public let intervals: [OrderStatsV4Interval]
 
-    public init(siteID: Int,
+    public init(siteID: Int64,
                 granularity: StatsGranularityV4,
                 totals: OrderStatsV4Totals,
                 intervals: [OrderStatsV4Interval]) {
@@ -19,7 +19,7 @@ public struct OrderStatsV4: Decodable {
     }
 
     public init(from decoder: Decoder) throws {
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw OrderStatsV4APIError.missingSiteID
         }
 

--- a/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
+++ b/Networking/Networking/Model/Stats/TopEarnerStatsItem.swift
@@ -7,7 +7,7 @@ public struct TopEarnerStatsItem: Decodable {
 
     /// Product ID
     ///
-    public let productID: Int
+    public let productID: Int64
 
     /// Product name
     ///
@@ -36,7 +36,7 @@ public struct TopEarnerStatsItem: Decodable {
 
     /// Designated Initializer.
     ///
-    public init(productID: Int, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
+    public init(productID: Int64, productName: String?, quantity: Int, price: Double, total: Double, currency: String, imageUrl: String?) {
         self.productID = productID
         self.productName = productName ?? ""
         self.quantity = quantity

--- a/Networking/Networking/Model/TaxClass.swift
+++ b/Networking/Networking/Model/TaxClass.swift
@@ -6,7 +6,7 @@ public struct TaxClass: Decodable {
 
     /// WordPress.com Site Identifier.
     ///
-    public let siteID: Int
+    public let siteID: Int64
 
     /// Tax class name.
     ///
@@ -19,7 +19,7 @@ public struct TaxClass: Decodable {
 
     /// Default initializer for TaxClass.
     ///
-    public init(siteID: Int, name: String, slug: String) {
+    public init(siteID: Int64, name: String, slug: String) {
         self.siteID = siteID
         self.name = name
         self.slug = slug
@@ -31,7 +31,7 @@ public struct TaxClass: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        guard let siteID = decoder.userInfo[.siteID] as? Int else {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
             throw TaxClassDecodingError.missingSiteID
         }
         let name = try container.decode(String.self, forKey: .name)

--- a/Networking/Networking/Remote/AccountRemote.swift
+++ b/Networking/Networking/Remote/AccountRemote.swift
@@ -21,7 +21,7 @@ public class AccountRemote: Remote {
     /// - Parameters:
     ///   - for: The dotcom user ID - used primarily for persistence not on the actual network call
     ///
-    public func loadAccountSettings(for userID: Int, completion: @escaping (AccountSettings?, Error?) -> Void) {
+    public func loadAccountSettings(for userID: Int64, completion: @escaping (AccountSettings?, Error?) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out"
@@ -36,7 +36,7 @@ public class AccountRemote: Remote {
     /// - Parameters:
     ///   - userID: The dotcom user ID - used primarily for persistence not on the actual network call
     ///
-    public func updateAccountSettings(for userID: Int, tracksOptOut: Bool, completion: @escaping (AccountSettings?, Error?) -> Void) {
+    public func updateAccountSettings(for userID: Int64, tracksOptOut: Bool, completion: @escaping (AccountSettings?, Error?) -> Void) {
         let path = "me/settings"
         let parameters = [
             "fields": "tracks_opt_out",
@@ -67,7 +67,7 @@ public class AccountRemote: Remote {
 
     /// Loads the site plan for the default site associated with the WordPress.com user.
     ///
-    public func loadSitePlan(for siteID: Int, completion: @escaping (SitePlan?, Error?) -> Void) {
+    public func loadSitePlan(for siteID: Int64, completion: @escaping (SitePlan?, Error?) -> Void) {
         let path = "sites/\(siteID)"
         let parameters = [
             "fields": "ID,plan"

--- a/Networking/Networking/Remote/CommentRemote.swift
+++ b/Networking/Networking/Remote/CommentRemote.swift
@@ -60,7 +60,7 @@ public class CommentRemote: Remote {
     ///   - status: New status for comment
     ///   - completion: callback to be executed on completion
     ///
-    public func moderateComment(siteID: Int, commentID: Int, status: CommentStatus, completion: @escaping (CommentStatus?, Error?) -> Void) {
+    public func moderateComment(siteID: Int64, commentID: Int64, status: CommentStatus, completion: @escaping (CommentStatus?, Error?) -> Void) {
         let path = "\(Paths.sites)/" + String(siteID) + "/" + "\(Paths.comments)/" + String(commentID)
         let parameters = [
             ParameterKeys.status: status.rawValue,

--- a/Networking/Networking/Remote/DevicesRemote.swift
+++ b/Networking/Networking/Remote/DevicesRemote.swift
@@ -18,7 +18,7 @@ public class DevicesRemote: Remote {
     public func registerDevice(device: APNSDevice,
                                applicationId: String,
                                applicationVersion: String,
-                               defaultStoreID: Int,
+                               defaultStoreID: Int64,
                                completion: @escaping (DotcomDevice?, Error?) -> Void) {
         var parameters = [
             ParameterKeys.applicationId: applicationId,

--- a/Networking/Networking/Remote/NotificationsRemote.swift
+++ b/Networking/Networking/Remote/NotificationsRemote.swift
@@ -9,12 +9,12 @@ public class NotificationsRemote: Remote {
     /// Retrieves latest Notifications (OR collection of specified Notifications, whenever the NoteIds is present).
     ///
     /// - Parameters:
-    ///     - noteIds: Identifiers of notifications to retrieve.
+    ///     - noteIDs: Identifiers of notifications to retrieve.
     ///     - pageSize: Number of hashes to retrieve.
     ///     - completion: callback to be executed on completion.
     ///
-    public func loadNotes(noteIds: [Int64]? = nil, pageSize: Int? = nil, completion: @escaping ([Note]?, Error?) -> Void) {
-        let request = requestForNotifications(fields: .all, noteIds: noteIds, pageSize: pageSize)
+    public func loadNotes(noteIDs: [Int64]? = nil, pageSize: Int? = nil, completion: @escaping ([Note]?, Error?) -> Void) {
+        let request = requestForNotifications(fields: .all, noteIDs: noteIDs, pageSize: pageSize)
         let mapper = NoteListMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -24,12 +24,12 @@ public class NotificationsRemote: Remote {
     /// Retrieves the top N Hashes (or the latest hashes for the specified NoteIds).
     ///
     /// - Parameters:
-    ///     - noteIds: Identifiers of notifications to retrieve.
+    ///     - noteIDs: Identifiers of notifications to retrieve.
     ///     - pageSize: Number of hashes to retrieve.
     ///     - completion: callback to be executed on completion.
     ///
-    public func loadHashes(noteIds: [Int64]? = nil, pageSize: Int? = nil, completion: @escaping ([NoteHash]?, Error?) -> Void) {
-        let request = requestForNotifications(fields: .hashes, noteIds: noteIds, pageSize: pageSize)
+    public func loadHashes(noteIDs: [Int64]? = nil, pageSize: Int? = nil, completion: @escaping ([NoteHash]?, Error?) -> Void) {
+        let request = requestForNotifications(fields: .hashes, noteIDs: noteIDs, pageSize: pageSize)
         let mapper = NoteHashListMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
@@ -43,7 +43,7 @@ public class NotificationsRemote: Remote {
     ///     - read: The new Read Status to be set.
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
-    public func updateReadStatus(noteIds: [Int64], read: Bool, completion: @escaping (Error?) -> Void) {
+    public func updateReadStatus(noteIDs: [Int64], read: Bool, completion: @escaping (Error?) -> Void) {
         // Note: Isn't the API wonderful?
         //
         let booleanFromPlanetMars = read ? Constants.readAsInteger : Constants.unreadAsInteger
@@ -52,9 +52,9 @@ public class NotificationsRemote: Remote {
         //
         var payload = [String: Int]()
 
-        for noteId in noteIds {
-            let noteIdAsString = String(noteId)
-            payload[noteIdAsString] = booleanFromPlanetMars
+        for noteID in noteIDs {
+            let noteIDAsString = String(noteID)
+            payload[noteIDAsString] = booleanFromPlanetMars
         }
 
         // Parameters: [.counts: [Payload]]
@@ -111,18 +111,18 @@ private extension NotificationsRemote {
     /// Note that only the specified fields will be retrieved.
     ///
     /// - Parameters:
-    ///     - noteIds: Identifier for the notifications that should be loaded.
+    ///     - noteIDs: Identifier for the notifications that should be loaded.
     ///     - fields: List of comma separated fields, to be loaded.
     ///     - pageSize: Number of notifications to load.
     ///     - completion: Callback to be executed on completion.
     ///
-    func requestForNotifications(fields: Fields? = nil, noteIds: [Int64]? = nil, pageSize: Int?) -> DotcomRequest {
+    func requestForNotifications(fields: Fields? = nil, noteIDs: [Int64]? = nil, pageSize: Int?) -> DotcomRequest {
         var parameters = [ParameterKeys.locale: Locale.current.description]
         if let fields = fields {
             parameters[ParameterKeys.fields] = fields.rawValue
         }
 
-        if let notificationIds = noteIds {
+        if let notificationIds = noteIDs {
             let identifiersAsStrings = notificationIds.map { String($0) }
             parameters[ParameterKeys.identifiers] = identifiersAsStrings.joined(separator: ",")
         }

--- a/Networking/Networking/Remote/OrderStatsRemote.swift
+++ b/Networking/Networking/Remote/OrderStatsRemote.swift
@@ -18,7 +18,7 @@ public class OrderStatsRemote: Remote {
     ///
     /// Note: by limiting the return values with the `_fields` param, we shrink the response size by over 90%! (~40kb to ~3kb)
     ///
-    public func loadOrderStats(for siteID: Int,
+    public func loadOrderStats(for siteID: Int64,
                                unit: StatGranularity,
                                latestDateToInclude: String,
                                quantity: Int,

--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -15,7 +15,7 @@ public final class OrderStatsRemoteV4: Remote {
     ///
     /// Note: by limiting the return values with the `_fields` param, we shrink the response size by over 90%! (~40kb to ~3kb)
     ///
-    public func loadOrderStats(for siteID: Int,
+    public func loadOrderStats(for siteID: Int64,
                                unit: StatsGranularityV4,
                                earliestDateToInclude: String,
                                latestDateToInclude: String,

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -15,7 +15,7 @@ public class OrdersRemote: Remote {
     ///     - pageSize: Number of Orders to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadAllOrders(for siteID: Int,
+    public func loadAllOrders(for siteID: Int64,
                               statusKey: String? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
@@ -41,7 +41,7 @@ public class OrdersRemote: Remote {
     ///     - orderID: Identifier of the Order.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadOrder(for siteID: Int, orderID: Int, completion: @escaping (Order?, Error?) -> Void) {
+    public func loadOrder(for siteID: Int64, orderID: Int64, completion: @escaping (Order?, Error?) -> Void) {
         let parameters = [
             ParameterKeys.fields: ParameterValues.fieldValues
         ]
@@ -60,7 +60,7 @@ public class OrdersRemote: Remote {
     ///     - orderID: Identifier of the Order.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadOrderNotes(for siteID: Int, orderID: Int, completion: @escaping ([OrderNote]?, Error?) -> Void) {
+    public func loadOrderNotes(for siteID: Int64, orderID: Int64, completion: @escaping ([OrderNote]?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/\(orderID)/\(Constants.notesPath)/"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = OrderNotesMapper()
@@ -77,7 +77,7 @@ public class OrdersRemote: Remote {
     ///     - pageSize: Number of Orders to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func searchOrders(for siteID: Int,
+    public func searchOrders(for siteID: Int64,
                              keyword: String,
                              pageNumber: Int = Defaults.pageNumber,
                              pageSize: Int = Defaults.pageSize,
@@ -105,7 +105,7 @@ public class OrdersRemote: Remote {
     ///     - status: New Status to be set.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateOrder(from siteID: Int, orderID: Int, statusKey: String, completion: @escaping (Order?, Error?) -> Void) {
+    public func updateOrder(from siteID: Int64, orderID: Int64, statusKey: String, completion: @escaping (Order?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/" + String(orderID)
         let parameters = [ParameterKeys.statusKey: statusKey]
         let mapper = OrderMapper(siteID: siteID)
@@ -124,7 +124,7 @@ public class OrdersRemote: Remote {
     ///     - note: The note to be posted.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func addOrderNote(for siteID: Int, orderID: Int, isCustomerNote: Bool, with note: String, completion: @escaping (OrderNote?, Error?) -> Void) {
+    public func addOrderNote(for siteID: Int64, orderID: Int64, isCustomerNote: Bool, with note: String, completion: @escaping (OrderNote?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/" + String(orderID) + "/" + "\(Constants.notesPath)"
         let parameters = [ParameterKeys.note: note,
                           ParameterKeys.customerNote: String(isCustomerNote),
@@ -142,7 +142,7 @@ public class OrdersRemote: Remote {
     ///     - ststusKey: the order status slug
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func countOrders(for siteID: Int, statusKey: String, completion: @escaping (OrderCount?, Error?) -> Void) {
+    public func countOrders(for siteID: Int64, statusKey: String, completion: @escaping (OrderCount?, Error?) -> Void) {
         let parameters = [ParameterKeys.statusKey: statusKey]
 
         let mapper = OrderCountMapper(siteID: siteID)

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -17,7 +17,7 @@ public final class ProductReviewsRemote: Remote {
     ///     - pageSize: Number of Orders to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadAllProductReviews(for siteID: Int,
+    public func loadAllProductReviews(for siteID: Int64,
                                 context: String? = nil,
                                 pageNumber: Int = Default.pageNumber,
                                 pageSize: Int = Default.pageSize,
@@ -43,7 +43,7 @@ public final class ProductReviewsRemote: Remote {
     ///     - reviewID: Identifier of the ProductReview.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadProductReview(for siteID: Int, reviewID: Int, completion: @escaping (ProductReview?, Error?) -> Void) {
+    public func loadProductReview(for siteID: Int64, reviewID: Int64, completion: @escaping (ProductReview?, Error?) -> Void) {
         let path = "\(Path.reviews)/\(reviewID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ProductReviewMapper(siteID: siteID)
@@ -59,7 +59,7 @@ public final class ProductReviewsRemote: Remote {
     ///     - statusKey: The new status
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateProductReviewStatus(for siteID: Int, reviewID: Int, statusKey: String, completion: @escaping (ProductReview?, Error?) -> Void) {
+    public func updateProductReviewStatus(for siteID: Int64, reviewID: Int64, statusKey: String, completion: @escaping (ProductReview?, Error?) -> Void) {
         let path = "\(Path.reviews)/\(reviewID)"
         let parameters = [ParameterKey.status: statusKey]
         let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)

--- a/Networking/Networking/Remote/ProductShippingClassRemote.swift
+++ b/Networking/Networking/Remote/ProductShippingClassRemote.swift
@@ -27,7 +27,7 @@ public class ProductShippingClassRemote: Remote {
         ]
 
         let path = "\(Path.models)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int(siteID), path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: parameters)
         let mapper = ProductShippingClassListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -42,7 +42,7 @@ public class ProductShippingClassRemote: Remote {
     ///
     public func loadOne(for siteID: Int64, remoteID: Int64, completion: @escaping (ProductShippingClass?, Error?) -> Void) {
         let path = "\(Path.models)/\(remoteID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int(siteID), path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: nil)
         let mapper = ProductShippingClassMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Remote/ProductShippingClassRemote.swift
+++ b/Networking/Networking/Remote/ProductShippingClassRemote.swift
@@ -27,7 +27,7 @@ public class ProductShippingClassRemote: Remote {
         ]
 
         let path = "\(Path.models)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductShippingClassListMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -42,7 +42,7 @@ public class ProductShippingClassRemote: Remote {
     ///
     public func loadOne(for siteID: Int64, remoteID: Int64, completion: @escaping (ProductShippingClass?, Error?) -> Void) {
         let path = "\(Path.models)/\(remoteID)"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ProductShippingClassMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)

--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -30,7 +30,7 @@ public class ProductVariationsRemote: Remote {
         ]
 
         let path = "\(Path.products)/\(productID)/variations"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int(siteID), path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: parameters)
         let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -30,7 +30,7 @@ public class ProductVariationsRemote: Remote {
         ]
 
         let path = "\(Path.products)/\(productID)/variations"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: parameters)
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -19,7 +19,7 @@ public class ProductsRemote: Remote {
     ///     - order: ascending or descending order. Default to ascending.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadAllProducts(for siteID: Int,
+    public func loadAllProducts(for siteID: Int64,
                                 context: String? = nil,
                                 pageNumber: Int = Default.pageNumber,
                                 pageSize: Int = Default.pageSize,
@@ -51,7 +51,7 @@ public class ProductsRemote: Remote {
     ///     - productIDs: The array of product IDs that are requested.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadProducts(for siteID: Int, by productIDs: [Int], completion: @escaping ([Product]?, Error?) -> Void) {
+    public func loadProducts(for siteID: Int64, by productIDs: [Int64], completion: @escaping ([Product]?, Error?) -> Void) {
         let stringOfProductIDs = productIDs.map { String($0) }
             .filter { !$0.isEmpty }
             .joined(separator: ",")
@@ -71,7 +71,7 @@ public class ProductsRemote: Remote {
     ///     - productID: Identifier of the Product.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadProduct(for siteID: Int, productID: Int, completion: @escaping (Product?, Error?) -> Void) {
+    public func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Product?, Error?) -> Void) {
         let path = "\(Path.products)/\(productID)"
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ProductMapper(siteID: siteID)
@@ -88,7 +88,7 @@ public class ProductsRemote: Remote {
     ///     - pageSize: Number of products to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func searchProducts(for siteID: Int,
+    public func searchProducts(for siteID: Int64,
                                keyword: String,
                                pageNumber: Int,
                                pageSize: Int,

--- a/Networking/Networking/Remote/RefundsRemote.swift
+++ b/Networking/Networking/Remote/RefundsRemote.swift
@@ -17,8 +17,8 @@ public final class RefundsRemote: Remote {
     ///     - pageSize: Number of Refunds to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadAllRefunds(for siteID: Int,
-                               by orderID: Int,
+    public func loadAllRefunds(for siteID: Int64,
+                               by orderID: Int64,
                                context: String = Default.context,
                                pageNumber: Int = Default.pageNumber,
                                pageSize: Int = Default.pageSize,
@@ -46,7 +46,7 @@ public final class RefundsRemote: Remote {
     ///     - refundIDs: The array of refund IDs that are requested.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadRefunds(for siteID: Int, by orderID: Int, with refundIDs: [Int], completion: @escaping ([Refund]?, Error?) -> Void) {
+    public func loadRefunds(for siteID: Int64, by orderID: Int64, with refundIDs: [Int64], completion: @escaping ([Refund]?, Error?) -> Void) {
         let stringOfRefundIDs = refundIDs.sortedUniqueIntToString()
         let parameters = [ ParameterKey.include: stringOfRefundIDs ]
         let path = "\(Path.orders)/" + String(orderID) + "/" + "\(Path.refunds)"
@@ -64,9 +64,9 @@ public final class RefundsRemote: Remote {
     ///     - refundID: Unique identifier for the refund we're searching for.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadRefund(siteID: Int,
-                           orderID: Int,
-                           refundID: Int,
+    public func loadRefund(siteID: Int64,
+                           orderID: Int64,
+                           refundID: Int64,
                            completion: @escaping (Refund?, Error?) -> Void) {
         let path = Path.orders + "/" + String(orderID) + "/" + Path.refunds + "/" + String(refundID)
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
@@ -83,8 +83,8 @@ public final class RefundsRemote: Remote {
     ///     - refund: The Refund model used to create the custom entity for the request.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func createRefund(for siteID: Int,
-                             by orderID: Int,
+    public func createRefund(for siteID: Int64,
+                             by orderID: Int64,
                              refund: Refund,
                              completion: @escaping (Refund?, Error?) -> Void) {
         let path = "\(Path.orders)/" + String(orderID) + "/" + "\(Path.refunds)"

--- a/Networking/Networking/Remote/ReportRemote.swift
+++ b/Networking/Networking/Remote/ReportRemote.swift
@@ -15,7 +15,7 @@ public class ReportRemote: Remote {
     ///   - siteID: Site for which we'll fetch the order totals.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadOrderTotals(for siteID: Int, completion: @escaping ([OrderStatusEnum: Int]?, Error?) -> Void) {
+    public func loadOrderTotals(for siteID: Int64, completion: @escaping ([OrderStatusEnum: Int]?, Error?) -> Void) {
         loadReportOrderTotals(for: siteID) { (orderStatuses, error) in
             var returnDict = [OrderStatusEnum: Int]()
             orderStatuses?.forEach({ (orderStatus) in
@@ -29,13 +29,13 @@ public class ReportRemote: Remote {
     /// Retrieves all known order statuses.
     /// Wraps the API request.
     ///
-    public func loadOrderStatuses(for siteID: Int, completion: @escaping ([OrderStatus]?, Error?) -> Void) {
+    public func loadOrderStatuses(for siteID: Int64, completion: @escaping ([OrderStatus]?, Error?) -> Void) {
         loadReportOrderTotals(for: siteID, completion: completion)
     }
 
     /// Retrieves an order totals report
     ///
-    private func loadReportOrderTotals(for siteID: Int, completion: @escaping ([OrderStatus]?, Error?) -> Void) {
+    private func loadReportOrderTotals(for siteID: Int64, completion: @escaping ([OrderStatus]?, Error?) -> Void) {
         let path = Constants.orderTotalsPath
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = ReportOrderTotalsMapper(siteID: siteID)

--- a/Networking/Networking/Remote/ShipmentsRemote.swift
+++ b/Networking/Networking/Remote/ShipmentsRemote.swift
@@ -97,7 +97,9 @@ public final class ShipmentsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    public func loadShipmentTrackingProviderGroups(for siteID: Int64, orderID: Int64, completion: @escaping ([ShipmentTrackingProviderGroup]?, Error?) -> Void) {
+    public func loadShipmentTrackingProviderGroups(for siteID: Int64,
+                                                   orderID: Int64,
+                                                   completion: @escaping ([ShipmentTrackingProviderGroup]?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/" + String(orderID) + "/" + "\(Constants.shipmentPath)/\(Constants.providersPath)"
 
         let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)

--- a/Networking/Networking/Remote/ShipmentsRemote.swift
+++ b/Networking/Networking/Remote/ShipmentsRemote.swift
@@ -13,7 +13,7 @@ public final class ShipmentsRemote: Remote {
     ///   - orderID: Identifier of the Order
     ///   - completion: Closure to be executed upon completion
     ///
-    public func loadShipmentTrackings(for siteID: Int, orderID: Int, completion: @escaping ([ShipmentTracking]?, Error?) -> Void) {
+    public func loadShipmentTrackings(for siteID: Int64, orderID: Int64, completion: @escaping ([ShipmentTracking]?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/" + String(orderID) + "/" + "\(Constants.shipmentPath)/"
 
         // 2019-2-15 — We are using the v2 endpoint here because this endpoint does not support v3 yet
@@ -32,8 +32,8 @@ public final class ShipmentsRemote: Remote {
     ///   - trackingNumber: The tracking number
     ///   - completion: Closure to be executed upon completion
     ///
-    public func createShipmentTracking(for siteID: Int,
-                                       orderID: Int,
+    public func createShipmentTracking(for siteID: Int64,
+                                       orderID: Int64,
                                        trackingProvider: String,
                                        dateShipped: String,
                                        trackingNumber: String,
@@ -60,8 +60,8 @@ public final class ShipmentsRemote: Remote {
     ///   - trackingLink: The custom url offered by this provider to track shipments
     ///   - completion: Closure to be executed upon completion
     ///
-    public func createShipmentTrackingWithCustomProvider(for siteID: Int,
-                                                         orderID: Int,
+    public func createShipmentTrackingWithCustomProvider(for siteID: Int64,
+                                                         orderID: Int64,
                                                          trackingProvider: String,
                                                          trackingNumber: String,
                                                          trackingURL: String,
@@ -88,7 +88,7 @@ public final class ShipmentsRemote: Remote {
     ///   - trackingID: The tracking identifier
     ///   - completion: Closure to be executed upon completion
     ///
-    public func deleteShipmentTracking(for siteID: Int, orderID: Int, trackingID: String, completion: @escaping (ShipmentTracking?, Error?) -> Void) {
+    public func deleteShipmentTracking(for siteID: Int64, orderID: Int64, trackingID: String, completion: @escaping (ShipmentTracking?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/" + String(orderID) + "/" + "\(Constants.shipmentPath)/" + trackingID
 
         let request = JetpackRequest(wooApiVersion: .mark2, method: .delete, siteID: siteID, path: path, parameters: nil)
@@ -97,7 +97,7 @@ public final class ShipmentsRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    public func loadShipmentTrackingProviderGroups(for siteID: Int, orderID: Int, completion: @escaping ([ShipmentTrackingProviderGroup]?, Error?) -> Void) {
+    public func loadShipmentTrackingProviderGroups(for siteID: Int64, orderID: Int64, completion: @escaping ([ShipmentTrackingProviderGroup]?, Error?) -> Void) {
         let path = "\(Constants.ordersPath)/" + String(orderID) + "/" + "\(Constants.shipmentPath)/\(Constants.providersPath)"
 
         let request = JetpackRequest(wooApiVersion: .mark2, method: .get, siteID: siteID, path: path, parameters: nil)

--- a/Networking/Networking/Remote/SiteAPIRemote.swift
+++ b/Networking/Networking/Remote/SiteAPIRemote.swift
@@ -13,7 +13,7 @@ public class SiteAPIRemote: Remote {
     ///   - siteID: Site for which we'll fetch the API settings.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadAPIInformation(for siteID: Int, completion: @escaping (SiteAPI?, Error?) -> Void) {
+    public func loadAPIInformation(for siteID: Int64, completion: @escaping (SiteAPI?, Error?) -> Void) {
         let path = String()
         let parameters = [ParameterKeys.fields: ParameterValues.fieldValues]
         let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: parameters)

--- a/Networking/Networking/Remote/SiteSettingsRemote.swift
+++ b/Networking/Networking/Remote/SiteSettingsRemote.swift
@@ -12,7 +12,7 @@ public class SiteSettingsRemote: Remote {
     ///   - siteID: Site for which we'll fetch the general settings.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadGeneralSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
+    public func loadGeneralSettings(for siteID: Int64, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.siteSettingsPath + Constants.generalSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.general)
@@ -26,7 +26,7 @@ public class SiteSettingsRemote: Remote {
     ///   - siteID: Site for which we'll fetch the product settings.
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadProductSettings(for siteID: Int, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
+    public func loadProductSettings(for siteID: Int64, completion: @escaping ([SiteSetting]?, Error?) -> Void) {
         let path = Constants.siteSettingsPath + Constants.productSettingsGroup
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
         let mapper = SiteSettingsMapper(siteID: siteID, settingsGroup: SiteSettingGroup.product)

--- a/Networking/Networking/Remote/SiteVisitStatsRemote.swift
+++ b/Networking/Networking/Remote/SiteVisitStatsRemote.swift
@@ -14,7 +14,7 @@ public class SiteVisitStatsRemote: Remote {
     ///   - quantity: How many `unit`s to fetch
     ///   - completion: Closure to be executed upon completion.
     ///
-    public func loadSiteVisitorStats(for siteID: Int,
+    public func loadSiteVisitorStats(for siteID: Int64,
                                      siteTimezone: TimeZone? = nil,
                                      unit: StatGranularity,
                                      latestDateToInclude: Date,

--- a/Networking/Networking/Remote/TaxClassRemote.swift
+++ b/Networking/Networking/Remote/TaxClassRemote.swift
@@ -17,8 +17,8 @@ public class TaxClassRemote: Remote {
                                 completion: @escaping ([TaxClass]?, Error?) -> Void) {
 
         let path = Path.taxes + "/classes"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: nil)
-        let mapper = TaxClassListMapper(siteID: Int64(siteID))
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: nil)
+        let mapper = TaxClassListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/TaxClassRemote.swift
+++ b/Networking/Networking/Remote/TaxClassRemote.swift
@@ -17,8 +17,8 @@ public class TaxClassRemote: Remote {
                                 completion: @escaping ([TaxClass]?, Error?) -> Void) {
 
         let path = Path.taxes + "/classes"
-        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int(siteID), path: path, parameters: nil)
-        let mapper = TaxClassListMapper(siteID: Int(siteID))
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: Int64(siteID), path: path, parameters: nil)
+        let mapper = TaxClassListMapper(siteID: Int64(siteID))
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/TopEarnersStatsRemote.swift
+++ b/Networking/Networking/Remote/TopEarnersStatsRemote.swift
@@ -18,7 +18,7 @@ public class TopEarnersStatsRemote: Remote {
     ///
     /// Note: `latestDateToInclude` string must be formatted appropriately given the `unit` param. See: `DateFormatter.Stats` extension for some helper funcs.
     ///
-    public func loadTopEarnersStats(for siteID: Int,
+    public func loadTopEarnersStats(for siteID: Int64,
                                     unit: StatGranularity,
                                     latestDateToInclude: String,
                                     limit: Int,

--- a/Networking/Networking/Requests/JetpackRequest.swift
+++ b/Networking/Networking/Requests/JetpackRequest.swift
@@ -20,7 +20,7 @@ struct JetpackRequest: URLRequestConvertible {
 
     /// Jetpack-Tunneled Site ID
     ///
-    let siteID: Int
+    let siteID: Int64
 
     /// Jetpack-Tunneled RPC
     ///
@@ -40,7 +40,7 @@ struct JetpackRequest: URLRequestConvertible {
     ///     - path: RPC that should be called.
     ///     - parameters: Collection of Key/Value parameters, to be forwarded to the Jetpack Connected site.
     ///
-    init(wooApiVersion: WooAPIVersion, method: HTTPMethod, siteID: Int, path: String, parameters: [String: Any]? = nil) {
+    init(wooApiVersion: WooAPIVersion, method: HTTPMethod, siteID: Int64, path: String, parameters: [String: Any]? = nil) {
         if [.mark1, .mark2].contains(wooApiVersion) {
             DDLogWarn("⚠️ You are using an older version of the Woo REST API: \(wooApiVersion.rawValue), for path: \(path)")
         }

--- a/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/ArrayWooTests.swift
@@ -9,7 +9,7 @@ class ArrayWooTests: XCTestCase {
     /// Verifies that a zero value in an array produces a valid String.
     ///
     func testArrayWithZeroValueReturnsAString() {
-        let exampleIDs = [0]
+        let exampleIDs: [Int64] = [0]
         let expected = "0"
         let actual = exampleIDs.sortedUniqueIntToString()
 
@@ -19,7 +19,7 @@ class ArrayWooTests: XCTestCase {
     /// Verifies that a single value in an array produces a valid String.
     ///
     func testArrayWithSingleValueReturnsAString() {
-        let exampleIDs = [999]
+        let exampleIDs: [Int64] = [999]
         let expected = "999"
         let actual = exampleIDs.sortedUniqueIntToString()
 
@@ -29,7 +29,7 @@ class ArrayWooTests: XCTestCase {
     /// Verifies that an empty array produces an emtpy String.
     ///
     func testEmptyArrayReturnsAnEmptyString() {
-        let exampleIDs = [Int]()
+        let exampleIDs = [Int64]()
         let expected = ""
         let actual = exampleIDs.sortedUniqueIntToString()
 
@@ -39,7 +39,7 @@ class ArrayWooTests: XCTestCase {
     /// Verifies that an array with int values produces a valid String.
     ///
     func testArrayWithValuesReturnsSortedValuesAsString() {
-        let exampleIDs = [75, 37, 259, 16, 83]
+        let exampleIDs: [Int64] = [75, 37, 259, 16, 83]
         let expected = "16,37,75,83,259"
         let actual = exampleIDs.sortedUniqueIntToString()
 
@@ -49,7 +49,7 @@ class ArrayWooTests: XCTestCase {
     /// Verifies that an array with duplicate entries produces a de-duplicated, valid String.
     ///
     func testArrayWithDuplicateValuesReturnsWithNoDuplicates() {
-        let exampleIDs = [123, 6, 13, 259, 3, 321, 7, 6, 87, 3, 9, 17, 85, 87]
+        let exampleIDs: [Int64] = [123, 6, 13, 259, 3, 321, 7, 6, 87, 3, 9, 17, 85, 87]
         let expected = "3,6,7,9,13,17,85,87,123,259,321"
         let actual = exampleIDs.sortedUniqueIntToString()
 

--- a/Networking/NetworkingTests/Mapper/NoteListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/NoteListMapperTests.swift
@@ -40,7 +40,7 @@ class NoteListMapperTests: XCTestCase {
         let note = sampleNotes[0]
 
         // Plain Fields
-        XCTAssertEqual(note.noteId, 100001)
+        XCTAssertEqual(note.noteID, 100001)
         XCTAssertEqual(note.hash, 987654)
         XCTAssertEqual(note.read, false)
         XCTAssert(note.icon == "https://gravatar.tld/some-hash")
@@ -87,7 +87,7 @@ class NoteListMapperTests: XCTestCase {
         let note = brokenNotes[0]
 
         // Plain Fields
-        XCTAssertEqual(note.noteId, 123456)
+        XCTAssertEqual(note.noteID, 123456)
         XCTAssertEqual(note.hash, 987654)
         XCTAssertFalse(note.read)
         XCTAssertNil(note.icon)
@@ -255,7 +255,7 @@ class NoteListMapperTests: XCTestCase {
     /// Verifies that the Notification's subtype is properly parsed.
     ///
     func testStoreReviewSubtypeIsProperlyParsed() {
-        let storeReview = sampleNotes.first(where: { $0.noteId == 100009 })
+        let storeReview = sampleNotes.first(where: { $0.noteID == 100009 })
         XCTAssertEqual(storeReview?.subtype, "store_review")
         XCTAssertEqual(storeReview?.subkind, .storeReview)
     }

--- a/Networking/NetworkingTests/Mapper/OrderListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderListMapperTests.swift
@@ -8,7 +8,7 @@ class OrderListMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 242424
+    private let dummySiteID: Int64 = 242424
 
 
     /// Verifies that all of the Order Fields are parsed correctly.

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -8,7 +8,7 @@ class OrderMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 424242
+    private let dummySiteID: Int64 = 424242
 
 
     /// Verifies that all of the Order Fields are parsed correctly.

--- a/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderStatsMapperV4Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 ///
 final class OrderStatsV4MapperTests: XCTestCase {
     private struct Constants {
-        static let siteID = 1234
+        static let siteID: Int64 = 1234
         static let hourlyGranularity = StatsGranularityV4.hourly
         static let dailyGranularity = StatsGranularityV4.daily
         static let weeklyGranularity = StatsGranularityV4.weekly

--- a/Networking/NetworkingTests/Mapper/ProductListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductListMapperTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class ProductListMapperTests: XCTestCase {
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 33334444
+    private let dummySiteID: Int64 = 33334444
 
     /// Verifies that all of the Product Fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -8,15 +8,15 @@ class ProductMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 33334444
+    private let dummySiteID: Int64 = 33334444
 
     /// Dummy Product ID.
     ///
-    private let dummyProductID = 282
+    private let dummyProductID: Int64 = 282
 
     /// Dummy Product Variation ID.
     ///
-    private let dummyProductVariationID = 295
+    private let dummyProductVariationID: Int64 = 295
 
     /// Verifies that all of the Product Fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReviewListMapperTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class ProductReviewListMapperTests: XCTestCase {
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 33334444
+    private let dummySiteID: Int64 = 33334444
 
     /// Verifies that all of the ProductReview Fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/RefundListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundListMapperTests.swift
@@ -8,11 +8,11 @@ final class RefundListMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 90210
+    private let dummySiteID: Int64 = 90210
 
     /// Order ID.
     ///
-    private let orderID = 560
+    private let orderID: Int64 = 560
 
     /// Verifies that all the Refund fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
@@ -8,11 +8,11 @@ final class RefundMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 33334444
+    private let dummySiteID: Int64 = 33334444
 
     /// Order ID.
     ///
-    private let orderID = 560
+    private let orderID: Int64 = 560
 
     /// Verifies that all of the Refund fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/ReportOrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ReportOrderMapperTests.swift
@@ -8,7 +8,7 @@ class ReportOrderMapperTests: XCTestCase {
 
     /// Sample SiteID
     ///
-    let siteID = 1234
+    let siteID: Int64 = 1234
 
     /// Verifies that the broken response causes the mapper to return an unknown status
     ///

--- a/Networking/NetworkingTests/Mapper/ShipmentTrackingListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShipmentTrackingListMapperTests.swift
@@ -8,11 +8,11 @@ class ShipmentTrackingListMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 424242
+    private let dummySiteID: Int64 = 424242
 
     /// Dummy Order ID.
     ///
-    private let dummyOrderID = 99999999
+    private let dummyOrderID: Int64 = 99999999
 
     /// Verifies that all of the ShipmentTracking Fields are parsed correctly for multiple tracking JSON objects.
     ///

--- a/Networking/NetworkingTests/Mapper/SiteAPIMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteAPIMapperTests.swift
@@ -8,7 +8,7 @@ class SiteAPIMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 242424
+    private let dummySiteID: Int64 = 242424
 
     /// Dummy Site Namespaces.
     ///

--- a/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SiteSettingsMapperTests.swift
@@ -8,7 +8,7 @@ class SiteSettingsMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID = 242424
+    private let dummySiteID: Int64 = 242424
 
     /// Verifies the SiteSetting fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/TaxClassListMapperTest.swift
+++ b/Networking/NetworkingTests/Mapper/TaxClassListMapperTest.swift
@@ -8,7 +8,7 @@ final class TaxClassListMapperTest: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Verifies that all of the Tax Class Fields are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/AccountRemoteTests.swift
@@ -36,13 +36,13 @@ class AccountRemoteTests: XCTestCase {
     }
 
     func testUpdateAccountDetailsProperlyReturnsParsedAccount() {
-        let id = 1
+        let remoteID: Int64 = 1
         let optOut = false
         let remote = AccountRemote(network: network)
         let expectation = self.expectation(description: "Update Account Details")
 
         network.simulateResponse(requestUrlSuffix: "me/settings", filename: "me-settings")
-        remote.updateAccountSettings(for: id, tracksOptOut: optOut) { (accountSettings, error) in
+        remote.updateAccountSettings(for: remoteID, tracksOptOut: optOut) { (accountSettings, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(accountSettings)
 

--- a/Networking/NetworkingTests/Remote/CommentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CommentRemoteTests.swift
@@ -12,11 +12,11 @@ class CommentRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Dummy Order ID
     ///
-    let sampleCommentID = 2
+    let sampleCommentID: Int64 = 2
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/DevicesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/DevicesRemoteTests.swift
@@ -104,6 +104,6 @@ private enum Parameters {
                                         identifierForVendor: "1234")
     static let applicationId = "9"
     static let applicationVersion = "99"
-    static let defaultStoreID = 1234
+    static let defaultStoreID: Int64 = 1234
     static let dotcomDeviceID = "1234"
 }

--- a/Networking/NetworkingTests/Remote/NotificationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/NotificationsRemoteTests.swift
@@ -118,7 +118,7 @@ class NotificationsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_error")
 
-        remote.updateReadStatus(noteIds: [], read: true) { error in
+        remote.updateReadStatus(noteIDs: [], read: true) { error in
             guard let error = error as? DotcomError else {
                 XCTFail()
                 return
@@ -140,7 +140,7 @@ class NotificationsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_success")
 
-        remote.updateReadStatus(noteIds: [], read: true) { error in
+        remote.updateReadStatus(noteIDs: [], read: true) { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }

--- a/Networking/NetworkingTests/Remote/OrderStatsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrderStatsRemoteTests.swift
@@ -12,7 +12,7 @@ class OrderStatsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
+++ b/Networking/NetworkingTests/Remote/OrderStatsRemoteV4Tests.swift
@@ -11,7 +11,7 @@ final class OrderStatsRemoteV4Tests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -12,11 +12,11 @@ final class OrdersRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Dummy Order ID
     ///
-    let sampleOrderID = 1467
+    let sampleOrderID: Int64 = 1467
 
     /// Dummy author string
     ///

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -12,11 +12,11 @@ final class ProductReviewsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Dummy Product ID
     ///
-    let sampleReviewID = 173
+    let sampleReviewID: Int64 = 173
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/ProductShippingClassRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductShippingClassRemoteTests.swift
@@ -35,7 +35,7 @@ final class ProductShippingClassRemoteTests: XCTestCase {
             XCTAssertEqual(productShippingClasses?.count, 3)
 
             // Validates on Shipping Class of ID 94.
-            let expectedShippingClassID = 94
+            let expectedShippingClassID: Int64 = 94
             guard let expectedShippingClass = productShippingClasses?.first(where: { $0.shippingClassID == expectedShippingClassID }) else {
                 XCTFail("Product shipping class with ID \(expectedShippingClassID) should exist")
                 return

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -39,7 +39,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
             XCTAssertEqual(productVariations?.count, 8)
 
             // Validates on Variation of ID 1275.
-            let expectedVariationID = 1275
+            let expectedVariationID: Int64 = 1275
             guard let expectedVariation = productVariations?.first(where: { $0.productVariationID == expectedVariationID }) else {
                 XCTFail("Product variation with ID \(expectedVariationID) should exist")
                 return

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -12,11 +12,11 @@ class ProductsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Dummy Product ID
     ///
-    let sampleProductID = 282
+    let sampleProductID: Int64 = 282
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/ReportRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReportRemoteTests.swift
@@ -12,7 +12,7 @@ class ReportRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/ShipmentsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShipmentsRemoteTests.swift
@@ -12,11 +12,11 @@ final class ShipmentsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Dummy Order ID
     ///
-    let sampleOrderID = 567
+    let sampleOrderID: Int64 = 567
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/SiteAPIRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteAPIRemoteTests.swift
@@ -12,7 +12,7 @@ class SiteAPIRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -12,7 +12,7 @@ class SiteSettingsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/SiteVisitStatsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/SiteVisitStatsRemoteTests.swift
@@ -12,7 +12,7 @@ class SiteVisitStatsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Remote/TaxClassRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/TaxClassRemoteTests.swift
@@ -44,7 +44,7 @@ final class TaxClassRemoteTests: XCTestCase {
                 XCTFail("Tax Class with slug \(expectedSlug) should exist")
                 return
             }
-            XCTAssertEqual(expectedTaxClass.siteID, Int(self.sampleSiteID))
+            XCTAssertEqual(expectedTaxClass.siteID, self.sampleSiteID)
             XCTAssertEqual(expectedTaxClass.name, "Standard Rate")
             expectation.fulfill()
         }

--- a/Networking/NetworkingTests/Remote/TopEarnerStatsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/TopEarnerStatsRemoteTests.swift
@@ -12,7 +12,7 @@ class TopEarnerStatsRemoteTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    let sampleSiteID = 1234
+    let sampleSiteID: Int64 = 1234
 
     /// Repeat always!
     ///

--- a/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
@@ -12,7 +12,7 @@ final class JetpackRequestTests: XCTestCase {
 
     /// Sample SiteID
     ///
-    private let sampleSiteID = 1234
+    private let sampleSiteID: Int64 = 1234
 
     /// RPC Sample Method Path
     ///

--- a/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
+++ b/Storage/Storage/Model/OrderStatsV4+CoreDataProperties.swift
@@ -8,7 +8,7 @@ extension OrderStatsV4 {
         return NSFetchRequest<OrderStatsV4>(entityName: "OrderStatsV4")
     }
 
-    @NSManaged public var siteID: Int
+    @NSManaged public var siteID: Int64
     @NSManaged public var granularity: String
     @NSManaged public var timeRange: String
     @NSManaged public var totals: OrderStatsV4Totals?

--- a/Storage/Storage/Model/PreselectedProvider.swift
+++ b/Storage/Storage/Model/PreselectedProvider.swift
@@ -2,11 +2,11 @@
 /// These entities will be serialised to a plist file
 ///
 public struct PreselectedProvider: Codable, Equatable {
-    public let siteID: Int
+    public let siteID: Int64
     public let providerName: String
     public let providerURL: String?
 
-    public init(siteID: Int, providerName: String, providerURL: String? = nil) {
+    public init(siteID: Int64, providerName: String, providerURL: String? = nil) {
         self.siteID = siteID
         self.providerName = providerName
         self.providerURL = providerURL

--- a/Storage/Storage/Model/StatsVersionBySite.swift
+++ b/Storage/Storage/Model/StatsVersionBySite.swift
@@ -2,9 +2,9 @@
 /// These entities will be serialised to a plist file
 ///
 public struct StatsVersionBySite: Codable, Equatable {
-    public let statsVersionBySite: [Int: StatsVersion]
+    public let statsVersionBySite: [Int64: StatsVersion]
 
-    public init(statsVersionBySite: [Int: StatsVersion]) {
+    public init(statsVersionBySite: [Int64: StatsVersion]) {
         self.statsVersionBySite = statsVersionBySite
     }
 }

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -9,7 +9,7 @@ public extension StorageType {
 
     /// Deletes all of the stored Products for the provided siteID.
     ///
-    func deleteProducts(siteID: Int) {
+    func deleteProducts(siteID: Int64) {
         guard let products = loadProducts(siteID: siteID) else {
             return
         }

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -7,21 +7,21 @@ public extension StorageType {
 
     /// Retrieves the Stored Account.
     ///
-    func loadAccount(userId: Int) -> Account? {
-        let predicate = NSPredicate(format: "userID = %ld", userId)
+    func loadAccount(userID: Int64) -> Account? {
+        let predicate = NSPredicate(format: "userID = %ld", userID)
         return firstObject(ofType: Account.self, matching: predicate)
     }
 
     /// Retrieves the Stores AccountSettings.
     ///
-    func loadAccountSettings(userId: Int) -> AccountSettings? {
-        let predicate = NSPredicate(format: "userID = %ld", userId)
+    func loadAccountSettings(userID: Int64) -> AccountSettings? {
+        let predicate = NSPredicate(format: "userID = %ld", userID)
         return firstObject(ofType: AccountSettings.self, matching: predicate)
     }
 
     /// Retrieves the Stored Site.
     ///
-    func loadSite(siteID: Int) -> Site? {
+    func loadSite(siteID: Int64) -> Site? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         return firstObject(ofType: Site.self, matching: predicate)
     }
@@ -30,7 +30,7 @@ public extension StorageType {
 
     /// Retrieves the Stored Order.
     ///
-    func loadOrder(orderID: Int) -> Order? {
+    func loadOrder(orderID: Int64) -> Order? {
         let predicate = NSPredicate(format: "orderID = %ld", orderID)
         return firstObject(ofType: Order.self, matching: predicate)
     }
@@ -44,42 +44,42 @@ public extension StorageType {
 
     /// Retrieves the Stored Order Item.
     ///
-    func loadOrderItem(siteID: Int, orderID: Int, itemID: Int) -> OrderItem? {
+    func loadOrderItem(siteID: Int64, orderID: Int64, itemID: Int64) -> OrderItem? {
         let predicate = NSPredicate(format: "order.siteID = %ld AND order.orderID = %ld AND itemID = %ld", siteID, orderID, itemID)
         return firstObject(ofType: OrderItem.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Item Tax.
     ///
-    func loadOrderItemTax(itemID: Int, taxID: Int) -> OrderItemTax? {
+    func loadOrderItemTax(itemID: Int64, taxID: Int64) -> OrderItemTax? {
         let predicate = NSPredicate(format: "item.itemID = %ld AND taxID = %ld", taxID)
         return firstObject(ofType: OrderItemTax.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Coupon.
     ///
-    func loadOrderCoupon(couponID: Int) -> OrderCoupon? {
+    func loadOrderCoupon(couponID: Int64) -> OrderCoupon? {
         let predicate = NSPredicate(format: "couponID = %ld", couponID)
         return firstObject(ofType: OrderCoupon.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Refund Condensed.
     ///
-    func loadOrderRefundCondensed(refundID: Int) -> OrderRefundCondensed? {
+    func loadOrderRefundCondensed(refundID: Int64) -> OrderRefundCondensed? {
         let predicate = NSPredicate(format: "refundID = %ld", refundID)
         return firstObject(ofType: OrderRefundCondensed.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Shipping Line.
     ///
-    func loadShippingLine(shippingID: Int) -> ShippingLine? {
+    func loadShippingLine(shippingID: Int64) -> ShippingLine? {
         let predicate = NSPredicate(format: "shippingID = %ld", shippingID)
         return firstObject(ofType: ShippingLine.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Note.
     ///
-    func loadOrderNote(noteID: Int) -> OrderNote? {
+    func loadOrderNote(noteID: Int64) -> OrderNote? {
         let predicate = NSPredicate(format: "noteID = %ld", noteID)
         return firstObject(ofType: OrderNote.self, matching: predicate)
     }
@@ -88,7 +88,7 @@ public extension StorageType {
 
     /// Retrieves the Stored OrderCount.
     ///
-    func loadOrderCount(siteID: Int) -> OrderCount? {
+    func loadOrderCount(siteID: Int64) -> OrderCount? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         return firstObject(ofType: OrderCount.self, matching: predicate)
     }
@@ -130,7 +130,7 @@ public extension StorageType {
 
     /// Retrieves the Stored OrderStats for V4 API.
     ///
-    func loadOrderStatsV4(siteID: Int, timeRange: String) -> OrderStatsV4? {
+    func loadOrderStatsV4(siteID: Int64, timeRange: String) -> OrderStatsV4? {
         let predicate = NSPredicate(format: "siteID = %ld AND timeRange ==[c] %@", siteID, timeRange)
         return firstObject(ofType: OrderStatsV4.self, matching: predicate)
     }
@@ -146,7 +146,7 @@ public extension StorageType {
 
     /// Retrieves all of the Stores OrderStatuses for the provided siteID.
     ///
-    func loadOrderStatuses(siteID: Int) -> [OrderStatus]? {
+    func loadOrderStatuses(siteID: Int64) -> [OrderStatus]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \OrderStatus.name, ascending: false)
         return allObjects(ofType: OrderStatus.self, matching: predicate, sortedBy: [descriptor])
@@ -154,7 +154,7 @@ public extension StorageType {
 
     /// Retrieves the Stored OrderStatus
     ///
-    func loadOrderStatus(siteID: Int, slug: String) -> OrderStatus? {
+    func loadOrderStatus(siteID: Int64, slug: String) -> OrderStatus? {
         let predicate = NSPredicate(format: "siteID = %ld AND slug ==[c] %@", siteID, slug)
         return firstObject(ofType: OrderStatus.self, matching: predicate)
     }
@@ -163,7 +163,7 @@ public extension StorageType {
 
     /// Retrieves **all** of the stored SiteSettings for the provided siteID.
     ///
-    func loadAllSiteSettings(siteID: Int) -> [SiteSetting]? {
+    func loadAllSiteSettings(siteID: Int64) -> [SiteSetting]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
@@ -171,7 +171,7 @@ public extension StorageType {
 
     /// Retrieves stored SiteSettings for the provided siteID and settingGroupKey.
     ///
-    func loadSiteSettings(siteID: Int, settingGroupKey: String) -> [SiteSetting]? {
+    func loadSiteSettings(siteID: Int64, settingGroupKey: String) -> [SiteSetting]? {
         let predicate = NSPredicate(format: "siteID = %ld AND settingGroupKey ==[c] %@", siteID, settingGroupKey)
         let descriptor = NSSortDescriptor(keyPath: \SiteSetting.settingID, ascending: false)
         return allObjects(ofType: SiteSetting.self, matching: predicate, sortedBy: [descriptor])
@@ -179,7 +179,7 @@ public extension StorageType {
 
     /// Retrieves the Stored SiteSetting.
     ///
-    func loadSiteSetting(siteID: Int, settingID: String) -> SiteSetting? {
+    func loadSiteSetting(siteID: Int64, settingID: String) -> SiteSetting? {
         let predicate = NSPredicate(format: "siteID = %ld AND settingID ==[c] %@", siteID, settingID)
         return firstObject(ofType: SiteSetting.self, matching: predicate)
     }
@@ -204,14 +204,14 @@ public extension StorageType {
 
     /// Retrieves a specific stored ShipmentTracking entity.
     ///
-    func loadShipmentTracking(siteID: Int, orderID: Int, trackingID: String) -> ShipmentTracking? {
+    func loadShipmentTracking(siteID: Int64, orderID: Int64, trackingID: String) -> ShipmentTracking? {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld AND trackingID ==[c] %@", siteID, orderID, trackingID)
         return firstObject(ofType: ShipmentTracking.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ShipmentTracking entities for the provided siteID and orderID.
     ///
-    func loadShipmentTrackingList(siteID: Int, orderID: Int) -> [ShipmentTracking]? {
+    func loadShipmentTrackingList(siteID: Int64, orderID: Int64) -> [ShipmentTracking]? {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTracking.orderID, ascending: false)
         return allObjects(ofType: ShipmentTracking.self, matching: predicate, sortedBy: [descriptor])
@@ -219,14 +219,14 @@ public extension StorageType {
 
     /// Retrieves a specific stored ShipmentTrackingProviderGroup
     ///
-    func loadShipmentTrackingProviderGroup(siteID: Int, providerGroupName: String) -> ShipmentTrackingProviderGroup? {
+    func loadShipmentTrackingProviderGroup(siteID: Int64, providerGroupName: String) -> ShipmentTrackingProviderGroup? {
         let predicate = NSPredicate(format: "siteID = %ld AND name ==[c] %@", siteID, providerGroupName)
         return firstObject(ofType: ShipmentTrackingProviderGroup.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ShipmentTrackingProviderGroup entities for the provided siteID.
     ///
-    func loadShipmentTrackingProviderGroupList(siteID: Int) -> [ShipmentTrackingProviderGroup]? {
+    func loadShipmentTrackingProviderGroupList(siteID: Int64) -> [ShipmentTrackingProviderGroup]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTrackingProviderGroup.name, ascending: true)
         return allObjects(ofType: ShipmentTrackingProviderGroup.self, matching: predicate, sortedBy: [descriptor])
@@ -234,7 +234,7 @@ public extension StorageType {
 
     /// Retrieves all of the stored ShipmentTrackingProvider entities for the provided siteID.
     ///
-    func loadShipmentTrackingProviderList(siteID: Int) -> [ShipmentTrackingProvider]? {
+    func loadShipmentTrackingProviderList(siteID: Int64) -> [ShipmentTrackingProvider]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \ShipmentTrackingProvider.name, ascending: true)
         return allObjects(ofType: ShipmentTrackingProvider.self, matching: predicate, sortedBy: [descriptor])
@@ -242,7 +242,7 @@ public extension StorageType {
 
     /// Retrieves a stored ShipmentTrackingProvider for the provided siteID.
     ///
-    func loadShipmentTrackingProvider(siteID: Int, name: String) -> ShipmentTrackingProvider? {
+    func loadShipmentTrackingProvider(siteID: Int64, name: String) -> ShipmentTrackingProvider? {
         let predicate = NSPredicate(format: "siteID = %ld AND name ==[c] %@", siteID, name)
         return firstObject(ofType: ShipmentTrackingProvider.self, matching: predicate)
     }
@@ -251,7 +251,7 @@ public extension StorageType {
 
     /// Retrieves all of the stored Products for the provided siteID.
     ///
-    func loadProducts(siteID: Int) -> [Product]? {
+    func loadProducts(siteID: Int64) -> [Product]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \Product.productID, ascending: false)
         return allObjects(ofType: Product.self, matching: predicate, sortedBy: [descriptor])
@@ -259,7 +259,7 @@ public extension StorageType {
 
     /// Retrieves a stored Product for the provided siteID.
     ///
-    func loadProduct(siteID: Int, productID: Int) -> Product? {
+    func loadProduct(siteID: Int64, productID: Int64) -> Product? {
         let predicate = NSPredicate(format: "siteID = %ld AND productID = %ld", siteID, productID)
         return firstObject(ofType: Product.self, matching: predicate)
     }
@@ -268,7 +268,7 @@ public extension StorageType {
     ///
     /// Note: WC attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    func loadProductAttribute(siteID: Int, productID: Int, attributeID: Int, name: String) -> ProductAttribute? {
+    func loadProductAttribute(siteID: Int64, productID: Int64, attributeID: Int64, name: String) -> ProductAttribute? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND attributeID = %ld AND name ==[c] %@",
                                     siteID, productID, attributeID, name)
         return firstObject(ofType: ProductAttribute.self, matching: predicate)
@@ -278,7 +278,7 @@ public extension StorageType {
     ///
     /// Note: WC default attribute ID's often have an ID of `0`, so we need to also look them up by name 😏
     ///
-    func loadProductDefaultAttribute(siteID: Int, productID: Int, defaultAttributeID: Int, name: String) -> ProductDefaultAttribute? {
+    func loadProductDefaultAttribute(siteID: Int64, productID: Int64, defaultAttributeID: Int64, name: String) -> ProductDefaultAttribute? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND attributeID = %ld AND name ==[c] %@",
                                     siteID, productID, defaultAttributeID, name)
         return firstObject(ofType: ProductDefaultAttribute.self, matching: predicate)
@@ -286,14 +286,14 @@ public extension StorageType {
 
     /// Retrieves the Stored Product Image.
     ///
-    func loadProductImage(siteID: Int, productID: Int, imageID: Int) -> ProductImage? {
+    func loadProductImage(siteID: Int64, productID: Int64, imageID: Int64) -> ProductImage? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND imageID = %ld", siteID, productID, imageID)
         return firstObject(ofType: ProductImage.self, matching: predicate)
     }
 
     /// Retrieves the Stored Product Category.
     ///
-    func loadProductCategory(siteID: Int, productID: Int, categoryID: Int) -> ProductCategory? {
+    func loadProductCategory(siteID: Int64, productID: Int64, categoryID: Int64) -> ProductCategory? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND categoryID = %ld", siteID, productID, categoryID)
         return firstObject(ofType: ProductCategory.self, matching: predicate)
     }
@@ -307,14 +307,14 @@ public extension StorageType {
 
     /// Retrieves the Stored Product Tag.
     ///
-    func loadProductTag(siteID: Int, productID: Int, tagID: Int) -> ProductTag? {
+    func loadProductTag(siteID: Int64, productID: Int64, tagID: Int64) -> ProductTag? {
         let predicate = NSPredicate(format: "product.siteID = %ld AND product.productID = %ld AND tagID = %ld", siteID, productID, tagID)
         return firstObject(ofType: ProductTag.self, matching: predicate)
     }
 
     /// Retrieves all of the stored ProductReviews for the provided siteID. Sorted by dateCreated, descending
     ///
-    func loadProductReviews(siteID: Int) -> [ProductReview]? {
+    func loadProductReviews(siteID: Int64) -> [ProductReview]? {
         let predicate = NSPredicate(format: "siteID = %ld", siteID)
         let descriptor = NSSortDescriptor(keyPath: \ProductReview.dateCreated, ascending: false)
         return allObjects(ofType: ProductReview.self, matching: predicate, sortedBy: [descriptor])
@@ -322,7 +322,7 @@ public extension StorageType {
 
     /// Retrieves a stored ProductReview for the provided siteID and reviewID.
     ///
-    func loadProductReview(siteID: Int, reviewID: Int) -> ProductReview? {
+    func loadProductReview(siteID: Int64, reviewID: Int64) -> ProductReview? {
         let predicate = NSPredicate(format: "siteID = %ld AND reviewID = %ld", siteID, reviewID)
         return firstObject(ofType: ProductReview.self, matching: predicate)
     }
@@ -382,21 +382,21 @@ public extension StorageType {
 
     /// Retrieves a stored Refund for the provided siteID, orderID, and refundID.
     ///
-    func loadRefund(siteID: Int, orderID: Int, refundID: Int) -> Refund? {
+    func loadRefund(siteID: Int64, orderID: Int64, refundID: Int64) -> Refund? {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld AND refundID = %ld", siteID, orderID, refundID)
         return firstObject(ofType: Refund.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderItemRefund.
     ///
-    func loadRefundItem(siteID: Int, refundID: Int, itemID: Int) -> OrderItemRefund? {
+    func loadRefundItem(siteID: Int64, refundID: Int64, itemID: Int64) -> OrderItemRefund? {
     let predicate = NSPredicate(format: "refund.siteID = %ld AND refund.refundID = %ld AND itemID = %ld", siteID, refundID, itemID)
         return firstObject(ofType: OrderItemRefund.self, matching: predicate)
     }
 
     /// Retrieves the Stored OrderItemTaxRefund.
     ///
-    func loadRefundItemTax(itemID: Int, taxID: Int) -> OrderItemTaxRefund? {
+    func loadRefundItemTax(itemID: Int64, taxID: Int64) -> OrderItemTaxRefund? {
         let predicate = NSPredicate(format: "item.itemID = %ld AND taxID = %ld", itemID, taxID)
         return firstObject(ofType: OrderItemTaxRefund.self, matching: predicate)
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -41,7 +41,7 @@ final class StorePickerCoordinator: Coordinator {
 //
 extension StorePickerCoordinator: StorePickerViewControllerDelegate {
 
-    func willSelectStore(with storeID: Int, onCompletion: @escaping SelectStoreClosure) {
+    func willSelectStore(with storeID: Int64, onCompletion: @escaping SelectStoreClosure) {
         guard selectedConfiguration == .switchingStores else {
             onCompletion()
             return
@@ -54,7 +54,7 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
         logOutOfCurrentStore(onCompletion: onCompletion)
     }
 
-    func didSelectStore(with storeID: Int) {
+    func didSelectStore(with storeID: Int64) {
         guard storeID != ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
@@ -141,7 +141,7 @@ private extension StorePickerCoordinator {
         }
     }
 
-    func finalizeStoreSelection(_ storeID: Int) {
+    func finalizeStoreSelection(_ storeID: Int64) {
         ServiceLocator.stores.updateDefaultStore(storeID: storeID)
 
         // We need to call refreshUserData() here because the user selected

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -16,11 +16,11 @@ protocol StorePickerViewControllerDelegate: AnyObject {
     /// - Parameter storeID: ID of the store selected by the user
     /// - Returns: a closure to be executed prior to store selection
     ///
-    func willSelectStore(with storeID: Int, onCompletion: @escaping SelectStoreClosure)
+    func willSelectStore(with storeID: Int64, onCompletion: @escaping SelectStoreClosure)
 
     /// Notifies the delegate that the store selection is complete
     ///
-    func didSelectStore(with storeID: Int)
+    func didSelectStore(with storeID: Int64)
 }
 
 
@@ -415,7 +415,7 @@ private extension StorePickerViewController {
 
     /// If the provided site's WC version is not valid, display a warning to the user.
     ///
-    func displaySiteWCRequirementWarningIfNeeded(siteID: Int, siteName: String) {
+    func displaySiteWCRequirementWarningIfNeeded(siteID: Int64, siteName: String) {
         updateActionButtonAndTableState(animating: true, enabled: false)
         RequirementsChecker.checkMinimumWooVersion(for: siteID) { [weak self] (result, error) in
             switch result {
@@ -450,7 +450,7 @@ private extension StorePickerViewController {
 
     /// Update the UI upon receiving an error or empty response instead of site info
     ///
-    func updateUIForEmptyOrErroredSite(named siteName: String, with siteID: Int) {
+    func updateUIForEmptyOrErroredSite(named siteName: String, with siteID: Int64) {
         toggleDismissButton(enabled: false)
         updateActionButtonAndTableState(animating: false, enabled: false)
         displayVersionCheckErrorNotice(siteID: siteID, siteName: siteName)
@@ -491,7 +491,7 @@ private extension StorePickerViewController {
 
     /// Displays the Error Notice for the version check.
     ///
-    func displayVersionCheckErrorNotice(siteID: Int, siteName: String) {
+    func displayVersionCheckErrorNotice(siteID: Int64, siteName: String) {
         let message = String.localizedStringWithFormat(
             NSLocalizedString(
                 "Unable to successfully connect to %@",
@@ -737,7 +737,7 @@ private extension StorePickerState {
 
     /// Returns the IndexPath for the specified Site.
     ///
-    func indexPath(for siteID: Int) -> IndexPath? {
+    func indexPath(for siteID: Int64) -> IndexPath? {
         guard case let .available(sites) = self else {
             return nil
         }

--- a/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
+++ b/WooCommerce/Classes/Notifications/ApplicationAdapter.swift
@@ -24,7 +24,7 @@ protocol ApplicationAdapter: class {
 
     /// Presents the Details for the specified Notification.
     ///
-    func presentNotificationDetails(for noteID: Int)
+    func presentNotificationDetails(for noteID: Int64)
 }
 
 
@@ -34,7 +34,7 @@ extension UIApplication: ApplicationAdapter {
 
     /// Presents the Details for the specified Notification ID
     ///
-    func presentNotificationDetails(for noteID: Int) {
+    func presentNotificationDetails(for noteID: Int64) {
         MainTabBarController.presentNotificationDetails(for: noteID)
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -122,7 +122,7 @@ extension PushNotificationsManager {
     ///     - tokenData: APNS's Token Data
     ///     - defaultStoreID: Default WooCommerce Store ID
     ///
-    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int) {
+    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64) {
         let newToken = tokenData.hexString
 
         if let _ = deviceToken, deviceToken != newToken {
@@ -261,12 +261,12 @@ private extension PushNotificationsManager {
     /// - Returns: True when handled. False otherwise
     ///
     func handleInactiveNotification(_ userInfo: [AnyHashable: Any], completionHandler: (UIBackgroundFetchResult) -> Void) -> Bool {
-        guard applicationState == .inactive, let notificationId = userInfo.integer(forKey: APNSKey.identifier) else {
+        guard applicationState == .inactive, let notificationID = userInfo.integer(forKey: APNSKey.identifier) else {
             return false
         }
 
         DDLogVerbose("📱 Handling Notification in Inactive State")
-        configuration.application.presentNotificationDetails(for: notificationId)
+        configuration.application.presentNotificationDetails(for: Int64(notificationID))
         completionHandler(.newData)
 
         return true
@@ -299,7 +299,7 @@ private extension PushNotificationsManager {
 
     /// Registers an APNS DeviceToken in the WordPress.com backend.
     ///
-    func registerDotcomDevice(with deviceToken: String, defaultStoreID: Int, onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
+    func registerDotcomDevice(with deviceToken: String, defaultStoreID: Int64, onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         let device = APNSDevice(deviceToken: deviceToken)
         let action = NotificationAction.registerDevice(device: device,
                                                        applicationId: WooConstants.pushApplicationID,
@@ -355,8 +355,8 @@ private extension PushNotificationsManager {
     func trackNotification(with userInfo: [AnyHashable: Any]) {
         var properties = [String: String]()
 
-        if let noteId = userInfo.string(forKey: APNSKey.identifier) {
-            properties[AnalyticKey.identifier] = noteId
+        if let noteID = userInfo.string(forKey: APNSKey.identifier) {
+            properties[AnalyticKey.identifier] = noteID
         }
 
         if let type = userInfo.string(forKey: APNSKey.type) {

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -34,7 +34,7 @@ protocol PushNotesManager {
     ///     - tokenData: APNS's Token Data
     ///     - defaultStoreID: Default WooCommerce Store ID
     ///
-    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int)
+    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64)
 
     /// Handles a Remote Push Notifican Payload. On completion the `completionHandler` will be executed.
     ///

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -89,7 +89,7 @@ final class ServiceLocator {
     static var shippingSettingsService: ShippingSettingsService {
         guard let shippingSettingsService = _shippingSettingsService else {
             let siteID = stores.sessionManager.defaultStoreID ?? Int64.min
-            let service = StorageShippingSettingsService(siteID: Int64(siteID),
+            let service = StorageShippingSettingsService(siteID: siteID,
                                                          storageManager: storageManager)
             _shippingSettingsService = service
             return service

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -88,7 +88,7 @@ final class ServiceLocator {
     ///
     static var shippingSettingsService: ShippingSettingsService {
         guard let shippingSettingsService = _shippingSettingsService else {
-            let siteID = stores.sessionManager.defaultStoreID ?? Int.min
+            let siteID = stores.sessionManager.defaultStoreID ?? Int64.min
             let service = StorageShippingSettingsService(siteID: Int64(siteID),
                                                          storageManager: storageManager)
             _shippingSettingsService = service

--- a/WooCommerce/Classes/ServiceLocator/StoresManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/StoresManager.swift
@@ -34,7 +34,7 @@ protocol StoresManager {
 
     /// Updates the Default Store as specified.
     ///
-    func updateDefaultStore(storeID: Int)
+    func updateDefaultStore(storeID: Int64)
 
     /// Indicates if the StoresManager is currently authenticated, or not.
     ///

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -72,13 +72,13 @@ struct SessionManager {
 
     /// Default AccountID: Returns the last known Account's User ID.
     ///
-    var defaultAccountID: Int? {
+    var defaultAccountID: Int64? {
         return defaults[.defaultAccountID]
     }
 
     /// Default StoreID.
     ///
-    var defaultStoreID: Int? {
+    var defaultStoreID: Int64? {
         get {
             return defaults[.defaultStoreID]
         }

--- a/WooCommerce/Classes/Tools/RequirementsChecker.swift
+++ b/WooCommerce/Classes/Tools/RequirementsChecker.swift
@@ -68,7 +68,7 @@ class RequirementsChecker {
     /// - parameter result: Closure param that is the result of the requirement check
     /// - parameter error: Closure param that is any error that occured while checking the WC version
     ///
-    static func checkMinimumWooVersion(for siteID: Int, onCompletion: ((_ result: RequirementCheckResult, _ error: Error?) -> Void)? = nil) {
+    static func checkMinimumWooVersion(for siteID: Int64, onCompletion: ((_ result: RequirementCheckResult, _ error: Error?) -> Void)? = nil) {
         let action = retrieveSiteAPIAction(siteID: siteID, onCompletion: onCompletion)
         ServiceLocator.stores.dispatch(action)
     }
@@ -90,7 +90,7 @@ private extension RequirementsChecker {
 
     /// Returns a `SettingAction.retrieveSiteAPI` action
     ///
-    static func retrieveSiteAPIAction(siteID: Int, onCompletion: ((RequirementCheckResult, Error?) -> Void)? = nil) -> SettingAction {
+    static func retrieveSiteAPIAction(siteID: Int64, onCompletion: ((RequirementCheckResult, Error?) -> Void)? = nil) -> SettingAction {
         return SettingAction.retrieveSiteAPI(siteID: siteID) { (siteAPI, error) in
             guard error == nil else {
                 DDLogError("⛔️ An error occurred while fetching API info for siteID \(siteID): \(String(describing: error))")

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
@@ -125,7 +125,7 @@ final class OrderDetailsDataSource: NSObject {
         return OrderDetailsResultsControllers(order: self.order)
     }()
 
-    private lazy var orderNoteAsyncDictionary: AsyncDictionary<Int, String> = {
+    private lazy var orderNoteAsyncDictionary: AsyncDictionary<Int64, String> = {
         return AsyncDictionary()
     }()
 
@@ -447,11 +447,11 @@ extension OrderDetailsDataSource {
         return currentSiteStatuses.filter({$0.slug == order.statusKey}).first
     }
 
-    func lookUpProduct(by productID: Int) -> Product? {
+    func lookUpProduct(by productID: Int64) -> Product? {
         return products.filter({ $0.productID == productID }).first
     }
 
-    func lookUpRefund(by refundID: Int) -> Refund? {
+    func lookUpRefund(by refundID: Int64) -> Refund? {
         return refunds.filter({ $0.refundID == refundID }).first
     }
 

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -93,11 +93,11 @@ final class OrderDetailsViewModel {
         return dataSource.lookUpOrderStatus(for: order)
     }
 
-    func lookUpProduct(by productID: Int) -> Product? {
+    func lookUpProduct(by productID: Int64) -> Product? {
         return dataSource.lookUpProduct(by: productID)
     }
 
-    func lookUpRefund(by refundID: Int) -> Refund? {
+    func lookUpRefund(by refundID: Int64) -> Refund? {
         return dataSource.lookUpRefund(by: refundID)
     }
 }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -51,7 +51,7 @@ final class ProductDetailsViewModel {
 
     /// Product ID
     ///
-    var productID: Int {
+    var productID: Int64 {
         return product.productID
     }
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -719,8 +719,8 @@ extension ProductDetailsViewModel {
             WebviewHelper.launch(product.externalURL, with: sender)
         case .productVariants:
             ServiceLocator.analytics.track(.productDetailsProductVariantsTapped)
-            let variationsViewController = ProductVariationsViewController(siteID: Int64(product.siteID),
-                                                                           productID: Int64(product.productID))
+            let variationsViewController = ProductVariationsViewController(siteID: product.siteID,
+                                                                           productID: product.productID)
             sender.navigationController?.pushViewController(variationsViewController, animated: true)
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -10,7 +10,7 @@ class DashboardViewController: UIViewController {
 
     // MARK: Properties
 
-    private var siteID: Int?
+    private var siteID: Int64?
 
     private var dashboardUIFactory: DashboardUIFactory?
     private var dashboardUI: DashboardUI?

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -21,13 +21,13 @@ protocol DashboardUI: UIViewController {
 }
 
 final class DashboardUIFactory {
-    private let siteID: Int
+    private let siteID: Int64
     private let stateCoordinator: StatsVersionStateCoordinator
 
     private var lastStatsV3DashboardUI: (DashboardUI & TopBannerPresenter)?
     private var lastStatsV4DashboardUI: DashboardUI?
 
-    init(siteID: Int) {
+    init(siteID: Int64) {
         self.siteID = siteID
         self.stateCoordinator = StatsVersionStateCoordinator(siteID: siteID)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
@@ -38,7 +38,7 @@ final class StatsVersionStateCoordinator {
     /// Called when stats version UI state is set.
     var onStateChange: StateChangeCallback?
 
-    private let siteID: Int
+    private let siteID: Int64
 
     private var state: StatsVersionState? {
         didSet {
@@ -52,7 +52,7 @@ final class StatsVersionStateCoordinator {
     ///
     /// - Parameters:
     ///   - siteID: the ID of a site/store where the stats version is concerned.
-    init(siteID: Int) {
+    init(siteID: Int64) {
         self.siteID = siteID
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -24,9 +24,9 @@ class BetaFeaturesViewController: UIViewController {
     ///
     private var sections = [Section]()
 
-    private let siteID: Int
+    private let siteID: Int64
 
-    init(siteID: Int) {
+    init(siteID: Int64) {
         self.siteID = siteID
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -292,7 +292,7 @@ private extension StoreStatsAndTopPerformersViewController {
 // MARK: - Sync'ing Helpers
 //
 private extension StoreStatsAndTopPerformersViewController {
-    func syncStats(for siteID: Int,
+    func syncStats(for siteID: Int64,
                    siteTimezone: TimeZone,
                    timeRange: StatsTimeRangeV4,
                    latestDateToInclude: Date,
@@ -313,7 +313,7 @@ private extension StoreStatsAndTopPerformersViewController {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func syncSiteVisitStats(for siteID: Int,
+    func syncSiteVisitStats(for siteID: Int64,
                             siteTimezone: TimeZone,
                             timeRange: StatsTimeRangeV4,
                             latestDateToInclude: Date,
@@ -331,7 +331,7 @@ private extension StoreStatsAndTopPerformersViewController {
         ServiceLocator.stores.dispatch(action)
     }
 
-    func syncTopEarnersStats(for siteID: Int, timeRange: StatsTimeRangeV4, latestDateToInclude: Date, onCompletion: ((Error?) -> Void)? = nil) {
+    func syncTopEarnersStats(for siteID: Int64, timeRange: StatsTimeRangeV4, latestDateToInclude: Date, onCompletion: ((Error?) -> Void)? = nil) {
         let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
                                                           timeRange: timeRange,
                                                           latestDateToInclude: Date()) { error in

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -306,7 +306,7 @@ extension MainTabBarController {
 
     /// Switches to the Notifications Tab, and displays the details for the specified Notification ID.
     ///
-    static func presentNotificationDetails(for noteID: Int) {
+    static func presentNotificationDetails(for noteID: Int64) {
         switchToReviewsTab {
             guard let reviewsViewController: ReviewsViewController = childViewController() else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
@@ -75,7 +75,7 @@ final class DefaultReviewsDataSource: NSObject, ReviewsDataSource {
     /// Identifiers of the Products mentioned in the reviews.
     /// Guaranteed to be uniqued (does not contain duplicates)
     ///
-    var reviewsProductsIDs: [Int] {
+    var reviewsProductsIDs: [Int64] {
         return reviewsResultsController
             .fetchedObjects
             .map { return $0.productID }
@@ -194,13 +194,13 @@ private extension DefaultReviewsDataSource {
         return ReviewViewModel(review: review, product: reviewProduct, notification: note)
     }
 
-    private func product(id productID: Int) -> Product? {
+    private func product(id productID: Int64) -> Product? {
         let products = productsResultsController.fetchedObjects
 
         return products.filter { $0.productID == productID }.first
     }
 
-    private func notification(id reviewID: Int) -> Note? {
+    private func notification(id reviewID: Int64) -> Note? {
         let notifications = notificationsResultsController.fetchedObjects
 
         return notifications.filter { $0.meta.identifier(forKey: .comment) == reviewID }.first
@@ -245,8 +245,8 @@ extension DefaultReviewsDataSource: ReviewsInteractionDelegate {
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
     }
 
-    func presentReviewDetails(for noteId: Int, in viewController: UIViewController) {
-        let notificationMaybe = notificationsResultsController.fetchedObjects.first { $0.noteId == noteId }
+    func presentReviewDetails(for noteID: Int64, in viewController: UIViewController) {
+        let notificationMaybe = notificationsResultsController.fetchedObjects.first { $0.noteID == noteID }
         guard let note = notificationMaybe,
             let reviewID = note.meta.identifier(forKey: .comment) else {
             return

--- a/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
@@ -203,7 +203,7 @@ private extension DefaultReviewsDataSource {
     private func notification(id reviewID: Int64) -> Note? {
         let notifications = notificationsResultsController.fetchedObjects
 
-        return notifications.filter { $0.meta.identifier(forKey: .comment) == reviewID }.first
+        return notifications.filter { $0.meta.identifier(forKey: .comment) == Int(reviewID) }.first
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift
@@ -163,7 +163,7 @@ private extension ReviewDetailsViewController {
 
     /// Synchronizes the Notifications associated to the active WordPress.com account.
     ///
-    func synchronizeReview(reviewID: Int, onCompletion: @escaping () -> Void) {
+    func synchronizeReview(reviewID: Int64, onCompletion: @escaping () -> Void) {
         guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
@@ -419,7 +419,7 @@ private extension ReviewDetailsViewController {
 // MARK: - Moderation actions
 //
 private extension ReviewDetailsViewController {
-    func moderateReview(siteID: Int, reviewID: Int, doneStatus: ProductReviewStatus, undoStatus: ProductReviewStatus) {
+    func moderateReview(siteID: Int64, reviewID: Int64, doneStatus: ProductReviewStatus, undoStatus: ProductReviewStatus) {
         guard let undo = moderateReviewAction(siteID: siteID, reviewID: reviewID, status: undoStatus, onCompletion: { error in
             guard let error = error else {
                 ServiceLocator.analytics.track(.notificationReviewActionSuccess)
@@ -456,7 +456,7 @@ private extension ReviewDetailsViewController {
 
     /// Returns an comment moderation action that will result in the specified comment being updated accordingly.
     ///
-    func moderateReviewAction(siteID: Int, reviewID: Int, status: ProductReviewStatus, onCompletion: @escaping (Error?) -> Void) -> [Action]? {
+    func moderateReviewAction(siteID: Int64, reviewID: Int64, status: ProductReviewStatus, onCompletion: @escaping (Error?) -> Void) -> [Action]? {
 
         switch status {
         case .approved:
@@ -501,9 +501,9 @@ private extension ReviewDetailsViewController {
 
         ServiceLocator.analytics.track(.reviewMarkRead,
                                        withProperties: ["remote_review_id": productReview.reviewID,
-                                                        "remote_note_id": note.noteId])
+                                                        "remote_note_id": note.noteID])
 
-        let action = NotificationAction.updateReadStatus(noteId: note.noteId, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: note.noteID, read: true) { (error) in
             if let error = error {
                 DDLogError("⛔️ Error marking single notification as read: \(error)")
                 ServiceLocator.analytics.track(.reviewMarkReadFailed,

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsDataSource.swift
@@ -16,7 +16,7 @@ protocol ReviewsInteractionDelegate: UITableViewDelegate {
 
     /// Called when we want to present a review after receiving a push notification
     ///
-    func presentReviewDetails(for noteId: Int, in viewController: UIViewController)
+    func presentReviewDetails(for noteID: Int64, in viewController: UIViewController)
 }
 
 
@@ -30,7 +30,7 @@ protocol ReviewsDataSource: UITableViewDataSource, ReviewsInteractionDelegate {
     /// Identifiers of the Products mentioned in the reviews.
     /// Guaranteed to be uniqued (does not contain duplicates)
     ///
-    var reviewsProductsIDs: [Int] { get }
+    var reviewsProductsIDs: [Int64] { get }
 
     /// Number of reviews in memory
     ///

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
@@ -128,14 +128,14 @@ final class ReviewsViewController: UIViewController {
         }
     }
 
-    func presentDetails(for noteId: Int) {
+    func presentDetails(for noteID: Int64) {
         syncingCoordinator.synchronizeFirstPage()
-        viewModel.loadReview(for: noteId) { [weak self] in
+        viewModel.loadReview(for: noteID) { [weak self] in
             guard let self = self else {
                 return
             }
 
-            self.viewModel.delegate.presentReviewDetails(for: noteId, in: self)
+            self.viewModel.delegate.presentReviewDetails(for: noteID, in: self)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
@@ -69,7 +69,7 @@ final class ReviewsViewModel {
         markAsRead(notes: unreadNotifications, onCompletion: onCompletion)
     }
 
-    func loadReview(for noteId: Int, onCompletion: @escaping () -> Void) {
+    func loadReview(for noteID: Int64, onCompletion: @escaping () -> Void) {
         synchronizeReviews() {
             onCompletion()
         }
@@ -187,7 +187,7 @@ private extension ReviewsViewModel {
             return
         }
 
-        let action = NotificationAction.updateReadStatus(noteId: note.noteId, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: note.noteID, read: true) { (error) in
             if let error = error {
                 DDLogError("⛔️ Error marking single notification as read: \(error)")
             }
@@ -198,8 +198,8 @@ private extension ReviewsViewModel {
     /// Marks the specified collection of Notifications as Read.
     ///
     func markAsRead(notes: [Note], onCompletion: @escaping (Error?) -> Void) {
-        let identifiers = notes.map { $0.noteId }
-        let action = NotificationAction.updateMultipleReadStatus(noteIds: identifiers, read: true, onCompletion: onCompletion)
+        let identifiers = notes.map { $0.noteID }
+        let action = NotificationAction.updateMultipleReadStatus(noteIDs: identifiers, read: true, onCompletion: onCompletion)
 
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -195,7 +195,7 @@ private extension OrderStatusListViewController {
 
     /// Returns an Order Update Action that will result in the specified Order Status updated accordingly.
     ///
-    private func updateOrderAction(siteID: Int, orderID: Int, statusKey: String) -> Action {
+    private func updateOrderAction(siteID: Int64, orderID: Int64, statusKey: String) -> Action {
         return OrderAction.updateOrder(siteID: siteID, orderID: orderID, statusKey: statusKey, onCompletion: { error in
             guard let error = error else {
                 NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
@@ -266,7 +266,7 @@ extension OrderStatusListViewController {
 
     /// Displays the `Unable to Change Status of Order` Notice.
     ///
-    func displayErrorNotice(orderID: Int) {
+    func displayErrorNotice(orderID: Int64) {
         let title = NSLocalizedString(
             "Unable to change status of order #\(orderID)",
             comment: "Content of error presented when updating the status of an Order fails. It reads: Unable to change status of order #{order number}"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -14,11 +14,11 @@ class OrderLoaderViewController: UIViewController {
 
     /// Target OrderID
     ///
-    private let orderID: Int
+    private let orderID: Int64
 
     /// Target Order's SiteID
     ///
-    private let siteID: Int
+    private let siteID: Int64
 
     /// UI Active State
     ///
@@ -46,7 +46,7 @@ class OrderLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(orderID: Int, siteID: Int) {
+    init(orderID: Int64, siteID: Int64) {
         self.orderID = orderID
         self.siteID = siteID
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -220,7 +220,7 @@ private extension FulfillViewController {
 
     /// Returns an Order Update Action that will result in the specified Order Status updated accordingly.
     ///
-    func updateOrderAction(siteID: Int, orderID: Int, statusKey: String) -> Action {
+    func updateOrderAction(siteID: Int64, orderID: Int64, statusKey: String) -> Action {
         return OrderAction.updateOrder(siteID: siteID, orderID: orderID, statusKey: statusKey, onCompletion: { error in
             guard let error = error else {
                 NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
@@ -247,7 +247,7 @@ private extension FulfillViewController {
 
     /// Displays the `Unable to Fulfill Order` Notice.
     ///
-    func displayErrorNotice(orderID: Int) {
+    func displayErrorNotice(orderID: Int64) {
         let title = NSLocalizedString(
             "Unable to fulfill order #\(orderID)",
             comment: "Content of error presented when Fullfill Order Action Failed. It reads: Unable to fulfill order #{order number}"
@@ -262,7 +262,7 @@ private extension FulfillViewController {
 
     /// Displays the product detail screen for the provided ProductID
     ///
-    func productWasPressed(for productID: Int) {
+    func productWasPressed(for productID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
                                                                siteID: order.siteID,
                                                                currency: order.currency)
@@ -537,7 +537,7 @@ private extension FulfillViewController {
 
     /// Displays the `Unable to delete tracking` Notice.
     ///
-    func displayDeleteErrorNotice(orderID: Int, tracking: ShipmentTracking) {
+    func displayDeleteErrorNotice(orderID: Int64, tracking: ShipmentTracking) {
         let title = NSLocalizedString(
             "Unable to delete tracking for order #\(orderID)",
             comment: "Content of error presented when Delete Shipment Tracking Action Failed. It reads: Unable to delete tracking for order #{order number}"
@@ -599,7 +599,7 @@ private extension FulfillViewController {
         return orderTracking[orderIndex]
     }
 
-    func lookUpProduct(by productID: Int) -> Product? {
+    func lookUpProduct(by productID: Int64) -> Product? {
         return products?.filter({ $0.productID == productID }).first
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -116,13 +116,13 @@ private extension ProductListViewController {
         return items[indexPath.row]
     }
 
-    func lookUpProduct(by productID: Int) -> Product? {
+    func lookUpProduct(by productID: Int64) -> Product? {
         return products?.filter({ $0.productID == productID }).first
     }
 
     /// Displays the product detail screen for the provided ProductID
     ///
-    func productWasPressed(for productID: Int) {
+    func productWasPressed(for productID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
                                                                siteID: viewModel.order.siteID,
                                                                currency: viewModel.order.currency)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -579,7 +579,7 @@ extension ManualTrackingViewController: KeyboardScrollable {
 private extension ManualTrackingViewController {
     /// Displays the `Unable to Add tracking` Notice.
     ///
-    func displayAddErrorNotice(orderID: Int) {
+    func displayAddErrorNotice(orderID: Int64) {
         let title = NSLocalizedString(
             "Unable to add tracking to order #\(orderID)",
             comment: "Content of error presented when Add Shipment Tracking Action Failed. It reads: Unable to add tracking to order #{order number}"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
@@ -10,7 +10,7 @@ struct PaginatedProductShippingClassListSelectorDataSource: PaginatedListSelecto
     private let siteID: Int64
 
     init(product: Product, selected: ProductShippingClass?) {
-        self.siteID = Int64(product.siteID)
+        self.siteID = product.siteID
         self.selected = selected
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -101,7 +101,7 @@ private extension ProductShippingSettingsViewController {
         }
 
         let action = ProductShippingClassAction
-            .retrieveProductShippingClass(siteID: Int64(product.siteID),
+            .retrieveProductShippingClass(siteID: product.siteID,
                                           remoteID: shippingClass.shippingClassID) { [weak self] (shippingClass, error) in
             self?.shippingClass = shippingClass
             self?.tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -14,11 +14,11 @@ final class ProductLoaderViewController: UIViewController {
 
     /// Target ProductID
     ///
-    private let productID: Int
+    private let productID: Int64
 
     /// Target Product's SiteID
     ///
-    private let siteID: Int
+    private let siteID: Int64
 
     /// The Target Product's Currency
     ///
@@ -35,7 +35,7 @@ final class ProductLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(productID: Int, siteID: Int, currency: String) {
+    init(productID: Int64, siteID: Int64, currency: String) {
         self.productID = productID
         self.siteID = siteID
         self.currency = currency

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -40,7 +40,7 @@ final class ProductsViewController: UIViewController {
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Products in sync.
     ///
     private lazy var resultsController: ResultsController<StorageProduct> = {
-        let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min
+        let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
         let resultsController = createResultsController(siteID: siteID)
         configureResultsController(resultsController) { [weak self] in
             self?.tableView.reloadData()
@@ -262,14 +262,14 @@ private extension ProductsViewController {
 // MARK: - Updates
 //
 private extension ProductsViewController {
-    func updateResultsController(siteID: Int) {
+    func updateResultsController(siteID: Int64) {
         resultsController = createResultsController(siteID: siteID)
         configureResultsController(resultsController) { [weak self] in
             self?.tableView.reloadData()
         }
     }
 
-    func createResultsController(siteID: Int) -> ResultsController<StorageProduct> {
+    func createResultsController(siteID: Int64) -> ResultsController<StorageProduct> {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "name", ascending: true, selector: #selector(NSString.localizedCompare(_:)))

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -303,7 +303,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
         transitionToSyncingState()
 
         let action = ProductVariationAction
-            .synchronizeProductVariations(siteID: Int64(siteID), productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
+            .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
                                     guard let self = self else {
                                         return
                                     }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -37,7 +37,7 @@ final class OrderSearchUICommand: SearchUICommand {
 
     /// Synchronizes the Orders matching a given Keyword
     ///
-    func synchronizeModels(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+    func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
         let action = OrderAction.searchOrders(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { error in
             if let error = error {
                 DDLogError("☠️ Order Search Failure! \(error)")

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -10,9 +10,9 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let emptyStateText = NSLocalizedString("No products found", comment: "Search Products (Empty State)")
 
-    private let siteID: Int
+    private let siteID: Int64
 
-    init(siteID: Int) {
+    init(siteID: Int64) {
         self.siteID = siteID
     }
 
@@ -30,7 +30,7 @@ final class ProductSearchUICommand: SearchUICommand {
 
     /// Synchronizes the Products matching a given Keyword
     ///
-    func synchronizeModels(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
+    func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
         let action = ProductAction.searchProducts(siteID: siteID,
                                                   keyword: keyword,
                                                   pageNumber: pageNumber,

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -23,7 +23,7 @@ protocol SearchUICommand {
     func createCellViewModel(model: Model) -> CellViewModel
 
     /// Synchronizes the models matching a given keyword.
-    func synchronizeModels(siteID: Int,
+    func synchronizeModels(siteID: Int64,
                            keyword: String,
                            pageNumber: Int,
                            pageSize: Int,

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -45,7 +45,7 @@ where Cell.SearchModel == Command.CellViewModel {
 
     /// Search Store ID
     ///
-    private let storeID: Int
+    private let storeID: Int64
 
     /// Indicates if there are no results onscreen.
     ///
@@ -78,7 +78,7 @@ where Cell.SearchModel == Command.CellViewModel {
 
     /// Designated Initializer
     ///
-    init(storeID: Int,
+    init(storeID: Int64,
          command: Command,
          cellType: Cell.Type) {
         self.resultsController = command.createResultsController()

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -153,7 +153,7 @@ class DefaultStoresManager: StoresManager {
 
     /// Updates the Default Store as specified.
     ///
-    func updateDefaultStore(storeID: Int) {
+    func updateDefaultStore(storeID: Int64) {
         sessionManager.defaultStoreID = storeID
         restoreSessionSiteIfPossible()
 
@@ -178,7 +178,7 @@ private extension DefaultStoresManager {
 
     /// Loads the specified accountID into the Session, if possible.
     ///
-    func restoreSessionAccount(with accountID: Int) {
+    func restoreSessionAccount(with accountID: Int64) {
         let action = AccountAction.loadAccount(userID: accountID) { [weak self] account in
             guard let `self` = self, let account = account else {
                 return
@@ -262,7 +262,7 @@ private extension DefaultStoresManager {
 
     /// Synchronizes the settings for the specified site, if possible.
     ///
-    func synchronizeSettings(with siteID: Int, onCompletion: @escaping () -> Void) {
+    func synchronizeSettings(with siteID: Int64, onCompletion: @escaping () -> Void) {
         guard siteID != 0 else {
             // Just return if the siteID == 0 so we are not making extra requests
             return
@@ -301,7 +301,7 @@ private extension DefaultStoresManager {
 
     /// Synchronizes the order statuses, if possible.
     ///
-    func retrieveOrderStatus(with siteID: Int) {
+    func retrieveOrderStatus(with siteID: Int64) {
         guard siteID != 0 else {
             // Just return if the siteID == 0 so we are not making extra requests
             return
@@ -333,7 +333,7 @@ private extension DefaultStoresManager {
 
     /// Loads the specified siteID into the Session, if possible.
     ///
-    func restoreSessionSite(with siteID: Int) {
+    func restoreSessionSite(with siteID: Int64) {
         let action = AccountAction.loadSite(siteID: siteID) { [weak self] site in
             guard let `self` = self, let site = site else {
                 return

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -326,7 +326,7 @@ private extension DefaultStoresManager {
         restoreSessionSite(with: siteID)
         synchronizeSettings(with: siteID) {
             CurrencySettings.shared.refresh()
-            ServiceLocator.shippingSettingsService.update(siteID: Int64(siteID))
+            ServiceLocator.shippingSettingsService.update(siteID: siteID)
         }
         retrieveOrderStatus(with: siteID)
     }

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -4,15 +4,15 @@ import Foundation
 
 final class MockProduct {
 
-    let testSiteID = 2019
-    let testProductID = 2020
+    let testSiteID: Int64 = 2019
+    let testProductID: Int64 = 2020
 
     func product(name: String = "Hogsmeade",
                  productShippingClass: ProductShippingClass? = nil,
                  backordersSetting: ProductBackordersSetting = .notAllowed,
                  stockQuantity: Int? = nil,
                  stockStatus: ProductStockStatus = .inStock,
-                 variations: [Int] = [],
+                 variations: [Int64] = [],
                  images: [ProductImage] = []) -> Product {
 
     return Product(siteID: testSiteID,

--- a/WooCommerce/WooCommerceTests/Mockups/MockReviews.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockReviews.swift
@@ -3,9 +3,9 @@ import Foundation
 
 
 final class MockReviews {
-    let siteID          = 123
-    let reviewID        = 1234
-    let productID       = 12345
+    let siteID: Int64 = 123
+    let reviewID: Int64 = 1234
+    let productID: Int64 = 12345
     let productName     = "Book the Green Room"
     let dateCreated     = Date()
     let statusKey       = "hold"
@@ -16,7 +16,7 @@ final class MockReviews {
     let rating          = 4
     let verified        = true
 
-    let sampleVariationTypeProductID = 295
+    let sampleVariationTypeProductID: Int64 = 295
 
     func review() -> Networking.ProductReview {
         return ProductReview(siteID: siteID,
@@ -49,7 +49,7 @@ final class MockReviews {
 
 
 extension MockReviews {
-    func product(_ siteID: Int? = nil) -> Networking.Product {
+    func product(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? self.siteID
         return Product(siteID: testSiteID,
                        productID: productID,
@@ -189,7 +189,7 @@ extension MockReviews {
         return [download1, download2, download3]
     }
 
-    func sampleProductMutated(_ siteID: Int? = nil) -> Networking.Product {
+    func sampleProductMutated(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? self.siteID
 
         return Product(siteID: testSiteID,
@@ -312,7 +312,7 @@ extension MockReviews {
         return [defaultAttribute1]
     }
 
-    func sampleVariationTypeProduct(_ siteID: Int? = nil) -> Networking.Product {
+    func sampleVariationTypeProduct(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? self.siteID
         return Product(siteID: testSiteID,
                        productID: sampleVariationTypeProductID,
@@ -421,7 +421,7 @@ extension MockReviews {
 extension MockReviews {
     func emptyNotification() -> Note {
         let data = Data()
-        return Note(noteId: 0,
+        return Note(noteID: 0,
                     hash: 0,
                     read: false,
                     icon: nil,

--- a/WooCommerce/WooCommerceTests/Mockups/MockupApplicationAdapter.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupApplicationAdapter.swift
@@ -25,7 +25,7 @@ class MockupApplicationAdapter: ApplicationAdapter {
 
     /// Notification Identifiers received via the `presentNotificationDetails` method.
     ///
-    var presentDetailsNoteIDs = [Int]()
+    var presentDetailsNoteIDs = [Int64]()
 
 
 
@@ -43,7 +43,7 @@ class MockupApplicationAdapter: ApplicationAdapter {
 
     /// Innocuous `displayNotificationDetails`
     ///
-    func presentNotificationDetails(for noteID: Int) {
+    func presentNotificationDetails(for noteID: Int64) {
         presentDetailsNoteIDs.append(noteID)
     }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -330,7 +330,7 @@ private extension PushNotificationsManagerTests {
 
     /// Returns a Sample Notification Payload
     ///
-    func notificationPayload(badgeCount: Int = 0, noteID: Int = 1234) -> [String: Any] {
+    func notificationPayload(badgeCount: Int = 0, noteID: Int64 = 1234) -> [String: Any] {
         return [
             "aps": [
                 "badge": badgeCount,
@@ -356,7 +356,7 @@ private struct Sample {
 
     /// Sample StoreID
     ///
-    static let defaultStoreID = 9999
+    static let defaultStoreID: Int64 = 9999
 
     /// UserDefaults Suite Name
     ///

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -99,7 +99,7 @@ final class MockReviewsDataSource: NSObject, ReviewsDataSource {
         return reviews.count
     }
 
-    var reviewsProductsIDs: [Int] {
+    var reviewsProductsIDs: [Int64] {
         return reviews
             .map { return $0.productID }
             .uniqued()
@@ -135,7 +135,7 @@ final class MockReviewsDataSource: NSObject, ReviewsDataSource {
 
     func didSelectItem(at indexPath: IndexPath, in viewController: UIViewController) {}
 
-    func presentReviewDetails(for noteId: Int, in viewController: UIViewController) {}
+    func presentReviewDetails(for noteID: Int64, in viewController: UIViewController) {}
 
     func tableView(_ tableView: UITableView,
                    willDisplay cell: UITableViewCell,

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -1,8 +1,8 @@
 @testable import Networking
 
 final class MockOrders {
-    let siteID = 1234
-    let orderID = 5678
+    let siteID: Int64 = 1234
+    let orderID: Int64 = 5678
 
     func sampleOrder() -> Networking.Order {
         return Order(siteID: siteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -4,7 +4,7 @@ import Yosemite
 @testable import WooCommerce
 
 final class DashboardUIFactoryTests: XCTestCase {
-    private let mockSiteID: Int = 1134
+    private let mockSiteID: Int64 = 1134
 
     private var dashboardUIFactory: DashboardUIFactory!
     private var mockStoresManager: MockupStatsVersionStoresManager!

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -35,7 +35,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
     // MARK: Variations
 
     func testDetailsForProductWithOneVariation() {
-        let variations = [134]
+        let variations: [Int64] = [134]
         let product = productMock(name: "Yay", variations: variations)
         let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
@@ -45,7 +45,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
     }
 
     func testDetailsForProductWithMultipleVariations() {
-        let variations = [201, 134]
+        let variations: [Int64] = [201, 134]
         let product = productMock(name: "Yay", variations: variations)
         let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
@@ -60,7 +60,7 @@ extension ProductsTabProductViewModelTests {
     func productMock(name: String = "Hogsmeade",
                      stockQuantity: Int? = nil,
                      stockStatus: ProductStockStatus = .inStock,
-                     variations: [Int] = [],
+                     variations: [Int64] = [],
                      images: [ProductImage] = []) -> Product {
 
         let mock = MockProduct()

--- a/Yosemite/Yosemite/Actions/AccountAction.swift
+++ b/Yosemite/Yosemite/Actions/AccountAction.swift
@@ -6,11 +6,11 @@ import Networking
 // MARK: - AccountAction: Defines all of the Actions supported by the AccountStore.
 //
 public enum AccountAction: Action {
-    case loadAccount(userID: Int, onCompletion: (Account?) -> Void)
-    case loadSite(siteID: Int, onCompletion: (Site?) -> Void)
+    case loadAccount(userID: Int64, onCompletion: (Account?) -> Void)
+    case loadSite(siteID: Int64, onCompletion: (Site?) -> Void)
     case synchronizeAccount(onCompletion: (Account?, Error?) -> Void)
-    case synchronizeAccountSettings(userID: Int, onCompletion: (AccountSettings?, Error?) -> Void)
+    case synchronizeAccountSettings(userID: Int64, onCompletion: (AccountSettings?, Error?) -> Void)
     case synchronizeSites(onCompletion: (Error?) -> Void)
-    case synchronizeSitePlan(siteID: Int, onCompletion: (Error?) -> Void)
-    case updateAccountSettings(userID: Int, tracksOptOut: Bool, onCompletion: (Error?) -> Void)
+    case synchronizeSitePlan(siteID: Int64, onCompletion: (Error?) -> Void)
+    case updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -6,25 +6,25 @@ import Storage
 public enum AppSettingsAction: Action {
     /// Adds a shipment tracking provider with `providerName` associated with the `siteID`
     ///
-    case addTrackingProvider(siteID: Int,
+    case addTrackingProvider(siteID: Int64,
         providerName: String,
         onCompletion: (Error?) -> Void)
 
     /// Loads the stored shipment tracking provider associated with the `siteID`
     ///
-    case loadTrackingProvider(siteID: Int,
+    case loadTrackingProvider(siteID: Int64,
         onCompletion: (ShipmentTrackingProvider?, ShipmentTrackingProviderGroup?, Error?) -> Void)
 
     /// Adds a custom shipment tracking provider with `providerName` and `providerURL` associated with the `siteID`
     ///
-    case addCustomTrackingProvider(siteID: Int,
+    case addCustomTrackingProvider(siteID: Int64,
         providerName: String,
         providerURL: String?,
         onCompletion: (Error?) -> Void)
 
     /// Loads the stored shipment tracking provider associated with the `siteID`
     ///
-    case loadCustomTrackingProvider(siteID: Int,
+    case loadCustomTrackingProvider(siteID: Int64,
         onCompletion: (ShipmentTrackingProvider?, Error?) -> Void)
 
     /// Clears the stored providers
@@ -35,7 +35,7 @@ public enum AppSettingsAction: Action {
 
     /// Loads the stats version to be shown given the latest app settings associated with the `siteID`
     ///
-    case loadInitialStatsVersionToShow(siteID: Int,
+    case loadInitialStatsVersionToShow(siteID: Int64,
         onCompletion: (StatsVersion?) -> Void)
 
     /// Loads whether a stats verion banner should be shown
@@ -44,7 +44,7 @@ public enum AppSettingsAction: Action {
 
     /// Loads the eligible stats version given the latest app settings associated with the `siteID`
     ///
-    case loadStatsVersionEligible(siteID: Int,
+    case loadStatsVersionEligible(siteID: Int64,
         onCompletion: (StatsVersion?) -> Void)
 
     /// Sets whether a stats version banner should be shown
@@ -53,17 +53,17 @@ public enum AppSettingsAction: Action {
 
     /// Sets the latest highest eligible stats version associated with the `siteID`
     ///
-    case setStatsVersionEligible(siteID: Int,
+    case setStatsVersionEligible(siteID: Int64,
         statsVersion: StatsVersion)
 
     /// Sets the last shown stats version associated with the `siteID`
     ///
-    case setStatsVersionLastShown(siteID: Int,
+    case setStatsVersionLastShown(siteID: Int64,
         statsVersion: StatsVersion)
 
     /// Sets the user preferred stats version associated with the `siteID`
     ///
-    case setStatsVersionPreference(siteID: Int,
+    case setStatsVersionPreference(siteID: Int64,
         statsVersion: StatsVersion)
 
     /// Loads the user preferred Product Features visibility given the latest app settings

--- a/Yosemite/Yosemite/Actions/AvailabilityAction.swift
+++ b/Yosemite/Yosemite/Actions/AvailabilityAction.swift
@@ -3,5 +3,5 @@
 public enum AvailabilityAction: Action {
     /// Checks if Stats v4 is available for the site.
     ///
-    case checkStatsV4Availability(siteID: Int, onCompletion: (_ isStatsV4Available: Bool) -> Void)
+    case checkStatsV4Availability(siteID: Int64, onCompletion: (_ isStatsV4Available: Bool) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/CommentAction.swift
+++ b/Yosemite/Yosemite/Actions/CommentAction.swift
@@ -10,15 +10,15 @@ public enum CommentAction: Action {
     /// Updates the approval status of a comment (approved/unapproved).
     /// The completion closure will return the updated comment status or error (if any).
     ///
-    case updateApprovalStatus(siteID: Int, commentID: Int, isApproved: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
+    case updateApprovalStatus(siteID: Int64, commentID: Int64, isApproved: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
 
     /// Updates the spam status of a comment (spam/not-spam).
     /// The completion closure will return the updated comment status or error (if any).
     ///
-    case updateSpamStatus(siteID: Int, commentID: Int, isSpam: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
+    case updateSpamStatus(siteID: Int64, commentID: Int64, isSpam: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
 
     /// Updates the trash status of a comment (trash/not-trash).
     /// The completion closure will return the updated comment status or error (if any).
     ///
-    case updateTrashStatus(siteID: Int, commentID: Int, isTrash: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
+    case updateTrashStatus(siteID: Int64, commentID: Int64, isTrash: Bool, onCompletion: (CommentStatus?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/NotificationAction.swift
+++ b/Yosemite/Yosemite/Actions/NotificationAction.swift
@@ -12,7 +12,7 @@ public enum NotificationAction: Action {
     case registerDevice(device: APNSDevice,
                         applicationId: String,
                         applicationVersion: String,
-                        defaultStoreID: Int,
+                        defaultStoreID: Int64,
                         onCompletion: (DotcomDevice?, Error?) -> Void)
 
     /// Unregisters a device for Push Notifications Delivery.
@@ -25,7 +25,7 @@ public enum NotificationAction: Action {
 
     /// Synchronizes a specified Notification.
     ///
-    case synchronizeNotification(noteId: Int64, onCompletion: (Error?) -> Void)
+    case synchronizeNotification(noteID: Int64, onCompletion: (Error?) -> Void)
 
     /// Updates the WordPress.com Last Seen field.
     ///
@@ -33,10 +33,10 @@ public enum NotificationAction: Action {
 
     /// Updates a given Notification's read flag.
     ///
-    case updateReadStatus(noteId: Int64, read: Bool, onCompletion: (Error?) -> Void)
+    case updateReadStatus(noteID: Int64, read: Bool, onCompletion: (Error?) -> Void)
 
     /// Updates, in batch, the Notification's read flag.
     ///
-    case updateMultipleReadStatus(noteIds: [Int64], read: Bool, onCompletion: (Error?) -> Void)
-    case updateLocalDeletedStatus(noteId: Int64, deleteInProgress: Bool, onCompletion: (Error?) -> Void)
+    case updateMultipleReadStatus(noteIDs: [Int64], read: Bool, onCompletion: (Error?) -> Void)
+    case updateLocalDeletedStatus(noteID: Int64, deleteInProgress: Bool, onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -9,11 +9,11 @@ public enum OrderAction: Action {
 
     /// Searches orders that contain a given keyword.
     ///
-    case searchOrders(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case searchOrders(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
     /// Synchronizes the Orders matching the specified criteria.
     ///
-    case synchronizeOrders(siteID: Int, statusKey: String?, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case synchronizeOrders(siteID: Int64, statusKey: String?, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
     /// Nukes all of the cached orders.
     ///
@@ -21,13 +21,13 @@ public enum OrderAction: Action {
 
     /// Retrieves the specified OrderID.
     ///
-    case retrieveOrder(siteID: Int, orderID: Int, onCompletion: (Order?, Error?) -> Void)
+    case retrieveOrder(siteID: Int64, orderID: Int64, onCompletion: (Order?, Error?) -> Void)
 
     /// Updates a given Order's Status.
     ///
-    case updateOrder(siteID: Int, orderID: Int, statusKey: String, onCompletion: (Error?) -> Void)
+    case updateOrder(siteID: Int64, orderID: Int64, statusKey: String, onCompletion: (Error?) -> Void)
 
     /// Gets the number of orders in processing status.
     ///
-    case countProcessingOrders(siteID: Int, onCompletion: (OrderCount?, Error?) -> Void)
+    case countProcessingOrders(siteID: Int64, onCompletion: (OrderCount?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderNoteAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderNoteAction.swift
@@ -5,6 +5,6 @@ import Networking
 // MARK: - OrderNoteAction: Defines all of the Actions supported by the OrderNoteStore.
 //
 public enum OrderNoteAction: Action {
-    case retrieveOrderNotes(siteID: Int, orderID: Int, onCompletion: ([OrderNote]?, Error?) -> Void)
-    case addOrderNote(siteID: Int, orderID: Int, isCustomerNote: Bool, note: String, onCompletion: (OrderNote?, Error?) -> Void)
+    case retrieveOrderNotes(siteID: Int64, orderID: Int64, onCompletion: ([OrderNote]?, Error?) -> Void)
+    case addOrderNote(siteID: Int64, orderID: Int64, isCustomerNote: Bool, note: String, onCompletion: (OrderNote?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/OrderStatusAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderStatusAction.swift
@@ -5,6 +5,6 @@ import Networking
 // MARK: - OrderStatusAction: Defines all of the Actions supported by the OrderStatusStore.
 //
 public enum OrderStatusAction: Action {
-    case retrieveOrderStatuses(siteID: Int, onCompletion: ([OrderStatus]?, Error?) -> Void)
+    case retrieveOrderStatuses(siteID: Int64, onCompletion: ([OrderStatus]?, Error?) -> Void)
     case resetStoredOrderStatuses(onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -8,19 +8,19 @@ public enum ProductAction: Action {
 
     /// Searches products that contain a given keyword.
     ///
-    case searchProducts(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
     /// Synchronizes the Products matching the specified criteria.
     ///
-    case synchronizeProducts(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case synchronizeProducts(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
     /// Retrieves the specified Product.
     ///
-    case retrieveProduct(siteID: Int, productID: Int, onCompletion: (Product?, Error?) -> Void)
+    case retrieveProduct(siteID: Int64, productID: Int64, onCompletion: (Product?, Error?) -> Void)
 
     /// Retrieves a specified list of Products.
     ///
-    case retrieveProducts(siteID: Int, productIDs: [Int], onCompletion: (Error?) -> Void)
+    case retrieveProducts(siteID: Int64, productIDs: [Int64], onCompletion: (Error?) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductReviewAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductReviewAction.swift
@@ -8,26 +8,26 @@ public enum ProductReviewAction: Action {
 
     /// Synchronizes the ProductReviews matching the specified criteria.
     ///
-    case synchronizeProductReviews(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case synchronizeProductReviews(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
     /// Retrieves the specified ProductReview.
     ///
-    case retrieveProductReview(siteID: Int, reviewID: Int, onCompletion: (ProductReview?, Error?) -> Void)
+    case retrieveProductReview(siteID: Int64, reviewID: Int64, onCompletion: (ProductReview?, Error?) -> Void)
 
     /// Updates the approval status of a review (approved/on hold).
     /// The completion closure will return the updated review status or error (if any).
     ///
-    case updateApprovalStatus(siteID: Int, reviewID: Int, isApproved: Bool, onCompletion: (ProductReviewStatus?, Error?) -> Void)
+    case updateApprovalStatus(siteID: Int64, reviewID: Int64, isApproved: Bool, onCompletion: (ProductReviewStatus?, Error?) -> Void)
 
     /// Updates the trash status of a review (trash/untrash).
     /// The completion closure will return the updated review status or error (if any).
     ///
-    case updateTrashStatus(siteID: Int, reviewID: Int, isTrashed: Bool, onCompletion: (ProductReviewStatus?, Error?) -> Void)
+    case updateTrashStatus(siteID: Int64, reviewID: Int64, isTrashed: Bool, onCompletion: (ProductReviewStatus?, Error?) -> Void)
 
     /// Updates the spam/unspam status of a review (trash/untrash).
     /// The completion closure will return the updated review status or error (if any).
     ///
-    case updateSpamStatus(siteID: Int, reviewID: Int, isSpam: Bool, onCompletion: (ProductReviewStatus?, Error?) -> Void)
+    case updateSpamStatus(siteID: Int64, reviewID: Int64, isSpam: Bool, onCompletion: (ProductReviewStatus?, Error?) -> Void)
 
     /// Deletes all of the cached product reviews.
     ///

--- a/Yosemite/Yosemite/Actions/RefundAction.swift
+++ b/Yosemite/Yosemite/Actions/RefundAction.swift
@@ -5,9 +5,9 @@ import Networking
 /// RefundAction: Defines all of the Actions supported by the RefundStore.
 ///
 public enum RefundAction: Action {
-    case createRefund(siteID: Int, orderID: Int, refund: Refund, onCompletion: (Refund?, Error?) -> Void)
-    case retrieveRefund(siteID: Int, orderID: Int, refundID: Int, onCompletion: (Refund?, Error?) -> Void)
-    case retrieveRefunds(siteID: Int, orderID: Int, refundIDs: [Int], onCompletion: (Error?) -> Void)
-    case synchronizeRefunds(siteID: Int, orderID: Int, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case createRefund(siteID: Int64, orderID: Int64, refund: Refund, onCompletion: (Refund?, Error?) -> Void)
+    case retrieveRefund(siteID: Int64, orderID: Int64, refundID: Int64, onCompletion: (Refund?, Error?) -> Void)
+    case retrieveRefunds(siteID: Int64, orderID: Int64, refundIDs: [Int64], onCompletion: (Error?) -> Void)
+    case synchronizeRefunds(siteID: Int64, orderID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
     case resetStoredRefunds(onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Actions/SettingAction.swift
+++ b/Yosemite/Yosemite/Actions/SettingAction.swift
@@ -8,13 +8,13 @@ public enum SettingAction: Action {
 
     /// Synchronizes the site's general settings
     ///
-    case synchronizeGeneralSiteSettings(siteID: Int, onCompletion: (Error?) -> Void)
+    case synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: (Error?) -> Void)
 
     /// Synchronizes the site's product settings
     ///
-    case synchronizeProductSiteSettings(siteID: Int, onCompletion: (Error?) -> Void)
+    case synchronizeProductSiteSettings(siteID: Int64, onCompletion: (Error?) -> Void)
 
     /// Retrieves the site API details (used to determine the WC version)
     ///
-    case retrieveSiteAPI(siteID: Int, onCompletion: (SiteAPI?, Error?) -> Void)
+    case retrieveSiteAPI(siteID: Int64, onCompletion: (SiteAPI?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ShipmentAction.swift
+++ b/Yosemite/Yosemite/Actions/ShipmentAction.swift
@@ -8,16 +8,16 @@ public enum ShipmentAction: Action {
 
     /// Synchronizes all the shipment tracking data associated with the provided `siteID` and `orderID`
     ///
-    case synchronizeShipmentTrackingData(siteID: Int, orderID: Int, onCompletion: (Error?) -> Void)
+    case synchronizeShipmentTrackingData(siteID: Int64, orderID: Int64, onCompletion: (Error?) -> Void)
 
     /// Synchronizes all the shipment tracking providers associated with the provided `siteID` and `orderID`
     ///
-    case synchronizeShipmentTrackingProviders(siteID: Int, orderID: Int, onCompletion: (Error?) -> Void)
+    case synchronizeShipmentTrackingProviders(siteID: Int64, orderID: Int64, onCompletion: (Error?) -> Void)
 
     /// Adds a shipment tracking with `trackingID` associated with the provided `siteID` and `orderID`
     ///
-    case addTracking(siteID: Int,
-        orderID: Int,
+    case addTracking(siteID: Int64,
+        orderID: Int64,
         providerGroupName: String,
         providerName: String,
         dateShipped: String,
@@ -27,8 +27,8 @@ public enum ShipmentAction: Action {
     /// Adds a custom shipment tracking with `trackingProvider`, `trackingNumber`
     /// and `trackingURL` associated with the provided `siteID` and `orderID`
     ///
-    case addCustomTracking(siteID: Int,
-        orderID: Int,
+    case addCustomTracking(siteID: Int64,
+        orderID: Int64,
         trackingProvider: String,
         trackingNumber: String,
         trackingURL: String,
@@ -37,5 +37,5 @@ public enum ShipmentAction: Action {
 
     /// Removes a shipment tracking with `trackingID` associated with the provided `siteID` and `orderID`
     ///
-    case deleteTracking(siteID: Int, orderID: Int, trackingID: String, onCompletion: (Error?) -> Void)
+    case deleteTracking(siteID: Int64, orderID: Int64, trackingID: String, onCompletion: (Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/StatsAction.swift
+++ b/Yosemite/Yosemite/Actions/StatsAction.swift
@@ -12,18 +12,18 @@ public enum StatsAction: Action {
 
     /// Synchronizes `OrderStats` for the provided siteID, StatGranularity, and date.
     ///
-    case retrieveOrderStats(siteID: Int, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: (Error?) -> Void)
+    case retrieveOrderStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: (Error?) -> Void)
 
     /// Synchronizes `SiteVisitStats` for the provided siteID, StatGranularity, and date.
     ///
-    case retrieveSiteVisitStats(siteID: Int, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: (Error?) -> Void)
+    case retrieveSiteVisitStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: (Error?) -> Void)
 
     /// Synchronizes `TopEarnerStats` for the provided siteID, `StatGranularity`, and date.
     ///
-    case retrieveTopEarnerStats(siteID: Int, granularity: StatGranularity, latestDateToInclude: Date, onCompletion: (Error?) -> Void)
+    case retrieveTopEarnerStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, onCompletion: (Error?) -> Void)
 
     /// Retrieves the current order count for a specifc `OrderStatus` from the server. By design, the server response is *not*
     /// persisted in the Storage framework but is instead returned within the completion closure.
     ///
-    case retrieveOrderTotals(siteID: Int, status: OrderStatusEnum, onCompletion: (Int?, Error?) -> Void)
+    case retrieveOrderTotals(siteID: Int64, status: OrderStatusEnum, onCompletion: (Int?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -11,7 +11,7 @@ public enum StatsActionV4: Action {
 
     /// Synchronizes `OrderStats` for the provided siteID, time range, and date.
     ///
-    case retrieveStats(siteID: Int,
+    case retrieveStats(siteID: Int64,
         timeRange: StatsTimeRangeV4,
         earliestDateToInclude: Date,
         latestDateToInclude: Date,
@@ -20,7 +20,7 @@ public enum StatsActionV4: Action {
 
     /// Synchronizes `SiteVisitStats` for the provided siteID, time range, and date.
     ///
-    case retrieveSiteVisitStats(siteID: Int,
+    case retrieveSiteVisitStats(siteID: Int64,
         siteTimezone: TimeZone,
         timeRange: StatsTimeRangeV4,
         latestDateToInclude: Date,
@@ -28,7 +28,7 @@ public enum StatsActionV4: Action {
 
     /// Synchronizes `TopEarnerStats` for the provided siteID, time range, and date.
     ///
-    case retrieveTopEarnerStats(siteID: Int,
+    case retrieveTopEarnerStats(siteID: Int64,
         timeRange: StatsTimeRangeV4,
         latestDateToInclude: Date,
         onCompletion: (Error?) -> Void)

--- a/Yosemite/Yosemite/Actions/TaxClassAction.swift
+++ b/Yosemite/Yosemite/Actions/TaxClassAction.swift
@@ -8,7 +8,7 @@ public enum TaxClassAction: Action {
 
     /// Retrieve and synchronizes Tax Classes matching the specified criteria.
     ///
-    case retrieveTaxClasses(siteID: Int, onCompletion: ([TaxClass]?, Error?) -> Void)
+    case retrieveTaxClasses(siteID: Int64, onCompletion: ([TaxClass]?, Error?) -> Void)
 
     /// Deletes all of the cached tax classes.
     ///

--- a/Yosemite/Yosemite/Model/ReadOnly/Note+ReadOnlyType.swift
+++ b/Yosemite/Yosemite/Model/ReadOnly/Note+ReadOnlyType.swift
@@ -13,6 +13,6 @@ extension Yosemite.Note: ReadOnlyType {
             return false
         }
 
-        return storageNote.noteID == noteId
+        return storageNote.noteID == noteID
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Account+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Account+ReadOnlyConvertible.swift
@@ -19,7 +19,7 @@ extension Storage.Account: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.Account {
-        return Account(userID: Int(userID),
+        return Account(userID: Int64(userID),
                        displayName: displayName ?? "",
                        email: email ?? "",
                        username: username ?? "",

--- a/Yosemite/Yosemite/Model/Storage/Account+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Account+ReadOnlyConvertible.swift
@@ -12,14 +12,14 @@ extension Storage.Account: ReadOnlyConvertible {
         displayName = account.displayName
         email = account.email
         gravatarUrl = account.gravatarUrl
-        userID = Int64(account.userID)
+        userID = account.userID
         username = account.username
     }
 
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.Account {
-        return Account(userID: Int64(userID),
+        return Account(userID: userID,
                        displayName: displayName ?? "",
                        email: email ?? "",
                        username: username ?? "",

--- a/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
@@ -16,7 +16,7 @@ extension Storage.AccountSettings: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.AccountSettings {
-        return AccountSettings(userID: Int(userID),
+        return AccountSettings(userID: Int64(userID),
                                tracksOptOut: tracksOptOut)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/AccountSettings+ReadOnlyConvertible.swift
@@ -9,14 +9,14 @@ extension Storage.AccountSettings: ReadOnlyConvertible {
     /// Updates the Storage.AccountSettings with the a ReadOnly.
     ///
     public func update(with accountSettings: Yosemite.AccountSettings) {
-        userID = Int64(accountSettings.userID)
+        userID = accountSettings.userID
         tracksOptOut = accountSettings.tracksOptOut
     }
 
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.AccountSettings {
-        return AccountSettings(userID: Int64(userID),
+        return AccountSettings(userID: userID,
                                tracksOptOut: tracksOptOut)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Note+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Note+ReadOnlyConvertible.swift
@@ -8,10 +8,10 @@ extension Storage.Note: ReadOnlyConvertible {
     /// Updates the Storage.Note with the a ReadOnly.
     ///
     public func update(with note: Yosemite.Note) {
-        let theSiteID = note.meta.identifier(forKey: .site) ?? Int.min
+        let theSiteID = note.meta.identifier(forKey: .site) ?? Int64.min
 
         siteID = Int64(theSiteID)
-        noteID = Int64(note.noteId)
+        noteID = Int64(note.noteID)
         noteHash = Int64(note.hash)
         read = note.read
         icon = note.icon
@@ -30,7 +30,7 @@ extension Storage.Note: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.Note {
-        return Note(noteId: noteID,
+        return Note(noteID: noteID,
                     hash: noteHash,
                     read: read,
                     icon: icon,

--- a/Yosemite/Yosemite/Model/Storage/Note+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Note+ReadOnlyConvertible.swift
@@ -8,9 +8,9 @@ extension Storage.Note: ReadOnlyConvertible {
     /// Updates the Storage.Note with the a ReadOnly.
     ///
     public func update(with note: Yosemite.Note) {
-        let theSiteID = note.meta.identifier(forKey: .site) ?? Int64.min
+        let theSiteID = note.meta.identifier(forKey: .site) ?? Int.min
 
-        siteID = theSiteID
+        siteID = Int64(theSiteID)
         noteID = note.noteID
         noteHash = Int64(note.hash)
         read = note.read

--- a/Yosemite/Yosemite/Model/Storage/Note+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Note+ReadOnlyConvertible.swift
@@ -10,8 +10,8 @@ extension Storage.Note: ReadOnlyConvertible {
     public func update(with note: Yosemite.Note) {
         let theSiteID = note.meta.identifier(forKey: .site) ?? Int64.min
 
-        siteID = Int64(theSiteID)
-        noteID = Int64(note.noteID)
+        siteID = theSiteID
+        noteID = note.noteID
         noteHash = Int64(note.hash)
         read = note.read
         icon = note.icon

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -9,10 +9,10 @@ extension Storage.Order: ReadOnlyConvertible {
     /// Updates the Storage.Order with the ReadOnly.
     ///
     public func update(with order: Yosemite.Order) {
-        siteID = Int64(order.siteID)
-        orderID = Int64(order.orderID)
-        parentID = Int64(order.parentID)
-        customerID = Int64(order.customerID)
+        siteID = order.siteID
+        orderID = order.orderID
+        parentID = order.parentID
+        customerID = order.customerID
         number = order.number
         statusKey = order.statusKey
         currency = order.currency
@@ -68,10 +68,10 @@ extension Storage.Order: ReadOnlyConvertible {
         let orderRefunds = refunds?.map { $0.toReadOnly() } ?? [Yosemite.OrderRefundCondensed]()
         let orderShippingLines = shippingLines?.map { $0.toReadOnly() } ?? [Yosemite.ShippingLine]()
 
-        return Order(siteID: Int64(siteID),
-                     orderID: Int64(orderID),
-                     parentID: Int64(parentID),
-                     customerID: Int64(customerID),
+        return Order(siteID: siteID,
+                     orderID: orderID,
+                     parentID: parentID,
+                     customerID: customerID,
                      number: number ?? "",
                      statusKey: statusKey,
                      currency: currency ?? "",

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -68,10 +68,10 @@ extension Storage.Order: ReadOnlyConvertible {
         let orderRefunds = refunds?.map { $0.toReadOnly() } ?? [Yosemite.OrderRefundCondensed]()
         let orderShippingLines = shippingLines?.map { $0.toReadOnly() } ?? [Yosemite.ShippingLine]()
 
-        return Order(siteID: Int(siteID),
-                     orderID: Int(orderID),
-                     parentID: Int(parentID),
-                     customerID: Int(customerID),
+        return Order(siteID: Int64(siteID),
+                     orderID: Int64(orderID),
+                     parentID: Int64(parentID),
+                     customerID: Int64(customerID),
                      number: number ?? "",
                      statusKey: statusKey,
                      currency: currency ?? "",

--- a/Yosemite/Yosemite/Model/Storage/OrderCount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderCount+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.OrderCount: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderCount {
         let orderCountItems = items?.map { $0.toReadOnly() } ?? [Yosemite.OrderCountItem]()
 
-        return OrderCount(siteID: Int(siteID),
+        return OrderCount(siteID: Int64(siteID),
                           items: orderCountItems)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderCount+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderCount+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.OrderCount: ReadOnlyConvertible {
     /// Updates the Storage.OrderCount with the ReadOnly.
     ///
     public func update(with orderCount: Yosemite.OrderCount) {
-        siteID = Int64(orderCount.siteID)
+        siteID = orderCount.siteID
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -17,7 +17,7 @@ extension Storage.OrderCount: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderCount {
         let orderCountItems = items?.map { $0.toReadOnly() } ?? [Yosemite.OrderCountItem]()
 
-        return OrderCount(siteID: Int64(siteID),
+        return OrderCount(siteID: siteID,
                           items: orderCountItems)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderCoupon+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderCoupon+ReadOnlyConvertible.swift
@@ -18,7 +18,7 @@ extension Storage.OrderCoupon: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderCouponLine {
-        return OrderCouponLine(couponID: Int(couponID),
+        return OrderCouponLine(couponID: Int64(couponID),
                                code: code ?? "",
                                discount: discount ?? "",
                                discountTax: discountTax ?? "")

--- a/Yosemite/Yosemite/Model/Storage/OrderCoupon+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderCoupon+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.OrderCoupon: ReadOnlyConvertible {
     /// Updates the Storage.OrderCoupon with the ReadOnly.
     ///
     public func update(with orderCoupon: Yosemite.OrderCouponLine) {
-        couponID = Int64(orderCoupon.couponID)
+        couponID = orderCoupon.couponID
         code = orderCoupon.code
         discount = orderCoupon.discount
         discountTax = orderCoupon.discountTax
@@ -18,7 +18,7 @@ extension Storage.OrderCoupon: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderCouponLine {
-        return OrderCouponLine(couponID: Int64(couponID),
+        return OrderCouponLine(couponID: couponID,
                                code: code ?? "",
                                discount: discount ?? "",
                                discountTax: discountTax ?? "")

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -28,10 +28,10 @@ extension Storage.OrderItem: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderItem {
         let orderItemTaxes = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemTax]()
 
-        return OrderItem(itemID: Int(itemID),
+        return OrderItem(itemID: Int64(itemID),
                          name: name ?? "",
-                         productID: Int(productID),
-                         variationID: Int(variationID),
+                         productID: Int64(productID),
+                         variationID: Int64(variationID),
                          quantity: quantity as Decimal,
                          price: price ?? NSDecimalNumber(integerLiteral: 0),
                          sku: sku,

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -9,18 +9,18 @@ extension Storage.OrderItem: ReadOnlyConvertible {
     /// Updates the Storage.OrderItem with the ReadOnly.
     ///
     public func update(with orderItem: Yosemite.OrderItem) {
-        itemID = Int64(orderItem.itemID)
+        itemID = orderItem.itemID
         name = orderItem.name
         quantity = NSDecimalNumber(decimal: orderItem.quantity)
         price = orderItem.price
-        productID = Int64(orderItem.productID)
+        productID = orderItem.productID
         sku = orderItem.sku
         subtotal = orderItem.subtotal
         subtotalTax = orderItem.subtotalTax
         taxClass = orderItem.taxClass
         total = orderItem.total
         totalTax = orderItem.totalTax
-        variationID = Int64(orderItem.variationID)
+        variationID = orderItem.variationID
     }
 
     /// Returns a ReadOnly version of the receiver.
@@ -28,10 +28,10 @@ extension Storage.OrderItem: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderItem {
         let orderItemTaxes = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemTax]()
 
-        return OrderItem(itemID: Int64(itemID),
+        return OrderItem(itemID: itemID,
                          name: name ?? "",
-                         productID: Int64(productID),
-                         variationID: Int64(variationID),
+                         productID: productID,
+                         variationID: variationID,
                          quantity: quantity as Decimal,
                          price: price ?? NSDecimalNumber(integerLiteral: 0),
                          sku: sku,

--- a/Yosemite/Yosemite/Model/Storage/OrderItemRefund+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemRefund+ReadOnlyConvertible.swift
@@ -28,10 +28,10 @@ extension Storage.OrderItemRefund: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderItemRefund {
         let orderItemTaxesRefund = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemTaxRefund]()
 
-        return OrderItemRefund(itemID: Int(itemID),
+        return OrderItemRefund(itemID: Int64(itemID),
                                name: name ?? "",
-                               productID: Int(productID),
-                               variationID: Int(variationID),
+                               productID: Int64(productID),
+                               variationID: Int64(variationID),
                                quantity: quantity?.decimalValue ?? Decimal.zero,
                                price: price ?? NSDecimalNumber(integerLiteral: 0),
                                sku: sku,

--- a/Yosemite/Yosemite/Model/Storage/OrderItemRefund+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemRefund+ReadOnlyConvertible.swift
@@ -9,10 +9,10 @@ extension Storage.OrderItemRefund: ReadOnlyConvertible {
     /// Updates the Storage.OrderItemRefund with the ReadOnly.
     ///
     public func update(with orderItemRefund: Yosemite.OrderItemRefund) {
-        itemID = Int64(orderItemRefund.itemID)
+        itemID = orderItemRefund.itemID
         name = orderItemRefund.name
-        productID = Int64(orderItemRefund.productID)
-        variationID = Int64(orderItemRefund.variationID)
+        productID = orderItemRefund.productID
+        variationID = orderItemRefund.variationID
         quantity = NSDecimalNumber(decimal: orderItemRefund.quantity)
         price = orderItemRefund.price
         sku = orderItemRefund.sku
@@ -28,10 +28,10 @@ extension Storage.OrderItemRefund: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.OrderItemRefund {
         let orderItemTaxesRefund = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemTaxRefund]()
 
-        return OrderItemRefund(itemID: Int64(itemID),
+        return OrderItemRefund(itemID: itemID,
                                name: name ?? "",
-                               productID: Int64(productID),
-                               variationID: Int64(variationID),
+                               productID: productID,
+                               variationID: variationID,
                                quantity: quantity?.decimalValue ?? Decimal.zero,
                                price: price ?? NSDecimalNumber(integerLiteral: 0),
                                sku: sku,

--- a/Yosemite/Yosemite/Model/Storage/OrderItemTax+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemTax+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.OrderItemTax: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderItemTax {
-        return OrderItemTax(taxID: Int(taxID),
+        return OrderItemTax(taxID: Int64(taxID),
                             subtotal: subtotal ?? "",
                             total: total ?? "")
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderItemTax+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemTax+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.OrderItemTax: ReadOnlyConvertible {
     /// Updates the Storage.OrderItemTax with the ReadOnly.
     ///
     public func update(with orderItemTax: Yosemite.OrderItemTax) {
-        taxID = Int64(orderItemTax.taxID)
+        taxID = orderItemTax.taxID
         subtotal = orderItemTax.subtotal
         total = orderItemTax.total
     }
@@ -17,7 +17,7 @@ extension Storage.OrderItemTax: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderItemTax {
-        return OrderItemTax(taxID: Int64(taxID),
+        return OrderItemTax(taxID: taxID,
                             subtotal: subtotal ?? "",
                             total: total ?? "")
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderItemTaxRefund+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemTaxRefund+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.OrderItemTaxRefund: ReadOnlyConvertible {
     /// Updates the Storage.OrderItemTax with the ReadOnly.
     ///
     public func update(with orderItemTaxRefund: Yosemite.OrderItemTaxRefund) {
-        taxID = Int64(orderItemTaxRefund.taxID)
+        taxID = orderItemTaxRefund.taxID
         subtotal = orderItemTaxRefund.subtotal
         total = orderItemTaxRefund.total
     }
@@ -17,7 +17,7 @@ extension Storage.OrderItemTaxRefund: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderItemTaxRefund {
-        return OrderItemTaxRefund(taxID: Int64(taxID),
+        return OrderItemTaxRefund(taxID: taxID,
                                   subtotal: subtotal ?? "",
                                   total: total ?? "")
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderItemTaxRefund+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItemTaxRefund+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.OrderItemTaxRefund: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderItemTaxRefund {
-        return OrderItemTaxRefund(taxID: Int(taxID),
+        return OrderItemTaxRefund(taxID: Int64(taxID),
                                   subtotal: subtotal ?? "",
                                   total: total ?? "")
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderNote+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderNote+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.OrderNote: ReadOnlyConvertible {
     /// Updates the Storage.OrderCoupon with the ReadOnly.
     ///
     public func update(with orderNote: Yosemite.OrderNote) {
-        noteID = Int64(orderNote.noteID)
+        noteID = orderNote.noteID
         dateCreated = orderNote.dateCreated
         note = orderNote.note
         isCustomerNote = orderNote.isCustomerNote
@@ -19,7 +19,7 @@ extension Storage.OrderNote: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderNote {
-        return OrderNote(noteId: Int(noteID),
+        return OrderNote(noteID: noteID,
                          dateCreated: dateCreated ?? Date(),
                          note: note ?? "",
                          isCustomerNote: isCustomerNote,

--- a/Yosemite/Yosemite/Model/Storage/OrderRefundCondensed+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderRefundCondensed+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.OrderRefundCondensed: ReadOnlyConvertible {
     /// Updates the Storage.OrderRefundCondensed with the ReadOnly.
     ///
     public func update(with orderRefundCondensed: Yosemite.OrderRefundCondensed) {
-        refundID = Int64(orderRefundCondensed.refundID)
+        refundID = orderRefundCondensed.refundID
         reason = orderRefundCondensed.reason
         total = orderRefundCondensed.total
     }
@@ -17,7 +17,7 @@ extension Storage.OrderRefundCondensed: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderRefundCondensed {
-        return OrderRefundCondensed(refundID: Int64(refundID),
+        return OrderRefundCondensed(refundID: refundID,
                                     reason: reason ?? "",
                                     total: total ?? "")
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderRefundCondensed+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderRefundCondensed+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.OrderRefundCondensed: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderRefundCondensed {
-        return OrderRefundCondensed(refundID: Int(refundID),
+        return OrderRefundCondensed(refundID: Int64(refundID),
                                     reason: reason ?? "",
                                     total: total ?? "")
     }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatus+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatus+ReadOnlyConvertible.swift
@@ -18,6 +18,6 @@ extension Storage.OrderStatus: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderStatus {
-        return OrderStatus(name: name, siteID: Int(siteID), slug: slug, total: Int(total))
+        return OrderStatus(name: name, siteID: Int64(siteID), slug: slug, total: Int(total))
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/OrderStatus+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderStatus+ReadOnlyConvertible.swift
@@ -10,7 +10,7 @@ extension Storage.OrderStatus: ReadOnlyConvertible {
     ///
     public func update(with orderStatus: Yosemite.OrderStatus) {
         name = orderStatus.name
-        siteID = Int64(orderStatus.siteID)
+        siteID = orderStatus.siteID
         slug = orderStatus.slug
         total = Int64(orderStatus.total)
     }
@@ -18,6 +18,6 @@ extension Storage.OrderStatus: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderStatus {
-        return OrderStatus(name: name, siteID: Int64(siteID), slug: slug, total: Int(total))
+        return OrderStatus(name: name, siteID: siteID, slug: slug, total: Int(total))
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -9,8 +9,8 @@ extension Storage.Product: ReadOnlyConvertible {
     /// Updates the Storage.Product with the ReadOnly.
     ///
     public func update(with product: Yosemite.Product) {
-        siteID = Int64(product.siteID)
-        productID = Int64(product.productID)
+        siteID = product.siteID
+        productID = product.productID
         productTypeKey = product.productTypeKey
         name = product.name
         slug = product.slug
@@ -52,17 +52,17 @@ extension Storage.Product: ReadOnlyConvertible {
         shippingRequired = product.shippingRequired
         shippingTaxable = product.shippingTaxable
         shippingClass = product.shippingClass
-        shippingClassID = Int64(product.shippingClassID)
+        shippingClassID = product.shippingClassID
         reviewsAllowed = product.reviewsAllowed
         averageRating = product.averageRating
         ratingCount = Int64(product.ratingCount)
-        relatedIDs = product.relatedIDs.map { Int64($0) }
-        upsellIDs = product.upsellIDs.map { Int64($0) }
-        crossSellIDs = product.crossSellIDs.map { Int64($0) }
-        parentID = Int64(product.parentID)
+        relatedIDs = product.relatedIDs
+        upsellIDs = product.upsellIDs
+        crossSellIDs = product.crossSellIDs
+        parentID = product.parentID
         purchaseNote = product.purchaseNote
-        variations = product.variations.map { Int64($0) }
-        groupedProducts = product.groupedProducts.map { Int64($0) }
+        variations = product.variations
+        groupedProducts = product.groupedProducts
         menuOrder = Int64(product.menuOrder)
         backordersKey = product.backordersKey
         backordersAllowed = product.backordersAllowed
@@ -86,8 +86,8 @@ extension Storage.Product: ReadOnlyConvertible {
             quantity = Int(stockQuantity)
         }
 
-        return Product(siteID: Int64(siteID),
-                       productID: Int64(productID),
+        return Product(siteID: siteID,
+                       productID: productID,
                        name: name,
                        slug: slug,
                        permalink: permalink,
@@ -128,7 +128,7 @@ extension Storage.Product: ReadOnlyConvertible {
                        shippingRequired: shippingRequired,
                        shippingTaxable: shippingTaxable,
                        shippingClass: shippingClass,
-                       shippingClassID: Int64(shippingClassID),
+                       shippingClassID: shippingClassID,
                        productShippingClass: productShippingClassModel,
                        reviewsAllowed: reviewsAllowed,
                        averageRating: averageRating,
@@ -136,7 +136,7 @@ extension Storage.Product: ReadOnlyConvertible {
                        relatedIDs: convertIDArray(relatedIDs),
                        upsellIDs: convertIDArray(upsellIDs),
                        crossSellIDs: convertIDArray(crossSellIDs),
-                       parentID: Int64(parentID),
+                       parentID: parentID,
                        purchaseNote: purchaseNote,
                        categories: productCategories.sorted(),
                        tags: productTags.sorted(),

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -86,8 +86,8 @@ extension Storage.Product: ReadOnlyConvertible {
             quantity = Int(stockQuantity)
         }
 
-        return Product(siteID: Int(siteID),
-                       productID: Int(productID),
+        return Product(siteID: Int64(siteID),
+                       productID: Int64(productID),
                        name: name,
                        slug: slug,
                        permalink: permalink,
@@ -128,7 +128,7 @@ extension Storage.Product: ReadOnlyConvertible {
                        shippingRequired: shippingRequired,
                        shippingTaxable: shippingTaxable,
                        shippingClass: shippingClass,
-                       shippingClassID: Int(shippingClassID),
+                       shippingClassID: Int64(shippingClassID),
                        productShippingClass: productShippingClassModel,
                        reviewsAllowed: reviewsAllowed,
                        averageRating: averageRating,
@@ -136,15 +136,15 @@ extension Storage.Product: ReadOnlyConvertible {
                        relatedIDs: convertIDArray(relatedIDs),
                        upsellIDs: convertIDArray(upsellIDs),
                        crossSellIDs: convertIDArray(crossSellIDs),
-                       parentID: Int(parentID),
+                       parentID: Int64(parentID),
                        purchaseNote: purchaseNote,
                        categories: productCategories.sorted(),
                        tags: productTags.sorted(),
                        images: productImages.sorted(),
                        attributes: productAttributes.sorted(),
                        defaultAttributes: productDefaultAttributes.sorted(),
-                       variations: convertIDArray(variations),
-                       groupedProducts: convertIDArray(groupedProducts),
+                       variations: variations ?? [],
+                       groupedProducts: groupedProducts ?? [],
                        menuOrder: Int(menuOrder))
     }
 
@@ -158,11 +158,11 @@ extension Storage.Product: ReadOnlyConvertible {
         return ProductDimensions(length: dimensions.length, width: dimensions.width, height: dimensions.height)
     }
 
-    private func convertIDArray(_ array: [Int64]? ) -> [Int] {
+    private func convertIDArray(_ array: [Int64]? ) -> [Int64] {
         guard let array = array else {
-            return [Int]()
+            return [Int64]()
         }
 
-        return array.map { Int($0) }
+        return array.map { Int64($0) }
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ProductAttribute+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductAttribute+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.ProductAttribute: ReadOnlyConvertible {
     /// Updates the Storage.ProductAttribute with the ReadOnly.
     ///
     public func update(with attribute: Yosemite.ProductAttribute) {
-        attributeID = Int64(attribute.attributeID)
+        attributeID = attribute.attributeID
         name = attribute.name
         position = Int64(attribute.position)
         visible = attribute.visible
@@ -20,7 +20,7 @@ extension Storage.ProductAttribute: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductAttribute {
-        return ProductAttribute(attributeID: Int64(attributeID),
+        return ProductAttribute(attributeID: attributeID,
                                 name: name,
                                 position: Int(position),
                                 visible: visible,

--- a/Yosemite/Yosemite/Model/Storage/ProductAttribute+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductAttribute+ReadOnlyConvertible.swift
@@ -20,7 +20,7 @@ extension Storage.ProductAttribute: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductAttribute {
-        return ProductAttribute(attributeID: Int(attributeID),
+        return ProductAttribute(attributeID: Int64(attributeID),
                                 name: name,
                                 position: Int(position),
                                 visible: visible,

--- a/Yosemite/Yosemite/Model/Storage/ProductCategory+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductCategory+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.ProductCategory: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductCategory {
-        return ProductCategory(categoryID: Int(categoryID),
+        return ProductCategory(categoryID: Int64(categoryID),
                                name: name,
                                slug: slug)
     }

--- a/Yosemite/Yosemite/Model/Storage/ProductCategory+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductCategory+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.ProductCategory: ReadOnlyConvertible {
     /// Updates the Storage.ProductCategory with the ReadOnly.
     ///
     public func update(with category: Yosemite.ProductCategory) {
-        categoryID = Int64(category.categoryID)
+        categoryID = category.categoryID
         name = category.name
         slug = category.slug
     }
@@ -17,7 +17,7 @@ extension Storage.ProductCategory: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductCategory {
-        return ProductCategory(categoryID: Int64(categoryID),
+        return ProductCategory(categoryID: categoryID,
                                name: name,
                                slug: slug)
     }

--- a/Yosemite/Yosemite/Model/Storage/ProductDefaultAttribute+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductDefaultAttribute+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.ProductDefaultAttribute: ReadOnlyConvertible {
     /// Updates the Storage.ProductDefaultAttribute with the ReadOnly.
     ///
     public func update(with defaultAttribute: Yosemite.ProductDefaultAttribute) {
-        attributeID = Int64(defaultAttribute.attributeID)
+        attributeID = defaultAttribute.attributeID
         name = defaultAttribute.name
         option = defaultAttribute.option
     }
@@ -17,7 +17,7 @@ extension Storage.ProductDefaultAttribute: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductDefaultAttribute {
-        return ProductDefaultAttribute(attributeID: Int64(attributeID),
+        return ProductDefaultAttribute(attributeID: attributeID,
                                        name: name,
                                        option: option)
     }

--- a/Yosemite/Yosemite/Model/Storage/ProductDefaultAttribute+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductDefaultAttribute+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.ProductDefaultAttribute: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductDefaultAttribute {
-        return ProductDefaultAttribute(attributeID: Int(attributeID),
+        return ProductDefaultAttribute(attributeID: Int64(attributeID),
                                        name: name,
                                        option: option)
     }

--- a/Yosemite/Yosemite/Model/Storage/ProductImage+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductImage+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.ProductImage: ReadOnlyConvertible {
     /// Updates the Storage.ProductAttribute with the ReadOnly.
     ///
     public func update(with image: Yosemite.ProductImage) {
-        imageID = Int64(image.imageID)
+        imageID = image.imageID
         dateCreated = image.dateCreated
         dateModified = image.dateModified
         src = image.src
@@ -20,7 +20,7 @@ extension Storage.ProductImage: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductImage {
-        return ProductImage(imageID: Int64(imageID),
+        return ProductImage(imageID: imageID,
                             dateCreated: dateCreated,
                             dateModified: dateModified,
                             src: src,

--- a/Yosemite/Yosemite/Model/Storage/ProductImage+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductImage+ReadOnlyConvertible.swift
@@ -20,7 +20,7 @@ extension Storage.ProductImage: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductImage {
-        return ProductImage(imageID: Int(imageID),
+        return ProductImage(imageID: Int64(imageID),
                             dateCreated: dateCreated,
                             dateModified: dateModified,
                             src: src,

--- a/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
@@ -25,9 +25,9 @@ extension Storage.ProductReview: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductReview {
-        return ProductReview(siteID: Int(siteID),
-                             reviewID: Int(reviewID),
-                             productID: Int(productID),
+        return ProductReview(siteID: Int64(siteID),
+                             reviewID: Int64(reviewID),
+                             productID: Int64(productID),
                              dateCreated: dateCreated ?? Date(),
                              statusKey: statusKey ?? "",
                              reviewer: reviewer ?? "" ,

--- a/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
@@ -9,9 +9,9 @@ extension Storage.ProductReview: ReadOnlyConvertible {
     /// Updates the Storage.ProductReview with the ReadOnly.
     ///
     public func update(with review: Yosemite.ProductReview) {
-        siteID              = Int64(review.siteID)
-        reviewID            = Int64(review.reviewID)
-        productID           = Int64(review.productID)
+        siteID              = review.siteID
+        reviewID            = review.reviewID
+        productID           = review.productID
         dateCreated         = review.dateCreated
         statusKey           = review.statusKey
         reviewer            = review.reviewer
@@ -25,9 +25,9 @@ extension Storage.ProductReview: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductReview {
-        return ProductReview(siteID: Int64(siteID),
-                             reviewID: Int64(reviewID),
-                             productID: Int64(productID),
+        return ProductReview(siteID: siteID,
+                             reviewID: reviewID,
+                             productID: productID,
                              dateCreated: dateCreated ?? Date(),
                              statusKey: statusKey ?? "",
                              reviewer: reviewer ?? "" ,

--- a/Yosemite/Yosemite/Model/Storage/ProductTag+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductTag+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.ProductTag: ReadOnlyConvertible {
     /// Updates the Storage.ProductTag with the ReadOnly.
     ///
     public func update(with tag: Yosemite.ProductTag) {
-        tagID = Int64(tag.tagID)
+        tagID = tag.tagID
         name = tag.name
         slug = tag.slug
     }
@@ -17,7 +17,7 @@ extension Storage.ProductTag: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductTag {
-        return ProductTag(tagID: Int64(tagID),
+        return ProductTag(tagID: tagID,
                           name: name,
                           slug: slug)
     }

--- a/Yosemite/Yosemite/Model/Storage/ProductTag+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductTag+ReadOnlyConvertible.swift
@@ -17,7 +17,7 @@ extension Storage.ProductTag: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ProductTag {
-        return ProductTag(tagID: Int(tagID),
+        return ProductTag(tagID: Int64(tagID),
                           name: name,
                           slug: slug)
     }

--- a/Yosemite/Yosemite/Model/Storage/Refund+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Refund+ReadOnlyConvertible.swift
@@ -9,13 +9,13 @@ extension Storage.Refund: ReadOnlyConvertible {
     /// Updates the Storage.Refund with the ReadOnly.
     ///
     public func update(with fullRefund: Yosemite.Refund) {
-        refundID = Int64(fullRefund.refundID)
-        orderID = Int64(fullRefund.orderID)
-        siteID = Int64(fullRefund.siteID)
+        refundID = fullRefund.refundID
+        orderID = fullRefund.orderID
+        siteID = fullRefund.siteID
         dateCreated = fullRefund.dateCreated
         amount = fullRefund.amount
         reason = fullRefund.reason
-        byUserID = Int64(fullRefund.refundedByUserID)
+        byUserID = fullRefund.refundedByUserID
 
         if let automated = fullRefund.isAutomated {
             isAutomated = automated
@@ -31,13 +31,13 @@ extension Storage.Refund: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.Refund {
         let orderItems = items?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemRefund]()
 
-        return Refund(refundID: Int64(refundID),
-                      orderID: Int64(orderID),
-                      siteID: Int64(siteID),
+        return Refund(refundID: refundID,
+                      orderID: orderID,
+                      siteID: siteID,
                       dateCreated: dateCreated ?? Date(),
                       amount: amount ?? "",
                       reason: reason ?? "",
-                      refundedByUserID: Int64(byUserID),
+                      refundedByUserID: byUserID,
                       isAutomated: isAutomated,
                       createAutomated: createAutomated,
                       items: orderItems)

--- a/Yosemite/Yosemite/Model/Storage/Refund+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Refund+ReadOnlyConvertible.swift
@@ -31,13 +31,13 @@ extension Storage.Refund: ReadOnlyConvertible {
     public func toReadOnly() -> Yosemite.Refund {
         let orderItems = items?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemRefund]()
 
-        return Refund(refundID: Int(refundID),
-                      orderID: Int(orderID),
-                      siteID: Int(siteID),
+        return Refund(refundID: Int64(refundID),
+                      orderID: Int64(orderID),
+                      siteID: Int64(siteID),
                       dateCreated: dateCreated ?? Date(),
                       amount: amount ?? "",
                       reason: reason ?? "",
-                      refundedByUserID: Int(byUserID),
+                      refundedByUserID: Int64(byUserID),
                       isAutomated: isAutomated,
                       createAutomated: createAutomated,
                       items: orderItems)

--- a/Yosemite/Yosemite/Model/Storage/ShipmentTracking+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShipmentTracking+ReadOnlyConvertible.swift
@@ -9,8 +9,8 @@ extension Storage.ShipmentTracking: ReadOnlyConvertible {
     /// Updates the Storage.SiteSetting with the a ReadOnly.
     ///
     public func update(with shipmentTracking: Yosemite.ShipmentTracking) {
-        siteID = Int64(shipmentTracking.siteID)
-        orderID = Int64(shipmentTracking.orderID)
+        siteID = shipmentTracking.siteID
+        orderID = shipmentTracking.orderID
         trackingID = shipmentTracking.trackingID
         trackingNumber = shipmentTracking.trackingNumber
         trackingProvider = shipmentTracking.trackingProvider
@@ -21,8 +21,8 @@ extension Storage.ShipmentTracking: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShipmentTracking {
-        return ShipmentTracking(siteID: Int64(siteID),
-                                orderID: Int64(orderID),
+        return ShipmentTracking(siteID: siteID,
+                                orderID: orderID,
                                 trackingID: trackingID,
                                 trackingNumber: trackingNumber ?? "",
                                 trackingProvider: trackingProvider,

--- a/Yosemite/Yosemite/Model/Storage/ShipmentTracking+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShipmentTracking+ReadOnlyConvertible.swift
@@ -21,8 +21,8 @@ extension Storage.ShipmentTracking: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShipmentTracking {
-        return ShipmentTracking(siteID: Int(siteID),
-                                orderID: Int(orderID),
+        return ShipmentTracking(siteID: Int64(siteID),
+                                orderID: Int64(orderID),
                                 trackingID: trackingID,
                                 trackingNumber: trackingNumber ?? "",
                                 trackingProvider: trackingProvider,

--- a/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProvider+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProvider+ReadOnlyConvertible.swift
@@ -8,7 +8,7 @@ extension Storage.ShipmentTrackingProvider: ReadOnlyConvertible {
     /// Updates the Storage.SiteTrackingProvider with the a ReadOnly.
     ///
     public func update(with shipmentTrackingProvider: Yosemite.ShipmentTrackingProvider) {
-        siteID = Int64(shipmentTrackingProvider.siteID)
+        siteID = shipmentTrackingProvider.siteID
         name = shipmentTrackingProvider.name
         url = shipmentTrackingProvider.url
     }
@@ -16,6 +16,6 @@ extension Storage.ShipmentTrackingProvider: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShipmentTrackingProvider {
-        return ShipmentTrackingProvider(siteID: Int64(siteID), name: name ?? "", url: url ?? "")
+        return ShipmentTrackingProvider(siteID: siteID, name: name ?? "", url: url ?? "")
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProvider+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProvider+ReadOnlyConvertible.swift
@@ -16,6 +16,6 @@ extension Storage.ShipmentTrackingProvider: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShipmentTrackingProvider {
-        return ShipmentTrackingProvider(siteID: Int(siteID), name: name ?? "", url: url ?? "")
+        return ShipmentTrackingProvider(siteID: Int64(siteID), name: name ?? "", url: url ?? "")
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift
@@ -9,13 +9,13 @@ extension Storage.ShipmentTrackingProviderGroup: ReadOnlyConvertible {
     ///
     public func update(with shipmentTrackingProviderGroup: Yosemite.ShipmentTrackingProviderGroup) {
         name = shipmentTrackingProviderGroup.name
-        siteID = Int64(shipmentTrackingProviderGroup.siteID)
+        siteID = shipmentTrackingProviderGroup.siteID
     }
 
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShipmentTrackingProviderGroup {
         let groupProviders = providers?.map { $0.toReadOnly() } ?? [Yosemite.ShipmentTrackingProvider]()
-        return ShipmentTrackingProviderGroup(name: name ?? "", siteID: Int64(siteID), providers: groupProviders )
+        return ShipmentTrackingProviderGroup(name: name ?? "", siteID: siteID, providers: groupProviders )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift
@@ -16,6 +16,6 @@ extension Storage.ShipmentTrackingProviderGroup: ReadOnlyConvertible {
     ///
     public func toReadOnly() -> Yosemite.ShipmentTrackingProviderGroup {
         let groupProviders = providers?.map { $0.toReadOnly() } ?? [Yosemite.ShipmentTrackingProvider]()
-        return ShipmentTrackingProviderGroup(name: name ?? "", siteID: Int(siteID), providers: groupProviders )
+        return ShipmentTrackingProviderGroup(name: name ?? "", siteID: Int64(siteID), providers: groupProviders )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/ShippingLine+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShippingLine+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.ShippingLine: ReadOnlyConvertible {
     /// Updates the Storage.ShippingLine with the ReadOnly.
     ///
     public func update(with shippingLine: Yosemite.ShippingLine) {
-        shippingID = Int64(shippingLine.shippingID)
+        shippingID = shippingLine.shippingID
         methodTitle = shippingLine.methodTitle
         methodID = shippingLine.methodID
         total = shippingLine.total
@@ -19,7 +19,7 @@ extension Storage.ShippingLine: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShippingLine {
-        return ShippingLine(shippingID: Int64(shippingID),
+        return ShippingLine(shippingID: shippingID,
                             methodTitle: methodTitle ?? "",
                             methodID: methodID ?? "",
                             total: total ?? "",

--- a/Yosemite/Yosemite/Model/Storage/ShippingLine+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ShippingLine+ReadOnlyConvertible.swift
@@ -19,7 +19,7 @@ extension Storage.ShippingLine: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.ShippingLine {
-        return ShippingLine(shippingID: Int(shippingID),
+        return ShippingLine(shippingID: Int64(shippingID),
                             methodTitle: methodTitle ?? "",
                             methodID: methodID ?? "",
                             total: total ?? "",

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.Site: ReadOnlyConvertible {
     /// Updates the Storage.Site with the a ReadOnly.
     ///
     public func update(with site: Yosemite.Site) {
-        siteID = Int64(site.siteID)
+        siteID = site.siteID
         name = site.name
         tagline = site.description
         url = site.url
@@ -22,7 +22,7 @@ extension Storage.Site: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.Site {
-        return Site(siteID: Int64(siteID),
+        return Site(siteID: siteID,
                     name: name ?? "",
                     description: tagline ?? "",
                     url: url ?? "",

--- a/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Site+ReadOnlyConvertible.swift
@@ -22,7 +22,7 @@ extension Storage.Site: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.Site {
-        return Site(siteID: Int(siteID),
+        return Site(siteID: Int64(siteID),
                     name: name ?? "",
                     description: tagline ?? "",
                     url: url ?? "",

--- a/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
@@ -20,7 +20,7 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.SiteSetting {
-        return SiteSetting(siteID: Int(siteID),
+        return SiteSetting(siteID: Int64(siteID),
                            settingID: settingID ?? "",
                            label: label ?? "",
                            description: settingDescription ?? "",

--- a/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/SiteSetting+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
     /// Updates the Storage.SiteSetting with the a ReadOnly.
     ///
     public func update(with setting: Yosemite.SiteSetting) {
-        siteID = Int64(setting.siteID)
+        siteID = setting.siteID
         settingID = setting.settingID
         label = setting.label
         settingDescription = setting.settingDescription
@@ -20,7 +20,7 @@ extension Storage.SiteSetting: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.SiteSetting {
-        return SiteSetting(siteID: Int64(siteID),
+        return SiteSetting(siteID: siteID,
                            settingID: settingID ?? "",
                            label: label ?? "",
                            description: settingDescription ?? "",

--- a/Yosemite/Yosemite/Model/Storage/TaxClass+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TaxClass+ReadOnlyConvertible.swift
@@ -17,6 +17,6 @@ extension Storage.TaxClass: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.TaxClass {
-        return TaxClass(siteID: Int(siteID), name: name, slug: slug)
+        return TaxClass(siteID: Int64(siteID), name: name, slug: slug)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/TaxClass+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TaxClass+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.TaxClass: ReadOnlyConvertible {
     /// Updates the Storage.TaxClass with the ReadOnly.
     ///
     public func update(with taxClass: Yosemite.TaxClass) {
-        siteID = Int64(taxClass.siteID)
+        siteID = taxClass.siteID
         name = taxClass.name
         slug = taxClass.slug
     }
@@ -17,6 +17,6 @@ extension Storage.TaxClass: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.TaxClass {
-        return TaxClass(siteID: Int64(siteID), name: name, slug: slug)
+        return TaxClass(siteID: siteID, name: name, slug: slug)
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
@@ -21,7 +21,7 @@ extension Storage.TopEarnerStatsItem: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.TopEarnerStatsItem {
-        return TopEarnerStatsItem(productID: Int(productID),
+        return TopEarnerStatsItem(productID: Int64(productID),
                                   productName: productName ?? "",
                                   quantity: Int(quantity),
                                   price: price,

--- a/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/TopEarnerStatsItem+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.TopEarnerStatsItem: ReadOnlyConvertible {
     /// Updates the Storage.TopEarnerStatsItem with the ReadOnly.
     ///
     public func update(with statsItem: Yosemite.TopEarnerStatsItem) {
-        productID = Int64(statsItem.productID)
+        productID = statsItem.productID
         productName = statsItem.productName
         quantity = Int64(statsItem.quantity)
         price = statsItem.price
@@ -21,7 +21,7 @@ extension Storage.TopEarnerStatsItem: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.TopEarnerStatsItem {
-        return TopEarnerStatsItem(productID: Int64(productID),
+        return TopEarnerStatsItem(productID: productID,
                                   productName: productName ?? "",
                                   quantity: Int(quantity),
                                   price: price,

--- a/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
+++ b/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
@@ -176,7 +176,7 @@ extension Product: ProductUpdater {
                        shippingRequired: shippingRequired,
                        shippingTaxable: shippingTaxable,
                        shippingClass: shippingClass?.slug,
-                       shippingClassID: shippingClass.flatMap({ Int($0.shippingClassID) }) ?? Int.min,
+                       shippingClassID: shippingClass?.shippingClassID ?? 0,
                        productShippingClass: shippingClass,
                        reviewsAllowed: reviewsAllowed,
                        averageRating: averageRating,

--- a/Yosemite/Yosemite/Stores/AccountStore.swift
+++ b/Yosemite/Yosemite/Stores/AccountStore.swift
@@ -71,7 +71,7 @@ private extension AccountStore {
     /// Synchronizes the WordPress.com account settings associated with the Network's Auth Token.
     /// User ID is passed along because the API doesn't include it in the response.
     ///
-    func synchronizeAccountSettings(userID: Int, onCompletion: @escaping (AccountSettings?, Error?) -> Void) {
+    func synchronizeAccountSettings(userID: Int64, onCompletion: @escaping (AccountSettings?, Error?) -> Void) {
         let remote = AccountRemote(network: network)
 
         remote.loadAccountSettings(for: userID) { [weak self] (accountSettings, error) in
@@ -104,7 +104,7 @@ private extension AccountStore {
 
     /// Loads the site plan for the default site.
     ///
-    func synchronizeSitePlan(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeSitePlan(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let remote = AccountRemote(network: network)
         remote.loadSitePlan(for: siteID) { [weak self]  (siteplan, error) in
             guard let siteplan = siteplan else {
@@ -120,21 +120,21 @@ private extension AccountStore {
 
     /// Loads the Account associated with the specified userID (if any!).
     ///
-    func loadAccount(userID: Int, onCompletion: @escaping (Account?) -> Void) {
-        let account = storageManager.viewStorage.loadAccount(userId: userID)?.toReadOnly()
+    func loadAccount(userID: Int64, onCompletion: @escaping (Account?) -> Void) {
+        let account = storageManager.viewStorage.loadAccount(userID: userID)?.toReadOnly()
         onCompletion(account)
     }
 
     /// Loads the Site associated with the specified siteID (if any!)
     ///
-    func loadSite(siteID: Int, onCompletion: @escaping (Site?) -> Void) {
+    func loadSite(siteID: Int64, onCompletion: @escaping (Site?) -> Void) {
         let site = storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly()
         onCompletion(site)
     }
 
     /// Submits the tracks opt-in / opt-out setting to be synced globally. 
     ///
-    func updateAccountSettings(userID: Int, tracksOptOut: Bool, onCompletion: @escaping (Error?) -> Void) {
+    func updateAccountSettings(userID: Int64, tracksOptOut: Bool, onCompletion: @escaping (Error?) -> Void) {
         let remote = AccountRemote(network: network)
         remote.updateAccountSettings(for: userID, tracksOptOut: tracksOptOut) { accountSettings, error in
             guard let _ = accountSettings else {
@@ -158,7 +158,7 @@ extension AccountStore {
         assert(Thread.isMainThread)
 
         let storage = storageManager.viewStorage
-        let storageAccount = storage.loadAccount(userId: readOnlyAccount.userID) ?? storage.insertNewObject(ofType: Storage.Account.self)
+        let storageAccount = storage.loadAccount(userID: readOnlyAccount.userID) ?? storage.insertNewObject(ofType: Storage.Account.self)
 
         storageAccount.update(with: readOnlyAccount)
         storage.saveIfNeeded()
@@ -170,7 +170,7 @@ extension AccountStore {
         assert(Thread.isMainThread)
 
         let storage = storageManager.viewStorage
-        let storageAccount = storage.loadAccountSettings(userId: readOnlyAccountSettings.userID) ??
+        let storageAccount = storage.loadAccountSettings(userID: readOnlyAccountSettings.userID) ??
             storage.insertNewObject(ofType: Storage.AccountSettings.self)
 
         storageAccount.update(with: readOnlyAccountSettings)

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -127,7 +127,7 @@ public class AppSettingsStore: Store {
 // MARK: - Shipment tracking providers!
 //
 private extension AppSettingsStore {
-    func addTrackingProvider(siteID: Int,
+    func addTrackingProvider(siteID: Int64,
                              providerName: String,
                              onCompletion: (Error?) -> Void) {
         addProvider(siteID: siteID,
@@ -137,7 +137,7 @@ private extension AppSettingsStore {
 
     }
 
-    func addCustomTrackingProvider(siteID: Int,
+    func addCustomTrackingProvider(siteID: Int64,
                              providerName: String,
                              providerURL: String?,
                              onCompletion: (Error?) -> Void) {
@@ -148,7 +148,7 @@ private extension AppSettingsStore {
                     onCompletion: onCompletion)
     }
 
-    func addProvider(siteID: Int,
+    func addProvider(siteID: Int64,
                      providerName: String,
                      providerURL: String? = nil,
                      fileURL: URL,
@@ -180,7 +180,7 @@ private extension AppSettingsStore {
         }
     }
 
-    func loadTrackingProvider(siteID: Int,
+    func loadTrackingProvider(siteID: Int64,
                               onCompletion: (ShipmentTrackingProvider?, ShipmentTrackingProviderGroup?, Error?) -> Void) {
         guard let allSavedProviders = read(from: selectedProvidersURL) as [PreselectedProvider]? else {
             let error = AppSettingsStoreErrors.readPreselectedProvider
@@ -206,7 +206,7 @@ private extension AppSettingsStore {
         onCompletion(provider?.toReadOnly(), provider?.group?.toReadOnly(), nil)
     }
 
-    func loadCustomTrackingProvider(siteID: Int,
+    func loadCustomTrackingProvider(siteID: Int64,
                               onCompletion: (ShipmentTrackingProvider?, Error?) -> Void) {
         guard let allSavedProviders = read(from: customSelectedProvidersURL) as [PreselectedProvider]? else {
             let error = AppSettingsStoreErrors.readPreselectedProvider
@@ -234,7 +234,7 @@ private extension AppSettingsStore {
         onCompletion(customProvider, nil)
     }
 
-    func upsertTrackingProvider(siteID: Int,
+    func upsertTrackingProvider(siteID: Int64,
                                 providerName: String,
                                 providerURL: String? = nil,
                                 preselectedData: [PreselectedProvider],
@@ -256,7 +256,7 @@ private extension AppSettingsStore {
         write(dataToSave, to: toFileURL, onCompletion: onCompletion)
     }
 
-    func insertNewProvider(siteID: Int,
+    func insertNewProvider(siteID: Int64,
                            providerName: String,
                            providerURL: String? = nil,
                            toFileURL: URL,
@@ -283,7 +283,7 @@ private extension AppSettingsStore {
 // MARK: - Stats version
 //
 private extension AppSettingsStore {
-    func setStatsVersionLastShownOrFromUserPreference(siteID: Int,
+    func setStatsVersionLastShownOrFromUserPreference(siteID: Int64,
                                                       statsVersion: StatsVersion) {
         set(statsVersion: statsVersion, for: siteID, to: statsVersionLastShownURL, onCompletion: { error in
             if let error = error {
@@ -292,7 +292,7 @@ private extension AppSettingsStore {
         })
     }
 
-    func setStatsVersionEligible(siteID: Int,
+    func setStatsVersionEligible(siteID: Int64,
                                  statsVersion: StatsVersion) {
         set(statsVersion: statsVersion, for: siteID, to: statsVersionEligibleURL, onCompletion: { error in
             if let error = error {
@@ -301,7 +301,7 @@ private extension AppSettingsStore {
         })
     }
 
-    func loadInitialStatsVersionToShow(siteID: Int, onCompletion: (StatsVersion?) -> Void) {
+    func loadInitialStatsVersionToShow(siteID: Int64, onCompletion: (StatsVersion?) -> Void) {
         guard let existingData: StatsVersionBySite = read(from: statsVersionLastShownURL),
             let statsVersion = existingData.statsVersionBySite[siteID] else {
             onCompletion(nil)
@@ -310,7 +310,7 @@ private extension AppSettingsStore {
         onCompletion(statsVersion)
     }
 
-    func loadStatsVersionEligible(siteID: Int, onCompletion: (StatsVersion?) -> Void) {
+    func loadStatsVersionEligible(siteID: Int64, onCompletion: (StatsVersion?) -> Void) {
         guard let existingData: StatsVersionBySite = read(from: statsVersionEligibleURL),
             let statsVersion = existingData.statsVersionBySite[siteID] else {
                 onCompletion(nil)
@@ -319,7 +319,7 @@ private extension AppSettingsStore {
         onCompletion(statsVersion)
     }
 
-    func set(statsVersion: StatsVersion, for siteID: Int, to fileURL: URL, onCompletion: (Error?) -> Void) {
+    func set(statsVersion: StatsVersion, for siteID: Int64, to fileURL: URL, onCompletion: (Error?) -> Void) {
         guard let existingData: StatsVersionBySite = read(from: fileURL) else {
             let statsVersionBySite: StatsVersionBySite = StatsVersionBySite(statsVersionBySite: [siteID: statsVersion])
             write(statsVersionBySite, to: fileURL, onCompletion: onCompletion)

--- a/Yosemite/Yosemite/Stores/AvailabilityStore.swift
+++ b/Yosemite/Yosemite/Stores/AvailabilityStore.swift
@@ -29,7 +29,7 @@ final public class AvailabilityStore: Store {
 private extension AvailabilityStore {
     /// Checks if Stats v4 is available for the site.
     ///
-    func checkStatsV4Availability(siteID: Int,
+    func checkStatsV4Availability(siteID: Int64,
                                   onCompletion: @escaping (_ isStatsV4Available: Bool) -> Void) {
         let date = String(describing: Date().timeIntervalSinceReferenceDate)
         let remote = OrderStatsRemoteV4(network: network)

--- a/Yosemite/Yosemite/Stores/CommentStore.swift
+++ b/Yosemite/Yosemite/Stores/CommentStore.swift
@@ -38,26 +38,26 @@ private extension CommentStore {
 
     /// Updates the comment's approval status
     ///
-    func updateApprovalStatus(siteID: Int, commentID: Int, isApproved: Bool, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
+    func updateApprovalStatus(siteID: Int64, commentID: Int64, isApproved: Bool, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
         let newStatus = isApproved ? CommentStatus.approved : CommentStatus.unapproved
         moderateComment(siteID: siteID, commentID: commentID, status: newStatus, onCompletion: onCompletion)
     }
 
     /// Updates the comment's spam status
     ///
-    func updateSpamStatus(siteID: Int, commentID: Int, isSpam: Bool, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
+    func updateSpamStatus(siteID: Int64, commentID: Int64, isSpam: Bool, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
         let newStatus = isSpam ? CommentStatus.spam : CommentStatus.unspam
         moderateComment(siteID: siteID, commentID: commentID, status: newStatus, onCompletion: onCompletion)
     }
 
     /// Updates the comment's trash status
     ///
-    func updateTrashStatus(siteID: Int, commentID: Int, isTrash: Bool, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
+    func updateTrashStatus(siteID: Int64, commentID: Int64, isTrash: Bool, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
         let newStatus = isTrash ? CommentStatus.trash : CommentStatus.untrash
         moderateComment(siteID: siteID, commentID: commentID, status: newStatus, onCompletion: onCompletion)
     }
 
-    func moderateComment(siteID: Int, commentID: Int, status: CommentStatus, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
+    func moderateComment(siteID: Int64, commentID: Int64, status: CommentStatus, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
         let remote = CommentRemote(network: network)
 
         remote.moderateComment(siteID: siteID, commentID: commentID, status: status) { (updatedStatus, error) in

--- a/Yosemite/Yosemite/Stores/NotificationStore.swift
+++ b/Yosemite/Yosemite/Stores/NotificationStore.swift
@@ -38,18 +38,18 @@ public class NotificationStore: Store {
                            onCompletion: onCompletion)
         case .synchronizeNotifications(let onCompletion):
             synchronizeNotifications(onCompletion: onCompletion)
-        case .synchronizeNotification(let noteId, let onCompletion):
-            synchronizeNotification(with: noteId, onCompletion: onCompletion)
+        case .synchronizeNotification(let noteID, let onCompletion):
+            synchronizeNotification(with: noteID, onCompletion: onCompletion)
         case .unregisterDevice(let deviceId, let onCompletion):
             unregisterDevice(deviceId: deviceId, onCompletion: onCompletion)
         case .updateLastSeen(let timestamp, let onCompletion):
             updateLastSeen(timestamp: timestamp, onCompletion: onCompletion)
-        case .updateReadStatus(let noteId, let read, let onCompletion):
-            updateReadStatus(for: [noteId], read: read, onCompletion: onCompletion)
-        case .updateMultipleReadStatus(let noteIds, let read, let onCompletion):
-            updateReadStatus(for: noteIds, read: read, onCompletion: onCompletion)
-        case .updateLocalDeletedStatus(let noteId, let deleteInProgress, let onCompletion):
-            updateDeletedStatus(noteId: noteId, deleteInProgress: deleteInProgress, onCompletion: onCompletion)
+        case .updateReadStatus(let noteID, let read, let onCompletion):
+            updateReadStatus(for: [noteID], read: read, onCompletion: onCompletion)
+        case .updateMultipleReadStatus(let noteIDs, let read, let onCompletion):
+            updateReadStatus(for: noteIDs, read: read, onCompletion: onCompletion)
+        case .updateLocalDeletedStatus(let noteID, let deleteInProgress, let onCompletion):
+            updateDeletedStatus(noteID: noteID, deleteInProgress: deleteInProgress, onCompletion: onCompletion)
         }
     }
 }
@@ -64,7 +64,7 @@ private extension NotificationStore {
     func registerDevice(device: APNSDevice,
                         applicationId: String,
                         applicationVersion: String,
-                        defaultStoreID: Int,
+                        defaultStoreID: Int64,
                         onCompletion: @escaping (DotcomDevice?, Error?) -> Void) {
         let remote = DevicesRemote(network: network)
         remote.registerDevice(device: device,
@@ -103,7 +103,7 @@ private extension NotificationStore {
                         return
                     }
 
-                    remote.loadNotes(noteIds: outdatedIDs, pageSize: Constants.maximumPageSize) { [weak self] (notes, error) in
+                    remote.loadNotes(noteIDs: outdatedIDs, pageSize: Constants.maximumPageSize) { [weak self] (notes, error) in
 
                         guard let notes = notes else {
                             onCompletion(error)
@@ -123,13 +123,13 @@ private extension NotificationStore {
     /// Synchronizes the Notification matching the specified ID, and updates the local entity.
     ///
     /// - Parameters:
-    ///     - noteId: Notification ID of the note to be downloaded.
+    ///     - noteID: Notification ID of the note to be downloaded.
     ///     - onCompletion: Closure to be executed on completion.
     ///
-    func synchronizeNotification(with noteId: Int64, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeNotification(with noteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let remote = NotificationsRemote(network: network)
 
-        remote.loadNotes(noteIds: [noteId]) { notes, error in
+        remote.loadNotes(noteIDs: [noteID]) { notes, error in
             guard let notes = notes else {
                 onCompletion(error)
                 return
@@ -154,15 +154,15 @@ private extension NotificationStore {
 
     /// Updates the read status for the given notification ID(s)
     ///
-    func updateReadStatus(for noteIds: [Int64], read: Bool, onCompletion: @escaping (Error?) -> Void) {
+    func updateReadStatus(for noteIDs: [Int64], read: Bool, onCompletion: @escaping (Error?) -> Void) {
         /// Optimistically Update
         ///
-        updateLocalNoteReadStatus(for: noteIds, read: read)
+        updateLocalNoteReadStatus(for: noteIDs, read: read)
 
         /// On error we'll just mark the Note for Refresh
         ///
         let remote = NotificationsRemote(network: network)
-        remote.updateReadStatus(noteIds: noteIds, read: read) { error in
+        remote.updateReadStatus(noteIDs: noteIDs, read: read) { error in
             guard let error = error else {
 
                 /// What is this about:
@@ -178,7 +178,7 @@ private extension NotificationStore {
                 return
             }
 
-            self.invalidateCache(for: noteIds) {
+            self.invalidateCache(for: noteIDs) {
                 onCompletion(error)
             }
         }
@@ -187,8 +187,8 @@ private extension NotificationStore {
     /// Marks the provided notification as "currently being deleted" — no network call is made. This is
     /// useful for filtering on the notifications list.
     ///
-    func updateDeletedStatus(noteId: Int64, deleteInProgress: Bool, onCompletion: @escaping (Error?) -> Void) {
-        markLocalNoteAsDeleted(for: noteId, isDeleted: deleteInProgress) {
+    func updateDeletedStatus(noteID: Int64, deleteInProgress: Bool, onCompletion: @escaping (Error?) -> Void) {
+        markLocalNoteAsDeleted(for: noteID, isDeleted: deleteInProgress) {
             onCompletion(nil)
         }
     }
@@ -235,7 +235,7 @@ extension NotificationStore {
 
         derivedStorage.perform {
             for remoteNote in remoteNotes {
-                let localNote = derivedStorage.loadNotification(noteID: remoteNote.noteId) ?? derivedStorage.insertNewObject(ofType: Storage.Note.self)
+                let localNote = derivedStorage.loadNotification(noteID: remoteNote.noteID) ?? derivedStorage.insertNewObject(ofType: Storage.Note.self)
                 localNote.update(with: remoteNote)
             }
         }
@@ -300,11 +300,11 @@ extension NotificationStore {
 
     /// Invalidates the Hash for the specified Notifications.
     ///
-    func invalidateCache(for noteIds: [Int64], onCompletion: (() -> Void)? = nil) {
+    func invalidateCache(for noteIDs: [Int64], onCompletion: (() -> Void)? = nil) {
         let derivedStorage = type(of: self).sharedDerivedStorage(with: storageManager)
 
         derivedStorage.perform {
-            let notifications = noteIds.compactMap { derivedStorage.loadNotification(noteID: $0) }
+            let notifications = noteIDs.compactMap { derivedStorage.loadNotification(noteID: $0) }
             for note in notifications {
                 note.noteHash = Int64.min
             }

--- a/Yosemite/Yosemite/Stores/OrderNoteStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderNoteStore.swift
@@ -42,7 +42,7 @@ private extension OrderNoteStore {
 
     /// Retrieves the order notes associated with the provided Site ID & Order ID (if any!).
     ///
-    func retrieveOrderNotes(siteID: Int, orderID: Int, onCompletion: @escaping ([OrderNote]?, Error?) -> Void) {
+    func retrieveOrderNotes(siteID: Int64, orderID: Int64, onCompletion: @escaping ([OrderNote]?, Error?) -> Void) {
         let remote = OrdersRemote(network: network)
         remote.loadOrderNotes(for: siteID, orderID: orderID) { [weak self] (orderNotes, error) in
             guard let orderNotes = orderNotes else {
@@ -58,7 +58,7 @@ private extension OrderNoteStore {
 
     /// Adds a single order note and associates it with the provided siteID and orderID.
     ///
-    func addOrderNote(siteID: Int, orderID: Int, isCustomerNote: Bool, note: String, onCompletion: @escaping (OrderNote?, Error?) -> Void) {
+    func addOrderNote(siteID: Int64, orderID: Int64, isCustomerNote: Bool, note: String, onCompletion: @escaping (OrderNote?, Error?) -> Void) {
         let remote = OrdersRemote(network: network)
         remote.addOrderNote(for: siteID, orderID: orderID, isCustomerNote: isCustomerNote, with: note) { [weak self] (orderNote, error) in
             guard let note = orderNote else {
@@ -80,7 +80,7 @@ extension OrderNoteStore {
 
     /// Updates (OR Inserts) the specified ReadOnly OrderNote Entity into the Storage Layer.
     ///
-    func upsertStoredOrderNoteInBackground(readOnlyOrderNote: Networking.OrderNote, orderID: Int, onCompletion: @escaping () -> Void) {
+    func upsertStoredOrderNoteInBackground(readOnlyOrderNote: Networking.OrderNote, orderID: Int64, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             self.saveNote(derivedStorage, readOnlyOrderNote, orderID)
@@ -93,7 +93,7 @@ extension OrderNoteStore {
 
     /// Updates (OR Inserts) the specified ReadOnly OrderNote Entities into the Storage Layer.
     ///
-    func upsertStoredOrderNotesInBackground(readOnlyOrderNotes: [Networking.OrderNote], orderID: Int, onCompletion: @escaping () -> Void) {
+    func upsertStoredOrderNotesInBackground(readOnlyOrderNotes: [Networking.OrderNote], orderID: Int64, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             for readOnlyOrderNote in readOnlyOrderNotes {
@@ -109,7 +109,7 @@ extension OrderNoteStore {
     /// Using the provided StorageType, update or insert a Storage.OrderNote using the provided ReadOnly
     /// OrderNote. This func does *not* persist any unsaved changes to storage.
     ///
-    private func saveNote(_ storage: StorageType, _ readOnlyOrderNote: OrderNote, _ orderID: Int) {
+    private func saveNote(_ storage: StorageType, _ readOnlyOrderNote: OrderNote, _ orderID: Int64) {
         if let existingStorageNote = storage.loadOrderNote(noteID: readOnlyOrderNote.noteID) {
             existingStorageNote.update(with: readOnlyOrderNote)
             return

--- a/Yosemite/Yosemite/Stores/OrderStatusStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStatusStore.swift
@@ -43,7 +43,7 @@ private extension OrderStatusStore {
 
     /// Retrieves the order statuses associated with the provided Site ID (if any!).
     ///
-    func retrieveOrderStatuses(siteID: Int, onCompletion: @escaping ([OrderStatus]?, Error?) -> Void) {
+    func retrieveOrderStatuses(siteID: Int64, onCompletion: @escaping ([OrderStatus]?, Error?) -> Void) {
         let remote = ReportRemote(network: network)
         remote.loadOrderStatuses(for: siteID) { [weak self] (orderStatuses, error) in
             guard let orderStatuses = orderStatuses else {
@@ -77,7 +77,7 @@ extension OrderStatusStore {
     /// Updates (OR Inserts) the specified ReadOnly Order Status Entities
     /// *in a background thread*. onCompletion will be called on the main thread!
     ///
-    func upsertStatusesInBackground(siteID: Int, readOnlyOrderStatuses: [Networking.OrderStatus], onCompletion: @escaping () -> Void) {
+    func upsertStatusesInBackground(siteID: Int64, readOnlyOrderStatuses: [Networking.OrderStatus], onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             for readOnlyItem in readOnlyOrderStatuses {

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -62,7 +62,7 @@ private extension OrderStore {
 
     /// Searches all of the orders that contain a given Keyword.
     ///
-    func searchOrders(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func searchOrders(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = OrdersRemote(network: network)
 
         remote.searchOrders(for: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (orders, error) in
@@ -79,7 +79,7 @@ private extension OrderStore {
 
     /// Retrieves the orders associated with a given Site ID (if any!).
     ///
-    func synchronizeOrders(siteID: Int, statusKey: String?, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeOrders(siteID: Int64, statusKey: String?, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = OrdersRemote(network: network)
 
         remote.loadAllOrders(for: siteID, statusKey: statusKey, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (orders, error) in
@@ -96,7 +96,7 @@ private extension OrderStore {
 
     /// Retrieves a specific order associated with a given Site ID (if any!).
     ///
-    func retrieveOrder(siteID: Int, orderID: Int, onCompletion: @escaping (Order?, Error?) -> Void) {
+    func retrieveOrder(siteID: Int64, orderID: Int64, onCompletion: @escaping (Order?, Error?) -> Void) {
         let remote = OrdersRemote(network: network)
 
         remote.loadOrder(for: siteID, orderID: orderID) { [weak self] (order, error) in
@@ -116,7 +116,7 @@ private extension OrderStore {
 
     /// Updates an Order with the specified Status.
     ///
-    func updateOrder(siteID: Int, orderID: Int, statusKey: String, onCompletion: @escaping (Error?) -> Void) {
+    func updateOrder(siteID: Int64, orderID: Int64, statusKey: String, onCompletion: @escaping (Error?) -> Void) {
         /// Optimistically update the Status
         let oldStatus = updateOrderStatus(orderID: orderID, statusKey: statusKey)
 
@@ -134,7 +134,7 @@ private extension OrderStore {
         }
     }
 
-    func countProcessingOrders(siteID: Int, onCompletion: @escaping (OrderCount?, Error?) -> Void) {
+    func countProcessingOrders(siteID: Int64, onCompletion: @escaping (OrderCount?, Error?) -> Void) {
         let remote = OrdersRemote(network: network)
 
         let status = OrderStatusEnum.processing.rawValue
@@ -159,7 +159,7 @@ extension OrderStore {
 
     /// Deletes any Storage.Order with the specified OrderID
     ///
-    func deleteStoredOrder(orderID: Int) {
+    func deleteStoredOrder(orderID: Int64) {
         let storage = storageManager.viewStorage
         guard let order = storage.loadOrder(orderID: orderID) else {
             return
@@ -174,7 +174,7 @@ extension OrderStore {
     /// - Returns: Status, prior to performing the Update OP.
     ///
     @discardableResult
-    func updateOrderStatus(orderID: Int, statusKey: String) -> String {
+    func updateOrderStatus(orderID: Int64, statusKey: String) -> String {
         let storage = storageManager.viewStorage
         guard let order = storage.loadOrder(orderID: orderID) else {
             return statusKey
@@ -418,7 +418,7 @@ private extension OrderStore {
 
     /// Updates the stored OrderCount with the new OrderCount fetched from the remote
     ///
-    private func upsertOrderCountInBackground(siteID: Int, readOnlyOrderCount: Networking.OrderCount, onCompletion: @escaping () -> Void) {
+    private func upsertOrderCountInBackground(siteID: Int64, readOnlyOrderCount: Networking.OrderCount, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             self.updateOrderCountResults(siteID: siteID, readOnlyOrderCount: readOnlyOrderCount, in: derivedStorage)
@@ -429,7 +429,7 @@ private extension OrderStore {
         }
     }
 
-    private func updateOrderCountResults(siteID: Int, readOnlyOrderCount: Networking.OrderCount, in storage: StorageType) {
+    private func updateOrderCountResults(siteID: Int64, readOnlyOrderCount: Networking.OrderCount, in storage: StorageType) {
         storage.deleteAllObjects(ofType: Storage.OrderCountItem.self)
         storage.deleteAllObjects(ofType: Storage.OrderCount.self)
 

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -60,7 +60,7 @@ private extension ProductReviewStore {
 
     /// Synchronizes the product reviews associated with a given Site ID (if any!).
     ///
-    func synchronizeProductReviews(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeProductReviews(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductReviewsRemote(network: network)
 
         remote.loadAllProductReviews(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (productReviews, error) in
@@ -77,7 +77,7 @@ private extension ProductReviewStore {
 
     /// Retrieves the product review associated with a given siteID + reviewID (if any!).
     ///
-    func retrieveProductReview(siteID: Int, reviewID: Int, onCompletion: @escaping (Networking.ProductReview?, Error?) -> Void) {
+    func retrieveProductReview(siteID: Int64, reviewID: Int64, onCompletion: @escaping (Networking.ProductReview?, Error?) -> Void) {
         let remote = ProductReviewsRemote(network: network)
 
         remote.loadProductReview(for: siteID, reviewID: reviewID) { [weak self] (productReview, error) in
@@ -97,21 +97,21 @@ private extension ProductReviewStore {
 
     /// Updates the review's approval status
     ///
-    func updateApprovalStatus(siteID: Int, reviewID: Int, isApproved: Bool, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
+    func updateApprovalStatus(siteID: Int64, reviewID: Int64, isApproved: Bool, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
         let newStatus = isApproved ? ProductReviewStatus.approved : ProductReviewStatus.hold
         moderateReview(siteID: siteID, reviewID: reviewID, status: newStatus, onCompletion: onCompletion)
     }
 
     /// Updates the review's trash status
     ///
-    func updateTrashStatus(siteID: Int, reviewID: Int, isTrashed: Bool, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
+    func updateTrashStatus(siteID: Int64, reviewID: Int64, isTrashed: Bool, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
         let newStatus = isTrashed ? ProductReviewStatus.trash : ProductReviewStatus.untrash
         moderateReview(siteID: siteID, reviewID: reviewID, status: newStatus, onCompletion: onCompletion)
     }
 
     /// Updates the review's spam status
     ///
-    func updateSpamStatus(siteID: Int, reviewID: Int, isSpam: Bool, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
+    func updateSpamStatus(siteID: Int64, reviewID: Int64, isSpam: Bool, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
         let newStatus = isSpam ? ProductReviewStatus.spam : ProductReviewStatus.unspam
         moderateReview(siteID: siteID, reviewID: reviewID, status: newStatus, onCompletion: onCompletion)
     }
@@ -124,7 +124,7 @@ private extension ProductReviewStore {
 
     /// Deletes any Storage.ProductReview with the specified `siteID` and `reviewID`
     ///
-    func deleteStoredProductReview(siteID: Int, reviewID: Int) {
+    func deleteStoredProductReview(siteID: Int64, reviewID: Int64) {
         let storage = storageManager.viewStorage
         guard let productReview = storage.loadProductReview(siteID: siteID, reviewID: reviewID) else {
             return
@@ -137,7 +137,7 @@ private extension ProductReviewStore {
     /// Updates (OR Inserts) the specified ReadOnly ProductReview Entities *in a background thread*. onCompletion will be called
     /// on the main thread!
     ///
-    func upsertStoredProductReviewsInBackground(readOnlyProductReviews: [Networking.ProductReview], siteID: Int, onCompletion: @escaping () -> Void) {
+    func upsertStoredProductReviewsInBackground(readOnlyProductReviews: [Networking.ProductReview], siteID: Int64, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             self.upsertStoredProductReviews(readOnlyProductReviews: readOnlyProductReviews, in: derivedStorage, siteID: siteID)
@@ -148,7 +148,7 @@ private extension ProductReviewStore {
         }
     }
 
-    func moderateReview(siteID: Int, reviewID: Int, status: ProductReviewStatus, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
+    func moderateReview(siteID: Int64, reviewID: Int64, status: ProductReviewStatus, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
         let remote = ProductReviewsRemote(network: network)
         let storage = storageManager.viewStorage
         remote.updateProductReviewStatus(for: siteID, reviewID: reviewID, statusKey: status.rawValue) { (productReview, error) in
@@ -174,7 +174,7 @@ extension ProductReviewStore {
     ///     - readOnlyProductReviews: Remote ProductReviews to be persisted.
     ///     - storage: Where we should save all the things!
     ///
-    func upsertStoredProductReviews(readOnlyProductReviews: [Networking.ProductReview], in storage: StorageType, siteID: Int) {
+    func upsertStoredProductReviews(readOnlyProductReviews: [Networking.ProductReview], in storage: StorageType, siteID: Int64) {
         // Upsert the Product reviews from the read-only reviews
         for readOnlyProductReview in readOnlyProductReviews {
             let storageProductReview = storage.loadProductReview(siteID: siteID, reviewID: readOnlyProductReview.reviewID) ??

--- a/Yosemite/Yosemite/Stores/ProductShippingClassStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductShippingClassStore.swift
@@ -61,14 +61,14 @@ private extension ProductShippingClassStore {
     func retrieveProductShippingClass(siteID: Int64, remoteID: Int64, onCompletion: @escaping (ProductShippingClass?, Error?) -> Void) {
         let remote = ProductShippingClassRemote(network: network)
 
-        remote.loadOne(for: Int64(siteID), remoteID: remoteID) { [weak self] (model, error) in
+        remote.loadOne(for: siteID, remoteID: remoteID) { [weak self] (model, error) in
             guard let model = model else {
                 onCompletion(nil, error)
                 return
             }
 
             self?.upsertStoredProductShippingClassModelsInBackground(readOnlyProductShippingClassModels: [model],
-                                                                     siteID: Int64(siteID)) {
+                                                                     siteID: siteID) {
                                                         onCompletion(model, nil)
             }
         }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -62,7 +62,7 @@ private extension ProductStore {
 
     /// Searches all of the products that contain a given Keyword.
     ///
-    func searchProducts(siteID: Int, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductsRemote(network: network)
         remote.searchProducts(for: siteID,
                               keyword: keyword,
@@ -83,7 +83,7 @@ private extension ProductStore {
 
     /// Synchronizes the products associated with a given Site ID, sorted by ascending name.
     ///
-    func synchronizeProducts(siteID: Int, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeProducts(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductsRemote(network: network)
 
         remote.loadAllProducts(for: siteID,
@@ -113,7 +113,7 @@ private extension ProductStore {
         let productIDs = itemIDs.uniqued()  // removes duplicate product IDs
 
         let storage = storageManager.viewStorage
-        var missingIDs = [Int]()
+        var missingIDs = [Int64]()
         for productID in productIDs {
             let storageProduct = storage.loadProduct(siteID: order.siteID, productID: productID)
             if storageProduct == nil {
@@ -137,8 +137,8 @@ private extension ProductStore {
     /// Retrieves multiple products with a given siteID + productIDs.
     /// - Note: This is NOT a wrapper for retrieving a single product.
     ///
-    func retrieveProducts(siteID: Int,
-                          productIDs: [Int],
+    func retrieveProducts(siteID: Int64,
+                          productIDs: [Int64],
                           onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductsRemote(network: network)
 
@@ -156,7 +156,7 @@ private extension ProductStore {
 
     /// Retrieves the product associated with a given siteID + productID (if any!).
     ///
-    func retrieveProduct(siteID: Int, productID: Int, onCompletion: @escaping (Networking.Product?, Error?) -> Void) {
+    func retrieveProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Networking.Product?, Error?) -> Void) {
         let remote = ProductsRemote(network: network)
 
         remote.loadProduct(for: siteID, productID: productID) { [weak self] (product, error) in
@@ -199,7 +199,7 @@ private extension ProductStore {
 
     /// Deletes any Storage.Product with the specified `siteID` and `productID`
     ///
-    func deleteStoredProduct(siteID: Int, productID: Int) {
+    func deleteStoredProduct(siteID: Int64, productID: Int64) {
         let storage = storageManager.viewStorage
         guard let product = storage.loadProduct(siteID: siteID, productID: productID) else {
             return
@@ -211,7 +211,7 @@ private extension ProductStore {
 
     /// Deletes any Storage.Product with the specified `siteID`
     ///
-    func deleteStoredProducts(siteID: Int) {
+    func deleteStoredProducts(siteID: Int64) {
         let storage = storageManager.viewStorage
         storage.deleteProducts(siteID: siteID)
         storage.saveIfNeeded()
@@ -427,7 +427,7 @@ private extension ProductStore {
 
     /// Upserts the Products, and associates them to the SearchResults Entity (in Background)
     ///
-    private func upsertSearchResultsInBackground(siteID: Int, keyword: String, readOnlyProducts: [Networking.Product], onCompletion: @escaping () -> Void) {
+    private func upsertSearchResultsInBackground(siteID: Int64, keyword: String, readOnlyProducts: [Networking.Product], onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform { [weak self] in
             self?.upsertStoredProducts(readOnlyProducts: readOnlyProducts, in: derivedStorage)
@@ -441,7 +441,7 @@ private extension ProductStore {
 
     /// Upserts the Products, and associates them to the Search Results Entity (in the specified Storage)
     ///
-    private func upsertStoredResults(siteID: Int, keyword: String, readOnlyProducts: [Networking.Product], in storage: StorageType) {
+    private func upsertStoredResults(siteID: Int64, keyword: String, readOnlyProducts: [Networking.Product], in storage: StorageType) {
         let searchResults = storage.loadProductSearchResults(keyword: keyword) ?? storage.insertNewObject(ofType: Storage.ProductSearchResults.self)
         searchResults.keyword = keyword
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -268,8 +268,8 @@ private extension ProductStore {
     /// Updates the provided StorageProduct's productShippingClass using the existing `ProductShippingClass` in storage, if any
     ///
     func handleProductShippingClass(storageProduct: Storage.Product, _ storage: StorageType) {
-        if let existingStorageShippingClass = storage.loadProductShippingClass(siteID: Int64(storageProduct.siteID),
-                                                                               remoteID: Int64(storageProduct.shippingClassID)) {
+        if let existingStorageShippingClass = storage.loadProductShippingClass(siteID: storageProduct.siteID,
+                                                                               remoteID: storageProduct.shippingClassID) {
             storageProduct.productShippingClass = existingStorageShippingClass
         } else {
             storageProduct.productShippingClass = nil

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -93,7 +93,7 @@ private extension ProductVariationStore {
                                        in storage: StorageType,
                                        siteID: Int64,
                                        productID: Int64) {
-        let product = storage.loadProduct(siteID: Int(siteID), productID: Int(productID))
+        let product = storage.loadProduct(siteID: Int64(siteID), productID: Int64(productID))
 
         // Upserts the Product Variations from the read-only version
         for readOnlyProductVariation in readOnlyProductVariations {
@@ -122,7 +122,7 @@ private extension ProductVariationStore {
 
     /// Replaces the provided StorageProductVariation's attributes with the provided read-only
     /// ProductVariation's attributes.
-    /// Because all local Product attributes have ID = 0, they are not unique in Storage and we always replace the whole
+    /// Because all local Product attributes have ID: Int64 = 0, they are not unique in Storage and we always replace the whole
     /// attribute array.
     ///
     func handleProductVariationAttributes(_ readOnlyVariation: Networking.ProductVariation,

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -93,7 +93,7 @@ private extension ProductVariationStore {
                                        in storage: StorageType,
                                        siteID: Int64,
                                        productID: Int64) {
-        let product = storage.loadProduct(siteID: Int64(siteID), productID: Int64(productID))
+        let product = storage.loadProduct(siteID: siteID, productID: productID)
 
         // Upserts the Product Variations from the read-only version
         for readOnlyProductVariation in readOnlyProductVariations {

--- a/Yosemite/Yosemite/Stores/RefundStore.swift
+++ b/Yosemite/Yosemite/Stores/RefundStore.swift
@@ -47,7 +47,7 @@ private extension RefundStore {
 
     /// Creates a new Refund.
     ///
-    func createRefund(siteID: Int, orderID: Int, refund: Refund, onCompletion: @escaping (Refund?, Error?) -> Void) {
+    func createRefund(siteID: Int64, orderID: Int64, refund: Refund, onCompletion: @escaping (Refund?, Error?) -> Void) {
         let remote = RefundsRemote(network: network)
 
         remote.createRefund(for: siteID, by: orderID, refund: refund) { [weak self] (refund, error) in
@@ -64,7 +64,7 @@ private extension RefundStore {
 
     /// Retrieves a single Refund by ID.
     ///
-    func retrieveRefund(siteID: Int, orderID: Int, refundID: Int, onCompletion: @escaping (Networking.Refund?, Error?) -> Void) {
+    func retrieveRefund(siteID: Int64, orderID: Int64, refundID: Int64, onCompletion: @escaping (Networking.Refund?, Error?) -> Void) {
         let remote = RefundsRemote(network: network)
 
         remote.loadRefund(siteID: siteID, orderID: orderID, refundID: refundID) { [weak self] (refund, error) in
@@ -84,7 +84,7 @@ private extension RefundStore {
 
     /// Retrieves all Refunds by an orderID.
     ///
-    func retrieveRefunds(siteID: Int, orderID: Int, refundIDs: [Int], onCompletion: @escaping (Error?) -> Void) {
+    func retrieveRefunds(siteID: Int64, orderID: Int64, refundIDs: [Int64], onCompletion: @escaping (Error?) -> Void) {
         let remote = RefundsRemote(network: network)
 
         remote.loadRefunds(for: siteID, by: orderID, with: refundIDs) { [weak self] (refunds, error) in
@@ -101,7 +101,7 @@ private extension RefundStore {
 
     /// Synchronizes the refunds associated with a given orderID
     ///
-    func synchronizeRefunds(siteID: Int, orderID: Int, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeRefunds(siteID: Int64, orderID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         let remote = RefundsRemote(network: network)
 
         remote.loadAllRefunds(for: siteID, by: orderID) { [weak self] (refunds, error) in
@@ -135,7 +135,7 @@ private extension RefundStore {
 
     /// Deletes any Storage.Refund with the specified `siteID`, `orderID`, and `refundID`
     ///
-    func deleteStoredRefund(siteID: Int, orderID: Int, refundID: Int) {
+    func deleteStoredRefund(siteID: Int64, orderID: Int64, refundID: Int64) {
         let storage = storageManager.viewStorage
         guard let refund = storage.loadRefund(siteID: siteID, orderID: orderID, refundID: refundID) else {
             return

--- a/Yosemite/Yosemite/Stores/SettingStore.swift
+++ b/Yosemite/Yosemite/Stores/SettingStore.swift
@@ -43,7 +43,7 @@ private extension SettingStore {
 
     /// Synchronizes the general site settings associated with the provided Site ID (if any!).
     ///
-    func synchronizeGeneralSiteSettings(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let remote = SiteSettingsRemote(network: network)
         remote.loadGeneralSettings(for: siteID) { [weak self] (settings, error) in
             guard let settings = settings else {
@@ -59,7 +59,7 @@ private extension SettingStore {
 
     /// Synchronizes the product site settings associated with the provided Site ID (if any!).
     ///
-    func synchronizeProductSiteSettings(siteID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let remote = SiteSettingsRemote(network: network)
         remote.loadProductSettings(for: siteID) { [weak self] (settings, error) in
             guard let settings = settings else {
@@ -76,7 +76,7 @@ private extension SettingStore {
     /// Retrieves the site API information associated with the provided Site ID (if any!).
     /// This call does NOT persist returned data into the Storage layer.
     ///
-    func retrieveSiteAPI(siteID: Int, onCompletion: @escaping (SiteAPI?, Error?) -> Void) {
+    func retrieveSiteAPI(siteID: Int64, onCompletion: @escaping (SiteAPI?, Error?) -> Void) {
         let remote = SiteAPIRemote(network: network)
         remote.loadAPIInformation(for: siteID) { (siteAPI, error) in
             onCompletion(siteAPI, error)
@@ -92,7 +92,7 @@ private extension SettingStore {
     /// Updates (OR Inserts) the specified **general** ReadOnly `SiteSetting` Entities **in a background thread**. `onCompletion` will be called
     /// on the main thread!
     ///
-    func upsertStoredGeneralSettingsInBackground(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
+    func upsertStoredGeneralSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             self.upsertSettings(readOnlySiteSettings, in: derivedStorage, siteID: siteID, settingGroup: SiteSettingGroup.general)
@@ -106,7 +106,7 @@ private extension SettingStore {
     /// Updates (OR Inserts) the specified **product** ReadOnly `SiteSetting` entities **in a background thread**. `onCompletion` will be called
     /// on the main thread!
     ///
-    func upsertStoredProductSettingsInBackground(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
+    func upsertStoredProductSettingsInBackground(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             self.upsertSettings(readOnlySiteSettings, in: derivedStorage, siteID: siteID, settingGroup: SiteSettingGroup.product)
@@ -117,7 +117,7 @@ private extension SettingStore {
         }
     }
 
-    func upsertSettings(_ readOnlySiteSettings: [SiteSetting], in storage: StorageType, siteID: Int, settingGroup: SiteSettingGroup) {
+    func upsertSettings(_ readOnlySiteSettings: [SiteSetting], in storage: StorageType, siteID: Int64, settingGroup: SiteSettingGroup) {
         // Upsert the settings from the read-only site settings
         for readOnlyItem in readOnlySiteSettings {
             if let existingStorageItem = storage.loadSiteSetting(siteID: siteID, settingID: readOnlyItem.settingID) {
@@ -146,13 +146,13 @@ extension SettingStore {
 
     /// Unit Testing Helper: Updates or Inserts the specified **general** ReadOnly SiteSetting entities in the provided Storage instance.
     ///
-    func upsertStoredGeneralSiteSettings(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
+    func upsertStoredGeneralSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
         upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.general)
     }
 
     /// Unit Testing Helper: Updates or Inserts the specified **product** ReadOnly SiteSetting entities in the provided Storage instance.
     ///
-    func upsertStoredProductSiteSettings(siteID: Int, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
+    func upsertStoredProductSiteSettings(siteID: Int64, readOnlySiteSettings: [Networking.SiteSetting], in storage: StorageType) {
         upsertSettings(readOnlySiteSettings, in: storage, siteID: siteID, settingGroup: SiteSettingGroup.product)
     }
 }

--- a/Yosemite/Yosemite/Stores/ShipmentStore.swift
+++ b/Yosemite/Yosemite/Stores/ShipmentStore.swift
@@ -294,7 +294,7 @@ extension ShipmentStore {
         let provider = storage.insertNewObject(ofType: Storage.ShipmentTrackingProvider.self)
         provider.name = trackingProvider
         provider.url = trackingURL
-        provider.siteID = Int64(siteID)
+        provider.siteID = siteID
 
 
         let customProvidersGroup = customGroup(siteID: siteID, storage: storage)
@@ -339,7 +339,7 @@ extension ShipmentStore {
         let newCustomGroup = storage.insertNewObject(ofType: Storage.ShipmentTrackingProviderGroup.self)
 
         newCustomGroup.name = customGroupName
-        newCustomGroup.siteID = Int64(siteID)
+        newCustomGroup.siteID = siteID
 
         return newCustomGroup
     }

--- a/Yosemite/Yosemite/Stores/ShipmentStore.swift
+++ b/Yosemite/Yosemite/Stores/ShipmentStore.swift
@@ -75,7 +75,7 @@ public class ShipmentStore: Store {
 //
 private extension ShipmentStore {
 
-    func synchronizeShipmentTrackingData(siteID: Int, orderID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeShipmentTrackingData(siteID: Int64, orderID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let remote = ShipmentsRemote(network: network)
         remote.loadShipmentTrackings(for: siteID, orderID: orderID) { [weak self] (shipmentTrackingData, error) in
             guard let readOnlyShipmentTrackingData = shipmentTrackingData else {
@@ -89,7 +89,7 @@ private extension ShipmentStore {
         }
     }
 
-    func syncronizeShipmentTrackingProviderGroupsData(siteID: Int, orderID: Int, onCompletion: @escaping (Error?) -> Void) {
+    func syncronizeShipmentTrackingProviderGroupsData(siteID: Int64, orderID: Int64, onCompletion: @escaping (Error?) -> Void) {
         let remote = ShipmentsRemote(network: network)
         remote.loadShipmentTrackingProviderGroups(for: siteID, orderID: orderID) { [weak self] (groups, error) in
             guard let readOnlyShipmentTrackingProviderGroups = groups else {
@@ -115,8 +115,8 @@ extension ShipmentStore {
     /// Updates (OR Inserts) the specified ReadOnly ShipmentTracking Entities into the Storage Layer *in a background thread*. onCompletion will be called
     /// on the main thread!
     ///
-    func upsertShipmentTrackingDataInBackground(siteID: Int,
-                                                orderID: Int,
+    func upsertShipmentTrackingDataInBackground(siteID: Int64,
+                                                orderID: Int64,
                                                 readOnlyShipmentTrackingData: [Networking.ShipmentTracking],
                                                 onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
@@ -143,14 +143,14 @@ extension ShipmentStore {
         }
     }
 
-    func upsertTrackingProviderData(siteID: Int, orderID: Int, readOnlyShipmentTrackingProviderGroups: [Networking.ShipmentTrackingProviderGroup]) {
+    func upsertTrackingProviderData(siteID: Int64, orderID: Int64, readOnlyShipmentTrackingProviderGroups: [Networking.ShipmentTrackingProviderGroup]) {
         let storage = storageManager.viewStorage
         upsertShipmentTrackingGroups(siteID: siteID, readOnlyGroups: readOnlyShipmentTrackingProviderGroups, in: storage)
         storage.saveIfNeeded()
     }
 
-    func upsertTrackingProviderDataInBackground(siteID: Int,
-                                                orderID: Int,
+    func upsertTrackingProviderDataInBackground(siteID: Int64,
+                                                orderID: Int64,
                                                 readOnlyShipmentTrackingProviderGroups: [Networking.ShipmentTrackingProviderGroup],
                                                         onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
@@ -165,7 +165,7 @@ extension ShipmentStore {
         }
     }
 
-    private func upsertShipmentTrackingGroups(siteID: Int,
+    private func upsertShipmentTrackingGroups(siteID: Int64,
                                               readOnlyGroups: [Networking.ShipmentTrackingProviderGroup],
                                               in storage: StorageType) {
         for readOnlyGroup in readOnlyGroups {
@@ -186,8 +186,8 @@ extension ShipmentStore {
         }
     }
 
-    func addTracking(siteID: Int,
-                     orderID: Int,
+    func addTracking(siteID: Int64,
+                     orderID: Int64,
                      providerGroupName: String,
                      providerName: String,
                      trackingNumber: String,
@@ -211,8 +211,8 @@ extension ShipmentStore {
         }
     }
 
-    func addCustomTracking(siteID: Int,
-                           orderID: Int,
+    func addCustomTracking(siteID: Int64,
+                           orderID: Int64,
                            trackingProvider: String,
                            trackingNumber: String,
                            trackingURL: String,
@@ -240,8 +240,8 @@ extension ShipmentStore {
         }
     }
 
-    func deleteTracking(siteID: Int,
-                        orderID: Int,
+    func deleteTracking(siteID: Int64,
+                        orderID: Int64,
                         trackingID: String,
                         onCompletion: @escaping (Error?) -> Void) {
         let remote = ShipmentsRemote(network: network)
@@ -258,8 +258,8 @@ extension ShipmentStore {
 
     /// Deletes any Storage.ShipmentTracking with the specified trackingID
     ///
-    func deleteStoredShipment(siteID: Int,
-                              orderID: Int,
+    func deleteStoredShipment(siteID: Int64,
+                              orderID: Int64,
                               trackingID: String) {
         let storage = storageManager.viewStorage
         guard let tracking = storage.loadShipmentTracking(siteID: siteID,
@@ -272,8 +272,8 @@ extension ShipmentStore {
         storage.saveIfNeeded()
     }
 
-    func addStoredShipment(siteID: Int,
-                           orderID: Int,
+    func addStoredShipment(siteID: Int64,
+                           orderID: Int64,
                            readOnlyTracking: Networking.ShipmentTracking) {
         let storage = storageManager.viewStorage
 
@@ -282,8 +282,8 @@ extension ShipmentStore {
         storage.saveIfNeeded()
     }
 
-    func addCustomStoredShipment(siteID: Int,
-                           orderID: Int,
+    func addCustomStoredShipment(siteID: Int64,
+                           orderID: Int64,
                            trackingProvider: String,
                            trackingURL: String,
                            readOnlyTracking: Networking.ShipmentTracking) {
@@ -328,7 +328,7 @@ extension ShipmentStore {
         }
     }
 
-    private func customGroup(siteID: Int, storage: StorageType) -> Storage.ShipmentTrackingProviderGroup {
+    private func customGroup(siteID: Int64, storage: StorageType) -> Storage.ShipmentTrackingProviderGroup {
         let customGroupName = type(of: self).customGroupName
 
         if let existingCustomGroup =  storage.loadShipmentTrackingProviderGroup(siteID: siteID,

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -85,7 +85,7 @@ private extension StatsStore {
 
     /// Retrieves the order stats associated with the provided Site ID (if any!).
     ///
-    func retrieveOrderStats(siteID: Int, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: @escaping (Error?) -> Void) {
+    func retrieveOrderStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: @escaping (Error?) -> Void) {
 
         let remote = OrderStatsRemote(network: network)
         let formattedDateString = StatsStore.buildDateString(from: latestDateToInclude, with: granularity)
@@ -103,7 +103,7 @@ private extension StatsStore {
 
     /// Retrieves the site visit stats associated with the provided Site ID (if any!).
     ///
-    func retrieveSiteVisitStats(siteID: Int, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: @escaping (Error?) -> Void) {
+    func retrieveSiteVisitStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: @escaping (Error?) -> Void) {
 
         let remote = SiteVisitStatsRemote(network: network)
 
@@ -123,7 +123,7 @@ private extension StatsStore {
 
     /// Retrieves the top earner stats associated with the provided Site ID (if any!).
     ///
-    func retrieveTopEarnerStats(siteID: Int, granularity: StatGranularity, latestDateToInclude: Date, onCompletion: @escaping (Error?) -> Void) {
+    func retrieveTopEarnerStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, onCompletion: @escaping (Error?) -> Void) {
 
         let remote = TopEarnersStatsRemote(network: network)
         let formattedDateString = StatsStore.buildDateString(from: latestDateToInclude, with: granularity)
@@ -144,7 +144,7 @@ private extension StatsStore {
 
     /// Retrieves current order totals for the given site & status
     ///
-    func retrieveOrderTotals(siteID: Int, statusEnum: OrderStatusEnum, onCompletion: @escaping (Int?, Error?) -> Void) {
+    func retrieveOrderTotals(siteID: Int64, statusEnum: OrderStatusEnum, onCompletion: @escaping (Int?, Error?) -> Void) {
         let remote = ReportRemote(network: network)
         remote.loadOrderTotals(for: siteID) { (orderTotals, error) in
             onCompletion(orderTotals?[statusEnum], error)

--- a/Yosemite/Yosemite/Stores/StatsStore.swift
+++ b/Yosemite/Yosemite/Stores/StatsStore.swift
@@ -103,7 +103,11 @@ private extension StatsStore {
 
     /// Retrieves the site visit stats associated with the provided Site ID (if any!).
     ///
-    func retrieveSiteVisitStats(siteID: Int64, granularity: StatGranularity, latestDateToInclude: Date, quantity: Int, onCompletion: @escaping (Error?) -> Void) {
+    func retrieveSiteVisitStats(siteID: Int64,
+                                granularity: StatGranularity,
+                                latestDateToInclude: Date,
+                                quantity: Int,
+                                onCompletion: @escaping (Error?) -> Void) {
 
         let remote = SiteVisitStatsRemote(network: network)
 

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -76,7 +76,7 @@ public extension StatsStoreV4 {
 
     /// Retrieves the order stats associated with the provided Site ID (if any!).
     ///
-    func retrieveStats(siteID: Int,
+    func retrieveStats(siteID: Int64,
                        timeRange: StatsTimeRangeV4,
                        earliestDateToInclude: Date,
                        latestDateToInclude: Date,
@@ -104,7 +104,7 @@ public extension StatsStoreV4 {
 
     /// Retrieves the site visit stats associated with the provided Site ID (if any!).
     ///
-    func retrieveSiteVisitStats(siteID: Int,
+    func retrieveSiteVisitStats(siteID: Int64,
                                 siteTimezone: TimeZone,
                                 timeRange: StatsTimeRangeV4,
                                 latestDateToInclude: Date,
@@ -130,7 +130,7 @@ public extension StatsStoreV4 {
 
     /// Retrieves the top earner stats associated with the provided Site ID (if any!).
     ///
-    func retrieveTopEarnerStats(siteID: Int,
+    func retrieveTopEarnerStats(siteID: Int64,
                                 timeRange: StatsTimeRangeV4,
                                 latestDateToInclude: Date,
                                 onCompletion: @escaping (Error?) -> Void) {

--- a/Yosemite/Yosemite/Stores/TaxClassStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxClassStore.swift
@@ -44,7 +44,7 @@ private extension TaxClassStore {
 
     /// Retrieve and synchronizes the Tax Classes associated with a given Site ID (if any!).
     ///
-    func retrieveTaxClasses(siteID: Int, onCompletion: @escaping ([TaxClass]?, Error?) -> Void) {
+    func retrieveTaxClasses(siteID: Int64, onCompletion: @escaping ([TaxClass]?, Error?) -> Void) {
         let remote = TaxClassRemote(network: network)
 
         remote.loadAllTaxClasses(for: Int64(siteID)) { [weak self] (taxClasses, error) in

--- a/Yosemite/Yosemite/Stores/TaxClassStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxClassStore.swift
@@ -47,7 +47,7 @@ private extension TaxClassStore {
     func retrieveTaxClasses(siteID: Int64, onCompletion: @escaping ([TaxClass]?, Error?) -> Void) {
         let remote = TaxClassRemote(network: network)
 
-        remote.loadAllTaxClasses(for: Int64(siteID)) { [weak self] (taxClasses, error) in
+        remote.loadAllTaxClasses(for: siteID) { [weak self] (taxClasses, error) in
             guard let taxClasses = taxClasses else {
                 onCompletion(nil, error)
                 return
@@ -86,7 +86,7 @@ private extension TaxClassStore {
         }
         else {
             let remote = TaxClassRemote(network: network)
-            remote.loadAllTaxClasses(for: Int64(product.siteID)) { [weak self] (taxClasses, error) in
+            remote.loadAllTaxClasses(for: product.siteID) { [weak self] (taxClasses, error) in
                 guard let taxClasses = taxClasses else {
                     onCompletion(nil, error)
                     return

--- a/Yosemite/YosemiteTests/Mockups/MockProduct.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockProduct.swift
@@ -3,14 +3,14 @@ import Foundation
 
 
 final class MockProduct {
-    func product(siteID: Int = 2019,
-                 productID: Int = 2020,
+    func product(siteID: Int64 = 2019,
+                 productID: Int64 = 2020,
                  name: String = "Hogsmeade",
                  stockQuantity: Int? = nil,
                  stockStatus: ProductStockStatus = .inStock,
-                 variations: [Int] = [],
+                 variations: [Int64] = [],
                  images: [ProductImage] = [],
-                 shippingClassID: Int = 0) -> Product {
+                 shippingClassID: Int64 = 0) -> Product {
 
         return Product(siteID: siteID,
                        productID: productID,

--- a/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
+++ b/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
@@ -28,7 +28,7 @@ final class Product_UpdaterTestCases: XCTestCase {
                                                     descriptionHTML: "Arriving in 2 days!",
                                                     name: "2 Days",
                                                     shippingClassID: 2022,
-                                                    siteID: Int64(product.siteID),
+                                                    siteID: product.siteID,
                                                     slug: "2-days")
         let updatedProduct = product.shippingSettingsUpdated(weight: newWeight, dimensions: newDimensions, shippingClass: newShippingClass)
         XCTAssertEqual(updatedProduct.fullDescription, product.fullDescription)
@@ -36,7 +36,7 @@ final class Product_UpdaterTestCases: XCTestCase {
         XCTAssertEqual(updatedProduct.weight, newWeight)
         XCTAssertEqual(updatedProduct.dimensions, newDimensions)
         XCTAssertEqual(updatedProduct.shippingClass, newShippingClass.slug)
-        XCTAssertEqual(Int64(updatedProduct.shippingClassID), newShippingClass.shippingClassID)
+        XCTAssertEqual(updatedProduct.shippingClassID, newShippingClass.shippingClassID)
         XCTAssertEqual(updatedProduct.productShippingClass, newShippingClass)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -114,7 +114,7 @@ class AccountStoreTests: XCTestCase {
         XCTAssert(viewStorage.countObjects(ofType: Storage.Account.self, matching: nil) == 1)
 
         let expectedAccount = sampleAccountUpdate()
-        let storageAccount = viewStorage.loadAccount(userId: expectedAccount.userID)!
+        let storageAccount = viewStorage.loadAccount(userID: expectedAccount.userID)!
         compare(storageAccount: storageAccount, remoteAccount: expectedAccount)
     }
 
@@ -124,10 +124,10 @@ class AccountStoreTests: XCTestCase {
         let accountStore = AccountStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let remoteAccount = sampleAccountPristine()
 
-        XCTAssertNil(viewStorage.loadAccount(userId: remoteAccount.userID))
+        XCTAssertNil(viewStorage.loadAccount(userID: remoteAccount.userID))
         accountStore.upsertStoredAccount(readOnlyAccount: remoteAccount)
 
-        let storageAccount = viewStorage.loadAccount(userId: remoteAccount.userID)!
+        let storageAccount = viewStorage.loadAccount(userID: remoteAccount.userID)!
         compare(storageAccount: storageAccount, remoteAccount: remoteAccount)
     }
 

--- a/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AccountStoreTests.swift
@@ -309,7 +309,7 @@ private extension AccountStoreTests {
     /// Verifies that the Storage.Account fields match with the specified Networking.Account.
     ///
     func compare(storageAccount: Storage.Account, remoteAccount: Networking.Account) {
-        XCTAssertEqual(storageAccount.userID, Int64(remoteAccount.userID))
+        XCTAssertEqual(storageAccount.userID, remoteAccount.userID)
         XCTAssertEqual(storageAccount.displayName, remoteAccount.displayName)
         XCTAssertEqual(storageAccount.email, remoteAccount.email)
         XCTAssertEqual(storageAccount.username, remoteAccount.username)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
@@ -36,7 +36,7 @@ final class AppSettingsStoreTests_StatsVersion: XCTestCase {
     }
 
     func testStatsVersionLastShownActions() {
-        let siteID = 134
+        let siteID: Int64 = 134
 
         let initialReadAction = AppSettingsAction.loadInitialStatsVersionToShow(siteID: siteID) { statsVersionLastShown in
             // Before any write actions, the stats version should be nil.
@@ -55,8 +55,8 @@ final class AppSettingsStoreTests_StatsVersion: XCTestCase {
     }
 
     func testStatsVersionLastShownWithTwoSites() {
-        let siteID1 = 134
-        let siteID2 = 268
+        let siteID1: Int64 = 134
+        let siteID2: Int64 = 268
 
         let statsVersionForSite1 = StatsVersion.v4
         let statsVersionForSite2 = StatsVersion.v3
@@ -77,7 +77,7 @@ final class AppSettingsStoreTests_StatsVersion: XCTestCase {
     }
 
     func testStatsVersionEligibleActions() {
-        let siteID = 134
+        let siteID: Int64 = 134
 
         let initialReadAction = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
             // Before any write actions, the stats version should be nil.

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -10,11 +10,11 @@ private struct TestConstants {
         .url(forResource: "shipment-provider", withExtension: "plist")
     static let customFileURL = Bundle(for: AppSettingsStoreTests.self)
         .url(forResource: "custom-shipment-provider", withExtension: "plist")
-    static let siteID = 156590080
+    static let siteID: Int64 = 156590080
     static let providerName = "post.at"
     static let providerURL = "http://some.where"
 
-    static let newSiteID = 1234
+    static let newSiteID: Int64 = 1234
     static let newProviderName = "Some provider"
     static let newProviderURL = "http://some.where"
 }

--- a/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CommentStoreTests.swift
@@ -29,11 +29,11 @@ class CommentStoreTests: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Testing CommentID
     ///
-    private let sampleCommentID = 999
+    private let sampleCommentID: Int64 = 999
 
 
     override func setUp() {

--- a/Yosemite/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -53,7 +53,7 @@ class NotificationStoreTests: XCTestCase {
 
             if let note = self.viewStorage.loadNotification(noteID: 100036, noteHash: 987654)?.toReadOnly() {
                 // Plain Fields
-                XCTAssertEqual(note.noteId, 100036)
+                XCTAssertEqual(note.noteID, 100036)
                 XCTAssertEqual(note.hash, 987654)
                 XCTAssertEqual(note.read, false)
                 XCTAssertEqual(note.icon, "https://s.wp.com/wp-content/mu-plugins/achievements/likeable-blog-5-2x.png")
@@ -130,7 +130,7 @@ class NotificationStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "notifications", filename: "notifications-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Note.self), 0)
 
-        let syncAction = NotificationAction.synchronizeNotification(noteId: notificationId) { error in
+        let syncAction = NotificationAction.synchronizeNotification(noteID: notificationId) { error in
             let note = self.viewStorage.loadNotification(noteID: notificationId)
             XCTAssertNil(error)
             XCTAssertNotNil(note)
@@ -207,9 +207,9 @@ class NotificationStoreTests: XCTestCase {
         let expectedNote = sampleNotificationMutated()
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_success")
-        let action = NotificationAction.updateReadStatus(noteId: originalNote.noteId, read: true) { [weak self] (error) in
+        let action = NotificationAction.updateReadStatus(noteID: originalNote.noteID, read: true) { [weak self] (error) in
             XCTAssertNil(error)
-            let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteId)
+            let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteID)
             XCTAssertEqual(storageNote?.toReadOnly().read, expectedNote.read)
             expectation.fulfill()
         }
@@ -230,7 +230,7 @@ class NotificationStoreTests: XCTestCase {
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_error")
-        let action = NotificationAction.updateReadStatus(noteId: 9999, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: 9999, read: true) { (error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -245,7 +245,7 @@ class NotificationStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Update notification read status empty response")
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = NotificationAction.updateReadStatus(noteId: 9999, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: 9999, read: true) { (error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -265,9 +265,9 @@ class NotificationStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Note.self), 0)
         noteStore.updateLocalNotes(with: [originalNote]) { [weak self] in
             XCTAssertEqual(self?.viewStorage.countObjects(ofType: Storage.Note.self), 1)
-            noteStore.updateLocalNoteReadStatus(for: [originalNote.noteId], read: true) {
+            noteStore.updateLocalNoteReadStatus(for: [originalNote.noteID], read: true) {
                 XCTAssertEqual(self?.viewStorage.countObjects(ofType: Storage.Note.self), 1)
-                let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteId)
+                let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteID)
                 XCTAssertEqual(storageNote?.toReadOnly().read, expectedNote.read)
                 expectation.fulfill()
             }
@@ -301,10 +301,10 @@ class NotificationStoreTests: XCTestCase {
         let originalNote = sampleNotification()
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_error")
-        let action = NotificationAction.updateReadStatus(noteId: originalNote.noteId, read: true) { [weak self] (error) in
+        let action = NotificationAction.updateReadStatus(noteID: originalNote.noteID, read: true) { [weak self] (error) in
             XCTAssertNotNil(error)
 
-            let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteId)
+            let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteID)
             XCTAssertEqual(storageNote?.toReadOnly().hash, Int64.min)
 
             expectation.fulfill()
@@ -333,10 +333,10 @@ class NotificationStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_success")
 
         // Mark as Read
-        let action = NotificationAction.updateMultipleReadStatus(noteIds: [originalNote.noteId], read: true) { error in
+        let action = NotificationAction.updateMultipleReadStatus(noteIDs: [originalNote.noteID], read: true) { error in
             XCTAssertNil(error)
 
-            let reloadedNote = self.viewStorage.loadNotification(noteID: originalNote.noteId)?.toReadOnly()
+            let reloadedNote = self.viewStorage.loadNotification(noteID: originalNote.noteID)?.toReadOnly()
             XCTAssertEqual(reloadedNote?.read, expectedNote.read)
             expectation.fulfill()
         }
@@ -453,10 +453,10 @@ class NotificationStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Note.self), 0)
         noteStore.updateLocalNotes(with: [originalNote]) { [weak self] in
             XCTAssertEqual(self?.viewStorage.countObjects(ofType: Storage.Note.self), 1)
-            let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteId)
+            let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteID)
             XCTAssertEqual(storageNote?.deleteInProgress, false)
 
-            noteStore.markLocalNoteAsDeleted(for: originalNote.noteId, isDeleted: true) {
+            noteStore.markLocalNoteAsDeleted(for: originalNote.noteID, isDeleted: true) {
                 XCTAssertEqual(self?.viewStorage.countObjects(ofType: Storage.Note.self), 1)
                 XCTAssertEqual(storageNote?.deleteInProgress, true)
                 expectation.fulfill()
@@ -492,7 +492,7 @@ private extension NotificationStoreTests {
 
     /// Returns a sample Default Store ID
     ///
-    var sampleDefaultStoreID: Int {
+    var sampleDefaultStoreID: Int64 {
         return 1234
     }
 
@@ -505,7 +505,7 @@ private extension NotificationStoreTests {
     /// Returns a sample Dotcom Notification
     ///
     func sampleNotification() -> Networking.Note {
-        return Note(noteId: 123456,
+        return Note(noteID: 123456,
                     hash: 11223344,
                     read: false,
                     icon: "https://gravatar.tld/some-hash",
@@ -524,7 +524,7 @@ private extension NotificationStoreTests {
     /// Returns a sample Dotcom Notification (same as above but slightly mutated!)
     ///
     func sampleNotificationMutated() -> Networking.Note {
-        return Note(noteId: 123456,
+        return Note(noteID: 123456,
                     hash: 11223344,
                     read: true,
                     icon: "https://gravatar.tld/some-hash",

--- a/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
@@ -28,11 +28,11 @@ class OrderNoteStoreTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Dummy Order ID
     ///
-    private let sampleOrderID = 963
+    private let sampleOrderID: Int64 = 963
 
     /// Dummy author string
     ///
@@ -178,7 +178,7 @@ class OrderNoteStoreTests: XCTestCase {
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrder(), in: viewStorage)
 
         let remoteOrderNote = sampleCustomerNote()
-        XCTAssertNil(viewStorage.loadAccount(userId: remoteOrderNote.noteID))
+        XCTAssertNil(viewStorage.loadAccount(userID: remoteOrderNote.noteID))
 
         let expectation = self.expectation(description: "Stored Order Note")
         orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: remoteOrderNote, orderID: sampleOrderID) {
@@ -238,7 +238,7 @@ class OrderNoteStoreTests: XCTestCase {
 //
 private extension OrderNoteStoreTests {
     func sampleCustomerNote() -> Networking.OrderNote {
-        return OrderNote(noteId: 2261,
+        return OrderNote(noteID: 2261,
                          dateCreated: date(with: "2018-06-23T17:06:55"),
                          note: "I love your products!",
                          isCustomerNote: true,
@@ -246,7 +246,7 @@ private extension OrderNoteStoreTests {
     }
 
     func sampleCustomerNoteMutated() -> Networking.OrderNote {
-        return OrderNote(noteId: 2261,
+        return OrderNote(noteID: 2261,
                          dateCreated: date(with: "2018-06-23T18:07:55"),
                          note: "I HATE your products!",
                          isCustomerNote: true,
@@ -254,7 +254,7 @@ private extension OrderNoteStoreTests {
     }
 
     func sampleSellerNote() -> Networking.OrderNote {
-        return OrderNote(noteId: 2260,
+        return OrderNote(noteID: 2260,
                          dateCreated: date(with: "2018-06-23T16:05:55"),
                          note: "This order is going to be a problem.",
                          isCustomerNote: false,
@@ -262,7 +262,7 @@ private extension OrderNoteStoreTests {
     }
 
     func sampleSystemNote() -> Networking.OrderNote {
-        return OrderNote(noteId: 2099,
+        return OrderNote(noteID: 2099,
                          dateCreated: date(with: "2018-05-29T03:07:46"),
                          note: "Order status changed from Completed to Processing.",
                          isCustomerNote: false,

--- a/Yosemite/YosemiteTests/Stores/OrderStatusStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStatusStoreTests.swift
@@ -28,7 +28,7 @@ class OrderStatusStoreTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     // MARK: - Overridden Methods
 

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -28,11 +28,11 @@ class OrderStoreTests: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Testing OrderID
     ///
-    private let sampleOrderID = 963
+    private let sampleOrderID: Int64 = 963
 
     /// Testing Page Number
     ///

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -441,7 +441,7 @@ class OrderStoreTests: XCTestCase {
 
         XCTAssertEqual(storageSearchResults?.keyword, defaultSearchKeyword)
         XCTAssertEqual(storageSearchResults?.orders?.count, 1)
-        XCTAssertEqual(storageSearchResults?.orders?.first?.orderID, Int64(remoteOrder.orderID))
+        XCTAssertEqual(storageSearchResults?.orders?.first?.orderID, remoteOrder.orderID)
         XCTAssertEqual(storageOrder?.searchResults?.first?.keyword, defaultSearchKeyword)
     }
 

--- a/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -32,15 +32,15 @@ final class ProductReviewStoreTests: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Testing ReviewID
     ///
-    private let sampleReviewID = 173
+    private let sampleReviewID: Int64 = 173
 
     /// Testing ProductID
     ///
-    private let sampleProductID = 32
+    private let sampleProductID: Int64 = 32
 
     /// Testing Page Number
     ///

--- a/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
@@ -183,7 +183,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/shipping_classes/\(sampleShippingClassID)", filename: "product-shipping-classes-load-one")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 0)
 
-        let product = MockProduct().product(siteID: Int(sampleSiteID), shippingClassID: Int(sampleShippingClassID))
+        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
@@ -217,7 +217,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
             filename: "product-shipping-classes-load-one")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 0)
 
-        let product = MockProduct().product(siteID: Int(sampleSiteID), shippingClassID: Int(sampleShippingClassID))
+        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
@@ -252,7 +252,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/shipping_classes/\(sampleShippingClassID)", filename: "generic_error")
 
-        let product = MockProduct().product(siteID: Int(sampleSiteID), shippingClassID: Int(sampleShippingClassID))
+        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (model, error) in
@@ -272,7 +272,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve ProductShippingClass empty response")
         let store = ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let product = MockProduct().product(siteID: Int(sampleSiteID), shippingClassID: Int(sampleShippingClassID))
+        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (model, error) in

--- a/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
@@ -183,7 +183,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/shipping_classes/\(sampleShippingClassID)", filename: "product-shipping-classes-load-one")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 0)
 
-        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
+        let product = MockProduct().product(siteID: sampleSiteID, shippingClassID: sampleShippingClassID)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
@@ -217,7 +217,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
             filename: "product-shipping-classes-load-one")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 0)
 
-        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
+        let product = MockProduct().product(siteID: sampleSiteID, shippingClassID: sampleShippingClassID)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
@@ -252,7 +252,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/shipping_classes/\(sampleShippingClassID)", filename: "generic_error")
 
-        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
+        let product = MockProduct().product(siteID: sampleSiteID, shippingClassID: sampleShippingClassID)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (model, error) in
@@ -272,7 +272,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve ProductShippingClass empty response")
         let store = ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let product = MockProduct().product(siteID: Int64(sampleSiteID), shippingClassID: Int64(sampleShippingClassID))
+        let product = MockProduct().product(siteID: sampleSiteID, shippingClassID: sampleShippingClassID)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (model, error) in

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -28,19 +28,19 @@ class ProductStoreTests: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Testing SiteID #2
     ///
-    private let sampleSiteID2 = 999
+    private let sampleSiteID2: Int64 = 999
 
     /// Testing ProductID
     ///
-    private let sampleProductID = 282
+    private let sampleProductID: Int64 = 282
 
     /// Testing Variation Type ProductID
     ///
-    private let sampleVariationTypeProductID = 295
+    private let sampleVariationTypeProductID: Int64 = 295
 
     /// Testing Page Number
     ///
@@ -116,10 +116,10 @@ class ProductStoreTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // Upserts some Products into the storage with two site IDs.
-        let siteID1 = 134
-        let siteID2 = 591
+        let siteID1: Int64 = 134
+        let siteID2: Int64 = 591
 
-        let productID = 123
+        let productID: Int64 = 123
         productStore.upsertStoredProduct(readOnlyProduct: sampleProduct(siteID1, productID: productID), in: viewStorage)
         productStore.upsertStoredProduct(readOnlyProduct: sampleProduct(siteID2, productID: productID), in: viewStorage)
 
@@ -155,10 +155,10 @@ class ProductStoreTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // Upserts some Products into the storage.
-        let siteID = 134
+        let siteID: Int64 = 134
 
         // This product ID should not exist in the network response.
-        let productID = 888
+        let productID: Int64 = 888
         productStore.upsertStoredProduct(readOnlyProduct: sampleProduct(siteID, productID: productID), in: viewStorage)
 
         let expectation = self.expectation(description: "Persist product list")
@@ -188,10 +188,10 @@ class ProductStoreTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         // Upserts some Products into the storage.
-        let siteID = 134
+        let siteID: Int64 = 134
 
         // This product ID should not exist in the network response.
-        let productID = 888
+        let productID: Int64 = 888
         productStore.upsertStoredProduct(readOnlyProduct: sampleProduct(siteID, productID: productID), in: viewStorage)
 
         let expectation = self.expectation(description: "Retrieve products error response")
@@ -602,7 +602,7 @@ class ProductStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
 
         // A product that is expected to be in the search results.
-        let expectedProductID = 67
+        let expectedProductID: Int64 = 67
         let expectedProductName = "Photo"
 
         let keyword = "photo"
@@ -726,10 +726,10 @@ class ProductStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Update product")
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let expectedProductID = 847
+        let expectedProductID: Int64 = 847
         let expectedProductName = "This is my new product name!"
         let expectedProductDescription = "Learn something!"
-        let expectedProductShippingClassID = 96987515
+        let expectedProductShippingClassID: Int64 = 96987515
         let expectedProductShippingClassSlug = "two-days"
 
         network.simulateResponse(requestUrlSuffix: "products/\(expectedProductID)", filename: "product-update")
@@ -765,7 +765,7 @@ class ProductStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Update product")
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let expectedProductID = 847
+        let expectedProductID: Int64 = 847
 
         network.simulateResponse(requestUrlSuffix: "products/\(expectedProductID)", filename: "product-update")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
@@ -872,7 +872,7 @@ class ProductStoreTests: XCTestCase {
 //
 private extension ProductStoreTests {
 
-    func sampleProduct(_ siteID: Int? = nil, productID: Int? = nil) -> Networking.Product {
+    func sampleProduct(_ siteID: Int64? = nil, productID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? sampleSiteID
         let testProductID = productID ?? sampleProductID
         return Product(siteID: testSiteID,
@@ -1013,7 +1013,7 @@ private extension ProductStoreTests {
         return [download1, download2, download3]
     }
 
-    func sampleProductMutated(_ siteID: Int? = nil) -> Networking.Product {
+    func sampleProductMutated(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? sampleSiteID
 
         return Product(siteID: testSiteID,
@@ -1136,7 +1136,7 @@ private extension ProductStoreTests {
         return [defaultAttribute1]
     }
 
-    func sampleVariationTypeProduct(_ siteID: Int? = nil) -> Networking.Product {
+    func sampleVariationTypeProduct(_ siteID: Int64? = nil) -> Networking.Product {
         let testSiteID = siteID ?? sampleSiteID
         return Product(siteID: testSiteID,
                        productID: sampleVariationTypeProductID,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -775,7 +775,7 @@ class ProductStoreTests: XCTestCase {
                                                          descriptionHTML: "Arriving in 2 days!",
                                                          name: "2 Days",
                                                          shippingClassID: 96987515,
-                                                         siteID: Int64(sampleSiteID),
+                                                         siteID: sampleSiteID,
                                                          slug: "2-days")
         let existingStorageShippingClass = viewStorage.insertNewObject(ofType: StorageProductShippingClass.self)
         existingStorageShippingClass.update(with: existingShippingClass)

--- a/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
@@ -28,23 +28,23 @@ class RefundStoreTests: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 999
+    private let sampleSiteID: Int64 = 999
 
     /// Testing SitID #2
     ///
-    private let sampleSiteID2 = 187634
+    private let sampleSiteID2: Int64 = 187634
 
     /// Testing OrderID
     ///
-    private let sampleOrderID = 560
+    private let sampleOrderID: Int64 = 560
 
     /// Testing RefundID
     ///
-    private let sampleRefundID = 590
+    private let sampleRefundID: Int64 = 590
 
     /// RefundID for a single refund
     ///
-    private let refundID = 562
+    private let refundID: Int64 = 562
 
     /// Testing Page Number
     ///
@@ -426,7 +426,7 @@ private extension RefundStoreTests {
 
     /// Generate a sample Refund
     ///
-    func sampleRefund(_ siteID: Int? = nil) -> Networking.Refund {
+    func sampleRefund(_ siteID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
         let testDate = date(with: "2019-10-09T16:18:23")
         return Refund(refundID: sampleRefundID,
@@ -443,7 +443,7 @@ private extension RefundStoreTests {
 
     /// Generate a mutated Refund
     ///
-    func sampleRefundMutated(_ siteID: Int? = nil) -> Networking.Refund {
+    func sampleRefundMutated(_ siteID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
         let testDate = date(with: "2019-10-09T16:18:23")
         return Refund(refundID: sampleRefundID,
@@ -460,7 +460,7 @@ private extension RefundStoreTests {
 
     /// Generate a single Refund
     ///
-    func sampleRefund2(_ siteID: Int? = nil) -> Networking.Refund {
+    func sampleRefund2(_ siteID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
         let testDate = date(with: "2019-10-01T19:33:46")
         return Refund(refundID: refundID,

--- a/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SettingStoreTests.swift
@@ -28,7 +28,7 @@ class SettingStoreTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
 
     override func setUp() {

--- a/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
@@ -28,11 +28,11 @@ final class ShipmentStoreTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     /// Dummy Order ID
     ///
-    private let sampleOrderID = 963
+    private let sampleOrderID: Int64 = 963
 
     /// Mock Country name
     ///

--- a/Yosemite/YosemiteTests/Stores/StatsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreTests.swift
@@ -28,7 +28,7 @@ class StatsStoreTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
 
     override func setUp() {

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -27,7 +27,7 @@ final class StatsStoreV4Tests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
 
     override func setUp() {

--- a/Yosemite/YosemiteTests/Stores/StatsV4AvailabilityStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsV4AvailabilityStoreTests.swift
@@ -17,7 +17,7 @@ class StatsV4AvailabilityStoreTests: XCTestCase {
 
     /// Dummy Site ID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     override func setUp() {
         super.setUp()

--- a/Yosemite/YosemiteTests/Stores/TaxClassStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/TaxClassStoreTests.swift
@@ -32,7 +32,7 @@ final class TaxClassStoreTests: XCTestCase {
 
     /// Testing SiteID
     ///
-    private let sampleSiteID = 123
+    private let sampleSiteID: Int64 = 123
 
     // MARK: - Overridden Methods
 

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -113,7 +113,7 @@ class ResultsControllerTests: XCTestCase {
         let indexPath = IndexPath(row: 0, section: 0)
         let readOnlyAccount = resultsController.object(at: indexPath)
 
-        XCTAssertEqual(Int(mutableAccount.userID), readOnlyAccount.userID)
+        XCTAssertEqual(mutableAccount.userID, readOnlyAccount.userID)
         XCTAssertEqual(mutableAccount.displayName, readOnlyAccount.displayName)
     }
 
@@ -297,8 +297,8 @@ class ResultsControllerTests: XCTestCase {
                 let expected = resultsController.object(at: indexPath)
                 let retrieved = resultsController.fetchedObjects[objectIndex]
 
-                XCTAssertEqual(retrieved.userID, Int(expected.userID))
-                XCTAssertEqual(object.userID, Int(expected.userID))
+                XCTAssertEqual(retrieved.userID, expected.userID)
+                XCTAssertEqual(object.userID, expected.userID)
             }
         }
     }


### PR DESCRIPTION
Fixes #1667

## Changes

(More context regarding why this PR is in #1667)

- Updated remote ID type from `Int` to `Int64` (thanks to AppCode's Replace in Path)
- Renamed `noteId` to `noteID` for consistent naming
- Fixed build errors and unit tests from the above changes
- Removed unnecessary `Int64` conversions
- For decoding a JSON payload into a dictionary `[String: AnyCodable]`, let's keep `Int` usage because iOS seems to default a number to `Int` type https://github.com/woocommerce/woocommerce-ios/commit/1e59c114b60ff723b8b4819f60abb7a64e5ba3b6

## Testing

- Log out from the app
- Log in to the app --> make sure the app runs normally and all the data are fetched correctly

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
