### PR TITLE
Scroll view bottom inset isn't properly adjusted when keyboard is dismissed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -49,10 +49,7 @@ private extension KeyboardFrameObserver {
     }
 
     mutating func keyboardWillHide(_ notification: Foundation.Notification) {
-        guard let keyboardFrame = keyboardRect(from: notification) else {
-            return
-        }
-        self.keyboardFrame = keyboardFrame
+        self.keyboardFrame = .zero
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -12,7 +12,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
         let expectedFrame = CGRect(origin: .zero, size: CGSize(width: 10, height: 18))
-        let expectedFrames: [CGRect] = [expectedFrame]
+        let expectedFrames: [CGRect] = [expectedFrame, .zero]
 
         var actualFrames = [CGRect]()
 
@@ -24,6 +24,8 @@ final class KeyboardFrameObserverTests: XCTestCase {
             }
         }
         keyboardFrameObserver.startObservingKeyboardFrame()
+
+        notificationCenter.postKeyboardWillShowNotification(keyboardFrame: expectedFrame)
 
         notificationCenter.postKeyboardWillShowNotification(keyboardFrame: expectedFrame)
         notificationCenter.postKeyboardWillHideNotification(keyboardFrame: expectedFrame)
@@ -40,7 +42,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
         let expectedFrameForShow = CGRect(origin: .zero, size: CGSize(width: 10, height: 18))
-        let expectedFrameForHide = CGRect(origin: .zero, size: CGSize(width: 17, height: 10))
+        let expectedFrameForHide = CGRect.zero
         let expectedFrames: [CGRect] = [expectedFrameForShow, expectedFrameForHide]
 
         var actualFrames = [CGRect]()


### PR DESCRIPTION
Fixes #1693 

## Changes

- On `UIResponder.keyboardWillHideNotification`, set the keyboard frame to zero instead of the end keyboard frame from the user info dictionary which is never 0 (ideally it indicates the target frame)

## Testing

- Launch the app
- Go to Products tab
- Tap on a simple Product
- Edit Product inventory settings
- Tap on the SKU field to bring up the keyboard --> the scroll view should have a bottom inset that accommodates the keyboard height
- Toggle "Manage stock" to dismiss the keyboard --> the scroll view should not have a bottom inset

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
