### PR TITLE
Amendment for Edit Product permission checks

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -28,33 +28,33 @@ private extension DefaultProductFormTableViewModel {
     }
 
     func primaryFieldRows(product: Product) -> [ProductFormSection.PrimaryFieldRow] {
-        if canEditImages == false && product.images.isEmpty {
+        guard canEditImages || product.images.isEmpty == false else {
             return [
-                .name(name: product.name),
-                .description(description: product.trimmedFullDescription)
-            ]
-        } else {
-            return [
-                .images(product: product),
                 .name(name: product.name),
                 .description(description: product.trimmedFullDescription)
             ]
         }
+
+        return [
+            .images(product: product),
+            .name(name: product.name),
+            .description(description: product.trimmedFullDescription)
+        ]
     }
 
     func settingsRows(product: Product) -> [ProductFormSection.SettingsRow] {
-        if product.downloadable || product.virtual {
+        guard product.downloadable == false && product.virtual == false else {
             return [
                 .price(viewModel: priceSettingsRow(product: product)),
-                .inventory(viewModel: inventorySettingsRow(product: product))
-            ]
-        } else {
-            return [
-                .price(viewModel: priceSettingsRow(product: product)),
-                .shipping(viewModel: shippingSettingsRow(product: product)),
                 .inventory(viewModel: inventorySettingsRow(product: product))
             ]
         }
+
+        return [
+            .price(viewModel: priceSettingsRow(product: product)),
+            .shipping(viewModel: shippingSettingsRow(product: product)),
+            .inventory(viewModel: inventorySettingsRow(product: product))
+        ]
     }
 }
 


### PR DESCRIPTION
Amendment for #1669 

## Changes

- This PR amended the previous PR https://github.com/woocommerce/woocommerce-ios/pull/1705 based on this CR comment thread https://github.com/woocommerce/woocommerce-ios/pull/1705#discussion_r364582988

## Testing

- Launch the app
- Go to the Products tab
- Tap on a simple Product without images --> it should go to the Edit Product screen with UI to add images (but no functionality)
- Go back to the Products tab
- Tap on a simple Product with images --> it should go to the Edit Product screen with UI to add images (but no functionality)
- On wp-admin, set the Product to be virtual
- Navigate back to the Products tab and then tap on the same Product --> the "shipping" row should not be shown
- On wp-admin, set the Product to be downloadable
- Navigate back to the Products tab and then tap on the same Product --> the "shipping" row should not be shown
- Go back to the Products tab
- Tap on a non-simple Product (like Bookable or Variable) --> it should navigate to the existing Product details screen without edit functionality

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
