### PR TITLE
TwoColumnSectionHeaderView now manage the column to take 100% of the width if the other column is hidden/empty

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
@@ -21,7 +21,7 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
         }
         set {
             leftColumn.text = newValue?.uppercased()
-            leftColumn.isHidden = newValue == nil
+            leftColumn.isHidden = newValue == nil || newValue?.isEmpty == true
         }
     }
 
@@ -33,7 +33,7 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
         }
         set {
             rightColumn.text = newValue?.uppercased()
-            rightColumn.isHidden = newValue == nil
+            rightColumn.isHidden = newValue == nil || newValue?.isEmpty == true
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnSectionHeaderView.swift
@@ -21,6 +21,7 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
         }
         set {
             leftColumn.text = newValue?.uppercased()
+            leftColumn.isHidden = newValue == nil
         }
     }
 
@@ -32,6 +33,7 @@ class TwoColumnSectionHeaderView: UITableViewHeaderFooterView {
         }
         set {
             rightColumn.text = newValue?.uppercased()
+            rightColumn.isHidden = newValue == nil
         }
     }
 


### PR DESCRIPTION
Fixes #1662 

## Description
Now `TwoColumnSectionHeaderView` takes the whole width of the left or right label if there is space available.

## Testing
1) Choose a small device like an iPhone 5s
2) Go to Orders tab
3) Tap on an Order with shipment tracking information
4) Scroll to the "OPTIONAL TRACKING INFORMATION" section --> the header should take the whole width if there is space available

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/495617/71597029-ee5a8600-2b41-11ea-8651-e3dc63583aae.png) | ![after](https://user-images.githubusercontent.com/495617/71597030-f0bce000-2b41-11ea-8dfa-36d59acb5297.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
