### PR TITLE
Edit Product Title: validation when it's empty

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -253,7 +253,7 @@ extension ProductFormViewController: TextViewViewControllerDelegate {
     }
 
     func validationError() -> String {
-        return NSLocalizedString("Title cannot be empty",
+        return NSLocalizedString("Please add a title",
                                  comment: "Product title error notice message, when the title is empty")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -248,11 +248,11 @@ private extension ProductFormViewController {
 }
 
 extension ProductFormViewController: TextViewViewControllerDelegate {
-    func shouldValidate(text: String) -> Bool {
+    func validate(text: String) -> Bool {
         return !text.isEmpty
     }
 
-    func validationError() -> String {
+    func validationErrorMessage() -> String {
         return NSLocalizedString("Please add a title",
                                  comment: "Product title error notice message, when the title is empty")
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -231,6 +231,7 @@ private extension ProductFormViewController {
         ) { [weak self] (newProductName) in
             self?.onEditProductNameCompletion(newName: newProductName ?? "")
         }
+        textViewController.delegate = self
 
         navigationController?.pushViewController(textViewController, animated: true)
     }
@@ -244,6 +245,19 @@ private extension ProductFormViewController {
         }
         self.product = productUpdater.nameUpdated(name: newName)
     }
+}
+
+extension ProductFormViewController: TextViewViewControllerDelegate {
+    func shouldValidate(text: String) -> Bool {
+        return !text.isEmpty
+    }
+
+    func validationError() -> String {
+        return NSLocalizedString("Title cannot be empty",
+                                 comment: "Product title error notice message, when the title is empty")
+    }
+
+
 }
 
 // MARK: Action - Edit Product Parameters

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -3,10 +3,10 @@ import UIKit
 protocol TextViewViewControllerDelegate: class {
 
     // Text validation.
-    func shouldValidate(text: String) -> Bool
+    func validate(text: String) -> Bool
 
     // Error text that will be shown if the text does not pass validation.
-    func validationError() -> String
+    func validationErrorMessage() -> String
 }
 
 /// Contains an editable text view with a placeholder label when the text is empty.
@@ -90,8 +90,8 @@ extension TextViewViewController {
             onCompletion(textView.text)
             return
         }
-        guard delegate?.shouldValidate(text: textView.text) == true else {
-            if let errorString = delegate?.validationError() {
+        guard delegate?.validate(text: textView.text) == true else {
+            if let errorString = delegate?.validationErrorMessage() {
                 displayErrorNotice(error: errorString)
             }
             return


### PR DESCRIPTION
Fixes #1677 

## Description
This implementation shows an error alert on Edit Product Title when a user tries to save an empty title. 
Since the title uses the generic `TextViewViewController`, I implemented a new optional protocol `TextViewViewControllerDelegate` which allows us to validate a text, and to set also a validation error.

## Testing
1) Go to Products tab
2) Select a product
3) Tap Title cell
4) Try to delete the title
5) Press save
6) You get an error since the title can't be empty.

Let me know if you like the message error, or if you'd like to change it.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
