### PR TITLE
Refund Details: Product & Qty section Mark II

### DIFF
--- a/WooCommerce/Classes/Extensions/NSDecimalNumber+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/NSDecimalNumber+Helpers.swift
@@ -18,6 +18,19 @@ extension NSDecimalNumber {
         return self.decimalValue._isNegative == 1
     }
 
+    /// Returns the absolute value of a decimal, in case the original is negative.
+    ///
+    func abs() -> NSDecimalNumber {
+        guard self.isNegative() else {
+            return self
+        }
+
+        let negativeOne = NSDecimalNumber(decimal: -1.0)
+        let positive = self.multiplying(by: negativeOne)
+
+        return positive
+    }
+
     /// Provides a short, friendly, and *localized* representation of the receiver.
     ///
     /// - Parameter roundSmallNumbers: if `true`, small numbers are rounded, if `false`, no rounding occurs (defaults to true)

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsDataSource.swift
@@ -573,11 +573,16 @@ extension OrderDetailsDataSource {
         updateOrderNoteAsyncDictionary(orderNotes: orderNotes)
     }
 
-    func refund(at indexPath: IndexPath) -> Refund {
+    func refund(at indexPath: IndexPath) -> Refund? {
         let index = indexPath.row - Constants.paymentCell - Constants.paidByCustomerCell
-        let refund = refunds[index]
+        let condensedRefund = order.refunds[index]
+        let refund = refunds.first { $0.refundID == condensedRefund.refundID }
 
-        return refund
+        guard let refundFound = refund else {
+            return nil
+        }
+
+        return refundFound
     }
 
     private func updateOrderNoteAsyncDictionary(orderNotes: [OrderNote]) {

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -201,7 +201,7 @@ extension OrderDetailsViewModel {
                 DDLogError("No refund details found.")
                 return
             }
-            
+
             let viewModel = RefundDetailsViewModel(order: order, refund: refund)
             let refundDetailsViewController = RefundDetailsViewController(viewModel: viewModel)
             viewController.navigationController?.pushViewController(refundDetailsViewController, animated: true)

--- a/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/OrderDetailsViewModel/OrderDetailsViewModel.swift
@@ -197,7 +197,11 @@ extension OrderDetailsViewModel {
             viewController.performSegue(withIdentifier: Constants.productDetailsSegue, sender: nil)
         case .refund:
             ServiceLocator.analytics.track(.orderDetailRefundDetailTapped)
-            let refund = dataSource.refund(at: indexPath)
+            guard let refund = dataSource.refund(at: indexPath) else {
+                DDLogError("No refund details found.")
+                return
+            }
+            
             let viewModel = RefundDetailsViewModel(order: order, refund: refund)
             let refundDetailsViewController = RefundDetailsViewController(viewModel: viewModel)
             viewController.navigationController?.pushViewController(refundDetailsViewController, animated: true)

--- a/WooCommerce/Classes/ViewModels/RefundDetails/RefundDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/RefundDetails/RefundDetailsDataSource.swift
@@ -102,6 +102,8 @@ private extension RefundDetailsDataSource {
         switch cell {
         case let cell as ProductDetailsTableViewCell:
             configureOrderItem(cell, at: indexPath)
+        case let cell as PaymentTableViewCell:
+            configureProductsRefund(cell, at: indexPath)
         default:
             fatalError("Unidentified refund details row type")
         }
@@ -119,6 +121,15 @@ private extension RefundDetailsDataSource {
 
         cell.selectionStyle = .default
         cell.configure(item: itemViewModel, imageService: imageService)
+    }
+
+    /// Setup: ProductsRefund summary Cell
+    ///
+    private func configureProductsRefund(_ cell: PaymentTableViewCell, at indexPath: IndexPath) {
+        let viewModel = RefundDetailsViewModel(order: order, refund: refund)
+
+        cell.selectionStyle = .none
+        cell.configure(with: viewModel)
     }
 }
 
@@ -143,7 +154,8 @@ extension RefundDetailsDataSource {
                 return nil
             }
 
-            let rows: [Row] = Array(repeating: .orderItem, count: items.count)
+            var rows: [Row] = Array(repeating: .orderItem, count: items.count)
+            rows.append(.productsRefund)
 
             return Section(title: SectionTitle.product, rightTitle: SectionTitle.quantity, rows: rows)
         }()
@@ -168,11 +180,14 @@ extension RefundDetailsDataSource {
     enum Row {
         /// Listed in the order they appear on screen
         case orderItem
+        case productsRefund
 
         var reuseIdentifier: String {
             switch self {
             case .orderItem:
                 return ProductDetailsTableViewCell.reuseIdentifier
+            case .productsRefund:
+                return PaymentTableViewCell.reuseIdentifier
             }
         }
     }

--- a/WooCommerce/Classes/ViewModels/RefundDetails/RefundDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/RefundDetails/RefundDetailsViewModel.swift
@@ -79,11 +79,13 @@ private extension RefundDetailsViewModel {
     /// Calculate the subtotal for each returned item
     ///
     func calculateItemSubtotal() -> NSDecimalNumber {
-        let itemSubtotals = refund.items.map { NSDecimalNumber(string: $0.subtotal) }
+        let itemSubtotals = refund.items.map { currencyFormatter.convertToDecimal(from: $0.subtotal) }
 
         var subtotal = NSDecimalNumber.zero
-        for i in itemSubtotals {
-            subtotal = subtotal.adding(i)
+        for itemSubtotal in itemSubtotals {
+            if let i = itemSubtotal {
+                subtotal = subtotal.adding(i)
+            }
         }
 
         if subtotal.isNegative() {
@@ -96,11 +98,13 @@ private extension RefundDetailsViewModel {
     /// Calculate the subtotal tax for each returned item
     ///
     func calculateSubtotalTax() -> NSDecimalNumber {
-        let itemsSubtotalTax = refund.items.map { NSDecimalNumber(string: $0.subtotalTax) }
+        let itemSubtotalTaxes = refund.items.map { currencyFormatter.convertToDecimal(from: $0.subtotalTax) }
 
         var subtotalTax = NSDecimalNumber.zero
-        for i in itemsSubtotalTax {
-            subtotalTax = subtotalTax.adding(i)
+        for itemSubtotalTax in itemSubtotalTaxes {
+            if let i = itemSubtotalTax {
+                subtotalTax = subtotalTax.adding(i)
+            }
         }
 
         return subtotalTax.abs()

--- a/WooCommerce/Classes/ViewModels/RefundDetails/RefundDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/RefundDetails/RefundDetailsViewModel.swift
@@ -14,6 +14,10 @@ final class RefundDetailsViewModel {
     ///
     private(set) var order: Order
 
+    /// Currency Formatter
+    ///
+    let currencyFormatter = CurrencyFormatter()
+
     /// Designated Initializer
     ///
     init(order: Order, refund: Refund) {
@@ -32,11 +36,75 @@ final class RefundDetailsViewModel {
         return dataSource.products
     }
 
+    /// Subtotal from all refunded products
+    ///
+    var itemSubtotal: String {
+        let subtotal = calculateItemSubtotal()
+        let formattedSubtotal = currencyFormatter.formatAmount(subtotal, with: order.currency) ?? String()
+
+        return formattedSubtotal
+    }
+
+    /// Tax subtotal from all refunded products
+    ///
+    var taxSubtotal: String {
+        let subtotalTax = calculateSubtotalTax()
+        let formattedSubtotalTax = currencyFormatter.formatAmount(subtotalTax, with: order.currency) ?? String()
+
+        return formattedSubtotalTax
+    }
+
+    /// Products Refund
+    ///
+    var productsRefund: String {
+        let subtotal = calculateItemSubtotal()
+        let subtotalTax = calculateSubtotalTax()
+        let productsRefundTotal = subtotal.adding(subtotalTax)
+        let formattedProductsRefund = currencyFormatter.formatAmount(productsRefundTotal, with: order.currency)
+
+        return formattedProductsRefund ?? String()
+    }
+
     /// The datasource that will be used to render the Refund Details screen
     ///
     private(set) lazy var dataSource: RefundDetailsDataSource = {
         return RefundDetailsDataSource(refund: self.refund, order: self.order)
     }()
+}
+
+
+// MARK: - Private methods
+//
+private extension RefundDetailsViewModel {
+    /// Calculate the subtotal for each returned item
+    ///
+    func calculateItemSubtotal() -> NSDecimalNumber {
+        let itemSubtotals = refund.items.map { NSDecimalNumber(string: $0.subtotal) }
+
+        var subtotal = NSDecimalNumber.zero
+        for i in itemSubtotals {
+            subtotal = subtotal.adding(i)
+        }
+
+        if subtotal.isNegative() {
+            subtotal = subtotal.multiplying(by: -1)
+        }
+
+        return subtotal.abs()
+    }
+
+    /// Calculate the subtotal tax for each returned item
+    ///
+    func calculateSubtotalTax() -> NSDecimalNumber {
+        let itemsSubtotalTax = refund.items.map { NSDecimalNumber(string: $0.subtotalTax) }
+
+        var subtotalTax = NSDecimalNumber.zero
+        for i in itemsSubtotalTax {
+            subtotalTax = subtotalTax.adding(i)
+        }
+
+        return subtotalTax.abs()
+    }
 }
 
 
@@ -73,6 +141,9 @@ extension RefundDetailsViewModel {
                                                                    currency: order.currency)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
+
+        default:
+            tableView.deselectRow(at: indexPath, animated: true)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/PaymentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/PaymentTableViewCell.swift
@@ -29,6 +29,8 @@ final class PaymentTableViewCell: UITableViewCell {
         configureLabels()
     }
 
+    /// Configure an order payment summary "table"
+    ///
     func configure(with viewModel: OrderPaymentDetailsViewModel) {
         subtotalLabel.text = Titles.subtotalLabel
         subtotalValue.text = viewModel.subtotalValue
@@ -59,6 +61,28 @@ final class PaymentTableViewCell: UITableViewCell {
                                  totalValue as Any
                                 ]
     }
+
+    /// Configure a refund details "table"
+    ///
+    func configure(with viewModel: RefundDetailsViewModel) {
+        subtotalLabel.text = Titles.subtotal
+        subtotalValue.text = viewModel.itemSubtotal
+
+        discountLabel.text = nil
+        discountValue.text = nil
+        discountView.isHidden = true
+
+        shippingLabel.text = nil
+        shippingValue.text = nil
+        shippingView.isHidden = true
+
+        taxesLabel.text = Titles.tax
+        taxesValue.text = viewModel.taxSubtotal
+        taxesView.isHidden = taxesValue == nil
+
+        totalLabel.text = Titles.productsRefund
+        totalValue.text = viewModel.productsRefund
+    }
 }
 
 
@@ -72,6 +96,13 @@ private extension PaymentTableViewCell {
                                                   comment: "Taxes label for payment view")
         static let totalLabel = NSLocalizedString("Order Total",
                                                   comment: "Order Total label for payment view")
+
+        static let subtotal = NSLocalizedString("Subtotal",
+                                                comment: "Subtotal label for a refund details view")
+        static let tax = NSLocalizedString("Tax",
+                                           comment: "Tax label for a refund details view")
+        static let productsRefund = NSLocalizedString("Products Refund",
+                                                      comment: "Label for computed value `product refunds + taxes = subtotal`.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
@@ -118,6 +118,7 @@ extension RefundDetailsViewModel {
     func registerTableViewCells(_ tableView: UITableView) {
         let cells = [
             ProductDetailsTableViewCell.self,
+            PaymentTableViewCell.self,
         ]
 
         for cell in cells {


### PR DESCRIPTION
Part 2. Closes #1681.

In this PR the Product & Qty section has the refund summary cell added to it.

For reference, here is the full Refund Details screen:
<img width="410" alt="Screen Shot 2020-01-02 at 2 47 17 PM" src="https://user-images.githubusercontent.com/1062444/71692247-f6e3d400-2d6e-11ea-9152-dbd149d2b955.png">

## To Test
1. On the website, choose an order and create a refund by item. Refund 2 items or more.
2. After creating the refund, go to the app and navigate to the Order Details for the chosen order.
3. The "Refunded" cell should be the new semantic color, "link", which is an active (pink) color. Tap on the "Refunded" cell.
4. The Refund Details screen should appear. As long as the refund was "refund by item", a subtotal, tax, and Products Refund cell will display.

### Screenshots
| Order Details | Refund Details |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/1062444/71732030-d9b11300-2e0b-11ea-8993-b9a274de752c.png" width="350" /> | <img src="https://user-images.githubusercontent.com/1062444/71731924-935bb400-2e0b-11ea-94e9-bfd312b27593.png" width="350" /> |




Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
