### PR TITLE
Shipment Tracking: Mark currently selected provider

### DIFF
--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -254,6 +254,19 @@ extension ShippingProvidersViewModel {
             .name
     }
 
+    /// Indicates if the item at `indexPath` is the same as the currently selected provider.
+    func isSelected(_ indexPath: IndexPath) -> Bool {
+        guard let selectedProvider = selectedProvider,
+            let selectedProviderGroupName = selectedProviderGroupName,
+            let provider = provider(at: indexPath),
+            let groupName = groupName(at: indexPath) else {
+            return false
+        }
+
+        return provider.name == selectedProvider.name &&
+            groupName == selectedProviderGroupName
+    }
+
     private func storeCountrySection() -> ResultsController<StorageShipmentTrackingProvider>.SectionInfo? {
         return providersForStoreCountry
             .sections.first

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -13,6 +13,11 @@ final class ShippingProvidersViewModel {
     let title = NSLocalizedString("Shipping Providers",
                                   comment: "Title of view displaying all available Shipment Tracking Providers")
 
+    /// The currently selected tracking provider.
+    private let selectedProvider: ShipmentTrackingProvider?
+    /// The currently selected tracking provider's group name.
+    private let selectedProviderGroupName: String?
+
     // MARK: - Store country
 
     /// Encapsulates the logic to figure out the current store's country
@@ -105,8 +110,10 @@ final class ShippingProvidersViewModel {
 
     /// Designated initializer
     ///
-    init(order: Order) {
+    init(order: Order, selectedProvider: ShipmentTrackingProvider?, selectedProviderGroupName: String?) {
         self.order = order
+        self.selectedProvider = selectedProvider
+        self.selectedProviderGroupName = selectedProviderGroupName
     }
 
     /// Setup: Results Controller

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -299,7 +299,10 @@ extension ShippingProvidersViewModel {
             return provider
         }
 
-        let group = providersExcludingStoreCountry.sections[indexPath.section - delta()]
+        guard let group = providersExcludingStoreCountry.sections[safe: indexPath.section - delta()] else {
+            return nil
+        }
+
         let provider = group.objects[indexPath.item]
 
         return provider

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -285,7 +285,7 @@ extension ShippingProvidersViewModel {
             indexPath.section == Constants.countrySectionIndex {
             return storeCountrySection()?.name
         }
-        return providersExcludingStoreCountry.sections[indexPath.section - delta()].name
+        return providersExcludingStoreCountry.sections[safe: indexPath.section - delta()]?.name
     }
 
     /// Returns the ShipmentTrackingProvider at a given IndexPath

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -375,7 +375,9 @@ private extension ManualTrackingViewController {
     }
 
     func showAllShipmentProviders() {
-        let shippingProviders = ShippingProvidersViewModel(order: viewModel.order)
+        let shippingProviders = ShippingProvidersViewModel(order: viewModel.order,
+                                                           selectedProvider: viewModel.shipmentProvider,
+                                                           selectedProviderGroupName: viewModel.shipmentProviderGroupName)
         let shippingList = ShipmentProvidersViewController(viewModel: shippingProviders, delegate: self)
         navigationController?.pushViewController(shippingList, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -202,6 +202,7 @@ extension ShipmentProvidersViewController: UITableViewDataSource {
 
         cell.bodyLabel?.text = viewModel.titleForCellAt(indexPath)
         cell.applyListSelectorStyle()
+        cell.accessoryType = viewModel.isSelected(indexPath) ? .checkmark : .none
 
         return cell
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -139,7 +139,7 @@ private extension ShipmentProvidersViewController {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
-        let cells = [StatusListTableViewCell.self]
+        let cells = [WooBasicTableViewCell.self]
 
         for cell in cells {
             table.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
@@ -195,12 +195,13 @@ extension ShipmentProvidersViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: StatusListTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? StatusListTableViewCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: WooBasicTableViewCell.reuseIdentifier,
+                                                       for: indexPath) as? WooBasicTableViewCell else {
                                                         fatalError()
         }
 
-        cell.textLabel?.text = viewModel.titleForCellAt(indexPath)
+        cell.bodyLabel?.text = viewModel.titleForCellAt(indexPath)
+        cell.applyListSelectorStyle()
 
         return cell
     }


### PR DESCRIPTION
Fixes #1052.

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/72911439-52aed680-3cf7-11ea-9385-ee91c609b1f7.gif" width="320">      |  <img src="https://user-images.githubusercontent.com/198826/72911071-aff65800-3cf6-11ea-81ba-d7a39e65138f.gif" width="320">

Before | After 
--------|-------
current provider is not marked | current provider is **marked with checkmark**
touching an item highlights it by changing the background and showing a checkmark | touching an item highlights it by changing the background **only**

## Design Review

@Garance91540 As shown in the Before and After GIFs above, this change removes the checkmark when highlighting (touching) an item in the provider list. Is this okay? Or the highlighting with checkmark is important? 

I noticed that we don't highlight with a checkmark in Android too. 

## Changes

### `WooBasicTableViewCell`

I changed `ShipmentProvidersViewController` to use `WooBasicTableViewCell`. The selection (checkmark) behavior of the previously used `StatusListTableViewCell` requires us to preselect the item using `table.select()`. This seems like an overhead since it requires us to search for the correct `indexPath`, possible `O(n)`, whenever the list is reloaded. 

Tracking reloads and finding and selecting the item can get complicated since the ViewController also has a search function.

I believe it’s better if the checkmark setting is _reactive_ — do it in `cellForRowAt`. With this, we don’t need to worry about _when_ the table reloading happens, just when the item (cell) is created and shown.

Please let me know if there's another reusable cell that I could use though. I experimented a bit and only found `WooBasicTableViewCell` that fits.

### "Same Item" Logic

In order to determine if a `ShipmentTrackingProvider` is the same as the currently selected provider, I opted to use `.name`. We do [the same thing in WooAndroid](https://github.com/woocommerce/woocommerce-android/blob/3aa1e6a180c29df0183370b556314aed275b58e8/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/orders/AddOrderTrackingProviderListAdapter.kt#L175-L177). 

https://github.com/woocommerce/woocommerce-ios/blob/21c3ebdd7a914a4f70b4cb0e0217e390d18b37ea/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift#L266-L267

The addition of the group name in the equality check is for good measure. It's probably unlikely that there are duplicate names though. I thought of just including this for consistency with how we pass the provider (and group name) back to the delegate:

https://github.com/woocommerce/woocommerce-ios/blob/21c3ebdd7a914a4f70b4cb0e0217e390d18b37ea/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/Shipment%20Tracking%20Section/Add%20Tracking/ShipmentProvidersViewController.swift#L230

## Others

### Unit Tests

I tried to make a unit test for `ShippingProvidersViewModel`. It ended up to be quite a big change. For example, I was blocked at `ServiceLocator.setStorageManager`.

https://github.com/woocommerce/woocommerce-ios/blob/21c3ebdd7a914a4f70b4cb0e0217e390d18b37ea/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift#L186-L192

I think the argument should be [`StorageManagerType`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Storage/Storage/Protocols/StorageManagerType.swift) instead so that I can pass a [`MockupStorageManager`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/YosemiteTests/Mockups/MockupStorage.swift).

Anyway, I concluded that all those changes do not belong in this PR. There's also a big chance that I'm doing this wrong. 🤷‍♂ 

## Testing

1. Navigate to an Order → Add Tracking
2. Tap on Shipping provider and select one. You should be navigated back to the Add Tracking page.
3. Tap on Shipping provider again. 
4. Confirm that there is a checkmark on the previously selected provider.
5. Enter something in the search field.
6. Confirm that if the selected provider is in one of the search results, it should still have a checkmark.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
