### PR TITLE
Edit Product: Product image UI with action to delete the image

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.swift
@@ -1,0 +1,112 @@
+import UIKit
+import Yosemite
+
+/// Displays one Product image with a delete action.
+///
+final class ProductImageViewController: UIViewController {
+    typealias Deletion = (_ productImage: ProductImage) -> Void
+
+    @IBOutlet private weak var imageView: UIImageView!
+
+    private let productImage: ProductImage
+    private let imageService: ImageService
+    private let onDeletion: Deletion
+
+    private var previousBarTintColor: UIColor?
+
+    init(productImage: ProductImage,
+         imageService: ImageService = ServiceLocator.imageService,
+         onDeletion: @escaping Deletion) {
+        self.productImage = productImage
+        self.imageService = imageService
+        self.onDeletion = onDeletion
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureMainView()
+        configureNavigation()
+        configureImageView()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        previousBarTintColor = navigationController?.navigationBar.barTintColor
+        navigationController?.navigationBar.barTintColor = .black
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        navigationController?.navigationBar.barTintColor = previousBarTintColor
+        super.viewWillDisappear(animated)
+    }
+}
+
+private extension ProductImageViewController {
+    func configureMainView() {
+        view.backgroundColor = .black
+    }
+
+    func configureNavigation() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: .trashImage,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(deleteProductImage))
+    }
+
+    func configureImageView() {
+        imageView.contentMode = Constants.imageContentMode
+        imageView.clipsToBounds = Constants.clipToBounds
+
+        imageService.downloadAndCacheImageForImageView(imageView,
+                                                       with: productImage.src,
+                                                       placeholder: .productImage,
+                                                       progressBlock: nil,
+                                                       completion: nil)
+    }
+}
+
+private extension ProductImageViewController {
+    @objc func deleteProductImage() {
+        let title = NSLocalizedString("Remove Image",
+                                      comment: "Title on the alert when the user taps to delete a Product image")
+        let message = NSLocalizedString("Are you sure you want to remove this image?",
+                                        comment: "Message on the alert when the user taps to delete a Product image")
+        let alert = UIAlertController(title: title,
+                                      message: message,
+                                      preferredStyle: .alert)
+        let cancel = UIAlertAction(title: NSLocalizedString(
+            "Cancel",
+            comment: "Dismiss button on the alert when the user taps to delete a Product image"
+        ), style: .cancel, handler: nil)
+
+        let delete = UIAlertAction(title: NSLocalizedString(
+            "Remove",
+            comment: "Confirm button on the alert when the user taps to delete a Product image"
+        ), style: .destructive) { [weak self] _ in
+            guard let self = self else {
+                return
+            }
+            self.onDeletion(self.productImage)
+        }
+
+        alert.addAction(cancel)
+        alert.addAction(delete)
+
+        present(alert, animated: true, completion: nil)
+    }
+}
+
+/// Constants
+///
+private extension ProductImageViewController {
+    enum Constants {
+        static let clipToBounds = true
+        static let imageContentMode = UIView.ContentMode.scaleAspectFit
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.swift
@@ -80,6 +80,7 @@ private extension ProductImageViewController {
         let alert = UIAlertController(title: title,
                                       message: message,
                                       preferredStyle: .alert)
+        alert.view.tintColor = .text
         let cancel = UIAlertAction(title: NSLocalizedString(
             "Cancel",
             comment: "Dismiss button on the alert when the user taps to delete a Product image"

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.xib
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductImageViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="imageView" destination="rWd-5C-mWI" id="pJP-EO-gSZ"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rWd-5C-mWI">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                </imageView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="rWd-5C-mWI" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="E7f-rN-0kv"/>
+                <constraint firstItem="rWd-5C-mWI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ktp-Eh-g3G"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="rWd-5C-mWI" secondAttribute="bottom" id="nr5-Ha-z1F"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="rWd-5C-mWI" secondAttribute="trailing" id="s5F-Bs-Wi4"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="139" y="93"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -8,10 +8,14 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
     private var productImages: [ProductImage]
 
     private let imageService: ImageService
+    private let onDeletion: ProductImageViewController.Deletion
 
-    init(images: [ProductImage], imageService: ImageService = ServiceLocator.imageService) {
+    init(images: [ProductImage],
+         imageService: ImageService = ServiceLocator.imageService,
+         onDeletion: @escaping ProductImageViewController.Deletion) {
         self.productImages = images
         self.imageService = imageService
+        self.onDeletion = onDeletion
         let columnLayout = ColumnFlowLayout(
             cellsPerRow: 2,
             minimumInteritemSpacing: 16,
@@ -72,5 +76,15 @@ extension ProductImagesCollectionViewController {
         }
 
         return cell
+    }
+}
+
+// MARK: UICollectionViewDelegate
+//
+extension ProductImagesCollectionViewController {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let productImage = productImages[indexPath.row]
+        let productImageViewController = ProductImageViewController(productImage: productImage, onDeletion: onDeletion)
+        navigationController?.pushViewController(productImageViewController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -20,7 +20,8 @@ final class ProductImagesViewController: UIViewController {
 
     // Child view controller.
     private lazy var imagesViewController: ProductImagesCollectionViewController = {
-        let viewController = ProductImagesCollectionViewController(images: productImages)
+        let viewController = ProductImagesCollectionViewController(images: productImages,
+                                                                   onDeletion: onDeletion)
         return viewController
     }()
 
@@ -41,6 +42,7 @@ final class ProductImagesViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        configureMainView()
         configureNavigation()
         configureAddButton()
         configureAddButtonBottomBorderView()
@@ -51,10 +53,16 @@ final class ProductImagesViewController: UIViewController {
 // MARK: - UI configurations
 //
 private extension ProductImagesViewController {
+    func configureMainView() {
+        view.backgroundColor = .basicBackground
+    }
+
     func configureNavigation() {
         title = NSLocalizedString("Photos", comment: "Product images (Product images page title)")
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeEditing))
+
+        removeNavigationBackBarButtonText()
     }
 
     func configureAddButton() {
@@ -89,5 +97,10 @@ private extension ProductImagesViewController {
 
     @objc func completeEditing() {
         onCompletion(productImages)
+    }
+
+    func onDeletion(productImage: ProductImage) {
+        productImages.removeAll(where: { $0.imageID == productImage.imageID })
+        navigationController?.popViewController(animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -66,7 +66,7 @@ private extension ProductImagesViewController {
     }
 
     func configureAddButton() {
-        addButton.setTitle(NSLocalizedString("ADD PHOTOS", comment: "Action to add photos on the Product images screen"), for: .normal)
+        addButton.setTitle(NSLocalizedString("Add Photos", comment: "Action to add photos on the Product images screen"), for: .normal)
         addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
         addButton.applyPrimaryButtonStyle()
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230534F237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift */; };
 		02305353237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02305350237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift */; };
 		0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230535A2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift */; };
+		02357B2A23CDB3E300147C2B /* ProductImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02357B2823CDB3E300147C2B /* ProductImageViewController.swift */; };
+		02357B2B23CDB3E300147C2B /* ProductImageViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02357B2923CDB3E300147C2B /* ProductImageViewController.xib */; };
 		02396251239948470096F34C /* UIImage+TintColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02396250239948470096F34C /* UIImage+TintColor.swift */; };
 		02404ED82314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */; };
 		02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */; };
@@ -670,6 +672,8 @@
 		0230534F237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecHorizontalRulerFormatBarCommand.swift; sourceTree = "<group>"; };
 		02305350237454C700487A64 /* AztecInsertMoreFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecInsertMoreFormatBarCommand.swift; sourceTree = "<group>"; };
 		0230535A2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecSourceCodeFormatBarCommand.swift; sourceTree = "<group>"; };
+		02357B2823CDB3E300147C2B /* ProductImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageViewController.swift; sourceTree = "<group>"; };
+		02357B2923CDB3E300147C2B /* ProductImageViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImageViewController.xib; sourceTree = "<group>"; };
 		02396250239948470096F34C /* UIImage+TintColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+TintColor.swift"; sourceTree = "<group>"; };
 		02404ED72314BF8A00FF1170 /* StatsV3ToV4BannerActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsV3ToV4BannerActionHandler.swift; sourceTree = "<group>"; };
 		02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinator.swift; sourceTree = "<group>"; };
@@ -1506,6 +1510,8 @@
 				0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */,
 				0286B27923C7051F003D784B /* ProductImagesViewController.swift */,
 				0286B27823C7051F003D784B /* ProductImagesViewController.xib */,
+				02357B2823CDB3E300147C2B /* ProductImageViewController.swift */,
+				02357B2923CDB3E300147C2B /* ProductImageViewController.xib */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -2977,6 +2983,7 @@
 				CE21B3E120FFC59700A259D5 /* ProductDetailsTableViewCell.xib in Resources */,
 				CE35F11C2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.xib in Resources */,
 				451A04E72386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib in Resources */,
+				02357B2B23CDB3E300147C2B /* ProductImageViewController.xib in Resources */,
 				CE85FD5320F677770080B73E /* Dashboard.storyboard in Resources */,
 				B56DB3CF2049BFAA00D4AA8E /* Main.storyboard in Resources */,
 				CE21B3D820FE669A00A259D5 /* BasicTableViewCell.xib in Resources */,
@@ -3263,6 +3270,7 @@
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				747AA0892107CEC60047A89B /* AnalyticsProvider.swift in Sources */,
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
+				02357B2A23CDB3E300147C2B /* ProductImageViewController.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,
 				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */,


### PR DESCRIPTION
"fullscreen image with action to delete an image" step for #1713 

## Changes

- Created `ProductImageViewController` with an image view and a delete action
- Implemented Product image delete action, and on tapping a Product image cell

## Testing

Prerequisites: have a Product with more than one image

- Launch the app
- Go to Products tab
- Tap on a Product with more than one image
- Tap the last “+” cell on the images header
- Tap on an image cell to delete
- Tap the trash icon on the navigation bar
- Tap “Cancel” in the alert —> should stay on the image screen
- Tap the trash icon on the navigation bar
- Tap “Remove” in the alert —> should go back to the Product images screen
- Tap “Done”
- Tap “Update” —> the image should be deleted after the Product is updated in the app and wp-admin

## Example screenshots

Product images | Product image | Confirmation alert
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2020-01-14 at 21 26 08](https://user-images.githubusercontent.com/1945542/72348249-f9521080-3714-11ea-9d51-984533f997b0.png) | ![Simulator Screen Shot - iPhone 11 - 2020-01-14 at 21 26 11](https://user-images.githubusercontent.com/1945542/72348250-f9521080-3714-11ea-8596-378c76d2bc34.png) | ![Simulator Screen Shot - iPhone 11 - 2020-01-15 at 14 03 38](https://user-images.githubusercontent.com/1945542/72409262-2d264800-37a0-11ea-8152-b55169f72207.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
