### PR TITLE
Edit Product/Shipping/Price/Inventory Settings: handled back navigation while there are outstanding changes

### DIFF
--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -7,7 +7,8 @@ extension UIAlertController {
 
     /// Save Changes Action Sheet
     ///
-    static func presentSaveChangesActionSheet(viewController: UIViewController, onSave: (() -> Void)?, onDiscard: (() -> Void)?, onCancel: (() -> Void)? = nil) {
+    static func presentSaveChangesActionSheet(viewController: UIViewController, onSave: (() -> Void)?,
+                                              onDiscard: (() -> Void)?, onCancel: (() -> Void)? = nil) {
         let actionSheet = UIAlertController(title: nil, message: ActionSheetStrings.message, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -7,7 +7,7 @@ extension UIAlertController {
 
     /// Save Changes Action Sheet
     ///
-    static func presentSaveChangesActionSheet(viewController: UIViewController, onSave: (() -> Void)?, onDiscard: (() -> Void)?, onCancel: (() -> Void)?) {
+    static func presentSaveChangesActionSheet(viewController: UIViewController, onSave: (() -> Void)?, onDiscard: (() -> Void)?, onCancel: (() -> Void)? = nil) {
         let actionSheet = UIAlertController(title: nil, message: ActionSheetStrings.message, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -1,8 +1,13 @@
 import UIKit
 
-extension UIViewController {
 
-    func presentSaveChangesActionSheet(onSave: (() -> Void)?, onDiscard: (() -> Void)?, onCancel: (() -> Void)?) {
+/// UIAlertController Helpers
+///
+extension UIAlertController {
+
+    /// Save Changes Action Sheet
+    ///
+    static func presentSaveChangesActionSheet(viewController: UIViewController, onSave: (() -> Void)?, onDiscard: (() -> Void)?, onCancel: (() -> Void)?) {
         let actionSheet = UIAlertController(title: nil, message: ActionSheetStrings.message, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
@@ -19,10 +24,10 @@ extension UIViewController {
         }
 
         let popoverController = actionSheet.popoverPresentationController
-        popoverController?.sourceView = view
-        popoverController?.sourceRect = view.bounds
+        popoverController?.sourceView = viewController.view
+        popoverController?.sourceRect = viewController.view.bounds
 
-        present(actionSheet, animated: true)
+        viewController.present(actionSheet, animated: true)
     }
 }
 
@@ -36,3 +41,4 @@ private enum ActionSheetStrings {
     static let cancel = NSLocalizedString("Cancel",
                                           comment: "Button title Cancel in Save Changes Action Sheet")
 }
+

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -41,4 +41,3 @@ private enum ActionSheetStrings {
     static let cancel = NSLocalizedString("Cancel",
                                           comment: "Button title Cancel in Save Changes Action Sheet")
 }
-

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -40,12 +40,14 @@ protocol  UINavigationBarBackButtonHandler {
     /// - Returns: true - don't block，false - block
     func  shouldPopOnBackButton() -> Bool
 }
+
 extension UIViewController: UINavigationBarBackButtonHandler {
     //Do not block the "Back" button action by default, otherwise, override this function in the specified viewcontroller
     @objc func  shouldPopOnBackButton() -> Bool {
         return true
     }
 }
+
 extension UINavigationController: UINavigationBarDelegate {
     public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
         guard let items = navigationBar.items else {
@@ -58,7 +60,7 @@ extension UINavigationController: UINavigationBarDelegate {
 
         var shouldPop = true
 
-        if let vc = topViewController, vc.responds(to: #selector(UIViewController.shouldPopOnBackButton)) {
+        if let vc = topViewController {
             shouldPop = vc.shouldPopOnBackButton()
         }
 

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -29,5 +29,44 @@ extension UINavigationController {
         popToRootViewController(animated: animated)
         CATransaction.commit()
     }
+}
 
+// MARK: - Handle UINavigationBar's 'Back' button action
+//
+protocol  UINavigationBarBackButtonHandler {
+
+    /// Should block the 'Back' button action
+    ///
+    /// - Returns: true - don't block，false - block
+    func  shouldPopOnBackButton() -> Bool
+}
+extension UIViewController: UINavigationBarBackButtonHandler {
+    //Do not block the "Back" button action by default, otherwise, override this function in the specified viewcontroller
+    @objc func  shouldPopOnBackButton() -> Bool {
+        return true
+    }
+}
+extension UINavigationController: UINavigationBarDelegate {
+    public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
+        guard let items = navigationBar.items else {
+            return false
+        }
+
+        if viewControllers.count < items.count {
+            return true
+        }
+
+        var shouldPop = true
+
+        if let vc = topViewController, vc.responds(to: #selector(UIViewController.shouldPopOnBackButton)) {
+            shouldPop = vc.shouldPopOnBackButton()
+        }
+
+        if shouldPop {
+            DispatchQueue.main.async {
+                self.popViewController(animated: true)
+            }
+        }
+        return false
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -232,11 +232,9 @@ extension AztecEditorViewController {
         let editedContent = getHTML()
         if content != editedContent {
             presentBackNavigationActionSheet()
+            return false
         }
-        else {
-            navigationController?.popViewController(animated: true)
-        }
-        return false
+        return true
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -124,7 +124,7 @@ final class AztecEditorViewController: UIViewController, Editor {
         setHTML(content)
 
         // getHTML() from the Rich Text View removes the HTML tags
-        // so we allign the original content to the value of the Rich Text View
+        // so we align the original content to the value of the Rich Text View
         content = getHTML()
 
         refreshPlaceholderVisibility()

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -218,10 +218,34 @@ private extension AztecEditorViewController {
 
 // MARK: - Navigation actions
 //
-private extension AztecEditorViewController {
-    @objc func saveButtonTapped() {
+extension AztecEditorViewController {
+    @objc private func saveButtonTapped() {
         let content = getHTML()
         onContentSave?(content)
+    }
+
+    override func shouldPopOnBackButton() -> Bool {
+        guard viewProperties.showSaveChangesActionSheet == true else {
+            return true
+        }
+
+        let editedContent = getHTML()
+        if content != editedContent {
+            presentBackNavigationActionSheet()
+        }
+        else {
+            navigationController?.popViewController(animated: true)
+        }
+        return false
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
+            self?.saveButtonTapped()
+        }, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        }, onCancel: {
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -6,7 +6,7 @@ import WordPressEditor
 final class AztecEditorViewController: UIViewController, Editor {
     var onContentSave: OnContentSave?
 
-    private let content: String
+    private var content: String
 
     private let viewProperties: EditorViewProperties
 
@@ -122,6 +122,10 @@ final class AztecEditorViewController: UIViewController, Editor {
                                                  placeholderView: placeholderLabel)
 
         setHTML(content)
+
+        // getHTML() from the Rich Text View removes the HTML tags
+        // so we allign the original content to the value of the Rich Text View
+        content = getHTML()
 
         refreshPlaceholderVisibility()
     }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -244,7 +244,6 @@ extension AztecEditorViewController {
             self?.saveButtonTapped()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }, onCancel: {
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -14,7 +14,7 @@ final class EditorFactory {
     func productDescriptionEditor(product: Product,
                                   onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
         let navigationTitle = NSLocalizedString("Description", comment: "The navigation bar title of the Aztec editor screen.")
-        let viewProperties = EditorViewProperties(navigationTitle: navigationTitle)
+        let viewProperties = EditorViewProperties(navigationTitle: navigationTitle, showSaveChangesActionSheet: true)
         let editor = AztecEditorViewController(content: product.fullDescription, viewProperties: viewProperties)
         editor.onContentSave = onContentSave
         return editor

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorViewProperties.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorViewProperties.swift
@@ -3,4 +3,5 @@ import UIKit
 /// Configurable UI properties for a text editor.
 struct EditorViewProperties {
     let navigationTitle: String
+    var showSaveChangesActionSheet: Bool = false
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ActionSheetSaveChangesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ActionSheetSaveChangesViewController.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+extension UIViewController {
+
+    func presentSaveChangesActionSheet(onSave: (() -> Void)?, onDiscard: (() -> Void)?, onCancel: (() -> Void)?) {
+        let actionSheet = UIAlertController(title: nil, message: ActionSheetStrings.message, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.save) { _ in
+            onSave?()
+        }
+
+        actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.discard) { _ in
+            onDiscard?()
+        }
+
+        actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel) { _ in
+            onCancel?()
+        }
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.sourceView = view
+        popoverController?.sourceRect = view.bounds
+
+        present(actionSheet, animated: true)
+    }
+}
+
+private enum ActionSheetStrings {
+    static let message = NSLocalizedString("Are you sure you want to discard these changes?",
+                                           comment: "Message title for Save Changes Action Sheet")
+    static let save = NSLocalizedString("Save changes",
+                                        comment: "Button title for Save Changes Action Sheet")
+    static let discard = NSLocalizedString("Discard changes",
+                                          comment: "Button title Discard Changes in Save Changes Action Sheet")
+    static let cancel = NSLocalizedString("Cancel",
+                                          comment: "Button title Cancel in Save Changes Action Sheet")
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -167,20 +167,14 @@ private extension ProductPriceSettingsViewController {
 extension ProductPriceSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
-        var editedData = false
         let newSalePrice = salePrice == "0" ? nil : salePrice
         let newTaxClass = taxClass?.slug == "standard" ? "" : taxClass?.slug
         if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart || dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
-            editedData = true
+            presentBackNavigationActionSheet()
         }
-
-        guard editedData else {
+        else {
             navigationController?.popViewController(animated: true)
-            return false
         }
-
-        presentBackNavigationActionSheet()
-
         return false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -189,7 +189,6 @@ extension ProductPriceSettingsViewController {
             self?.completeUpdating()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }, onCancel: {
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -184,26 +184,12 @@ extension ProductPriceSettingsViewController {
     }
 
     func presentBackNavigationActionSheet() {
-        let actionSheetMessage = NSLocalizedString("Are you sure you want to discard these changes?",
-                                                 comment: "Action sheet title in Edit Product > Edit Pricing")
-        let actionSheet = UIAlertController(title: nil, message: actionSheetMessage, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .text
-
-        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.save) { [weak self] _ in
+        presentSaveChangesActionSheet(onSave: { [weak self] in
             self?.completeUpdating()
-        }
-
-        actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.discard) { [weak self] _ in
+        }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }
-
-        actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel)
-
-        let popoverController = actionSheet.popoverPresentationController
-        popoverController?.sourceView = view
-        popoverController?.sourceRect = view.bounds
-
-        present(actionSheet, animated: true)
+        }, onCancel: {
+        })
     }
 }
 
@@ -542,13 +528,4 @@ private extension ProductPriceSettingsViewController {
 private struct Constants {
     static let sectionHeight = CGFloat(44)
     static let pickerRowHeight = CGFloat(216)
-}
-
-private enum ActionSheetStrings {
-    static let save = NSLocalizedString("Save changes",
-                                        comment: "Button title in the action sheet in Edit Product > Edit pricing")
-    static let discard = NSLocalizedString("Discard changes",
-                                          comment: "Button title in the action sheet in Edit Product > Edit pricing")
-    static let cancel = NSLocalizedString("Cancel",
-                                          comment: "Dismiss the action sheet in Edit Product > Edit Pricing")
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -172,11 +172,9 @@ extension ProductPriceSettingsViewController {
         if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart ||
             dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
             presentBackNavigationActionSheet()
+            return false
         }
-        else {
-            navigationController?.popViewController(animated: true)
-        }
-        return false
+        return true
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -169,7 +169,8 @@ extension ProductPriceSettingsViewController {
     override func shouldPopOnBackButton() -> Bool {
         let newSalePrice = salePrice == "0" ? nil : salePrice
         let newTaxClass = taxClass?.slug == "standard" ? "" : taxClass?.slug
-        if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart || dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
+        if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart ||
+            dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
             presentBackNavigationActionSheet()
         }
         else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -164,10 +164,52 @@ private extension ProductPriceSettingsViewController {
 
 // MARK: - Navigation actions handling
 //
-private extension ProductPriceSettingsViewController {
-    @objc func completeUpdating() {
+extension ProductPriceSettingsViewController {
+
+    override func shouldPopOnBackButton() -> Bool {
+        var editedData = false
+        let newSalePrice = salePrice == "0" ? nil : salePrice
+        let newTaxClass = taxClass?.slug == "standard" ? "" : taxClass?.slug
+        if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart || dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
+            editedData = true
+        }
+
+        guard editedData else {
+            navigationController?.popViewController(animated: true)
+            return false
+        }
+
+        presentBackNavigationActionSheet()
+
+        return false
+    }
+
+    @objc private func completeUpdating() {
         let newSalePrice = salePrice == "0" ? nil : salePrice
         onCompletion(regularPrice, newSalePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass)
+    }
+
+    func presentBackNavigationActionSheet() {
+        let actionSheetMessage = NSLocalizedString("Are you sure you want to discard these changes?",
+                                                 comment: "Action sheet title in Edit Product > Edit Pricing")
+        let actionSheet = UIAlertController(title: nil, message: actionSheetMessage, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.save) { [weak self] _ in
+            self?.completeUpdating()
+        }
+
+        actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.discard) { [weak self] _ in
+            self?.navigationController?.popViewController(animated: true)
+        }
+
+        actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel)
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.sourceView = view
+        popoverController?.sourceRect = view.bounds
+
+        present(actionSheet, animated: true)
     }
 }
 
@@ -506,4 +548,13 @@ private extension ProductPriceSettingsViewController {
 private struct Constants {
     static let sectionHeight = CGFloat(44)
     static let pickerRowHeight = CGFloat(216)
+}
+
+private enum ActionSheetStrings {
+    static let save = NSLocalizedString("Save changes",
+                                        comment: "Button title in the action sheet in Edit Product > Edit pricing")
+    static let discard = NSLocalizedString("Discard changes",
+                                          comment: "Button title in the action sheet in Edit Product > Edit pricing")
+    static let cancel = NSLocalizedString("Cancel",
+                                          comment: "Dismiss the action sheet in Edit Product > Edit Pricing")
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -184,7 +184,7 @@ extension ProductPriceSettingsViewController {
     }
 
     func presentBackNavigationActionSheet() {
-        presentSaveChangesActionSheet(onSave: { [weak self] in
+        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
             self?.completeUpdating()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -183,7 +183,7 @@ extension ProductPriceSettingsViewController {
         onCompletion(regularPrice, newSalePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass)
     }
 
-    func presentBackNavigationActionSheet() {
+    private func presentBackNavigationActionSheet() {
         UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
             self?.completeUpdating()
         }, onDiscard: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -168,7 +168,7 @@ extension ProductPriceSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
         let newSalePrice = salePrice == "0" ? nil : salePrice
-        let newTaxClass = taxClass?.slug == "standard" ? "" : taxClass?.slug
+        let newTaxClass = taxClass?.slug == standardTaxClass.slug ? "" : taxClass?.slug
         if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart ||
             dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
             presentBackNavigationActionSheet()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -159,7 +159,8 @@ private extension ProductInventorySettingsViewController {
 extension ProductInventorySettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
-        if sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually || stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting || stockStatus != product.productStockStatus {
+        if sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually ||
+            stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting || stockStatus != product.productStockStatus {
             presentBackNavigationActionSheet()
         }
         else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -5,6 +5,8 @@ final class ProductInventorySettingsViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
 
+    private let product: Product
+
     private let siteID: Int64
 
     // Editable data - shared.
@@ -36,6 +38,8 @@ final class ProductInventorySettingsViewController: UIViewController {
 
     init(product: Product, completion: @escaping Completion) {
         self.onCompletion = completion
+
+        self.product = product
 
         self.siteID = product.siteID
 
@@ -152,8 +156,19 @@ private extension ProductInventorySettingsViewController {
 
 // MARK: - Navigation actions handling
 //
-private extension ProductInventorySettingsViewController {
-    @objc func completeUpdating() {
+extension ProductInventorySettingsViewController {
+
+    override func shouldPopOnBackButton() -> Bool {
+        if sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually || stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting || stockStatus != product.productStockStatus {
+            presentBackNavigationActionSheet()
+        }
+        else {
+            navigationController?.popViewController(animated: true)
+        }
+        return false
+    }
+
+    @objc private func completeUpdating() {
         let action = ProductAction.validateProductSKU(sku, siteID: siteID) { [weak self] isValid in
             guard let self = self else {
                 return
@@ -171,6 +186,15 @@ private extension ProductInventorySettingsViewController {
             self.onCompletion(data)
         }
         ServiceLocator.stores.dispatch(action)
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
+            self?.completeUpdating()
+        }, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        }, onCancel: {
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -162,11 +162,9 @@ extension ProductInventorySettingsViewController {
         if sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually ||
             stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting || stockStatus != product.productStockStatus {
             presentBackNavigationActionSheet()
+            return false
         }
-        else {
-            navigationController?.popViewController(animated: true)
-        }
-        return false
+        return true
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -194,7 +194,6 @@ extension ProductInventorySettingsViewController {
             self?.completeUpdating()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }, onCancel: {
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -112,12 +112,33 @@ private extension ProductShippingSettingsViewController {
 
 // MARK: - Navigation actions handling
 //
-private extension ProductShippingSettingsViewController {
-    @objc func completeUpdating() {
+extension ProductShippingSettingsViewController {
+
+    override func shouldPopOnBackButton() -> Bool {
+        
+        if weight != product.weight || length != product.dimensions.length || width != product.dimensions.width || height != product.dimensions.height || shippingClass != product.productShippingClass {
+            presentBackNavigationActionSheet()
+        }
+        else {
+            navigationController?.popViewController(animated: true)
+        }
+        return false
+    }
+
+    @objc private func completeUpdating() {
         let dimensions = ProductDimensions(length: length ?? "",
                                            width: width ?? "",
                                            height: height ?? "")
         onCompletion(weight, dimensions, shippingClass)
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
+            self?.completeUpdating()
+        }, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        }, onCancel: {
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -115,7 +115,6 @@ private extension ProductShippingSettingsViewController {
 extension ProductShippingSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
-        
         if weight != product.weight || length != product.dimensions.length || width != product.dimensions.width || height != product.dimensions.height || shippingClass != product.productShippingClass {
             presentBackNavigationActionSheet()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -118,11 +118,9 @@ extension ProductShippingSettingsViewController {
         if weight != product.weight || length != product.dimensions.length || width != product.dimensions.width || height != product.dimensions.height ||
             shippingClass != product.productShippingClass {
             presentBackNavigationActionSheet()
+            return false
         }
-        else {
-            navigationController?.popViewController(animated: true)
-        }
-        return false
+        return true
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -115,7 +115,8 @@ private extension ProductShippingSettingsViewController {
 extension ProductShippingSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
-        if weight != product.weight || length != product.dimensions.length || width != product.dimensions.width || height != product.dimensions.height || shippingClass != product.productShippingClass {
+        if weight != product.weight || length != product.dimensions.length || width != product.dimensions.width || height != product.dimensions.height ||
+            shippingClass != product.productShippingClass {
             presentBackNavigationActionSheet()
         }
         else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -137,7 +137,6 @@ extension ProductShippingSettingsViewController {
             self?.completeUpdating()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }, onCancel: {
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -80,7 +80,7 @@ extension TextViewViewController {
         onCompletion(textView.text)
     }
 
-    func presentBackNavigationActionSheet() {
+    private func presentBackNavigationActionSheet() {
         UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
             self?.completeEditing()
         }, onDiscard: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -81,26 +81,12 @@ extension TextViewViewController {
     }
 
     func presentBackNavigationActionSheet() {
-        let actionSheetMessage = NSLocalizedString("Are you sure you want to discard these changes?",
-                                                 comment: "Action sheet title in Edit Product > Edit Pricing")
-        let actionSheet = UIAlertController(title: nil, message: actionSheetMessage, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .text
-
-        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.save) { [weak self] _ in
+        presentSaveChangesActionSheet(onSave: { [weak self] in
             self?.completeEditing()
-        }
-
-        actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.discard) { [weak self] _ in
+        }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }
-
-        actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel)
-
-        let popoverController = actionSheet.popoverPresentationController
-        popoverController?.sourceView = view
-        popoverController?.sourceRect = view.bounds
-
-        present(actionSheet, animated: true)
+        }, onCancel: {
+        })
     }
 }
 
@@ -179,14 +165,4 @@ private extension TextViewViewController {
     enum Constants {
         static let textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     }
-
-    enum ActionSheetStrings {
-        static let save = NSLocalizedString("Save changes",
-                                            comment: "Button title in the action sheet in the generic text editor")
-        static let discard = NSLocalizedString("Discard changes",
-                                              comment: "Button title in the action sheet in the generic text editor")
-        static let cancel = NSLocalizedString("Cancel",
-                                              comment: "Dismiss the action sheet in the generic text editor")
-    }
-
 }

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -69,11 +69,9 @@ extension TextViewViewController {
     override func shouldPopOnBackButton() -> Bool {
         if initialText != textView.text {
             presentBackNavigationActionSheet()
+            return false
         }
-        else {
-            navigationController?.popViewController(animated: true)
-        }
-        return false
+        return true
     }
 
     @objc private func completeEditing() {

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -63,9 +63,44 @@ final class TextViewViewController: UIViewController {
     }
 }
 
-private extension TextViewViewController {
-    @objc func completeEditing() {
+// MARK: - Navigation actions handling
+//
+extension TextViewViewController {
+    override func shouldPopOnBackButton() -> Bool {
+        if initialText != textView.text {
+            presentBackNavigationActionSheet()
+        }
+        else {
+            navigationController?.popViewController(animated: true)
+        }
+        return false
+    }
+
+    @objc private func completeEditing() {
         onCompletion(textView.text)
+    }
+
+    func presentBackNavigationActionSheet() {
+        let actionSheetMessage = NSLocalizedString("Are you sure you want to discard these changes?",
+                                                 comment: "Action sheet title in Edit Product > Edit Pricing")
+        let actionSheet = UIAlertController(title: nil, message: actionSheetMessage, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.save) { [weak self] _ in
+            self?.completeEditing()
+        }
+
+        actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.discard) { [weak self] _ in
+            self?.navigationController?.popViewController(animated: true)
+        }
+
+        actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel)
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.sourceView = view
+        popoverController?.sourceRect = view.bounds
+
+        present(actionSheet, animated: true)
     }
 }
 
@@ -144,4 +179,14 @@ private extension TextViewViewController {
     enum Constants {
         static let textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     }
+
+    enum ActionSheetStrings {
+        static let save = NSLocalizedString("Save changes",
+                                            comment: "Button title in the action sheet in the generic text editor")
+        static let discard = NSLocalizedString("Discard changes",
+                                              comment: "Button title in the action sheet in the generic text editor")
+        static let cancel = NSLocalizedString("Cancel",
+                                              comment: "Dismiss the action sheet in the generic text editor")
+    }
+
 }

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -85,7 +85,6 @@ extension TextViewViewController {
             self?.completeEditing()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-        }, onCancel: {
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -81,7 +81,7 @@ extension TextViewViewController {
     }
 
     func presentBackNavigationActionSheet() {
-        presentSaveChangesActionSheet(onSave: { [weak self] in
+        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
             self?.completeEditing()
         }, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -191,7 +191,7 @@
 		453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */; };
 		453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
-		459097F623CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459097F523CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift */; };
+		459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
 		45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */; };
@@ -792,7 +792,7 @@
 		453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Helpers.swift"; sourceTree = "<group>"; };
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
-		459097F523CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetSaveChangesViewController.swift; sourceTree = "<group>"; };
+		459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Helpers.swift"; sourceTree = "<group>"; };
 		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewController.swift; sourceTree = "<group>"; };
@@ -1289,7 +1289,6 @@
 				02F4F50A237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift */,
 				025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */,
 				025B1749237AA49D00C780B4 /* Product+ProductForm.swift */,
-				459097F523CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -2362,6 +2361,7 @@
 				748AD086219F481B00023535 /* UIView+Animation.swift */,
 				B57C744620F55BC800EEFC87 /* UIView+Helpers.swift */,
 				B5A82EE6210263460053ADC8 /* UIViewController+Helpers.swift */,
+				459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */,
 				B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */,
 				B59D49CC219B587E006BF0AD /* UILabel+OrderStatus.swift */,
 				B53B3F38219C817800DF1EB6 /* UIStoryboard+Woo.swift */,
@@ -3196,6 +3196,7 @@
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
+				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
@@ -3393,7 +3394,6 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
-				459097F623CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */; };
 		453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
+		459097F623CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459097F523CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
 		45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */; };
@@ -791,6 +792,7 @@
 		453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Helpers.swift"; sourceTree = "<group>"; };
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
+		459097F523CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetSaveChangesViewController.swift; sourceTree = "<group>"; };
 		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewController.swift; sourceTree = "<group>"; };
@@ -1287,6 +1289,7 @@
 				02F4F50A237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift */,
 				025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */,
 				025B1749237AA49D00C780B4 /* Product+ProductForm.swift */,
+				459097F523CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -3390,6 +3393,7 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
+				459097F623CDDB2E00DEA9E0 /* ActionSheetSaveChangesViewController.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,


### PR DESCRIPTION
Fixes #1640 

## Description
If there are outstanding changes on the Product Title/Description/Shipping/Price/Inventory Settings, now we show this action sheet when the user navigates back from the settings screen in case they intend to save the changes.

## Changes
- New `UIAlertController` helpers extension useful to present the Save Changes ActionSheet
- New extension and protocol in `UINavigationController` extension to handle `UINavigationBar`'s **Back** button action
- Managed Save Changes Action Sheet in `AztecEditor`
- Managed Save Changes Action Sheet in `TextViewViewController`
- Managed Save Changes Action Sheet in all the controllers for editing product settings 

## Testing
1) Open a product detail
2) For every editable field (Title, Description, Price, Shipping, Inventory) try to edit something, and press the back button.
3) Try to discard change, and make sure that the new value was not shown in the product detail.
4) Repeat point 2, and now try to save changes. Make sure that every value was correctly saved and showed in the product detail.

## Screenshots
| Title             |  Description |  Price |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-14 at 15 10 10](https://user-images.githubusercontent.com/495617/72352910-69e03980-36e3-11ea-9637-fd25f969476c.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-14 at 15 10 28](https://user-images.githubusercontent.com/495617/72352930-75336500-36e3-11ea-93bf-c2c1915be104.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-14 at 15 10 36](https://user-images.githubusercontent.com/495617/72352954-7f556380-36e3-11ea-812c-f5d7ca9d2062.png)

| Shipping             |  Inventory |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-14 at 15 10 52](https://user-images.githubusercontent.com/495617/72353263-0a365e00-36e4-11ea-8f44-3326b8e85203.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-14 at 15 11 01](https://user-images.githubusercontent.com/495617/72353273-0e627b80-36e4-11ea-8cd5-383603fe5676.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
