### PR TITLE
Networking layer: Media remote - upload media

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */ = {isa = PBXBuildFile; fileRef = 020220E123966CD900290165 /* product-shipping-classes-load-one.json */; };
+		020D07B823D852BB00FD9580 /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07B723D852BB00FD9580 /* Media.swift */; };
+		020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07B923D8542000FD9580 /* UploadableMedia.swift */; };
+		020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07BB23D856BF00FD9580 /* MediaRemote.swift */; };
+		020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07BD23D8570800FD9580 /* MediaListMapper.swift */; };
+		020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */; };
+		020D07C223D858BB00FD9580 /* media-upload.json in Resources */ = {isa = PBXBuildFile; fileRef = 020D07C123D858BB00FD9580 /* media-upload.json */; };
 		0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */; };
 		021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */; };
 		021E2A1423A9FC5900B1DE07 /* ProductBackordersSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */; };
@@ -310,6 +316,12 @@
 
 /* Begin PBXFileReference section */
 		020220E123966CD900290165 /* product-shipping-classes-load-one.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-one.json"; sourceTree = "<group>"; };
+		020D07B723D852BB00FD9580 /* Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
+		020D07B923D8542000FD9580 /* UploadableMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadableMedia.swift; sourceTree = "<group>"; };
+		020D07BB23D856BF00FD9580 /* MediaRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemote.swift; sourceTree = "<group>"; };
+		020D07BD23D8570800FD9580 /* MediaListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaListMapper.swift; sourceTree = "<group>"; };
+		020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemoteTests.swift; sourceTree = "<group>"; };
+		020D07C123D858BB00FD9580 /* media-upload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-upload.json"; sourceTree = "<group>"; };
 		0219B03823964BB3007DCD5E /* ProductShippingClassMapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductShippingClassMapper.swift; sourceTree = "<group>"; };
 		021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Serialization.swift"; sourceTree = "<group>"; };
 		021E2A1323A9FC5900B1DE07 /* ProductBackordersSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSetting.swift; sourceTree = "<group>"; };
@@ -630,6 +642,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		020D07B623D852AB00FD9580 /* Media */ = {
+			isa = PBXGroup;
+			children = (
+				020D07B723D852BB00FD9580 /* Media.swift */,
+				020D07B923D8542000FD9580 /* UploadableMedia.swift */,
+			);
+			path = Media;
+			sourceTree = "<group>";
+		};
 		35C45CCE73A311BE252F6BF4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -709,6 +730,7 @@
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
+				020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */,
 				B554FA8A2180B1D500C54DFF /* NotificationsRemoteTests.swift */,
 				B518662920A09C6F00037A38 /* OrdersRemoteTests.swift */,
 				74AE244C2113704C00CA8C54 /* OrderStatsRemoteTests.swift */,
@@ -832,6 +854,7 @@
 				74ABA1D0213F22CA00FFAD30 /* TopEarnersStatsRemote.swift */,
 				026CF61F237D69D6009563D4 /* ProductVariationsRemote.swift */,
 				025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */,
+				020D07BB23D856BF00FD9580 /* MediaRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -861,6 +884,7 @@
 			isa = PBXGroup;
 			children = (
 				B50A583A21AD872E00617455 /* Devices */,
+				020D07B623D852AB00FD9580 /* Media */,
 				CE6BFEE62236CF0D005C79FB /* Product */,
 				45AE58142306ADA8001901E3 /* Refund */,
 				74A1D26921189AC100931DFA /* Stats */,
@@ -919,6 +943,7 @@
 				B524194621AC643900D6FC0A /* device-settings.json */,
 				B505F6D420BEE4E600BB1B69 /* me.json */,
 				93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */,
+				020D07C123D858BB00FD9580 /* media-upload.json */,
 				B58D10C92114D22E00107ED4 /* new-order-note.json */,
 				022902D322E2436400059692 /* no_stats_permission_error.json */,
 				B5A24178217F98F600595DEF /* notifications-load-all.json */,
@@ -999,6 +1024,7 @@
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
+				020D07BD23D8570800FD9580 /* MediaListMapper.swift */,
 				D823D904223746CE00C90817 /* NewShipmentTrackingMapper.swift */,
 				B554FA8E2180BC7000C54DFF /* NoteHashListMapper.swift */,
 				B59325CB217E2B4C000B0E8E /* NoteListMapper.swift */,
@@ -1340,6 +1366,7 @@
 				457FC68C2382B2FD00B41B02 /* product-update.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
 				74159628224D63CE003C21CF /* settings-product-alt.json in Resources */,
