### PR TITLE
Edit Product Inventory: new option to check if SKU already exists

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		450106912399B2C800E24722 /* TaxClassListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106902399B2C800E24722 /* TaxClassListMapper.swift */; };
 		457FC68C2382B2FD00B41B02 /* product-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 457FC68B2382B2FD00B41B02 /* product-update.json */; };
 		45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */; };
+		45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */; };
 		45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E3EEBA237009CF00A826AC /* ShippingLine.swift */; };
 		45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */; };
 		45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ED4F11239E8C57004F1BE3 /* taxes-classes.json */; };
@@ -330,6 +331,7 @@
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
 		457FC68B2382B2FD00B41B02 /* product-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-update.json"; sourceTree = "<group>"; };
 		45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatus.swift; sourceTree = "<group>"; };
+		45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSkuMapper.swift; sourceTree = "<group>"; };
 		45E3EEBA237009CF00A826AC /* ShippingLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLine.swift; sourceTree = "<group>"; };
 		45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapperTest.swift; sourceTree = "<group>"; };
 		45ED4F11239E8C57004F1BE3 /* taxes-classes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "taxes-classes.json"; sourceTree = "<group>"; };
@@ -1005,6 +1007,7 @@
 				D8C251CF230BD72700F49782 /* ProductReviewMapper.swift */,
 				0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */,
 				025CA2C1238EBBAA00B05C81 /* ProductShippingClassListMapper.swift */,
+				45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */,
 				CE430673234BA6AD0073CBFF /* RefundMapper.swift */,
 				CE430675234BA7920073CBFF /* RefundListMapper.swift */,
 				7412A8EB21B6E286005D182A /* ReportOrderTotalsMapper.swift */,
@@ -1437,6 +1440,7 @@
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
 				743E84EC22171F4600FAC9D7 /* ShipmentTracking.swift in Sources */,
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,
+				45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */,
 				D8736B6022F0887900A14A29 /* OrderCountMapper.swift in Sources */,
 				7412A8EA21B6E192005D182A /* ReportRemote.swift in Sources */,
 				B5A2417D217F9ECC00595DEF /* MetaContainer.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		457FC68C2382B2FD00B41B02 /* product-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 457FC68B2382B2FD00B41B02 /* product-update.json */; };
 		45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */; };
 		45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */; };
+		45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */ = {isa = PBXBuildFile; fileRef = 45D685F923D0C3CF005F87D0 /* product-search-sku.json */; };
+		45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */; };
 		45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E3EEBA237009CF00A826AC /* ShippingLine.swift */; };
 		45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */; };
 		45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ED4F11239E8C57004F1BE3 /* taxes-classes.json */; };
@@ -332,6 +334,8 @@
 		457FC68B2382B2FD00B41B02 /* product-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-update.json"; sourceTree = "<group>"; };
 		45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatus.swift; sourceTree = "<group>"; };
 		45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSkuMapper.swift; sourceTree = "<group>"; };
+		45D685F923D0C3CF005F87D0 /* product-search-sku.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-search-sku.json"; sourceTree = "<group>"; };
+		45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSkuMapperTests.swift; sourceTree = "<group>"; };
 		45E3EEBA237009CF00A826AC /* ShippingLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLine.swift; sourceTree = "<group>"; };
 		45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapperTest.swift; sourceTree = "<group>"; };
 		45ED4F11239E8C57004F1BE3 /* taxes-classes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "taxes-classes.json"; sourceTree = "<group>"; };
@@ -944,6 +948,7 @@
 				026CF623237D839A009563D4 /* product-variations-load-all.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				0282DD90233A120A006A5FDB /* products-search-photo.json */,
+				45D685F923D0C3CF005F87D0 /* product-search-sku.json */,
 				CEC4BF90234E40B5008D9195 /* refund-single.json */,
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
 				7412A8EF21B6E415005D182A /* report-orders.json */,
@@ -1090,6 +1095,7 @@
 				CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */,
 				74CF0A8B22414D7800DB993F /* ProductMapperTests.swift */,
 				D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */,
+				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
 				CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */,
 				CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */,
 				7412A8ED21B6E335005D182A /* ReportOrderMapperTests.swift */,
