### PR TITLE
Image Upload: media picking action sheet UI (no actions)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/CameraCaptureCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/CameraCaptureCoordinator.swift
@@ -1,0 +1,17 @@
+import Photos
+import UIKit
+
+/// Encapsulates capturing media from a device camera.
+///
+final class CameraCaptureCoordinator {
+    typealias Completion = ((_ media: PHAsset?, _ error: Error?) -> Void)
+    private let onCompletion: Completion
+
+    init(onCompletion: @escaping Completion) {
+        self.onCompletion = onCompletion
+    }
+
+    func presentMediaCaptureIfAuthorized(origin: UIViewController) {
+        // TODO-1713: camera capture
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DeviceMediaLibraryPicker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DeviceMediaLibraryPicker.swift
@@ -1,0 +1,17 @@
+import Photos
+import UIKit
+
+/// Encapsulates launching and customization of a media picker to import media from the Photo Library.
+///
+final class DeviceMediaLibraryPicker: NSObject {
+    typealias Completion = ((_ selectedMediaItems: [PHAsset]) -> Void)
+    private let onCompletion: Completion
+
+    init(onCompletion: @escaping Completion) {
+        self.onCompletion = onCompletion
+    }
+
+    func presentPicker(origin: UIViewController) {
+        // TODO-1713: presents device media library picker
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingContext.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingContext.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+/// Encapsulates context parameters to initiate a flow to pick media from several sources
+///
+struct MediaPickingContext {
+    let origin: UIViewController
+    let view: UIView
+
+    init(origin: UIViewController, view: UIView) {
+        self.origin = origin
+        self.view = view
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
@@ -27,11 +27,11 @@ final class MediaPickingCoordinator {
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         menuAlert.view.tintColor = .text
 
+        menuAlert.addAction(photoLibraryAction(origin: origin))
+
         if UIImagePickerController.isSourceTypeAvailable(.camera) {
             menuAlert.addAction(cameraAction(origin: origin))
         }
-
-        menuAlert.addAction(photoLibraryAction(origin: origin))
 
         menuAlert.addAction(siteMediaLibraryAction(origin: origin))
 
@@ -48,7 +48,7 @@ final class MediaPickingCoordinator {
 //
 private extension MediaPickingCoordinator {
     func cameraAction(origin: UIViewController) -> UIAlertAction {
-        let title = NSLocalizedString("Take a Photo",
+        let title = NSLocalizedString("Take a photo",
                                       comment: "Menu option for taking an image or video with the device's camera.")
         return UIAlertAction(title: title, style: .default) { [weak self] action in
             self?.showCameraCapture(origin: origin)
@@ -56,7 +56,7 @@ private extension MediaPickingCoordinator {
     }
 
     func photoLibraryAction(origin: UIViewController) -> UIAlertAction {
-        let title = NSLocalizedString("Choose from My Device",
+        let title = NSLocalizedString("Choose from device",
                                       comment: "Menu option for selecting media from the device's photo library.")
         return UIAlertAction(title: title, style: .default) { [weak self] action in
             self?.showDeviceMediaLibraryPicker(origin: origin)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
@@ -34,7 +34,6 @@ final class MediaPickingCoordinator {
         }
 
         menuAlert.addAction(siteMediaLibraryAction(origin: origin))
-
         menuAlert.addAction(cancelAction())
 
         menuAlert.popoverPresentationController?.sourceView = fromView

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
@@ -1,0 +1,93 @@
+import UIKit
+
+/// Prepares the alert controller that will be presented when trying to add media to a site.
+///
+final class MediaPickingCoordinator {
+    private lazy var cameraCapture: CameraCaptureCoordinator = {
+        return CameraCaptureCoordinator(onCompletion: onCameraCaptureCompletion)
+    }()
+
+    private lazy var deviceMediaLibraryPicker: DeviceMediaLibraryPicker = {
+        return DeviceMediaLibraryPicker(onCompletion: onDeviceMediaLibraryPickerCompletion)
+    }()
+
+    private let onCameraCaptureCompletion: CameraCaptureCoordinator.Completion
+    private let onDeviceMediaLibraryPickerCompletion: DeviceMediaLibraryPicker.Completion
+
+    init(onCameraCaptureCompletion: @escaping CameraCaptureCoordinator.Completion,
+         onDeviceMediaLibraryPickerCompletion: @escaping DeviceMediaLibraryPicker.Completion) {
+        self.onCameraCaptureCompletion = onCameraCaptureCompletion
+        self.onDeviceMediaLibraryPickerCompletion = onDeviceMediaLibraryPickerCompletion
+    }
+
+    func present(context: MediaPickingContext) {
+        let origin = context.origin
+        let fromView = context.view
+
+        let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        menuAlert.view.tintColor = .text
+
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            menuAlert.addAction(cameraAction(origin: origin))
+        }
+
+        menuAlert.addAction(photoLibraryAction(origin: origin))
+
+        menuAlert.addAction(siteMediaLibraryAction(origin: origin))
+
+        menuAlert.addAction(cancelAction())
+
+        menuAlert.popoverPresentationController?.sourceView = fromView
+        menuAlert.popoverPresentationController?.sourceRect = fromView.bounds
+
+        origin.present(menuAlert, animated: true)
+    }
+}
+
+// MARK: Alert Actions
+//
+private extension MediaPickingCoordinator {
+    func cameraAction(origin: UIViewController) -> UIAlertAction {
+        let title = NSLocalizedString("Take a Photo",
+                                      comment: "Menu option for taking an image or video with the device's camera.")
+        return UIAlertAction(title: title, style: .default) { [weak self] action in
+            self?.showCameraCapture(origin: origin)
+        }
+    }
+
+    func photoLibraryAction(origin: UIViewController) -> UIAlertAction {
+        let title = NSLocalizedString("Choose from My Device",
+                                      comment: "Menu option for selecting media from the device's photo library.")
+        return UIAlertAction(title: title, style: .default) { [weak self] action in
+            self?.showDeviceMediaLibraryPicker(origin: origin)
+        }
+    }
+
+    func siteMediaLibraryAction(origin: UIViewController) -> UIAlertAction {
+        let title = NSLocalizedString("WordPress Media Library",
+                                      comment: "Menu option for selecting media from the site's media library.")
+        return UIAlertAction(title: title, style: .default) { [weak self] action in
+            self?.showSiteMediaPicker(origin: origin)
+        }
+    }
+
+    func cancelAction() -> UIAlertAction {
+        return UIAlertAction(title: NSLocalizedString("Dismiss", comment: "Dismiss the media picking action sheet"), style: .cancel, handler: nil)
+    }
+}
+
+// MARK: Alert Action Handlers
+//
+private extension MediaPickingCoordinator {
+    func showCameraCapture(origin: UIViewController) {
+        cameraCapture.presentMediaCaptureIfAuthorized(origin: origin)
+    }
+
+    func showDeviceMediaLibraryPicker(origin: UIViewController) {
+        deviceMediaLibraryPicker.presentPicker(origin: origin)
+    }
+
+    func showSiteMediaPicker(origin: UIViewController) {
+        // TODO-1713: WordPress media library picker implementation
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -74,7 +74,7 @@ private extension ProductImagesViewController {
     func configureAddButton() {
         addButton.setTitle(NSLocalizedString("Add Photos", comment: "Action to add photos on the Product images screen"), for: .normal)
         addButton.addTarget(self, action: #selector(addTapped), for: .touchUpInside)
-        addButton.applyPrimaryButtonStyle()
+        addButton.applySecondaryButtonStyle()
     }
 
     func configureAddButtonBottomBorderView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -1,3 +1,4 @@
+import Photos
 import UIKit
 import Yosemite
 
@@ -23,6 +24,11 @@ final class ProductImagesViewController: UIViewController {
         let viewController = ProductImagesCollectionViewController(images: productImages,
                                                                    onDeletion: onDeletion)
         return viewController
+    }()
+
+    private lazy var mediaPickingCoordinator: MediaPickingCoordinator = {
+        return MediaPickingCoordinator(onCameraCaptureCompletion: self.onCameraCaptureCompletion,
+                                       onDeviceMediaLibraryPickerCompletion: self.onDeviceMediaLibraryPickerCompletion(assets:))
     }()
 
     private let onCompletion: Completion
@@ -92,15 +98,36 @@ private extension ProductImagesViewController {
 private extension ProductImagesViewController {
 
     @objc func addTapped() {
-        // TODO-1713: display options to add an image.
+        showOptionsMenu()
     }
 
     @objc func completeEditing() {
         onCompletion(productImages)
     }
 
+    func showOptionsMenu() {
+        let pickingContext = MediaPickingContext(origin: self, view: addButton)
+        mediaPickingCoordinator.present(context: pickingContext)
+    }
+
     func onDeletion(productImage: ProductImage) {
         productImages.removeAll(where: { $0.imageID == productImage.imageID })
         navigationController?.popViewController(animated: true)
+    }
+}
+
+// MARK: - Action handling for camera capture
+//
+private extension ProductImagesViewController {
+    func onCameraCaptureCompletion(asset: PHAsset?, error: Error?) {
+        // TODO-1713: handle media from camera
+    }
+}
+
+// MARK: Action handling for device media library picker
+//
+private extension ProductImagesViewController {
+    func onDeviceMediaLibraryPickerCompletion(assets: [PHAsset]) {
+        // TODO-1713: handle media from photo library
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -161,6 +161,10 @@
 		02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2923B5BB1C00F880B1 /* ImageService.swift */; };
 		02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */; };
 		02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */; };
+		02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */; };
+		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
+		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
+		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorDataSource.swift */; };
@@ -763,6 +767,10 @@
 		02C0CD2923B5BB1C00F880B1 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageService.swift; sourceTree = "<group>"; };
 		02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageServiceTests.swift; sourceTree = "<group>"; };
+		02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraCaptureCoordinator.swift; sourceTree = "<group>"; };
+		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
+		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
+		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02E262C8238D0AD300B79588 /* ProductStockStatusListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorDataSource.swift; sourceTree = "<group>"; };
@@ -1512,6 +1520,10 @@
 		0286B27523C704FC003D784B /* Media */ = {
 			isa = PBXGroup;
 			children = (
+				02CA63D623D1ADD100BBF148 /* CameraCaptureCoordinator.swift */,
+				02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */,
+				02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */,
+				02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */,
 				0286B27723C7051F003D784B /* ProductImagesCollectionViewController.swift */,
 				0286B27623C7051F003D784B /* ProductImagesCollectionViewController.xib */,
 				0286B27923C7051F003D784B /* ProductImagesViewController.swift */,
@@ -3205,6 +3217,8 @@
 				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,
 				74460D4222289C7A00D7316A /* StorePickerCoordinator.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
+				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
+				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
@@ -3408,6 +3422,7 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
+				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,
@@ -3473,6 +3488,7 @@
 				CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */,
 				020F41E623163C0100776C4D /* TopBannerView.swift in Sources */,
 				B57C744E20F56E3800EEFC87 /* UITableViewCell+Helpers.swift in Sources */,
+				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				CEEC9B5C21E79B3E0055EEF0 /* FeatureFlag.swift in Sources */,
 				02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */,
 				74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */,


### PR DESCRIPTION
Media picking action sheet for #1713 

## Summary

This PR creates the UI and its coordinator that displays an action sheet to add images from various sources.

## Changes

- Created `CameraCaptureCoordinator` that enables the user to take a photo from the device camera, no implementation yet
- Created `DeviceMediaLibraryPicker` that enables the user to pick photos from the device Photo Library, no implementation yet
- Created `MediaPickingCoordinator` that displays an action sheet menu for picking media from various sources, with `MediaPickingContext` that contains the UI context for presenting the action sheet
- Added `MediaPickingCoordinator` to `ProductImagesViewController` and displayed the media picking options menu when the user taps the "Add Photos" CTA
- Updated the "Add Photos" CTA to secondary button style based on Kylea's feedback https://github.com/woocommerce/woocommerce-ios/pull/1727#issuecomment-575237839

## Testing

- On a device, build the PR branch (otherwise the camera option wouldn't be shown)
- Go to Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos" button --> should see the action sheet with the options below:
  - Choose from device
  - Take a Photo (if camera is available)
  - WordPress Media Library

## Example screenshot

<img src="https://user-images.githubusercontent.com/1945542/72600340-669cb600-394e-11ea-96b4-51ac02c2b70d.PNG" width="320" />

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
