### PR TITLE
Refunded Products: summarize algorithm

### DIFF
--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -157,3 +157,14 @@ extension OrderItemRefund: Comparable {
             (lhs.itemID == rhs.itemID && lhs.productID == rhs.productID && lhs.name < rhs.name)
     }
 }
+
+
+// MARK: - Hashable Conformance
+//
+extension OrderItemRefund: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(itemID)
+        hasher.combine(productID)
+        hasher.combine(variationID)
+    }
+}

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -157,3 +157,13 @@ extension OrderItemRefund: Comparable {
             (lhs.itemID == rhs.itemID && lhs.productID == rhs.productID && lhs.name < rhs.name)
     }
 }
+
+
+// MARK: - Hashable Conformance
+//
+extension OrderItemRefund: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(productID)
+        hasher.combine(variationID)
+    }
+}

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -157,14 +157,3 @@ extension OrderItemRefund: Comparable {
             (lhs.itemID == rhs.itemID && lhs.productID == rhs.productID && lhs.name < rhs.name)
     }
 }
-
-
-// MARK: - Hashable Conformance
-//
-extension OrderItemRefund: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(itemID)
-        hasher.combine(productID)
-        hasher.combine(variationID)
-    }
-}

--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -17,24 +17,6 @@ extension Array {
 }
 
 
