### PR TITLE
Hotfix: fixed rounded prices when the Locale is not correct

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -16,7 +16,7 @@ public class CurrencyFormatter {
         let localeDecimalSeparator = Locale.current.decimalSeparator ?? CurrencySettings.shared.decimalSeparator
         var newStringValue = stringValue.replacingOccurrences(of: ",", with: localeDecimalSeparator)
         newStringValue = newStringValue.replacingOccurrences(of: ".", with: localeDecimalSeparator)
-        let decimalValue = NSDecimalNumber(string: newStringValue)
+        let decimalValue = NSDecimalNumber(string: newStringValue, locale: Locale.current)
 
         guard decimalValue != NSDecimalNumber.notANumber else {
             DDLogError("Error: string input is not a number: \(stringValue)")


### PR DESCRIPTION
Fixes #1756 

This is a hotfix for the release 3.4.

## Description
In some UI languages (such as Spanish, German, French, and Dutch), prices (e.g. order totals, order details, product prices) are rounded to whole numbers instead of showing an accurate amount. es. $12.34 will be shown as $12.00
The problem was caused by `NSDecimalNumber` which use by default the device Locale, and not the Locale (`Locale.current`) configured in Settings app > Woo > Language.
Thanks to @rachelmcr for discovering this bug! 💯 

## Testing
1. Create an order with an order total that is not a whole number (e.g. `$12.34`).
2. In the Settings app > Woo > Language set the language to English.
3. Open the Woo app and confirm that the new order appears with the correct order total ($12.34).
4. In the Settings app > Woo > Language set the language to Spanish or German.
5.  Open the Woo app and confirm that the new order appears with the correct order total ($12.34).

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![72830277-48012c80-3c78-11ea-9067-64277119d6e8](https://user-images.githubusercontent.com/495617/72843736-6fb5bc00-3c9b-11ea-889d-2090d83d2926.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-21 at 21 31 22](https://user-images.githubusercontent.com/495617/72843609-28c7c680-3c9b-11ea-8342-fb8e33639b70.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
