### PR TITLE
Product images UI with CTA to add images (no functionality)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -16,12 +16,17 @@ private extension ProductFormSection.SettingsRow.ViewModel {
 final class ProductFormTableViewDataSource: NSObject {
     private let viewModel: ProductFormTableViewModel
     private let canEditImages: Bool
+    private var onAddImage: (() -> Void)?
 
     init(viewModel: ProductFormTableViewModel,
          canEditImages: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2)) {
         self.viewModel = viewModel
         self.canEditImages = canEditImages
         super.init()
+    }
+
+    func configureActions(onAddImage: @escaping () -> Void) {
+        self.onAddImage = onAddImage
     }
 }
 
@@ -94,8 +99,8 @@ private extension ProductFormTableViewDataSource {
         cell.onImageSelected = { (productImage, indexPath) in
             // TODO: open image detail
         }
-        cell.onAddImage = {
-            // TODO: start add image process
+        cell.onAddImage = { [weak self] in
+            self?.onAddImage?()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -10,6 +10,7 @@ final class ProductFormViewController: UIViewController {
         didSet {
             viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
             tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel)
+            tableViewDataSource.configureActions(onAddImage: showProductImages)
             tableView.dataSource = tableViewDataSource
             tableView.reloadData()
         }
@@ -30,6 +31,7 @@ final class ProductFormViewController: UIViewController {
         self.viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
         self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel)
         super.init(nibName: nil, bundle: nil)
+        tableViewDataSource.configureActions(onAddImage: showProductImages)
     }
 
     required init?(coder: NSCoder) {
@@ -117,6 +119,11 @@ private extension ProductFormViewController {
             self?.navigationController?.dismiss(animated: true, completion: nil)
         }
         ServiceLocator.stores.dispatch(action)
+    }
+
+    func showProductImages() {
+        let imagesViewController = ProductImagesViewController(product: product)
+        navigationController?.pushViewController(imagesViewController, animated: true)
     }
 
     func displayError(error: ProductUpdateError?) {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -46,10 +46,6 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
 //
 extension ProductImagesCollectionViewController {
 
-    override func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
-    }
-
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return productImages.count
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -55,8 +55,9 @@ extension ProductImagesCollectionViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier, for: indexPath) as? ProductImageCollectionViewCell else {
-            fatalError()
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier,
+                                                            for: indexPath) as? ProductImageCollectionViewCell else {
+                                                                fatalError()
         }
 
         let productImage = productImages[indexPath.row]

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -1,0 +1,79 @@
+import UIKit
+import Yosemite
+
+/// Displays Product images in grid layout.
+///
+final class ProductImagesCollectionViewController: UICollectionViewController {
+
+    private var productImages: [ProductImage]
+
+    private let imageService: ImageService
+
+    init(images: [ProductImage], imageService: ImageService = ServiceLocator.imageService) {
+        self.productImages = images
+        self.imageService = imageService
+        let columnLayout = ColumnFlowLayout(
+            cellsPerRow: 2,
+            minimumInteritemSpacing: 16,
+            minimumLineSpacing: 16,
+            sectionInset: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        )
+        super.init(collectionViewLayout: columnLayout)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        collectionView.backgroundColor = .listBackground
+
+        collectionView.register(ProductImageCollectionViewCell.loadNib(), forCellWithReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier)
+
+        collectionView.reloadData()
+    }
+
+    func updateProductImages(_ productImages: [ProductImage]) {
+        self.productImages = productImages
+
+        collectionView.reloadData()
+    }
+}
+
+// MARK: UICollectionViewDataSource
+//
+extension ProductImagesCollectionViewController {
+
+    override func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return productImages.count
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier, for: indexPath) as? ProductImageCollectionViewCell else {
+            fatalError()
+        }
+
+        let productImage = productImages[indexPath.row]
+
+        imageService.downloadAndCacheImageForImageView(cell.imageView,
+                                                       with: productImage.src,
+                                                       placeholder: .productPlaceholderImage,
+                                                       progressBlock: nil) { (image, error) in
+                                                        let success = image != nil && error == nil
+                                                        if success {
+                                                            cell.imageView.contentMode = .scaleAspectFit
+                                                        }
+                                                        else {
+                                                            cell.imageView.contentMode = .center
+                                                        }
+        }
+
+        return cell
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -28,7 +28,7 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        collectionView.backgroundColor = .listBackground
+        collectionView.backgroundColor = .basicBackground
 
         collectionView.register(ProductImageCollectionViewCell.loadNib(), forCellWithReuseIdentifier: ProductImageCollectionViewCell.reuseIdentifier)
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.xib
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductImagesCollectionViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <viewLayoutGuide key="safeArea" id="oBF-5E-Iza"/>
+            <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="c7k-ch-oGk">
+                <size key="itemSize" width="50" height="50"/>
+                <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+            </collectionViewFlowLayout>
+            <connections>
+                <outlet property="dataSource" destination="-1" id="Tng-2m-Rnh"/>
+                <outlet property="delegate" destination="-1" id="9aC-8N-iBw"/>
+            </connections>
+        </collectionView>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -5,6 +5,7 @@ import Yosemite
 ///
 final class ProductImagesViewController: UIViewController {
     @IBOutlet private weak var addButton: UIButton!
+    @IBOutlet private weak var addButtonBottomBorderView: UIView!
     @IBOutlet private weak var imagesContainerView: UIView!
 
     private let siteID: Int64
@@ -37,6 +38,7 @@ final class ProductImagesViewController: UIViewController {
 
         configureNavigation()
         configureAddButton()
+        configureAddButtonBottomBorderView()
         configureImagesContainerView()
     }
 }
@@ -54,8 +56,12 @@ private extension ProductImagesViewController {
         addButton.applyPrimaryButtonStyle()
     }
 
+    func configureAddButtonBottomBorderView() {
+        addButtonBottomBorderView.backgroundColor = .systemColor(.separator)
+    }
+
     func configureImagesContainerView() {
-        imagesContainerView.backgroundColor = .listBackground
+        imagesContainerView.backgroundColor = .basicBackground
 
         addChild(imagesViewController)
         imagesContainerView.addSubview(imagesViewController.view)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -1,0 +1,77 @@
+import UIKit
+import Yosemite
+
+/// Displays Product images with edit functionality.
+///
+final class ProductImagesViewController: UIViewController {
+    @IBOutlet private weak var addButton: UIButton!
+    @IBOutlet private weak var imagesContainerView: UIView!
+
+    private let siteID: Int64
+    private let productID: Int64
+    private var productImages: [ProductImage] {
+        didSet {
+            imagesViewController.updateProductImages(productImages)
+        }
+    }
+
+    // Child view controller.
+    private lazy var imagesViewController: ProductImagesCollectionViewController = {
+        let viewController = ProductImagesCollectionViewController(images: productImages)
+        return viewController
+    }()
+
+    init(product: Product) {
+        self.siteID = product.siteID
+        self.productID = product.productID
+        self.productImages = product.images
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigation()
+        configureAddButton()
+        configureImagesContainerView()
+    }
+}
+
+// MARK: - UI configurations
+//
+private extension ProductImagesViewController {
+    func configureNavigation() {
+        title = NSLocalizedString("Photos", comment: "Product images (Product images page title)")
+    }
+
+    func configureAddButton() {
+        addButton.setTitle(NSLocalizedString("ADD PHOTOS", comment: "Action to add photos on the Product images screen"), for: .normal)
+        addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
+        addButton.applyPrimaryButtonStyle()
+    }
+
+    func configureImagesContainerView() {
+        imagesContainerView.backgroundColor = .listBackground
+
+        addChild(imagesViewController)
+        imagesContainerView.addSubview(imagesViewController.view)
+        imagesViewController.didMove(toParent: self)
+
+        imagesViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        imagesContainerView.pinSubviewToSafeArea(imagesViewController.view)
+    }
+}
+
+// MARK: - Actions
+//
+private extension ProductImagesViewController {
+
+    @objc func addTapped() {
+        // TODO-1713: display options to add an image.
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductImagesViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="addButton" destination="0Ax-am-fAo" id="QNl-lB-JSc"/>
+                <outlet property="imagesContainerView" destination="SsJ-ZU-y5E" id="MoY-hV-AkN"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dk2-8r-KNb" userLabel="Top Container View">
+                    <rect key="frame" x="0.0" y="44" width="414" height="62"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Ax-am-fAo">
+                            <rect key="frame" x="16" y="16" width="382" height="30"/>
+                            <state key="normal" title="Button"/>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstItem="0Ax-am-fAo" firstAttribute="leading" secondItem="Dk2-8r-KNb" secondAttribute="leading" constant="16" id="Cxh-B4-v30"/>
+                        <constraint firstItem="0Ax-am-fAo" firstAttribute="centerY" secondItem="Dk2-8r-KNb" secondAttribute="centerY" id="bsU-a9-Qwh"/>
+                        <constraint firstItem="0Ax-am-fAo" firstAttribute="top" secondItem="Dk2-8r-KNb" secondAttribute="top" constant="16" id="m6y-9Z-jVb"/>
+                        <constraint firstItem="0Ax-am-fAo" firstAttribute="centerX" secondItem="Dk2-8r-KNb" secondAttribute="centerX" id="v2z-mg-x6v"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SsJ-ZU-y5E" userLabel="Images Container View">
+                    <rect key="frame" x="0.0" y="106" width="414" height="756"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="SsJ-ZU-y5E" secondAttribute="trailing" id="Jyc-HD-LGF"/>
+                <constraint firstItem="SsJ-ZU-y5E" firstAttribute="top" secondItem="Dk2-8r-KNb" secondAttribute="bottom" id="LTj-Wm-7IT"/>
+                <constraint firstItem="SsJ-ZU-y5E" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Qp6-lt-mgi"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="SsJ-ZU-y5E" secondAttribute="bottom" id="YEi-eA-Yib"/>
+                <constraint firstItem="Dk2-8r-KNb" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="dXs-wX-EmW"/>
+                <constraint firstItem="Dk2-8r-KNb" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="iE9-KH-1ui"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Dk2-8r-KNb" secondAttribute="trailing" id="iT9-hr-OFf"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="139" y="81"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,6 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductImagesViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="addButton" destination="0Ax-am-fAo" id="QNl-lB-JSc"/>
+                <outlet property="addButtonBottomBorderView" destination="KbB-CQ-TNt" id="94x-9o-kxI"/>
                 <outlet property="imagesContainerView" destination="SsJ-ZU-y5E" id="MoY-hV-AkN"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -27,11 +28,21 @@
                             <rect key="frame" x="16" y="16" width="382" height="30"/>
                             <state key="normal" title="Button"/>
                         </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KbB-CQ-TNt">
+                            <rect key="frame" x="0.0" y="61.5" width="414" height="0.5"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.5" id="47e-lI-f8z"/>
+                            </constraints>
+                        </view>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>
                         <constraint firstItem="0Ax-am-fAo" firstAttribute="leading" secondItem="Dk2-8r-KNb" secondAttribute="leading" constant="16" id="Cxh-B4-v30"/>
+                        <constraint firstAttribute="bottom" secondItem="KbB-CQ-TNt" secondAttribute="bottom" id="KjN-PF-4mY"/>
+                        <constraint firstItem="KbB-CQ-TNt" firstAttribute="leading" secondItem="Dk2-8r-KNb" secondAttribute="leading" id="Qj7-eC-kFt"/>
                         <constraint firstItem="0Ax-am-fAo" firstAttribute="centerY" secondItem="Dk2-8r-KNb" secondAttribute="centerY" id="bsU-a9-Qwh"/>
+                        <constraint firstAttribute="trailing" secondItem="KbB-CQ-TNt" secondAttribute="trailing" id="huF-CE-lcd"/>
                         <constraint firstItem="0Ax-am-fAo" firstAttribute="top" secondItem="Dk2-8r-KNb" secondAttribute="top" constant="16" id="m6y-9Z-jVb"/>
                         <constraint firstItem="0Ax-am-fAo" firstAttribute="centerX" secondItem="Dk2-8r-KNb" secondAttribute="centerX" id="v2z-mg-x6v"/>
                     </constraints>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+/// Renders a grid layout with a specified number of cells per row.
+///
+final class ColumnFlowLayout: UICollectionViewFlowLayout {
+
+    let cellsPerRow: Int
+
+    init(cellsPerRow: Int,
+         minimumInteritemSpacing: CGFloat = 0,
+         minimumLineSpacing: CGFloat = 0,
+         sectionInset: UIEdgeInsets = .zero) {
+        self.cellsPerRow = cellsPerRow
+        super.init()
+        
+        self.minimumInteritemSpacing = minimumInteritemSpacing
+        self.minimumLineSpacing = minimumLineSpacing
+        self.sectionInset = sectionInset
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepare() {
+        super.prepare()
+
+        guard let collectionView = collectionView else { return }
+        let marginsAndInsets = sectionInset.left + sectionInset.right + collectionView.safeAreaInsets.left + collectionView.safeAreaInsets.right + minimumInteritemSpacing * CGFloat(cellsPerRow - 1)
+        let itemDimension = ((collectionView.bounds.size.width - marginsAndInsets) / CGFloat(cellsPerRow)).rounded(.down)
+        itemSize = CGSize(width: itemDimension, height: itemDimension)
+    }
+
+    override func invalidationContext(forBoundsChange newBounds: CGRect) -> UICollectionViewLayoutInvalidationContext {
+        guard let context = super.invalidationContext(forBoundsChange: newBounds) as? UICollectionViewFlowLayoutInvalidationContext else {
+            return super.invalidationContext(forBoundsChange: newBounds)
+        }
+        context.invalidateFlowLayoutDelegateMetrics = newBounds.size != collectionView?.bounds.size
+        return context
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 final class ColumnFlowLayout: UICollectionViewFlowLayout {
 
-    let cellsPerRow: Int
+    private let cellsPerRow: Int
 
     init(cellsPerRow: Int,
          minimumInteritemSpacing: CGFloat = 0,
@@ -12,7 +12,7 @@ final class ColumnFlowLayout: UICollectionViewFlowLayout {
          sectionInset: UIEdgeInsets = .zero) {
         self.cellsPerRow = cellsPerRow
         super.init()
-        
+
         self.minimumInteritemSpacing = minimumInteritemSpacing
         self.minimumLineSpacing = minimumLineSpacing
         self.sectionInset = sectionInset

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
@@ -26,7 +26,9 @@ final class ColumnFlowLayout: UICollectionViewFlowLayout {
         super.prepare()
 
         guard let collectionView = collectionView else { return }
-        let marginsAndInsets = sectionInset.left + sectionInset.right + collectionView.safeAreaInsets.left + collectionView.safeAreaInsets.right + minimumInteritemSpacing * CGFloat(cellsPerRow - 1)
+        let marginsAndInsets = sectionInset.left + sectionInset.right
+            + collectionView.safeAreaInsets.left + collectionView.safeAreaInsets.right
+            + minimumInteritemSpacing * CGFloat(cellsPerRow - 1)
         let itemDimension = ((collectionView.bounds.size.width - marginsAndInsets) / CGFloat(cellsPerRow)).rounded(.down)
         itemSize = CGSize(width: itemDimension, height: itemDimension)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -27,11 +27,10 @@
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
 		020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */; };
 		020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */; };
+		020B2F9923BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9823BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift */; };
 		020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74723B05CF2007FE54C /* ProductInventoryEditableData.swift */; };
 		020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74B23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.swift */; };
 		020BE74E23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */; };
-		020B2F9923BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9823BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift */; };
-		020BE74823B05CF2007FE54C /* ProductInventoryEditableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE74723B05CF2007FE54C /* ProductInventoryEditableData.swift */; };
 		020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76623B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift */; };
 		020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76823B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift */; };
 		020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE76A23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift */; };
@@ -130,6 +129,11 @@
 		0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */; };
 		0282DD9A233CA32D006A5FDB /* OrderSearchCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282DD99233CA32D006A5FDB /* OrderSearchCellViewModel.swift */; };
 		0285BF7022FBD91C003A2525 /* TopPerformersSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */; };
