### PR TITLE
Support: fix name/email to contact support during login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - bugfix/enhancement: on the Products tab, if there are no Products the "Work In Progress" banner is shown with an image placeholder below now.
 - bugfix: the deleted Product Variations should not show up after syncing anymore.
 - bugfix: now the shipping address in the Order Detail is hidden if the order contains only virtual products
+- bugfix: when logged out, Contact Support should be enabled now after typing a valid email address with an email keyboard type.
 
 3.3
 -----

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -628,6 +628,7 @@ private extension ZendeskManager {
         // Email Text Field
         alertController.addTextField { textField in
             textField.clearButtonMode = .always
+            textField.keyboardType = .emailAddress
             textField.placeholder = LocalizedText.emailPlaceholder
             textField.text = self.userEmail
 

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -360,6 +360,7 @@ private extension ZendeskManager {
     }
 
     func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping onUserInformationCompletion) {
+        presentInController = viewController
         getUserInformationIfAvailable()
         promptUserForInformation(withName: withName, from: viewController) { (success, email) in
             guard success else {


### PR DESCRIPTION
Fixes #1738 

## Summary

The cause of the issue was from `presentInController` being nil, which causes the app to early return when we react to email text changes in https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift#L656. The "OK" action button is only enabled when the email input is a valid email. Because the `presentInController` was never set in the name/email text field entry point, it is always nil and thus no-op when the email text changes.

## Changes

- Set `presentInController` in `getUserInformationAndShowPrompt`
- Set the email text field keyboard type to email, a minor UX improvement

## Testing

(thanks @rachelmcr for the steps to repro)

1. Log out of the app.
2. Select "Log in with Jetpack" to start logging in.
3. Tap "Help" in the top right.
4. On the Help screen, tap "Contact Support."
5. In the window that pops up, enter your email address and name. --> when the email is valid (**@**.*), the "OK" button should be enabled and tapping "OK" should navigate to the support input screen. (Optional) You can submit a ticket and verify on Zendesk

## Example screenshot

<img src="https://user-images.githubusercontent.com/1945542/72583529-92ee0d80-3921-11ea-8a0c-c8fe7fdc088d.PNG" width="320"/>


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