-// MARK: - Networking.Array+Woo
-//
-extension Array where Element == Int64 {
-    /// Returns a sorted, de-duplicated array of integer values as a comma-separated String.
-    ///
-    func sortedUniqueIntToString() -> String {
-        let uniqued: Array = Array(Set<Int64>(self))
-
-        let items = uniqued.sorted()
-        .map { String($0) }
-        .filter { !$0.isEmpty }
-        .joined(separator: ",")
-
-        return items
-    }
-}
-
-
 extension Collection {
 
     /// Returns the element at the specified index if it is within bounds, otherwise nil.

--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -4,7 +4,6 @@ import Foundation
 // MARK: - Array Helpers
 //
 extension Array {
-
     /// Removes and returns the first element in the array. If any!
     ///
     mutating func popFirst() -> Element? {
@@ -17,11 +16,33 @@ extension Array {
 }
 
 
+// MARK: - Collection Helpers
+//
 extension Collection {
-
     /// Returns the element at the specified index if it is within bounds, otherwise nil.
     ///
     subscript (safe index: Index) -> Element? {
         return indices.contains(index) ? self[index] : nil
     }
+}
+
+
+// MARK: - Sequence Helpers
+//
+extension Sequence {
+    /// Get the keypaths for a elemtents in a sequence.
+    ///
+    func map<T>(_ keyPath: KeyPath<Element, T>) -> [T] {
+        return map { $0[keyPath: keyPath] }
+    }
+
+    /// Sum a sequence of elements by keypath.
+    func sum<T: Numeric>(_ keyPath: KeyPath<Element, T>) -> T {
+        return map(keyPath).sum()
+    }
+}
+
+extension Sequence where Element: Numeric {
+    /// Returns the sum of all elements in the collection.
+    func sum() -> Element { return reduce(0, +) }
 }

--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -17,6 +17,24 @@ extension Array {
 }
 
 
+// MARK: - Networking.Array+Woo
+//
+extension Array where Element == Int64 {
+    /// Returns a sorted, de-duplicated array of integer values as a comma-separated String.
+    ///
+    func sortedUniqueIntToString() -> String {
+        let uniqued: Array = Array(Set<Int64>(self))
+
+        let items = uniqued.sorted()
+        .map { String($0) }
+        .filter { !$0.isEmpty }
+        .joined(separator: ",")
+
+        return items
+    }
+}
+
+
 extension Collection {
 
     /// Returns the element at the specified index if it is within bounds, otherwise nil.

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -43,6 +43,7 @@ final class OrderDetailsViewModel {
     var refundedItems: [OrderItemRefund] {
         let refunds = dataSource.refunds
         var items = [OrderItemRefund]()
+
         for refund in refunds {
             items.append(contentsOf: refund.items)
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -43,7 +43,6 @@ final class OrderDetailsViewModel {
     var refundedItems: [OrderItemRefund] {
         let refunds = dataSource.refunds
         var items = [OrderItemRefund]()
-
         for refund in refunds {
             items.append(contentsOf: refund.items)
         }

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
@@ -52,16 +52,6 @@ extension OrderItemRefundSummary: Comparable {
 
     public static func < (lhs: OrderItemRefundSummary, rhs: OrderItemRefundSummary) -> Bool {
         return lhs.productID < rhs.productID ||
-            (lhs.productID == rhs.productID && lhs.name < rhs.name)
-    }
-}
-
-
-// MARK: - Hashable Conformance
-//
-extension OrderItemRefundSummary: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(productID)
-        hasher.combine(variationID)
+            (lhs.productID == rhs.productID && lhs.variationID < rhs.variationID)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
@@ -22,7 +22,15 @@ final class OrderItemRefundSummary {
 
     /// Designated initializer.
     ///
-    init(productID: Int64, variationID: Int64, name: String, price: NSDecimalNumber, quantity: Decimal, sku: String?, total: NSDecimalNumber, totalTax: NSDecimalNumber?) {
+    init(productID: Int64,
+         variationID: Int64,
+         name: String,
+         price: NSDecimalNumber,
+         quantity: Decimal,
+         sku: String?,
+         total: NSDecimalNumber,
+         totalTax: NSDecimalNumber?)
+    {
         self.productID = productID
         self.variationID = variationID
         self.name = name

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
@@ -3,20 +3,21 @@ import Foundation
 
 /// Represents a computed summary of refunded products
 ///
-public class OrderItemRefundSummary {
-    public let name: String
-    public let productID: Int64
-    public let variationID: Int64
-    public var quantity: Decimal
+final class OrderItemRefundSummary {
+    let productID: Int64
+    let variationID: Int64
+
+    let name: String
+    var quantity: Decimal
 
     /// Price is a currency.
     /// When handling currencies, `NSDecimalNumber` is a powerhouse
     /// for localization and string-to-number conversions.
     /// `Decimal` doesn't yet have all of the `NSDecimalNumber` APIs.
     ///
-    public let price: NSDecimalNumber
-    public let sku: String?
-    public var totalTax: NSDecimalNumber?
+    let price: NSDecimalNumber
+    let sku: String?
+    var totalTax: NSDecimalNumber?
 
     /// Designated initializer.
     ///

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
@@ -8,26 +8,28 @@ final class OrderItemRefundSummary {
     let variationID: Int64
 
     let name: String
-    var quantity: Decimal
 
-    /// Price is a currency.
+    /// Price, total, and totalTax are currency values.
     /// When handling currencies, `NSDecimalNumber` is a powerhouse
     /// for localization and string-to-number conversions.
-    /// `Decimal` doesn't yet have all of the `NSDecimalNumber` APIs.
+    /// `Decimal` doesn't have all of the `NSDecimalNumber` APIs (yet).
     ///
     let price: NSDecimalNumber
+    var quantity: Decimal
     let sku: String?
+    var total: NSDecimalNumber
     var totalTax: NSDecimalNumber?
 
     /// Designated initializer.
     ///
-    init(name: String, productID: Int64, variationID: Int64, quantity: Decimal, price: NSDecimalNumber, sku: String?, totalTax: NSDecimalNumber?) {
-        self.name = name
+    init(productID: Int64, variationID: Int64, name: String, price: NSDecimalNumber, quantity: Decimal, sku: String?, total: NSDecimalNumber, totalTax: NSDecimalNumber?) {
         self.productID = productID
         self.variationID = variationID
-        self.quantity = quantity
+        self.name = name
         self.price = price
+        self.quantity = quantity
         self.sku = sku
+        self.total = total
         self.totalTax = totalTax
     }
 }

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+
+/// Represents a computed summary of refunded products
+///
+public class OrderItemRefundSummary {
+    public let name: String
+    public let productID: Int64
+    public let variationID: Int64
+    public var quantity: Decimal
+
+    /// Price is a currency.
+    /// When handling currencies, `NSDecimalNumber` is a powerhouse
+    /// for localization and string-to-number conversions.
+    /// `Decimal` doesn't yet have all of the `NSDecimalNumber` APIs.
+    ///
+    public let price: NSDecimalNumber
+    public let sku: String?
+    public var totalTax: NSDecimalNumber?
+
+    /// Designated initializer.
+    ///
+    init(name: String, productID: Int64, variationID: Int64, quantity: Decimal, price: NSDecimalNumber, sku: String?, totalTax: NSDecimalNumber?) {
+        self.name = name
+        self.productID = productID
+        self.variationID = variationID
+        self.quantity = quantity
+        self.price = price
+        self.sku = sku
+        self.totalTax = totalTax
+    }
+}
+
+
+// MARK: - Comparable Conformance
+//
+extension OrderItemRefundSummary: Comparable {
+    public static func == (lhs: OrderItemRefundSummary, rhs: OrderItemRefundSummary) -> Bool {
+        return lhs.productID == rhs.productID &&
+            lhs.variationID == rhs.variationID
+    }
+
+    public static func < (lhs: OrderItemRefundSummary, rhs: OrderItemRefundSummary) -> Bool {
+        return lhs.productID < rhs.productID ||
+            (lhs.productID == rhs.productID && lhs.name < rhs.name)
+    }
+}
+
+
+// MARK: - Hashable Conformance
+//
+extension OrderItemRefundSummary: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(productID)
+        hasher.combine(variationID)
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummary.swift
@@ -29,8 +29,7 @@ final class OrderItemRefundSummary {
          quantity: Decimal,
          sku: String?,
          total: NSDecimalNumber,
-         totalTax: NSDecimalNumber?)
-    {
+         totalTax: NSDecimalNumber?) {
         self.productID = productID
         self.variationID = variationID
         self.name = name

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummaryViewModel.swift
@@ -16,7 +16,7 @@ struct OrderItemRefundSummaryViewModel {
 
     /// Yosemite.Order.currency
     ///
-    let currency: String
+    let currencyCode: String
 
     /// Item's Name
     ///
@@ -36,21 +36,21 @@ struct OrderItemRefundSummaryViewModel {
 
     /// Item's Total
     ///
-    var total: NSDecimalNumber {
-        let itemQuantity = NSDecimalNumber(decimal: abs(item.quantity))
-        return item.price.multiplying(by: itemQuantity)
+    var total: String {
+        let positiveTotal = item.total.abs()
+        return currencyFormatter.formatAmount(positiveTotal, with: currencyCode) ?? String()
     }
 
-    /// Item's Price
+    /// Item's Price Summary
+    /// Example: $140 ($35 x 4)
     /// Always return a string, even for zero amounts.
     ///
     var price: String {
-        let itemTotal = currencyFormatter.formatAmount(total, with: currency) ?? String()
-        let itemPrice = currencyFormatter.formatAmount(item.price, with: currency) ?? String()
+        let itemPrice = currencyFormatter.formatAmount(item.price, with: currencyCode) ?? String()
 
         let priceTemplate = NSLocalizedString("%@ (%@ x %@)",
                                               comment: "<item total> (<item individual price> multipled by <quantity>)")
-        let priceText = String.localizedStringWithFormat(priceTemplate, itemTotal, itemPrice, quantity)
+        let priceText = String.localizedStringWithFormat(priceTemplate, total, itemPrice, quantity)
 
         return priceText
     }
@@ -81,11 +81,11 @@ struct OrderItemRefundSummaryViewModel {
     /// Designated initializer
     ///
     init(item: OrderItemRefundSummary,
-         currency: String,
+         currencyCode: String,
          formatter: CurrencyFormatter = CurrencyFormatter(),
          product: Product? = nil) {
         self.item = item
-        self.currency = currency
+        self.currencyCode = currencyCode
         self.currencyFormatter = formatter
         self.product = product
     }

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummaryViewModel.swift
@@ -55,27 +55,6 @@ struct OrderItemRefundSummaryViewModel {
         return priceText
     }
 
-    /// Item's Tax
-    /// Return $0.00 if there is no tax.
-    ///
-    var tax: String {
-        guard let tax = item.totalTax else {
-            let totalTax = currencyFormatter.formatAmount(NSDecimalNumber.zero, with: currency) ?? String()
-            let taxTemplate = NSLocalizedString("Tax: %@",
-                                                comment: "Tax label for total taxes line, followed by the tax amount.")
-            let taxText = String.localizedStringWithFormat(taxTemplate, totalTax)
-
-            return taxText
-        }
-
-        let totalTax = currencyFormatter.formatAmount(tax, with: currency) ?? String()
-        let taxTemplate = NSLocalizedString("Tax: %@",
-                                            comment: "Tax label for total taxes line, followed by the tax amount.")
-        let taxText = String.localizedStringWithFormat(taxTemplate, totalTax)
-
-        return taxText
-    }
-
     /// Item's SKU
     ///
     var sku: String? {
@@ -99,12 +78,8 @@ struct OrderItemRefundSummaryViewModel {
         return URL(string: productImageURLString)
     }
 
-    /// Check to see if the product has an image URL.
+    /// Designated initializer
     ///
-    var productHasImage: Bool {
-        return imageURL != nil
-    }
-
     init(item: OrderItemRefundSummary,
          currency: String,
          formatter: CurrencyFormatter = CurrencyFormatter(),

--- a/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/OrderItemRefundSummaryViewModel.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Yosemite
+
+
+// MARK: - OrderItemRefundSummary View Model
+//
+struct OrderItemRefundSummaryViewModel {
+
+    /// Yosemite.OrderItemRefundSummary
+    ///
+    let item: OrderItemRefundSummary
+
+    /// Yosemite.Product?
+    ///
+    var product: Product?
+
+    /// Yosemite.Order.currency
+    ///
+    let currency: String
+
+    /// Item's Name
+    ///
+    var name: String {
+        return item.name
+    }
+
+    /// Currency Formatter
+    ///
+    let currencyFormatter: CurrencyFormatter
+
+    /// Item's Quantity
+    ///
+    var quantity: String {
+        return abs(item.quantity).description
+    }
+
+    /// Item's Total
+    ///
+    var total: NSDecimalNumber {
+        let itemQuantity = NSDecimalNumber(decimal: abs(item.quantity))
+        return item.price.multiplying(by: itemQuantity)
+    }
+
+    /// Item's Price
+    /// Always return a string, even for zero amounts.
+    ///
+    var price: String {
+        let itemTotal = currencyFormatter.formatAmount(total, with: currency) ?? String()
+        let itemPrice = currencyFormatter.formatAmount(item.price, with: currency) ?? String()
+
+        let priceTemplate = NSLocalizedString("%@ (%@ x %@)",
+                                              comment: "<item total> (<item individual price> multipled by <quantity>)")
+        let priceText = String.localizedStringWithFormat(priceTemplate, itemTotal, itemPrice, quantity)
+
+        return priceText
+    }
+
+    /// Item's Tax
+    /// Return $0.00 if there is no tax.
+    ///
+    var tax: String {
+        guard let tax = item.totalTax else {
+            let totalTax = currencyFormatter.formatAmount(NSDecimalNumber.zero, with: currency) ?? String()
+            let taxTemplate = NSLocalizedString("Tax: %@",
+                                                comment: "Tax label for total taxes line, followed by the tax amount.")
+            let taxText = String.localizedStringWithFormat(taxTemplate, totalTax)
+
+            return taxText
+        }
+
+        let totalTax = currencyFormatter.formatAmount(tax, with: currency) ?? String()
+        let taxTemplate = NSLocalizedString("Tax: %@",
+                                            comment: "Tax label for total taxes line, followed by the tax amount.")
+        let taxText = String.localizedStringWithFormat(taxTemplate, totalTax)
+
+        return taxText
+    }
+
+    /// Item's SKU
+    ///
+    var sku: String? {
+        guard let sku = item.sku, sku.isEmpty == false else {
+            return nil
+        }
+
+        let skuTemplate = NSLocalizedString("SKU: %@", comment: "SKU label, followed by the SKU")
+        let skuText = String.localizedStringWithFormat(skuTemplate, sku)
+
+        return skuText
+    }
+
+    /// Grab the first available image for a product.
+    ///
+    var imageURL: URL? {
+        guard let productImageURLString = product?.images.first?.src else {
+            return nil
+        }
+
+        return URL(string: productImageURLString)
+    }
+
+    /// Check to see if the product has an image URL.
+    ///
+    var productHasImage: Bool {
+        return imageURL != nil
+    }
+
+    init(item: OrderItemRefundSummary,
+         currency: String,
+         formatter: CurrencyFormatter = CurrencyFormatter(),
+         product: Product? = nil) {
+        self.item = item
+        self.currency = currency
+        self.currencyFormatter = formatter
+        self.product = product
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
@@ -114,7 +114,7 @@ private extension RefundedProductsDataSource {
         let item = items[indexPath.row]
         let product = lookUpProduct(by: item.productID)
         let itemViewModel = OrderItemRefundSummaryViewModel(item: item,
-                                                            currency: order.currency,
+                                                            currencyCode: order.currency,
                                                             product: product)
         let imageService = ServiceLocator.imageService
 
@@ -145,6 +145,25 @@ extension RefundedProductsDataSource {
         }()
 
         sections = [refundedProducts].compactMap { $0 }
+    }
+
+    /// Handle taps on cells
+    ///
+    func tableView(_ tableView: UITableView,
+                   in viewController: UIViewController,
+                   didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch sections[indexPath.section].rows[indexPath.row] {
+        case .orderItemRefunded:
+            let item = items[indexPath.row]
+            let productID = item.variationID == 0 ? item.productID : item.variationID
+            let loaderViewController = ProductLoaderViewController(productID: productID,
+                                                                   siteID: order.siteID,
+                                                                   currency: order.currency)
+            let navController = WooNavigationController(rootViewController: loaderViewController)
+            viewController.present(navController, animated: true, completion: nil)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
@@ -9,7 +9,7 @@ import Yosemite
 final class RefundedProductsDataSource: NSObject {
     /// Refunds
     ///
-    private(set) var items: [OrderItemRefundSummary]
+    private var items: [OrderItemRefundSummary]
 
     /// Order
     ///

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
@@ -9,7 +9,7 @@ import Yosemite
 final class RefundedProductsDataSource: NSObject {
     /// Refunds
     ///
-    private(set) var items: [OrderItemRefund]
+    private(set) var items: [OrderItemRefundSummary]
 
     /// Order
     ///
@@ -21,7 +21,7 @@ final class RefundedProductsDataSource: NSObject {
 
     /// Designated initializer.
     ///
-    init(order: Order, items: [OrderItemRefund]) {
+    init(order: Order, items: [OrderItemRefundSummary]) {
         self.order = order
         self.items = items
     }
@@ -102,7 +102,7 @@ private extension RefundedProductsDataSource {
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
         case let cell as ProductDetailsTableViewCell where row == .orderItemRefunded:
-            configureOrderItemRefund(cell, at: indexPath)
+            configureOrderItemRefundSummary(cell, at: indexPath)
         default:
             fatalError("Unidentified customer info row type")
         }
@@ -110,12 +110,12 @@ private extension RefundedProductsDataSource {
 
     /// Setup: Refunded product details cell
     ///
-    func configureOrderItemRefund(_ cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
+    func configureOrderItemRefundSummary(_ cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
         let item = items[indexPath.row]
         let product = lookUpProduct(by: item.productID)
-        let itemViewModel = OrderItemRefundViewModel(item: item,
-                                                     currency: order.currency,
-                                                     product: product)
+        let itemViewModel = OrderItemRefundSummaryViewModel(item: item,
+                                                            currency: order.currency,
+                                                            product: product)
         let imageService = ServiceLocator.imageService
 
         cell.selectionStyle = .default

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
@@ -152,18 +152,8 @@ extension RefundedProductsDataSource {
     func tableView(_ tableView: UITableView,
                    in viewController: UIViewController,
                    didSelectRowAt indexPath: IndexPath) {
+        // This tableview shouldn't have any actions, so deselect the row.
         tableView.deselectRow(at: indexPath, animated: true)
-
-        switch sections[indexPath.section].rows[indexPath.row] {
-        case .orderItemRefunded:
-            let item = items[indexPath.row]
-            let productID = item.variationID == 0 ? item.productID : item.variationID
-            let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: order.siteID,
-                                                                   currency: order.currency)
-            let navController = WooNavigationController(rootViewController: loaderViewController)
-            viewController.present(navController, animated: true, completion: nil)
-        }
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsDataSource.swift
@@ -146,15 +146,6 @@ extension RefundedProductsDataSource {
 
         sections = [refundedProducts].compactMap { $0 }
     }
-
-    /// Handle taps on cells
-    ///
-    func tableView(_ tableView: UITableView,
-                   in viewController: UIViewController,
-                   didSelectRowAt indexPath: IndexPath) {
-        // This tableview shouldn't have any actions, so deselect the row.
-        tableView.deselectRow(at: indexPath, animated: true)
-    }
 }
 
 

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -131,24 +131,4 @@ extension RefundedProductsViewModel {
     func reloadSections() {
         dataSource.reloadSections()
     }
-
-    /// Handle taps on cells
-    ///
-    func tableView(_ tableView: UITableView,
-                   in viewController: UIViewController,
-                   didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-
-        switch dataSource.sections[indexPath.section].rows[indexPath.row] {
-
-        case .orderItemRefunded:
-            let item = summedItems[indexPath.row]
-            let productID = item.variationID == 0 ? item.productID : item.variationID
-            let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: order.siteID,
-                                                                   currency: order.currency)
-            let navController = WooNavigationController(rootViewController: loaderViewController)
-            viewController.present(navController, animated: true, completion: nil)
-        }
-    }
 }

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -64,7 +64,8 @@ final class RefundedProductsViewModel {
     /// The datasource that will be used to render the Refunded Products screen.
     ///
     private(set) lazy var dataSource: RefundedProductsDataSource = {
-        return RefundedProductsDataSource(order: self.order, items: self.summedItems)
+        let sortedItems = summedItems.sorted()
+        return RefundedProductsDataSource(order: self.order, items: sortedItems)
     }()
 
     /// Designated initializer.

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -41,15 +41,21 @@ final class RefundedProductsViewModel {
             let totalTax = items
                 .compactMap( { currency.convertToDecimal(from: $0.totalTax) } )
                 .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
+            // Sum the total
+            let total = items
+                .compactMap( { currency.convertToDecimal(from: $0.total) } )
+                .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
             return OrderItemRefundSummary(
-                name: item.name,
                 productID: item.productID,
                 variationID: item.variationID,
-                quantity: totalQuantity,
+                name: item.name,
                 price: item.price,
+                quantity: totalQuantity,
                 sku: item.sku,
-                totalTax: totalTax)
+                total: total,
+                totalTax: totalTax
+            )
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -36,27 +36,32 @@ final class RefundedProductsViewModel {
         var variations = [OrderItemRefundSummary]()
 
         for productID in uniqueProductIDs {
-            var repeatedItems = [OrderItemRefund]()
+            var productGroup = [OrderItemRefund]()
             var variationIDs = [Int64]()
+
+            // Get every item that has the same productID
             for item in sorted {
                 if item.productID == productID {
-                    repeatedItems.append(item)
+                    productGroup.append(item)
                     variationIDs.append(item.variationID)
                 }
             }
 
-            for repeatedItem in repeatedItems {
+            for repeatedItem in productGroup {
                 let tax = currency.convertToDecimal(from: repeatedItem.totalTax)
 
+                // See if a product with a variation is in the varitions array.
                 let hasVariant = variations.contains { element in
-                    if element.variationID == repeatedItem.variationID {
+                    if  element.productID == repeatedItem.productID &&
+                        element.variationID == repeatedItem.variationID {
                         return true
                     }
                     return false
                 }
 
                 if hasVariant {
-                    let variant = variations.first(where: { $0.variationID == repeatedItem.variationID })
+                    // Edit an existing variable product
+                    let variant = variations.first(where: { $0.productID == repeatedItem.productID && $0.variationID == repeatedItem.variationID })
                     let tax = currency.convertToDecimal(from: repeatedItem.totalTax)
                     variant?.quantity += repeatedItem.quantity
 
@@ -66,6 +71,7 @@ final class RefundedProductsViewModel {
                         }
                     }
                 } else {
+                    // Make a new variable product
                     let variant = OrderItemRefundSummary(name: repeatedItem.name,
                                                          productID: repeatedItem.productID,
                                                          variationID: repeatedItem.variationID,

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -23,11 +23,9 @@ final class RefundedProductsViewModel {
         let currency = CurrencyFormatter()
 
         let grouped = Dictionary(grouping: items) { (item) in
-            // This needs to be hashable so a tuple won't do it
-            // I doubt this would become a performance issue, but it could be replaced
-            // by a hashable struct
-            return "\(item.productID)-\(item.variationID)"
+            return item.hashValue
         }
+
         return grouped.compactMap { (_, items) in
             // Here we iterate over each group's items
 

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -37,11 +37,11 @@ final class RefundedProductsViewModel {
 
             // Sum the quantities
             let totalQuantity = items.sum(\.quantity)
-            // Sum the refunded amount
+            // Sum the total taxes refunded
             let totalTax = items
                 .compactMap( { currency.convertToDecimal(from: $0.totalTax) } )
                 .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
-            // Sum the total
+            // Sum the refunded amount
             let total = items
                 .compactMap( { currency.convertToDecimal(from: $0.total) } )
                 .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -15,13 +15,15 @@ final class RefundedProductsViewModel {
 
     /// Condense order items into summarized data
     ///
-    var summedItems: [OrderItemRefundSummary] {
-        /// OrderItemRefund.orderItemID isn't useful for finding duplicates here,
-        /// because multiple refunds cause orderItemIDs to be unique.
+    private var summedItems: [OrderItemRefundSummary] {
+        /// OrderItemRefund.orderItemID isn't useful for finding duplicates in
+        /// items because multiple refunds cause orderItemIDs to be unique.
         /// Instead, we need to find duplicate *Products*.
 
         let currency = CurrencyFormatter()
-
+        // Creates an array of dictionaries, with the hash value as the key.
+        // Example: [hashValue: [item, item], hashvalue: [item]]
+        // Since dictionary keys are unique, this eliminates the duplicate `OrderItemRefund`s.
         let grouped = Dictionary(grouping: items) { (item) in
             return item.hashValue
         }

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -11,7 +11,7 @@ final class RefundedProductsViewModel {
 
     /// Array of all refunded items from every refund.
     ///
-    private(set) var items: [OrderItemRefund]
+    private var items: [OrderItemRefund]
 
     /// Condense order items into summarized data
     ///
@@ -37,20 +37,18 @@ final class RefundedProductsViewModel {
 
         for productID in uniqueProductIDs {
             var productGroup = [OrderItemRefund]()
-            var variationIDs = [Int64]()
 
             // Get every item that has the same productID
             for item in sorted {
                 if item.productID == productID {
                     productGroup.append(item)
-                    variationIDs.append(item.variationID)
                 }
             }
 
             for repeatedItem in productGroup {
                 let tax = currency.convertToDecimal(from: repeatedItem.totalTax)
 
-                // See if a product with a variation is in the varitions array.
+                // See if a product with a variation is in the variations array.
                 let hasVariant = variations.contains { element in
                     if  element.productID == repeatedItem.productID &&
                         element.variationID == repeatedItem.variationID {

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -36,9 +36,7 @@ final class RefundedProductsViewModel {
             }
 
             // Sum the quantities
-            let totalQuantity = items
-                .map( { $0.quantity } )
-                .reduce(0, +)
+            let totalQuantity = items.sum(\.quantity)
             // Sum the refunded amount
             let totalTax = items
                 .compactMap( { currency.convertToDecimal(from: $0.totalTax) } )

--- a/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Refunds/RefundedProductsViewModel.swift
@@ -39,11 +39,11 @@ final class RefundedProductsViewModel {
             let totalQuantity = items.sum(\.quantity)
             // Sum the total taxes refunded
             let totalTax = items
-                .compactMap( { currency.convertToDecimal(from: $0.totalTax) } )
+                .compactMap({ currency.convertToDecimal(from: $0.totalTax) })
                 .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
             // Sum the refunded amount
             let total = items
-                .compactMap( { currency.convertToDecimal(from: $0.total) } )
+                .compactMap({ currency.convertToDecimal(from: $0.total) })
                 .reduce(NSDecimalNumber(value: 0), { $0.adding($1) })
 
             return OrderItemRefundSummary(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
@@ -73,6 +73,7 @@ private extension RefundedProductsViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.allowsSelection = false
 
         tableView.dataSource = viewModel.dataSource
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
@@ -151,12 +151,6 @@ private extension RefundedProductsViewController {
 // MARK: - UITableViewDelegate Conformance
 //
 extension RefundedProductsViewController: UITableViewDelegate {
-
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        viewModel.tableView(tableView, in: self, didSelectRowAt: indexPath)
-    }
-
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -172,4 +172,20 @@ extension ProductDetailsTableViewCell {
         price = item.price
         sku = item.sku
     }
+
+    /// Configure a summary of all refunded products (with variants, if any)
+    ///
+    func configure(item: OrderItemRefundSummaryViewModel, imageService: ImageService) {
+
+        imageService.downloadAndCacheImageForImageView(productImageView,
+                                                       with: item.imageURL?.absoluteString,
+                                                       placeholder: .productPlaceholderImage,
+                                                       progressBlock: nil,
+                                                       completion: nil)
+
+        name = item.name
+        quantity = item.quantity
+        price = item.price
+        sku = item.sku
+    }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -458,6 +458,8 @@
 		CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FC723C3D2D4002BEC1C /* RefundedProductsDataSource.swift */; };
 		CE2A9FCF23C4F2C8002BEC1C /* RefundedProductsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */; };
 		CE2A9FD023C4F2C8002BEC1C /* RefundedProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */; };
+		CE2A9FD423C67A8D002BEC1C /* OrderItemRefundSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FD323C67A8D002BEC1C /* OrderItemRefundSummary.swift */; };
+		CE2A9FD623C68164002BEC1C /* OrderItemRefundSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FD523C68164002BEC1C /* OrderItemRefundSummaryViewModel.swift */; };
 		CE32B10B20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */; };
 		CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */; };
 		CE32B11520BF8779006FBCF4 /* FulfillButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32B11320BF8779006FBCF4 /* FulfillButtonTableViewCell.swift */; };
@@ -1082,6 +1084,8 @@
 		CE2A9FC723C3D2D4002BEC1C /* RefundedProductsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundedProductsDataSource.swift; sourceTree = "<group>"; };
 		CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RefundedProductsViewController.xib; sourceTree = "<group>"; };
 		CE2A9FCE23C4F2C8002BEC1C /* RefundedProductsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefundedProductsViewController.swift; sourceTree = "<group>"; };
+		CE2A9FD323C67A8D002BEC1C /* OrderItemRefundSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundSummary.swift; sourceTree = "<group>"; };
+		CE2A9FD523C68164002BEC1C /* OrderItemRefundSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderItemRefundSummaryViewModel.swift; sourceTree = "<group>"; };
 		CE32B10A20BEDE05006FBCF4 /* TwoColumnSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TwoColumnSectionHeaderView.xib; sourceTree = "<group>"; };
 		CE32B10C20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnSectionHeaderView.swift; sourceTree = "<group>"; };
 		CE32B11320BF8779006FBCF4 /* FulfillButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FulfillButtonTableViewCell.swift; sourceTree = "<group>"; };
@@ -2531,6 +2535,8 @@
 				CE7E780D23AAE96F00BC5C54 /* OrderItemRefundViewModel.swift */,
 				CE2A9FC523BFFADE002BEC1C /* RefundedProductsViewModel.swift */,
 				CE2A9FC723C3D2D4002BEC1C /* RefundedProductsDataSource.swift */,
+				CE2A9FD323C67A8D002BEC1C /* OrderItemRefundSummary.swift */,
+				CE2A9FD523C68164002BEC1C /* OrderItemRefundSummaryViewModel.swift */,
 			);
 			path = Refunds;
 			sourceTree = "<group>";
@@ -3418,6 +3424,7 @@
 				74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
+				CE2A9FD623C68164002BEC1C /* OrderItemRefundSummaryViewModel.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
@@ -3459,6 +3466,7 @@
 				020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */,
 				0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */,
 				024DF31423742B7A006658FE /* AztecUnderlineFormatBarCommand.swift in Sources */,
+				CE2A9FD423C67A8D002BEC1C /* OrderItemRefundSummary.swift in Sources */,
 				CE32B10D20BEDE1C006FBCF4 /* TwoColumnSectionHeaderView.swift in Sources */,
 				D8D15F85230A18AB00D48B3F /* Analytics.swift in Sources */,
 				B57B678E21078C5400AF8905 /* OrderItemViewModel.swift in Sources */,


### PR DESCRIPTION
Part 1 of #1717.

So the first step is to get it working. I can successfully smush the data together to create aggregate product cells. It's now readable enough to start making changes 😀 

cc: @koke @jleandroperez (if can spare the time)

### The problem in pictures

The data provided by the API makes the Refunded Products table render like this:
<img src="https://user-images.githubusercontent.com/1062444/72114558-9eca4600-3309-11ea-9512-49853fa3c409.png" width="350" />

The aggregate data, which is what the user wants to see, should render like this:
<img src="https://user-images.githubusercontent.com/1062444/72114605-c7ead680-3309-11ea-9be6-e86dec1eaaec.png" width="350" />

### Changes
- I added a new class, `OrderItemRefundSummary`. It's based off of the struct `OrderItemRefund`.
- The `OrderItemRefundSummaryViewModel` is used for configuring the `ProductDetailsTableViewCell`.
- [summedItems](https://github.com/woocommerce/woocommerce-ios/pull/1720/files#diff-ef4a45e82a4b0b7d3eae5834c6f6d07cR18) is where the calculations happen. 

### To Test

The goal is to create multiple refunds with several of the same product type(s) in the refunds.

1. On your test site, have an order with multiple product types. Make sure to note the Order Number.
2. Find the order and "refund by item".
3. Make another refund. Refund a couple more of the same product, and add another product to make it interesting.
4. Make another refund. Refund a couple more of the same product(s) or refund a different item by itself.
5. Check out the develop branch and navigate in the app to: Orders tab > Order Number (Order Details screen). Scroll down a bit until you see the "N Items" cell. [It looks like this](https://user-images.githubusercontent.com/1062444/72114781-45aee200-330a-11ea-8774-cd437ae49d6a.png). Tap the cell to navigate to the Refunded Products screen. Notice that there are multiple cells.
6. Check out this branch. Navigate to the same location. The cells should now be summarized.

### Concerns
I'm still learning about Big O notation. If I understand it right, what I have is approaching (has arrived at?) a quadratic time complexity. Considering I'll have to re-use this algorithm in the Order Details page, that's not good.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
