### PR TITLE
Edit Product Price: sale price validation if is higher or equal to the regular price

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -16,6 +16,12 @@ public class CurrencyFormatter {
         let localeDecimalSeparator = Locale.current.decimalSeparator ?? CurrencySettings.shared.decimalSeparator
         var newStringValue = stringValue.replacingOccurrences(of: ",", with: localeDecimalSeparator)
         newStringValue = newStringValue.replacingOccurrences(of: ".", with: localeDecimalSeparator)
+        
+        // Removes the currency symbol, if any.
+        let currencyCode = CurrencySettings.shared.currencyCode
+        let unit = CurrencySettings.shared.symbol(from: currencyCode)
+        newStringValue = newStringValue.replacingOccurrences(of: unit, with: "")
+        
         let decimalValue = NSDecimalNumber(string: newStringValue)
 
         guard decimalValue != NSDecimalNumber.notANumber else {

--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -16,12 +16,12 @@ public class CurrencyFormatter {
         let localeDecimalSeparator = Locale.current.decimalSeparator ?? CurrencySettings.shared.decimalSeparator
         var newStringValue = stringValue.replacingOccurrences(of: ",", with: localeDecimalSeparator)
         newStringValue = newStringValue.replacingOccurrences(of: ".", with: localeDecimalSeparator)
-        
+
         // Removes the currency symbol, if any.
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
         newStringValue = newStringValue.replacingOccurrences(of: unit, with: "")
-        
+
         let decimalValue = NSDecimalNumber(string: newStringValue)
 
         guard decimalValue != NSDecimalNumber.notANumber else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -222,7 +222,7 @@ private extension ProductPriceSettingsViewController {
     ///
     func displaySalePriceErrorNotice() {
         UIApplication.shared.keyWindow?.endEditing(true)
-        let message = NSLocalizedString("The sale price need to be less than the regular price",
+        let message = NSLocalizedString("The sale price should be lower than the regular price.",
                                         comment: "Product price error notice message, when the sale price is higher than the regular price")
 
         let notice = Notice(title: message, feedbackType: .error)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -510,10 +510,7 @@ private extension ProductPriceSettingsViewController {
             return nil
         }
         let currencyFormatter = CurrencyFormatter()
-        let currencyCode = CurrencySettings.shared.currencyCode
-        let unit = CurrencySettings.shared.symbol(from: currencyCode)
-        let value = price.replacingOccurrences(of: unit, with: "")
-        return currencyFormatter.convertToDecimal(from: value)
+        return currencyFormatter.convertToDecimal(from: price)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -182,7 +182,6 @@ extension ProductPriceSettingsViewController {
 
         // Check if the sale price is less of the regular price, else show an error.
         if let decimalSalePrice = getDecimalPrice(salePrice), let decimalRegularPrice = getDecimalPrice(regularPrice) {
-            print(decimalSalePrice, decimalRegularPrice)
             let comparison = decimalSalePrice.compare(decimalRegularPrice)
             guard comparison == .orderedAscending else {
                 displaySalePriceErrorNotice()


### PR DESCRIPTION
Part of #1652 

## Description
Display an error notice on Product Price Settings if the user tries to save a sale price which is higher or equal than the regular price.

## Testing
1) Go to Products tab
2) Select a product
3) Tap price cell
4) Try to add a sale price higher than the regular price, and press save.
5) You get an error.
6) Try to add a sale price equal to the regular price, and press save.
7) You get an error.
8) Try to add a sale price less than the regular price, and press save.
9) The price is saved correctly.

Let me know if you like the message error, or if you'd like to change it.

## Screenshot
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-20 at 18 28 32](https://user-images.githubusercontent.com/495617/72747020-d069c980-3bb3-11ea-95c4-866a8b3440b7.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