+				020D07C223D858BB00FD9580 /* media-upload.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1428,8 +1455,10 @@
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
 				D88D5A47230BC838007B6E01 /* ProductReview.swift in Sources */,
 				741B950120EBC8A700DD6E2D /* OrderCouponLine.swift in Sources */,
+				020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,
+				020D07B823D852BB00FD9580 /* Media.swift in Sources */,
 				B5BB1D0C20A2050300112D92 /* DateFormatter+Woo.swift in Sources */,
 				743E84EE2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift in Sources */,
 				B567AF2520A0CCA300AB6C62 /* AuthenticatedRequest.swift in Sources */,
@@ -1448,6 +1477,7 @@
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
+				020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */,
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
 				743E84EC22171F4600FAC9D7 /* ShipmentTracking.swift in Sources */,
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,
@@ -1521,6 +1551,7 @@
 				74D3BD142114FE6900A6E85E /* MIContainer.swift in Sources */,
 				B5BB1D1220A255EC00112D92 /* OrderStatusEnum.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
+				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
 				74C8F06820EEB7BD00B6EDC9 /* OrderNotesMapper.swift in Sources */,
 				4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */,
 				B53EF5342180F646003E146F /* DotcomValidator.swift in Sources */,
@@ -1580,6 +1611,7 @@
 				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
