### PR TITLE
Product List: show the empty state overlay to the bottom of the WIP banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -408,7 +408,16 @@ private extension ProductsViewController {
         overlayView.messageText = NSLocalizedString("No products yet",
                                                     comment: "The text on the placeholder overlay when there are no products on the Products tab")
         overlayView.actionVisible = false
-        overlayView.attach(to: view)
+
+        // Pins the overlay view to the bottom of the top banner view.
+        overlayView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(overlayView)
+        NSLayoutConstraint.activate([
+            overlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            overlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            overlayView.topAnchor.constraint(equalTo: topBannerView.bottomAnchor),
+            overlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 
     /// Removes all of the the OverlayMessageView instances in the view hierarchy.


### PR DESCRIPTION
Resolves #1584 

## Changes

- Showed the Products tab empty overlay view below the top banner view

## Testing

Prerequisite: the store has no Products (or hard code to show the empty state)

- Launch the app
- Go to Products tab --> the WIP banner should be shown above the "No products yet" message view

## Example screenshots

Dark | Light
-- | --
![Simulator Screen Shot - iPhone 8 - 2019-12-30 at 14 39 49](https://user-images.githubusercontent.com/1945542/71570856-4083b300-2b12-11ea-8ca3-cc53b686cc53.png) | ![Simulator Screen Shot - iPhone 8 - 2019-12-30 at 14 34 43](https://user-images.githubusercontent.com/1945542/71570843-319d0080-2b12-11ea-903e-860688a04e88.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
