### PR TITLE
Edit Product Inventory: fixed SKU label content compression resistance priority

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.xib
@@ -20,7 +20,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ef2-0Q-If9">
                         <rect key="frame" x="16" y="10" width="288" height="24"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wat-L0-9KQ">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wat-L0-9KQ">
                                 <rect key="frame" x="0.0" y="0.0" width="42" height="24"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>


### PR DESCRIPTION
Fixes #1740 

## Description
This PR fixes a problem with the SKU label in the Edit Product Inventory. When the Product SKU is too long, the SKU label is not visible.

## Testing
1) Open a product detail
2) Tap edit
3) Tap Inventory
4) Write a SKU super long, and press save. Reopen the inventory settings. You are able to see the SKU label entirely.


## Screenshot
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-17 at 12 02 13](https://user-images.githubusercontent.com/495617/72608508-1ceaa600-3923-11ea-956b-6794eab7a574.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-17 at 12 09 33](https://user-images.githubusercontent.com/495617/72608511-1fe59680-3923-11ea-8f1c-84a1d9e8bf64.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
