### PR TITLE
Updated order badge to show 99+ for 100 or more orders to be fulfilled.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+3.6
+-----
+- Orders tab: Orders to fulfill badge shows numbers 1-99, and now 99+ for anything over 99. Previously, it was 9+.
+
 3.5
 -----
 - bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -30,9 +30,9 @@ final class MainTabViewModel {
 
 private extension MainTabViewModel {
     enum Constants {
-        static let ninePlus = NSLocalizedString(
-            "9+",
-            comment: "Content of the badge presented over the Orders icon when there are more than 9 orders processing"
+        static let ninetyNinePlus = NSLocalizedString(
+            "99+",
+            comment: "Content of the badge presented over the Orders icon when there are more than 99 orders processing"
         )
     }
 
@@ -68,7 +68,7 @@ private extension MainTabViewModel {
     }
 
     private func readableCount(_ count: Int) -> String {
-        return count > 9 ? Constants.ninePlus : String(count)
+        return count > 99 ? Constants.ninetyNinePlus : String(count)
     }
 
     private func observeBadgeRefreshNotifications() {


### PR DESCRIPTION
Closes #1763 

Changes the logic to show orders to fulfill counts for 1-99, then 99+ instead of 9+ for the upper limit.

<img src="https://user-images.githubusercontent.com/373903/72933916-527aff00-3d28-11ea-8e3d-e6d8f7386138.png" width="270" alt="Simulator Screen Shot - iPhone 11 Pro Max - 2020-01-22 at 14 58 49">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc: @elibud 