@@ -1248,6 +1254,7 @@
 			files = (
 				74C8F07020EEC3A800B6EDC9 /* broken-notes.json in Resources */,
 				74C8F06C20EEBD5D00B6EDC9 /* broken-order.json in Resources */,
+				45D685FA23D0C3CF005F87D0 /* product-search-sku.json in Resources */,
 				45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */,
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
@@ -1555,6 +1562,7 @@
 				74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */,
 				D8FBFF1C22D51C34006E3336 /* OrderStatsRemoteV4Tests.swift in Sources */,
 				CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */,
+				45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */,
 				CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */,
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductSkuMapper.swift
+++ b/Networking/Networking/Mapper/ProductSkuMapper.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+
+/// Mapper: Product Sku String
+///
+struct ProductSkuMapper: Mapper {
+
+    /// (Attempts) to convert an instance of Data into a Product Sku string
+    ///
+    func map(response: Data) throws -> String {
+        let decoder = JSONDecoder()
+
+        return try decoder.decode(ProductSkuEnvelope.self, from: response).productsSkus["sku"] ?? ""
+    }
+}
+
+
+/// ProductSkuEnvelope Disposable Entity:
+/// `Products` endpoint returns if a sku exists. This entity
+/// allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductSkuEnvelope: Decodable {
+    let productsSkus: [String: String]
+
+    private enum CodingKeys: String, CodingKey {
+        case productsSkus = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ProductSkuMapper.swift
+++ b/Networking/Networking/Mapper/ProductSkuMapper.swift
@@ -10,7 +10,7 @@ struct ProductSkuMapper: Mapper {
     func map(response: Data) throws -> String {
         let decoder = JSONDecoder()
 
-        return try decoder.decode(ProductSkuEnvelope.self, from: response).productsSkus["sku"] ?? ""
+        return try decoder.decode(ProductSkuEnvelope.self, from: response).productsSkus.first?["sku"] ?? ""
     }
 }
 
@@ -20,7 +20,7 @@ struct ProductSkuMapper: Mapper {
 /// allows us to do parse all the things with JSONDecoder.
 ///
 private struct ProductSkuEnvelope: Decodable {
-    let productsSkus: [String: String]
+    let productsSkus: [[String: String]]
 
     private enum CodingKeys: String, CodingKey {
         case productsSkus = "data"

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -105,6 +105,28 @@ public class ProductsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+    
+    /// Retrieves a product SKU if available.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll fetch remote products.
+    ///     - sku: Product SKU to search for.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func searchSku(for siteID: Int64,
+                               sku: String,
+                               completion: @escaping (String?, Error?) -> Void) {
+        let parameters = [
+            ParameterKey.sku: sku,
+            ParameterKey.fields: ParameterValues.skuFieldValues
+        ]
+
+        let path = Path.products
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductSkuMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 
     /// Updates a specific `Product`.
     ///
@@ -159,6 +181,12 @@ public extension ProductsRemote {
         static let search: String     = "search"
         static let orderBy: String    = "orderby"
         static let order: String      = "order"
+        static let sku: String        = "sku"
+        static let fields: String     = "_fields"
+    }
+    
+    private enum ParameterValues {
+        static let skuFieldValues: String = "sku"
     }
 }
 

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -105,7 +105,7 @@ public class ProductsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
-    
+
     /// Retrieves a product SKU if available.
     ///
     /// - Parameters:
@@ -184,7 +184,7 @@ public extension ProductsRemote {
         static let sku: String        = "sku"
         static let fields: String     = "_fields"
     }
-    
+
     private enum ParameterValues {
         static let skuFieldValues: String = "sku"
     }

--- a/Networking/NetworkingTests/Mapper/ProductSkuMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductSkuMapperTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// ProductSkuMapper Unit Tests
 ///
-class ProductSkuMapperTests: XCTestCase {
+final class ProductSkuMapperTests: XCTestCase {
 
     /// Verifies that SKU are parsed correctly.
     ///

--- a/Networking/NetworkingTests/Mapper/ProductSkuMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductSkuMapperTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductSkuMapper Unit Tests
+///
+class ProductSkuMapperTests: XCTestCase {
+
+    /// Verifies that SKU are parsed correctly.
+    ///
+    func testSkuIsProperlyParsed() {
+        let sku = mapLoadSkuResponse()
+
+        XCTAssertEqual(sku, "T-SHIRT-HAPPY-NINJA")
+    }
+}
+
+
+/// Private Methods.
+///
+private extension ProductSkuMapperTests {
+
+    /// Returns the ProductSkuMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapSku(from filename: String) -> String {
+        guard let response = Loader.contentsOf(filename) else {
+            return ""
+        }
+
+        return try! ProductSkuMapper().map(response: response)
+    }
+
+    /// Returns the ProductSkuMapper output upon receiving `product-search-sku`
+    ///
+    func mapLoadSkuResponse() -> String {
+        return mapSku(from: "product-search-sku")
+    }
+}

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -138,6 +138,46 @@ class ProductsRemoteTests: XCTestCase {
     }
 
 
+    // MARK: - Search Product SKU tests
+
+    /// Verifies that searchSku properly parses the product `sku` sample response.
+    ///
+    func testSearchSkuProperlyReturnsParsedSku() {
+        let remote = ProductsRemote(network: network)
+        let expectation = self.expectation(description: "Search for a product sku")
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "product-search-sku")
+
+        let expectedSku = "T-SHIRT-HAPPY-NINJA"
+
+        remote.searchSku(for: sampleSiteID, sku: expectedSku) { (sku, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(sku)
+            XCTAssertEqual(sku, expectedSku)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that searchSku properly relays Networking Layer errors.
+    ///
+    func testSearchSkuProperlyRelaysNetwokingErrors() {
+        let remote = ProductsRemote(network: network)
+        let expectation = self.expectation(description: "Wait for a product sku result")
+
+        let skuToSearch = "T-SHIRT-HAPPY-NINJA"
+
+        remote.searchSku(for: sampleSiteID, sku: skuToSearch) { (sku, error) in
+            XCTAssertNil(sku)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+
     // MARK: - Update Product
 
     /// Verifies that updateProduct properly parses the `product-update` sample response.

--- a/Networking/NetworkingTests/Responses/product-search-sku.json
+++ b/Networking/NetworkingTests/Responses/product-search-sku.json
@@ -1,0 +1,7 @@
+{
+    "data": [
+        {
+            "sku": "T-SHIRT-HAPPY-NINJA"
+        }
+    ]
+}

--- a/WooCommerce/Classes/Tools/Throttler.swift
+++ b/WooCommerce/Classes/Tools/Throttler.swift
@@ -6,15 +6,15 @@ import Foundation
 /// Throttle function must be called at each change of the state.
 /// (eg: in a search box you may want call it on textDidChange)
 ///
-class Throttler {
+final class Throttler {
 
     private let queue: DispatchQueue = DispatchQueue.global(qos: .background)
 
     private var job: DispatchWorkItem = DispatchWorkItem(block: {})
     private var previousRun: Date = Date.distantPast
-    private var maxInterval: Int
+    private var maxInterval: Double
 
-    init(seconds: Int) {
+    init(seconds: Double) {
         self.maxInterval = seconds
     }
 
@@ -24,13 +24,13 @@ class Throttler {
             self?.previousRun = Date()
             block()
         }
-        let delay = Date.second(from: previousRun) > maxInterval ? 0 : maxInterval
+        let delay = maxInterval.isLess(than: Date.second(from: previousRun)) ? 0 : maxInterval
         queue.asyncAfter(deadline: .now() + Double(delay), execute: job)
     }
 }
 
 private extension Date {
-    static func second(from referenceDate: Date) -> Int {
-        return Int(Date().timeIntervalSince(referenceDate).rounded())
+    static func second(from referenceDate: Date) -> Double {
+        return Date().timeIntervalSince(referenceDate)
     }
 }

--- a/WooCommerce/Classes/Tools/Throttler.swift
+++ b/WooCommerce/Classes/Tools/Throttler.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 /// Throttler class
-///
-/// throttle function must be called at each change of the state (eg: in a search box you may want call it on textDidChange);
+/// 
+/// To throttle a function means to ensure that the function is called at most once in a specified time period (for instance, once every 10 seconds).
+/// Throttle function must be called at each change of the state.
+/// (eg: in a search box you may want call it on textDidChange)
 ///
 class Throttler {
 

--- a/WooCommerce/Classes/Tools/Throttler.swift
+++ b/WooCommerce/Classes/Tools/Throttler.swift
@@ -19,13 +19,17 @@ final class Throttler {
     }
 
     func throttle(block: @escaping () -> ()) {
-        job.cancel()
+        cancel()
         job = DispatchWorkItem() { [weak self] in
             self?.previousRun = Date()
             block()
         }
         let delay = maxInterval.isLess(than: Date.second(from: previousRun)) ? 0 : maxInterval
         queue.asyncAfter(deadline: .now() + Double(delay), execute: job)
+    }
+
+    func cancel() {
+        job.cancel()
     }
 }
 

--- a/WooCommerce/Classes/Tools/Throttler.swift
+++ b/WooCommerce/Classes/Tools/Throttler.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Throttler class
+///
+/// throttle function must be called at each change of the state (eg: in a search box you may want call it on textDidChange);
+///
+class Throttler {
+
+    private let queue: DispatchQueue = DispatchQueue.global(qos: .background)
+
+    private var job: DispatchWorkItem = DispatchWorkItem(block: {})
+    private var previousRun: Date = Date.distantPast
+    private var maxInterval: Int
+
+    init(seconds: Int) {
+        self.maxInterval = seconds
+    }
+
+    func throttle(block: @escaping () -> ()) {
+        job.cancel()
+        job = DispatchWorkItem() { [weak self] in
+            self?.previousRun = Date()
+            block()
+        }
+        let delay = Date.second(from: previousRun) > maxInterval ? 0 : maxInterval
+        queue.asyncAfter(deadline: .now() + Double(delay), execute: job)
+    }
+}
+
+private extension Date {
+    static func second(from referenceDate: Date) -> Int {
+        return Int(Date().timeIntervalSince(referenceDate).rounded())
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -427,10 +427,10 @@ private extension ProductInventorySettingsViewController {
     }
 
     func getIndexPathForRow(_ row: Row) -> IndexPath? {
-        for i in 0 ..< sections.count {
-            for j in 0 ..< sections[i].rows.count {
-                if sections[i].rows[j] == row {
-                    return IndexPath(row: j, section: i)
+        for s in 0 ..< sections.count {
+            for r in 0 ..< sections[s].rows.count {
+                if sections[s].rows[r] == row {
+                    return IndexPath(row: r, section: s)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -31,7 +31,7 @@ final class ProductInventorySettingsViewController: UIViewController {
     // Sku validation
     private var skuIsValid: Bool = true
 
-    private var throttler: Throttler = Throttler(seconds: 1)
+    private lazy var throttler: Throttler = Throttler(seconds: 0.5)
 
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
         let keyboardFrameObserver = KeyboardFrameObserver(onKeyboardFrameUpdate: handleKeyboardFrameUpdate(keyboardFrame:))

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -207,6 +207,7 @@ private extension ProductInventorySettingsViewController {
             return
         }
 
+        // Throttled API call
         let siteID = self.siteID
         throttler.throttle {
             DispatchQueue.main.async {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -203,6 +203,7 @@ private extension ProductInventorySettingsViewController {
         guard sku != product.sku else {
             skuIsValid = true
             hideError()
+            throttler.cancel()
             getSkuCell()?.textFieldBecomeFirstResponder()
             return
         }
@@ -216,13 +217,13 @@ private extension ProductInventorySettingsViewController {
                         return
                     }
                     self.skuIsValid = isValid
-                    if isValid {
-                        self.hideError()
-                    }
-                    else {
+
+                    guard isValid else {
                         self.displayError(error: .duplicatedSKU)
+                        self.getSkuCell()?.textFieldBecomeFirstResponder()
+                        return
                     }
-                    self.getSkuCell()?.textFieldBecomeFirstResponder()
+                    self.hideError()
                 }
 
                 ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -203,7 +203,7 @@ private extension ProductInventorySettingsViewController {
         guard sku != product.sku else {
             skuIsValid = true
             hideError()
-            self.getSkuCell()?.textFieldBecomeFirstResponder()
+            getSkuCell()?.textFieldBecomeFirstResponder()
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -247,7 +247,7 @@ private extension ProductInventorySettingsViewController {
     }
 
     func hideError() {
-        // This check is useful to not reload at every tipying all the sections
+        // This check is useful so we don't reload while typing each letter in the sections
         if error != nil {
             error = nil
             reloadSections()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -207,7 +207,7 @@ private extension ProductInventorySettingsViewController {
     func handleSKUChange(_ sku: String?) {
         self.sku = sku
 
-        // If the sku is identical to the old one, is always valid.
+        // If the sku is identical to the old one, is always valid
         guard sku != product.sku else {
             skuIsValid = true
             hideError()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -234,7 +234,7 @@ private extension ProductInventorySettingsViewController {
                         return
                     }
                     self.hideError()
-                    self.enableDoneButton(false)
+                    self.enableDoneButton(true)
                 }
 
                 ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -203,6 +203,7 @@ private extension ProductInventorySettingsViewController {
         guard sku != product.sku else {
             skuIsValid = true
             hideError()
+            self.getSkuCell()?.textFieldBecomeFirstResponder()
             return
         }
 
@@ -214,11 +215,13 @@ private extension ProductInventorySettingsViewController {
                         return
                     }
                     self.skuIsValid = isValid
-                    guard isValid else {
-                        self.displayError(error: .duplicatedSKU)
-                        return
+                    if isValid {
+                        self.hideError()
                     }
-                    self.hideError()
+                    else {
+                        self.displayError(error: .duplicatedSKU)
+                    }
+                    self.getSkuCell()?.textFieldBecomeFirstResponder()
                 }
 
                 ServiceLocator.stores.dispatch(action)
@@ -420,6 +423,24 @@ private extension ProductInventorySettingsViewController {
 
     func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
         return sections[indexPath.section].rows[indexPath.row]
+    }
+
+    func getIndexPathForRow(_ row: Row) -> IndexPath? {
+        for i in 0 ..< sections.count {
+            for j in 0 ..< sections[i].rows.count {
+                if sections[i].rows[j] == row {
+                    return IndexPath(row: j, section: i)
+                }
+            }
+        }
+        return nil
+    }
+
+    func getSkuCell() -> TitleAndTextFieldTableViewCell? {
+        guard let indexPath = getIndexPathForRow(.sku) else {
+            return nil
+        }
+        return tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -164,6 +164,10 @@ private extension ProductInventorySettingsViewController {
 extension ProductInventorySettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
+        guard skuIsValid else {
+            return true
+        }
+
         if sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually ||
             stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting || stockStatus != product.productStockStatus {
             presentBackNavigationActionSheet()
@@ -191,6 +195,10 @@ extension ProductInventorySettingsViewController {
             self?.navigationController?.popViewController(animated: true)
         })
     }
+
+    private func enableDoneButton(_ enabled: Bool) {
+        navigationItem.rightBarButtonItem?.isEnabled = enabled
+    }
 }
 
 // MARK: - Input changes handling
@@ -205,6 +213,7 @@ private extension ProductInventorySettingsViewController {
             hideError()
             throttler.cancel()
             getSkuCell()?.textFieldBecomeFirstResponder()
+            enableDoneButton(true)
             return
         }
 
@@ -221,9 +230,11 @@ private extension ProductInventorySettingsViewController {
                     guard isValid else {
                         self.displayError(error: .duplicatedSKU)
                         self.getSkuCell()?.textFieldBecomeFirstResponder()
+                        self.enableDoneButton(false)
                         return
                     }
                     self.hideError()
+                    self.enableDoneButton(false)
                 }
 
                 ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -52,6 +52,10 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         textField.textColor = viewModel.state.textColor
         onTextChange = viewModel.onTextChange
     }
+
+    func textFieldBecomeFirstResponder() {
+        textField.becomeFirstResponder()
+    }
 }
 
 private extension TitleAndTextFieldTableViewCell {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		45C8B2692316B2440002FA77 /* BillingAddressTableViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C8B2682316B2440002FA77 /* BillingAddressTableViewCellTests.swift */; };
 		45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */; };
 		45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */; };
+		45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FD23D0FB25005F87D0 /* Throttler.swift */; };
 		45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */; };
 		45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2C238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift */; };
 		45FBDF34238D33F100127F77 /* MockProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF33238D33F100127F77 /* MockProduct.swift */; };
@@ -817,6 +818,7 @@
 		45C8B2682316B2440002FA77 /* BillingAddressTableViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingAddressTableViewCellTests.swift; sourceTree = "<group>"; };
 		45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatusListSelectorDataSource.swift; sourceTree = "<group>"; };
+		45D685FD23D0FB25005F87D0 /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
 		45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FBDF2C238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FBDF33238D33F100127F77 /* MockProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProduct.swift; sourceTree = "<group>"; };
@@ -1980,6 +1982,7 @@
 				B5D6DC53214802740003E48A /* SyncCoordinator.swift */,
 				B55D4C2620B717C000D7A50F /* UserAgent.swift */,
 				CE22709E2293052700C0626C /* WebviewHelper.swift */,
+				45D685FD23D0FB25005F87D0 /* Throttler.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -3209,6 +3212,7 @@
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
+				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				CE0F17D222A8308900964A63 /* FancyAlertController+PurchaseNote.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -10,6 +10,10 @@ public enum ProductAction: Action {
     ///
     case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
+    /// Searches if a product sky already exist.
+    ///
+    case searchIfSkuExist(siteID: Int64, sku: String, onCompletion: (Bool?, Error?) -> Void)
+
     /// Synchronizes the Products matching the specified criteria.
     ///
     case synchronizeProducts(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -10,10 +10,6 @@ public enum ProductAction: Action {
     ///
     case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
 
-    /// Searches if a product sky already exist.
-    ///
-    case searchIfSkuExist(siteID: Int64, sku: String, onCompletion: (Bool?, Error?) -> Void)
-
     /// Synchronizes the Products matching the specified criteria.
     ///
     case synchronizeProducts(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
@@ -38,7 +34,7 @@ public enum ProductAction: Action {
     ///
     case updateProduct(product: Product, onCompletion: (Product?, ProductUpdateError?) -> Void)
 
-    /// Checks whether a Product SKU is valid against other Products in storage.
+    /// Checks whether a Product SKU is valid against other Products in the store.
     ///
     case validateProductSKU(_ sku: String?, siteID: Int64, onCompletion: (Bool) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -205,7 +205,7 @@ private extension ProductStore {
         let remote = ProductsRemote(network: network)
         remote.searchSku(for: siteID, sku: sku) { (value, error) in
             if error != nil {
-                onCompletion(false)
+                onCompletion(true)
                 return
             }
             let isValid = (value != nil && value == sku) ? false : true

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -34,8 +34,6 @@ public class ProductStore: Store {
             retrieveProducts(siteID: siteID, productIDs: productIDs, onCompletion: onCompletion)
         case .searchProducts(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .searchIfSkuExist(let siteID, let sku, let onCompletion):
-            searchIfSkuExist(siteID: siteID, sku: sku, onCompletion: onCompletion)
         case .synchronizeProducts(let siteID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProducts(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .requestMissingProducts(let order, let onCompletion):
@@ -82,23 +80,6 @@ private extension ProductStore {
                                                                       readOnlyProducts: products) {
                                     onCompletion(nil)
                                 }
-        }
-    }
-
-    /// Searches if a given sku already exists.
-    ///
-    func searchIfSkuExist(siteID: Int64, sku: String, onCompletion: @escaping (Bool?, Error?) -> Void) {
-        let remote = ProductsRemote(network: network)
-        remote.searchSku(for: siteID, sku: sku) { (sku, error) in
-            if error != nil {
-                onCompletion(nil, error)
-            }
-            else if sku != nil && sku?.isEmpty == false {
-                onCompletion(true, nil)
-            }
-            else {
-                onCompletion(false, nil)
-            }
         }
     }
 
@@ -221,12 +202,15 @@ private extension ProductStore {
             return
         }
 
-        guard let products = storageManager.viewStorage.loadProducts(siteID: siteID) else {
-            onCompletion(true)
-            return
+        let remote = ProductsRemote(network: network)
+        remote.searchSku(for: siteID, sku: sku) { (value, error) in
+            if error != nil {
+                onCompletion(false)
+                return
+            }
+            let isValid = value != nil ? false : true
+            onCompletion(isValid)
         }
-        let anyProductHasTheSameSKU = products.compactMap({ $0.sku }).contains(sku)
-        onCompletion(anyProductHasTheSameSKU == false)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -208,7 +208,7 @@ private extension ProductStore {
                 onCompletion(false)
                 return
             }
-            let isValid = value != nil ? false : true
+            let isValid = (value != nil && value == sku) ? false : true
             onCompletion(isValid)
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -34,6 +34,8 @@ public class ProductStore: Store {
             retrieveProducts(siteID: siteID, productIDs: productIDs, onCompletion: onCompletion)
         case .searchProducts(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .searchIfSkuExist(let siteID, let sku, let onCompletion):
+            searchIfSkuExist(siteID: siteID, sku: sku, onCompletion: onCompletion)
         case .synchronizeProducts(let siteID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProducts(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .requestMissingProducts(let order, let onCompletion):
@@ -80,6 +82,23 @@ private extension ProductStore {
                                                                       readOnlyProducts: products) {
                                     onCompletion(nil)
                                 }
+        }
+    }
+
+    /// Searches if a given sku already exists.
+    ///
+    func searchIfSkuExist(siteID: Int64, sku: String, onCompletion: @escaping (Bool?, Error?) -> Void) {
+        let remote = ProductsRemote(network: network)
+        remote.searchSku(for: siteID, sku: sku) { (sku, error) in
+            if error != nil {
+                onCompletion(nil, error)
+            }
+            else if sku != nil && sku?.isEmpty == false {
+                onCompletion(true, nil)
+            }
+            else {
+                onCompletion(false, nil)
+            }
         }
     }
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -204,7 +204,7 @@ private extension ProductStore {
 
         let remote = ProductsRemote(network: network)
         remote.searchSku(for: siteID, sku: sku) { (result, error) in
-            if error != nil {
+            guard error == nil else {
                 onCompletion(true)
                 return
             }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -203,12 +203,12 @@ private extension ProductStore {
         }
 
         let remote = ProductsRemote(network: network)
-        remote.searchSku(for: siteID, sku: sku) { (value, error) in
+        remote.searchSku(for: siteID, sku: sku) { (result, error) in
             if error != nil {
                 onCompletion(true)
                 return
             }
-            let isValid = (value != nil && value == sku) ? false : true
+            let isValid = (result != nil && result == sku) ? false : true
             onCompletion(isValid)
         }
     }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests+Validation.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests+Validation.swift
@@ -42,12 +42,6 @@ final class ProductStoreTests_Validation: XCTestCase {
         let expectation = self.expectation(description: "Product SKU validation")
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        // Inserts a sample Product into storage with nil sku.
-        let sampleProduct = MockProduct().product(siteID: sampleSiteID, productID: 1, sku: nil)
-        storageManager.insertSampleProduct(readOnlyProduct: sampleProduct)
-
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 1)
-
         let action = ProductAction.validateProductSKU(nil, siteID: sampleSiteID) { isValid in
             XCTAssertTrue(isValid)
             expectation.fulfill()
@@ -62,12 +56,6 @@ final class ProductStoreTests_Validation: XCTestCase {
         let expectation = self.expectation(description: "Product SKU validation")
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        // Inserts a sample Product into storage with nil sku.
-        let sampleProduct = MockProduct().product(siteID: sampleSiteID, productID: 1, sku: "")
-        storageManager.insertSampleProduct(readOnlyProduct: sampleProduct)
-
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 1)
-
         let action = ProductAction.validateProductSKU("", siteID: sampleSiteID) { isValid in
             XCTAssertTrue(isValid)
             expectation.fulfill()
@@ -77,24 +65,22 @@ final class ProductStoreTests_Validation: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    /// Verifies that a duplicated SKU is invalid.
-    func testValidatingSKUWithAnExistingValue() {
+    /// Verifies that an existing SKU is not valid.
+    func testValidatingSKUWithExistingValue() {
         let expectation = self.expectation(description: "Product SKU validation")
-        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        // Inserts a sample Product into storage with nil sku.
-        let sku = "uks"
-        let sampleProduct = MockProduct().product(siteID: sampleSiteID, productID: 1, sku: sku)
-        storageManager.insertSampleProduct(readOnlyProduct: sampleProduct)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "product-search-sku")
 
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 1)
+        let expectedResult = false
 
-        let action = ProductAction.validateProductSKU(sku, siteID: sampleSiteID) { isValid in
-            XCTAssertFalse(isValid)
+        let skuToSearchFor = "T-SHIRT-HAPPY-NINJA"
+        let action = ProductAction.validateProductSKU(skuToSearchFor, siteID: sampleSiteID) { isValid in
+            XCTAssertEqual(isValid, expectedResult)
             expectation.fulfill()
         }
 
-        productStore.onAction(action)
+        store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests+Validation.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests+Validation.swift
@@ -83,7 +83,7 @@ final class ProductStoreTests_Validation: XCTestCase {
         store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
-    
+
     /// Verifies that a non existing SKU is valid.
     func testValidatingSKUWithNotExistingValue() {
         let expectation = self.expectation(description: "Product SKU validation")

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests+Validation.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests+Validation.swift
@@ -83,4 +83,23 @@ final class ProductStoreTests_Validation: XCTestCase {
         store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+    
+    /// Verifies that a non existing SKU is valid.
+    func testValidatingSKUWithNotExistingValue() {
+        let expectation = self.expectation(description: "Product SKU validation")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "product-search-sku")
+
+        let expectedResult = true
+
+        let skuToSearchFor = "T-SHIRT-HAPPY-PANDA"
+        let action = ProductAction.validateProductSKU(skuToSearchFor, siteID: sampleSiteID) { isValid in
+            XCTAssertEqual(isValid, expectedResult)
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -719,6 +719,29 @@ class ProductStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    // MARK: - ProductAction.
+
+    /// Verifies that `ProductAction.searchIfSkuExist` effectively fetch an existing sku
+    ///
+    func testSearchIfSkuExistEffectivelyRetrievedAnExistingSku() {
+        let expectation = self.expectation(description: "Search given Product SKU if already exists")
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        network.simulateResponse(requestUrlSuffix: "products", filename: "product-search-sku")
+
+        let expectedResult = true
+
+        let skuToSearchFor = "T-SHIRT-HAPPY-NINJA"
+        let action = ProductAction.searchIfSkuExist(siteID: sampleSiteID, sku: skuToSearchFor) { (result, error) in
+            XCTAssertEqual(result, expectedResult)
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+
+        store.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     // MARK: - ProductAction.updateProduct
 
     /// Verifies that `ProductAction.updateProduct` returns the expected `Product`.

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -719,29 +719,6 @@ class ProductStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    // MARK: - ProductAction.
-
-    /// Verifies that `ProductAction.searchIfSkuExist` effectively fetch an existing sku
-    ///
-    func testSearchIfSkuExistEffectivelyRetrieveAnExistingSku() {
-        let expectation = self.expectation(description: "Search given Product SKU if already exists")
-        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
-        network.simulateResponse(requestUrlSuffix: "products", filename: "product-search-sku")
-
-        let expectedResult = true
-
-        let skuToSearchFor = "T-SHIRT-HAPPY-NINJA"
-        let action = ProductAction.searchIfSkuExist(siteID: sampleSiteID, sku: skuToSearchFor) { (result, error) in
-            XCTAssertEqual(result, expectedResult)
-            XCTAssertNil(error)
-            expectation.fulfill()
-        }
-
-        store.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-    }
-
     // MARK: - ProductAction.updateProduct
 
     /// Verifies that `ProductAction.updateProduct` returns the expected `Product`.

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -723,7 +723,7 @@ class ProductStoreTests: XCTestCase {
 
     /// Verifies that `ProductAction.searchIfSkuExist` effectively fetch an existing sku
     ///
-    func testSearchIfSkuExistEffectivelyRetrievedAnExistingSku() {
+    func testSearchIfSkuExistEffectivelyRetrieveAnExistingSku() {
         let expectation = self.expectation(description: "Search given Product SKU if already exists")
         let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 


### PR DESCRIPTION
Fixes #1710 

## Description
This implementation improve how we check if a product SKU already exists on the website while the user is editing it.
The solution was to implement this new endpoint `/wc/v3/products/&_method=get&sku={sku}` and use also the parameter `_fields` to obtain only the `sku` field (this will increase the performance of the API speed).
Another solution was to call the API every time the user is typing the SKU, implementing a throttling method to make sure we call the API not much frequently.
In the end, I catch the SKU text field to be the first responder. Initially, when the error appears/disappears during the table view refresh, the keyboard will disappear.

## Changes
- Implemented the `ProductSkuMapper` + tests
- Implement the new method `searchSku` in `ProductsRemote` + tests 
- Implemented a new tool class `Throttler` used for throttling a function
- Implemented the new SKU handling logic in `ProductInventorySettingsViewController`
- Implemented the new `searchSku()` method in `ProductStore` + tests

## Testing
1) Navigate to a product detail
2) Tap edit
3) Tap inventory
4) Try to type a new SKU. You will not see the SKU error and you are able to save it.
5) Try to type an existing SKU. You will be able to see the SKU error
6) Try to delete the SKU and retype the old SKU. You will not see the SKU error.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
