### PR TITLE
Order Details: Fix clipped content

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.xib
@@ -51,8 +51,8 @@
                     <constraint firstItem="Kz9-1h-fRY" firstAttribute="top" secondItem="VuR-wG-Bbc" secondAttribute="bottom" constant="8" id="4yW-xe-vMw"/>
                     <constraint firstItem="VuR-wG-Bbc" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="ALe-dT-Iae"/>
                     <constraint firstItem="uIV-Sn-Yeh" firstAttribute="top" secondItem="Kz9-1h-fRY" secondAttribute="bottom" constant="8" id="B6Q-cI-ASJ"/>
+                    <constraint firstItem="0jq-dU-DSt" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uIV-Sn-Yeh" secondAttribute="trailing" constant="16" id="GXV-DS-eh5"/>
                     <constraint firstItem="Kz9-1h-fRY" firstAttribute="trailing" secondItem="VuR-wG-Bbc" secondAttribute="trailing" id="H8X-uc-vIl"/>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="uIV-Sn-Yeh" secondAttribute="trailing" constant="16" id="Iv2-nI-HgU"/>
                     <constraint firstItem="0jq-dU-DSt" firstAttribute="trailing" secondItem="VuR-wG-Bbc" secondAttribute="trailing" id="Yrn-9W-9Dw"/>
                     <constraint firstItem="uIV-Sn-Yeh" firstAttribute="leading" secondItem="VuR-wG-Bbc" secondAttribute="leading" id="h9K-qI-gKu"/>
                     <constraint firstItem="VuR-wG-Bbc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="mSL-pS-fig"/>


### PR DESCRIPTION
Fixes #1061. 

## Findings

It looks like most of the issues described in #1061 have already been fixed. 

"Show billing" / "Hide billing" button ✔️  | quantity text under "QTY" column ✔️ | section header with long title ✔️ 
--------|-------|----
![image](https://user-images.githubusercontent.com/198826/72827790-a9091000-3c38-11ea-9502-35d4bb5facdc.png)        |       Fixed in #1751 | ![image](https://user-images.githubusercontent.com/198826/72827923-e40b4380-3c38-11ea-803e-1d58daaf9829.png) | 

## Fixes

The **edit button beside long order payment status (e.g. "Pending payment")** issue is the only pending issue as far as I can tell. Fixed in b01540d.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72828014-09984d00-3c39-11ea-94e5-398935fc1ee9.png)        |       ![image](https://user-images.githubusercontent.com/198826/72828024-0e5d0100-3c39-11ea-88c3-a98890c8344e.png)

## Testing

1. Set the font size to the largest that you can.
2. Navigate to an Order with _Pending payment_ status. 
3. Confirm that the “Pending payment” text does not bleed through the button.
4. Rejoice if I didn't break anything. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