+		0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */; };
+		0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */; };
+		0286B27C23C7051F003D784B /* ProductImagesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0286B27823C7051F003D784B /* ProductImagesViewController.xib */; };
+		0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27923C7051F003D784B /* ProductImagesViewController.swift */; };
+		0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0286B27E23C70557003D784B /* ColumnFlowLayout.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4022F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3F22F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift */; };
 		028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */; };
@@ -619,11 +623,10 @@
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
 		020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatterTests.swift; sourceTree = "<group>"; };
 		020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductUpdateError+UI.swift"; sourceTree = "<group>"; };
+		020B2F9823BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModelTests.swift; sourceTree = "<group>"; };
 		020BE74723B05CF2007FE54C /* ProductInventoryEditableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventoryEditableData.swift; sourceTree = "<group>"; };
 		020BE74B23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndTextFieldTableViewCell.swift; sourceTree = "<group>"; };
 		020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndTextFieldTableViewCell.xib; sourceTree = "<group>"; };
-		020B2F9823BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModelTests.swift; sourceTree = "<group>"; };
-		020BE74723B05CF2007FE54C /* ProductInventoryEditableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventoryEditableData.swift; sourceTree = "<group>"; };
 		020BE76623B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecBoldFormatBarCommandTests.swift; sourceTree = "<group>"; };
 		020BE76823B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecItalicFormatBarCommandTests.swift; sourceTree = "<group>"; };
 		020BE76A23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecUnderlineFormatBarCommandTests.swift; sourceTree = "<group>"; };
@@ -722,6 +725,11 @@
 		0282DD97233CA093006A5FDB /* OrderSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchUICommand.swift; sourceTree = "<group>"; };
 		0282DD99233CA32D006A5FDB /* OrderSearchCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchCellViewModel.swift; sourceTree = "<group>"; };
 		0285BF6F22FBD91C003A2525 /* TopPerformersSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersSectionHeaderView.swift; sourceTree = "<group>"; };
+		0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductImagesCollectionViewController.xib; sourceTree = "<group>"; };
+		0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductImagesCollectionViewController.swift; sourceTree = "<group>"; };
+		0286B27823C7051F003D784B /* ProductImagesViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductImagesViewController.xib; sourceTree = "<group>"; };
+		0286B27923C7051F003D784B /* ProductImagesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductImagesViewController.swift; sourceTree = "<group>"; };
+		0286B27E23C70557003D784B /* ColumnFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnFlowLayout.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC3F22F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewController.swift; sourceTree = "<group>"; };
 		028BAC4122F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4PeriodViewController.swift; sourceTree = "<group>"; };
@@ -1489,6 +1497,17 @@
 			path = Search;
 			sourceTree = "<group>";
 		};
+		0286B27523C704FC003D784B /* Media */ = {
+			isa = PBXGroup;
+			children = (
+				0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */,
+				0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */,
+				0286B27923C7051F003D784B /* ProductImagesViewController.swift */,
+				0286B27823C7051F003D784B /* ProductImagesViewController.xib */,
+			);
+			path = Media;
+			sourceTree = "<group>";
+		};
 		028BAC4322F3AE3B008BB4AF /* Stats v4 */ = {
 			isa = PBXGroup;
 			children = (
@@ -1783,6 +1802,7 @@
 		74EC34A3225FE1F3004BBC2E /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				0286B27523C704FC003D784B /* Media */,
 				026CF637237E9AA5009563D4 /* Variations */,
 				021627232379637E000208D2 /* Edit Product */,
 				020DD48B2322A5F9005822B1 /* View Models */,
@@ -2623,8 +2643,6 @@
 				CE583A0A2107937F00D73C1C /* TextViewTableViewCell.xib */,
 				D843D5C922437E59001BFA55 /* TitleAndEditableValueTableViewCell.swift */,
 				D843D5CA22437E59001BFA55 /* TitleAndEditableValueTableViewCell.xib */,
-				020BE74B23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.swift */,
-				020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */,
 				CE22E3F921714776005A6BEF /* TopLeftImageTableViewCell.swift */,
 				CE22E3FA21714776005A6BEF /* TopLeftImageTableViewCell.xib */,
 				CE1EC8C920B479F1009762BF /* TwoColumnLabelView.swift */,
@@ -2635,8 +2653,6 @@
 				CE1D5A54228A0AD200DF3715 /* TwoColumnTableViewCell.xib */,
 				CE35F1192343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift */,
 				CE35F11A2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.xib */,
-				0262DA5123A238460029AF30 /* UnitInputTableViewCell.swift */,
-				0262DA5223A238460029AF30 /* UnitInputTableViewCell.xib */,
 				CE27257D21925AE8002B22EB /* ValueOneTableViewCell.swift */,
 				CE27257E21925AE8002B22EB /* ValueOneTableViewCell.xib */,
 				B5A56BEF219F2CE90065A902 /* VerticalButton.swift */,
@@ -2648,6 +2664,7 @@
 				020BE74C23B1F5EA007FE54C /* TitleAndTextFieldTableViewCell.xib */,
 				02F49ADB23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift */,
 				02F49ADD23BF3A4100FA0BFA /* ErrorSectionHeaderView.xib */,
+				0286B27E23C70557003D784B /* ColumnFlowLayout.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -2933,6 +2950,7 @@
 				D83C129F22250BF0004CA04C /* OrderTrackingTableViewCell.xib in Resources */,
 				B59D1EE121907304009D1978 /* ProductReviewTableViewCell.xib in Resources */,
 				021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */,
+				0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */,
 				0290E270238E3CE400B5C466 /* ListSelectorViewController.xib in Resources */,
 				B59D1EE821908A08009D1978 /* Noticons.ttf in Resources */,
 				D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */,
@@ -2946,6 +2964,7 @@
 				740ADFE521C33688009EE5A9 /* licenses.html in Resources */,
 				CE2A9FC023BFB1BE002BEC1C /* LedgerTableViewCell.xib in Resources */,
 				45C8B2592313FA570002FA77 /* CustomerNoteTableViewCell.xib in Resources */,
+				0286B27C23C7051F003D784B /* ProductImagesViewController.xib in Resources */,
 				02F49ADE23BF3A4100FA0BFA /* ErrorSectionHeaderView.xib in Resources */,
 				B554016B2170D6010067DC90 /* ChartPlaceholderView.xib in Resources */,
 				CE32B11620BF8779006FBCF4 /* FulfillButtonTableViewCell.xib in Resources */,
@@ -3194,6 +3213,7 @@
 				B5D1AFC620BC7B7300DB0E8C /* StorePickerViewController.swift in Sources */,
 				0240B3AC230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift in Sources */,
 				74D0A5302139CF1300E2919F /* String+Helpers.swift in Sources */,
+				0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */,
 				7435E58E21C0151B00216F0F /* OrderNote+Woo.swift in Sources */,
 				451A04F42386F7C900E368C9 /* AddProductImageCollectionViewCell.swift in Sources */,
 				D843D5CB22437E59001BFA55 /* TitleAndEditableValueTableViewCell.swift in Sources */,
@@ -3218,6 +3238,7 @@
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				B59D1EE321907C7B009D1978 /* NSAttributedString+Helpers.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
+				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
 				D8149F532251CFE60006A245 /* EditableOrderTrackingTableViewCell.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,
 				028BAC4222F30B05008BB4AF /* StoreStatsV4PeriodViewController.swift in Sources */,
@@ -3337,6 +3358,7 @@
 				02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */,
 				D8C2A291231BD0FD00F503E9 /* DefaultReviewsDataSource.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
+				0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */,
 				CE35F11B2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift in Sources */,
 				D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,


### PR DESCRIPTION
UI part for #1713 

## Changes

- Created a generic `ColumnFlowLayout` collection view flow layout to render a grid layout
- Created `ProductImagesCollectionViewController` to render a collection view of Product images in a grid layout
- Created `ProductImagesViewController` that displays a Call-to-Action for adding images (no-op in this PR) and Product images via a child view controller `ProductImagesCollectionViewController`
- Added action configuration to `ProductFormTableViewDataSource` for adding images `onAddImage`
- In `ProductFormViewController`, implemented `onAddImage` to display `ProductImagesViewController`

## Testing

- Launch the app
- Go to Products tab
- Tap on a simple Product without images
- Tap on the top images header view with "+" action --> a "Photos" screen should be displayed with a CTA to add images
- Navigate back to the Products tab
- Tap on a simple Product with at least one image
- Tap on the "+" cell to the right of the last Product image --> a "Photos" screen should be displayed with a CTA to add images

## Example screenshots

Dark | Light
-- | --
![Simulator Screen Shot - iPhone 8 - 2020-01-09 at 15 26 03](https://user-images.githubusercontent.com/1945542/72047063-acc19c00-32f4-11ea-8151-9dbc1d26729b.png) | ![Simulator Screen Shot - iPhone 8 - 2020-01-09 at 15 26 10](https://user-images.githubusercontent.com/1945542/72047064-ad5a3280-32f4-11ea-9bb3-aeac5bb02c25.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
