### PR TITLE
Edit Product Price: adjust table view's bottom content inset from keyboard frame changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -47,6 +47,11 @@ final class ProductPriceSettingsViewController: UIViewController {
     ///
     private var sections: [Section] = []
 
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: handleKeyboardFrameUpdate(keyboardFrame:))
+        return keyboardFrameObserver
+    }()
+
     /// Init
     ///
     init(product: Product) {
@@ -75,11 +80,28 @@ final class ProductPriceSettingsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        startListeningToNotifications()
         configureNavigationBar()
         configureMainView()
         configureSections()
         configureTableView()
         retrieveProductTaxClass()
+    }
+}
+
+// MARK: - Keyboard management
+//
+extension ProductPriceSettingsViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return tableView
+    }
+}
+
+ private extension ProductPriceSettingsViewController {
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        keyboardFrameObserver.startObservingKeyboardFrame()
     }
 }
 


### PR DESCRIPTION
Part of #1423

## Description
In Edit Price Settings screen, when the keyboard was open was impossible to see all the fields, especially the fields at the bottom of the screen.

## Testing
1) Open a product
2) Go in edit mode
3) Go in edit price settings
4) Make sure that with the keyboard open and also with all the date pickers opened, you are able to see and select all the fields.

## Screenshots
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-02 at 17 06 56](https://user-images.githubusercontent.com/495617/71677375-f7866580-2d82-11ea-8ead-3eb5cdcc862d.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