+				020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */,
 				D88D5A4F230BD276007B6E01 /* ProductReviewListMapperTests.swift in Sources */,
 				B567AF3120A0FB8F00AB6C62 /* JetpackRequestTests.swift in Sources */,
 				7412A8F221B6E47A005D182A /* ReportRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/MediaListMapper.swift
+++ b/Networking/Networking/Mapper/MediaListMapper.swift
@@ -1,0 +1,19 @@
+/// Mapper: Media List
+///
+struct MediaListMapper: Mapper {
+    /// (Attempts) to convert a dictionary into an Account entity.
+    ///
+    func map(response: Data) throws -> [Media] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.iso8601)
+        return try decoder.decode(MediaListEnvelope.self, from: response).mediaList
+    }
+}
+
+private struct MediaListEnvelope: Decodable {
+    let mediaList: [Media]
+
+    private enum CodingKeys: String, CodingKey {
+        case mediaList = "media"
+    }
+}

--- a/Networking/Networking/Mapper/MediaListMapper.swift
+++ b/Networking/Networking/Mapper/MediaListMapper.swift
@@ -1,7 +1,7 @@
 /// Mapper: Media List
 ///
 struct MediaListMapper: Mapper {
-    /// (Attempts) to convert a dictionary into an Account entity.
+    /// (Attempts) to convert data into a Media list.
     ///
     func map(response: Data) throws -> [Media] {
         let decoder = JSONDecoder()

--- a/Networking/Networking/Model/Media/Media.swift
+++ b/Networking/Networking/Model/Media/Media.swift
@@ -1,0 +1,85 @@
+/// WordPress Site Media
+///
+public struct Media {
+    public let mediaID: Int64
+    public let date: Date    // gmt iso8601
+    public let fileExtension: String
+    public let mimeType: String
+    public let src: String
+    public let thumbnailURL: String?
+    public let name: String?
+    public let alt: String?
+    public let height: Double?
+    public let width: Double?
+
+    /// Media initializer.
+    ///
+    public init(mediaID: Int64,
+                date: Date,
+                fileExtension: String,
+                mimeType: String,
+                src: String,
+                thumbnailURL: String?,
+                name: String?,
+                alt: String?,
+                height: Double?,
+                width: Double?) {
+        self.mediaID = mediaID
+        self.date = date
+        self.fileExtension = fileExtension
+        self.mimeType = mimeType
+        self.src = src
+        self.thumbnailURL = thumbnailURL
+        self.name = name
+        self.alt = alt
+        self.height = height
+        self.width = width
+    }
+}
+
+extension Media: Decodable {
+    /// Decodable Initializer.
+    ///
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let mediaID = try container.decode(Int64.self, forKey: .mediaID)
+        let date = try container.decodeIfPresent(Date.self, forKey: .date) ?? Date()
+        let fileExtension = try container.decodeIfPresent(String.self, forKey: .fileExtension) ?? ""
+        let mimeType = try container.decodeIfPresent(String.self, forKey: .mimeType) ?? ""
+        let src = try container.decodeIfPresent(URL.self, forKey: .src)?.absoluteString ?? ""
+        let name = try container.decode(String.self, forKey: .name)
+        let alt = try container.decodeIfPresent(String.self, forKey: .alt)
+        let height = try container.decodeIfPresent(Double.self, forKey: .height)
+        let width = try container.decodeIfPresent(Double.self, forKey: .width)
+
+        let thumbnailsByType = try container.decodeIfPresent(Dictionary<String, String>.self, forKey: .thumbnails)
+        let thumbnailURL = thumbnailsByType?["thumbnail"]
+
+        self.init(mediaID: mediaID,
+                  date: date,
+                  fileExtension: fileExtension,
+                  mimeType: mimeType,
+                  src: src,
+                  thumbnailURL: thumbnailURL,
+                  name: name,
+                  alt: alt,
+                  height: height,
+                  width: width)
+    }
+}
+
+private extension Media {
+    enum CodingKeys: String, CodingKey {
+        case mediaID  = "ID"
+        case date
+        case fileExtension = "extension"
+        case mimeType = "mime_type"
+        case src = "URL"
+        case thumbnails
+        case name = "title"
+        case alt
+        case height
+        case width
+    }
+}

--- a/Networking/Networking/Model/Media/UploadableMedia.swift
+++ b/Networking/Networking/Model/Media/UploadableMedia.swift
@@ -1,0 +1,13 @@
+/// Media that has the data fields to be uploaded to the WordPress Site Media
+///
+public struct UploadableMedia {
+    public let localURL: URL
+    public let filename: String
+    public let mimeType: String
+
+    public init(localURL: URL, filename: String, mimeType: String) {
+        self.localURL = localURL
+        self.filename = filename
+        self.mimeType = mimeType
+    }
+}

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -19,7 +19,8 @@ public class AlamofireNetwork: Network {
     ///
     public required init(credentials: Credentials) {
         self.credentials = credentials
-        self.backgroundSessionManager = Alamofire.SessionManager(configuration: URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession"))
+        let configuration = URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession")
+        self.backgroundSessionManager = Alamofire.SessionManager(configuration: configuration)
     }
 
     /// Executes the specified Network Request. Upon completion, the payload will be sent back to the caller as a Data instance.

--- a/Networking/Networking/Network/MockupNetwork.swift
+++ b/Networking/Networking/Network/MockupNetwork.swift
@@ -66,6 +66,12 @@ class MockupNetwork: Network {
 
         completion(data, nil)
     }
+
+    func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
+                                 to request: URLRequestConvertible,
+                                 completion: @escaping (Data?, Error?) -> Void) {
+        responseData(for: request, completion: completion)
+    }
 }
 
 

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Alamofire
 
+/// Constructs `multipart/form-data` for uploads within an HTTP or HTTPS body.
+///
+public protocol MultipartFormData {
+    func append(_ fileURL: URL, withName name: String, fileName: String, mimeType: String)
+}
 
 /// Defines all of the Network Operations we'll be performing. This allows us to swap the actual Wrapper in our
 /// Unit Testing target, and inject mocked up responses.
@@ -21,4 +26,14 @@ public protocol Network {
     ///     - completion: Closure to be executed upon completion.
     ///
     func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void)
+
+    /// Executes the specified Network Request for file uploads. Upon completion, the payload will be sent back to the caller as a Data instance.
+    ///
+    /// - Parameters:
+    ///   - multipartFormData: Used for appending data for multipart form data uploads.
+    ///   - request: Request that should be performed.
+    ///   - completion: Closure to be executed upon completion.
+    func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
+                                 to request: URLRequestConvertible,
+                                 completion: @escaping (Data?, Error?) -> Void)
 }

--- a/Networking/Networking/Network/NullNetwork.swift
+++ b/Networking/Networking/Network/NullNetwork.swift
@@ -11,5 +11,7 @@ public final class NullNetwork: Network {
 
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) { }
 
-    public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void, to request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) { }
+    public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
+                                        to request: URLRequestConvertible,
+                                        completion: @escaping (Data?, Error?) -> Void) { }
 }

--- a/Networking/Networking/Network/NullNetwork.swift
+++ b/Networking/Networking/Network/NullNetwork.swift
@@ -10,4 +10,6 @@ public final class NullNetwork: Network {
     public required init(credentials: Credentials) { }
 
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) { }
+
+    public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void, to request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) { }
 }

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Media: Remote Endpoints
+///
+public class MediaRemote: Remote {
+    /// Uploads an array of media in the local file system.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll upload the media to.
+    ///     - context: Display or edit. Scope under which the request is made;
+    ///                determines fields present in response. Default is Display.
+    ///     - mediaItems: An array of uploadable media items.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func uploadMedia(for siteID: Int64,
+                            context: String? = Default.context,
+                            mediaItems: [UploadableMedia],
+                            completion: @escaping ([Media]?, Error?) -> Void) {
+        let parameters = [
+            ParameterKey.contextKey: context ?? Default.context,
+        ]
+
+        let path = "sites/\(siteID)/media/new"
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1,
+                                    method: .post,
+                                    path: path,
+                                    parameters: parameters)
+        let mapper = MediaListMapper()
+
+        enqueueMultipartFormDataUpload(request, mapper: mapper, multipartFormData: { multipartFormData in
+            mediaItems.forEach { mediaItem in
+                multipartFormData.append(mediaItem.localURL,
+                                         withName: "media[]",
+                                         fileName: mediaItem.filename,
+                                         mimeType: mediaItem.mimeType)
+            }
+        }, completion: completion)
+    }
+}
+
+
+// MARK: - Constants
+//
+public extension MediaRemote {
+    enum Default {
+        public static let context: String = "display"
+    }
+
+    private enum ParameterKey {
+        static let contextKey: String = "context"
+    }
+}

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Networking
+
+final class MediaRemoteTests: XCTestCase {
+    /// Dummy Network Wrapper
+    ///
+    let network = MockupNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID: Int64 = 1234
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        super.setUp()
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - uploadMedia
+
+    /// Verifies that `uploadMedia` properly parses the `media-upload` sample response.
+    ///
+    func testUploadMediaProperlyReturnsParsedMedia() {
+        let remote = MediaRemote(network: network)
+        let expectation = self.expectation(description: "Upload one media item")
+        let path = "sites/\(sampleSiteID)/media/new"
+
+        network.simulateResponse(requestUrlSuffix: path, filename: "media-upload")
+
+        remote.uploadMedia(for: sampleSiteID,
+                           mediaItems: []) { mediaItems, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(mediaItems)
+            XCTAssertEqual(mediaItems?.count, 1)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `uploadMedia` properly relays Networking Layer errors.
+    ///
+    func testUploadMediaProperlyRelaysNetwokingErrors() {
+        let remote = MediaRemote(network: network)
+        let expectation = self.expectation(description: "Upload one media item")
+
+        remote.uploadMedia(for: sampleSiteID,
+                           mediaItems: []) { mediaItems, error in
+            XCTAssertNil(mediaItems)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+}

--- a/Networking/NetworkingTests/Responses/media-upload.json
+++ b/Networking/NetworkingTests/Responses/media-upload.json
@@ -1,0 +1,53 @@
+{
+    "media": [
+        {
+            "ID": 1899,
+            "URL": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2.jpg",
+            "guid": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2.jpg",
+            "date": "2020-01-22T12:01:52+02:30",
+            "post_ID": 0,
+            "author_ID": 44301761,
+            "file": "BTLY3763-2.jpg",
+            "mime_type": "image/jpeg",
+            "extension": "jpg",
+            "title": "BTLY3763",
+            "caption": "",
+            "description": "",
+            "alt": "",
+            "icon": "https://test.com/wp-includes/images/media/default.png",
+            "thumbnails": {
+                "medium": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-225x300.jpg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-150x150.jpg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-324x324.jpg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-416x555.jpg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-100x100.jpg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-324x324.jpg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-416x555.jpg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/01/BTLY3763-2-100x100.jpg"
+            },
+            "height": 1024,
+            "width": 768,
+            "exif": {
+                "aperture": "0",
+                "credit": "",
+                "camera": "",
+                "caption": "",
+                "created_timestamp": "0",
+                "copyright": "",
+                "focal_length": "0",
+                "iso": "0",
+                "shutter_speed": "0",
+                "title": "",
+                "orientation": "0",
+                "keywords": []
+            },
+            "meta": {
+                "links": {
+                    "self": "https://public-api.wordpress.com/rest/v1.1/sites/000/media/1899",
+                    "help": "https://public-api.wordpress.com/rest/v1.1/sites/000/media/1899/help",
+                    "site": "https://public-api.wordpress.com/rest/v1.1/sites/000"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
"Media remote: upload media" part for #1713 

## Changes

- Created 2 models in Networking:
  - `Media`: it has the necessary fields to render a remote media (for WordPress Media library later)
  - `UploadableMedia`: it has the necessary fields for a media to be uploaded
- Created `MediaListMapper` that maps API response to a list of `Media`
- Added `uploadMultipartFormData` to `Network` protocol, and implemented in `AlamofireNetwork` with [AlamoFire's `upload(multipartFormData:)`](https://github.com/Alamofire/Alamofire/blob/master/Documentation/Usage.md#uploading-multipart-form-data) with a background session manager
- Created `MediaRemote` for uploading media via WP.com API + unit tests with recorded json

## Testing

Just CI for now, since there are no user-facing changes

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
