### PR TITLE
Notifications: update the badge on the Orders and Reviews tab based on the notification type

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - bugfix/enhancement: on the Products tab, if there are no Products the "Work In Progress" banner is shown with an image placeholder below now.
 - bugfix: the deleted Product Variations should not show up after syncing anymore.
 - bugfix: now the shipping address in the Order Detail is hidden if the order contains only virtual products
+- bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.
 
 3.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 3.5
 -----
+- bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.
  
 3.4
 -----
@@ -10,7 +11,6 @@
 - bugfix/enhancement: on the Products tab, if there are no Products the "Work In Progress" banner is shown with an image placeholder below now.
 - bugfix: the deleted Product Variations should not show up after syncing anymore.
 - bugfix: now the shipping address in the Order Detail is hidden if the order contains only virtual products
-- bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.
 
 3.3
 -----

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -166,8 +166,17 @@ extension PushNotificationsManager {
         DDLogVerbose("📱 Push Notification Received: \n\(userInfo)\n")
 
         // Badge: Update
-        if let badgeNumber = userInfo.dictionary(forKey: APNSKey.aps)?.integer(forKey: APNSKey.badge) {
-            configuration.application.applicationIconBadgeNumber = badgeNumber
+        if let badgeNumber = userInfo.dictionary(forKey: APNSKey.aps)?.integer(forKey: APNSKey.badge),
+            let typeString = userInfo.string(forKey: APNSKey.type),
+            let type = Note.Kind(rawValue: typeString) {
+            switch type {
+            case .comment:
+                configuration.application.applicationIconBadgeNumber = badgeNumber
+            case .storeOrder:
+                NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
+            default:
+                break
+            }
         }
 
         // Badge: Reset

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -234,7 +234,7 @@ class PushNotificationsManagerTests: XCTestCase {
     ///
     func testHandleNotificationUpdatesApplicationsBadgeNumber() {
         let updatedBadgeNumber = 10
-        let userInfo = notificationPayload(badgeCount: updatedBadgeNumber)
+        let userInfo = notificationPayload(badgeCount: updatedBadgeNumber, type: .comment)
 
         XCTAssertEqual(application.applicationIconBadgeNumber, Int.min)
 
@@ -330,13 +330,14 @@ private extension PushNotificationsManagerTests {
 
     /// Returns a Sample Notification Payload
     ///
-    func notificationPayload(badgeCount: Int = 0, noteID: Int64 = 1234) -> [String: Any] {
+    func notificationPayload(badgeCount: Int = 0, noteID: Int64 = 1234, type: Note.Kind = .comment) -> [String: Any] {
         return [
             "aps": [
                 "badge": badgeCount,
                 "alert": Sample.defaultMessage
             ],
-            "note_id": noteID
+            "note_id": noteID,
+            "type": type.rawValue
         ]
     }
 }


### PR DESCRIPTION
Fixes #1735 
Fixes #1736 

## Summary

Before this PR, we always assumed the badge update is on the Reviews tab (previously the Notifications tab). This PR checks the notification type and then updates the badge accordingly.

## Changes

- When handling a notification in `PushNotificationsManager`, added a check for notification type and then updated the badge for Orders and Reviews tab based on the type

## Testing

Prerequisites: the store has < 9 processing orders, so that we can observe the order badge count update

### New Order notification

1. Open the app and visit the Reviews tab to clear any badge on the Reviews tab icon.
2. Go to another tab e.g. My Store tab and leave the app open.
3. Receive a new order on your store.
4. Wait for the new order notice to appear in the app --> the badge count on the Orders tab should change, and there should **not** be a badge on the Reviews tab
5. Open the Orders tab and confirm the new order appears there.

### New Review notification

1. Open the app and visit the Reviews tab to clear any badge on the Reviews tab icon.
2. Go to another tab e.g. My Store tab and leave the app open.
3. Receive a new review on your store.
5. Wait for the new review notice to appear in the app --> the badge count on the Orders tab should **not** change, and there should be a badge on the Reviews tab

## Example screenshots

New Review | New Order
-- | -- 
![IMG_7650](https://user-images.githubusercontent.com/1945542/72592265-31d43300-393d-11ea-9228-990726683fed.PNG) | ![IMG_7651](https://user-images.githubusercontent.com/1945542/72592266-31d43300-393d-11ea-956e-42d34ccd2bff.PNG)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
