### PR TITLE
Order Detail: hide shipping address for virtual products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,12 +1,12 @@
 3.4
 -----
- 
 - bugfix: on the Order Details screen, the product quantity title in the 2-column header view aligns to the right now
 - bugfix: tapping on a new Order push notification, it used to go to the Reviews tab. Now it should go to the new Order screen
 - bugfix: on the Products tab, if tapping on a Product and then switching stores, the old Product details used to remain on the Products tab. Now the Product list is always shown on the Products tab after switching stores.
 - Dark mode: colors are updated up to design for the navigation bar, tab bar, Fulfill Order > add tracking icon, Review Details > product link icon.
 - bugfix/enhancement: on the Products tab, if there are no Products the "Work In Progress" banner is shown with an image placeholder below now.
 - bugfix: the deleted Product Variations should not show up after syncing anymore.
+- bugfix: now the shipping address in the Order Detail is hidden if the order contains only virtual products
 
 3.3
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -576,7 +576,7 @@ extension OrderDetailsDataSource {
             }
 
             let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
-                return self.items.first(where: { $0.productID == product.productID}) != nil
+                return items.first(where: { $0.productID == product.productID}) != nil
             }.allSatisfy { $0.virtual == true }
 
             if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -574,7 +574,12 @@ extension OrderDetailsDataSource {
             if customerNote.isEmpty == false {
                 rows.append(.customerNote)
             }
-            if order.shippingAddress != nil {
+
+            let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
+                return self.items.first(where: { $0.productID == product.productID}) != nil
+            }.allSatisfy { $0.virtual == true }
+
+            if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {
                 rows.append(.shippingAddress)
             }
             if shippingLines.count > 0 {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -630,24 +630,25 @@ private extension FulfillViewController {
             return Section(title: title, secondaryTitle: nil, rows: [row])
         }()
 
-        let address: Section = {
+        let address: Section? = {
             var rows: [Row] = []
 
             if shippingLines.count > 0 {
                 rows.append(.shippingMethod)
             }
 
+            let orderContainsOnlyVirtualProducts = self.products?.filter { (product) -> Bool in
+                return self.order.items.first(where: { $0.productID == product.productID}) != nil
+            }.allSatisfy { $0.virtual == true }
+
             let title = NSLocalizedString("Customer Information", comment: "Section title for the customer's billing and shipping address")
-            if let shippingAddress = order.shippingAddress {
+            if let shippingAddress = order.shippingAddress, orderContainsOnlyVirtualProducts == false {
                 let row = Row.address(shipping: shippingAddress)
                 rows.insert(row, at: 0)
                 return Section(title: title, secondaryTitle: nil, rows: rows)
             }
 
-            let row = Row.address(shipping: order.billingAddress)
-            rows.insert(row, at: 0)
-
-            return Section(title: title, secondaryTitle: nil, rows: rows)
+            return nil
         }()
 
         let tracking: Section? = {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -637,8 +637,8 @@ private extension FulfillViewController {
                 rows.append(.shippingMethod)
             }
 
-            let orderContainsOnlyVirtualProducts = self.products?.filter { (product) -> Bool in
-                return self.order.items.first(where: { $0.productID == product.productID}) != nil
+            let orderContainsOnlyVirtualProducts = products?.filter { (product) -> Bool in
+                return order.items.first(where: { $0.productID == product.productID}) != nil
             }.allSatisfy { $0.virtual == true }
 
             let title = NSLocalizedString("Customer Information", comment: "Section title for the customer's billing and shipping address")


### PR DESCRIPTION
Fixes #705 by hiding the shipping address for an order, if all the products in the order are virtual. This change takes place in both Order Detail and Order Fulfill screens.

## Testing
1) Open one order detail with only virtual products, and make sure there are not shipping details showed.
2) Open one order detail with both virtual and non-virtual products, and make sure shipping details are shown.
3) Open one order detail with only non-virtual products, and make sure shipping details are shown.

## Screenshots
| Order with only virtual products             |  Order Fulfill with only virtual products |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-10 at 16 57 28](https://user-images.githubusercontent.com/495617/72167430-6723d280-33cb-11ea-991d-0e2331bd2cc5.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-10 at 16 57 32](https://user-images.githubusercontent.com/495617/72167443-69862c80-33cb-11ea-8eca-604f27de1111.png)



| Order with both virtual and non-virtual             |  Order Fulfill with both virtual and non-virtual |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-10 at 16 57 44](https://user-images.githubusercontent.com/495617/72167454-6d19b380-33cb-11ea-906a-10834c10f614.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-10 at 16 57 47](https://user-images.githubusercontent.com/495617/72167459-6ee37700-33cb-11ea-9d1d-5728e26c008a.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
