### PR TITLE
Image Upload: export an image asset to local file system

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */; };
 		02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */; };
 		02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055E23D985710058E6E7 /* URL+MediaTests.swift */; };
+		02FF056123D98FD40058E6E7 /* ImageSourceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056023D98FD40058E6E7 /* ImageSourceWriter.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
@@ -237,6 +238,7 @@
 		02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManagerTests.swift; sourceTree = "<group>"; };
 		02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+URLTests.swift"; sourceTree = "<group>"; };
 		02FF055E23D985710058E6E7 /* URL+MediaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+MediaTests.swift"; sourceTree = "<group>"; };
+		02FF056023D98FD40058E6E7 /* ImageSourceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSourceWriter.swift; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 				02FF054523D983F30058E6E7 /* MediaFileManager.swift */,
 				02FF054623D983F30058E6E7 /* MediaImageExporter.swift */,
 				02FF054B23D983F30058E6E7 /* URL+Media.swift */,
+				02FF056023D98FD40058E6E7 /* ImageSourceWriter.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -1102,6 +1105,7 @@
 				026CF628237D8F30009563D4 /* ProductVariationAction.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
+				02FF056123D98FD40058E6E7 /* ImageSourceWriter.swift in Sources */,
 				026CF626237D8EFB009563D4 /* ProductVariationStore.swift in Sources */,
 				B52E0034211A449600700FDE /* Site+ReadOnlyType.swift in Sources */,
 				D8C11A5822DFB2FF00D4A88D /* OrderStatsV4Interval+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -36,6 +36,18 @@
 		02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262BF238CE80100B79588 /* StorageShippingSettingsServiceTests.swift */; };
 		02E262C2238CF74D00B79588 /* StorageShippingSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C1238CF74D00B79588 /* StorageShippingSettingsService.swift */; };
 		02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */; };
+		02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054523D983F30058E6E7 /* MediaFileManager.swift */; };
+		02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054623D983F30058E6E7 /* MediaImageExporter.swift */; };
+		02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054723D983F30058E6E7 /* FileManager+URL.swift */; };
+		02FF055023D983F30058E6E7 /* ExportableAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054823D983F30058E6E7 /* ExportableAsset.swift */; };
+		02FF055123D983F30058E6E7 /* MediaAssetExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054923D983F30058E6E7 /* MediaAssetExporter.swift */; };
+		02FF055223D983F30058E6E7 /* MediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054A23D983F30058E6E7 /* MediaExportService.swift */; };
+		02FF055323D983F30058E6E7 /* URL+Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054B23D983F30058E6E7 /* URL+Media.swift */; };
+		02FF055423D983F30058E6E7 /* MediaExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054C23D983F30058E6E7 /* MediaExport.swift */; };
+		02FF055623D984310058E6E7 /* MockupFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055523D984310058E6E7 /* MockupFileManager.swift */; };
+		02FF055B23D9846A0058E6E7 /* MediaDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055823D9846A0058E6E7 /* MediaDirectoryTests.swift */; };
+		02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */; };
+		02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
@@ -211,6 +223,18 @@
 		02E262BF238CE80100B79588 /* StorageShippingSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageShippingSettingsServiceTests.swift; sourceTree = "<group>"; };
 		02E262C1238CF74D00B79588 /* StorageShippingSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageShippingSettingsService.swift; sourceTree = "<group>"; };
 		02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSOrderedSet+Array.swift"; sourceTree = "<group>"; };
+		02FF054523D983F30058E6E7 /* MediaFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManager.swift; sourceTree = "<group>"; };
+		02FF054623D983F30058E6E7 /* MediaImageExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImageExporter.swift; sourceTree = "<group>"; };
+		02FF054723D983F30058E6E7 /* FileManager+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+URL.swift"; sourceTree = "<group>"; };
+		02FF054823D983F30058E6E7 /* ExportableAsset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportableAsset.swift; sourceTree = "<group>"; };
+		02FF054923D983F30058E6E7 /* MediaAssetExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaAssetExporter.swift; sourceTree = "<group>"; };
+		02FF054A23D983F30058E6E7 /* MediaExportService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaExportService.swift; sourceTree = "<group>"; };
+		02FF054B23D983F30058E6E7 /* URL+Media.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+Media.swift"; sourceTree = "<group>"; };
+		02FF054C23D983F30058E6E7 /* MediaExport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaExport.swift; sourceTree = "<group>"; };
+		02FF055523D984310058E6E7 /* MockupFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockupFileManager.swift; sourceTree = "<group>"; };
+		02FF055823D9846A0058E6E7 /* MediaDirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaDirectoryTests.swift; sourceTree = "<group>"; };
+		02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManagerTests.swift; sourceTree = "<group>"; };
+		02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+URLTests.swift"; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -461,6 +485,31 @@
 			path = ShippingSettings;
 			sourceTree = "<group>";
 		};
+		02FF054423D983C40058E6E7 /* Media */ = {
+			isa = PBXGroup;
+			children = (
+				02FF054823D983F30058E6E7 /* ExportableAsset.swift */,
+				02FF054723D983F30058E6E7 /* FileManager+URL.swift */,
+				02FF054923D983F30058E6E7 /* MediaAssetExporter.swift */,
+				02FF054C23D983F30058E6E7 /* MediaExport.swift */,
+				02FF054A23D983F30058E6E7 /* MediaExportService.swift */,
+				02FF054523D983F30058E6E7 /* MediaFileManager.swift */,
+				02FF054623D983F30058E6E7 /* MediaImageExporter.swift */,
+				02FF054B23D983F30058E6E7 /* URL+Media.swift */,
+			);
+			path = Media;
+			sourceTree = "<group>";
+		};
+		02FF055723D984500058E6E7 /* Media */ = {
+			isa = PBXGroup;
+			children = (
+				02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */,
+				02FF055823D9846A0058E6E7 /* MediaDirectoryTests.swift */,
+				02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */,
+			);
+			path = Media;
+			sourceTree = "<group>";
+		};
 		B52E002C2119E6C000700FDE /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -558,6 +607,7 @@
 		B56C1EBC20EABD1C00D749F9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				02FF054423D983C40058E6E7 /* Media */,
 				02E262BB238CE45300B79588 /* ShippingSettings */,
 				B52E002C2119E6C000700FDE /* Internal */,
 				B5631ECC2114DF8C008D3535 /* EntityListener.swift */,
@@ -730,6 +780,7 @@
 				D87F615F2265B2400031A13B /* shipment-provider.plist */,
 				B5C9DE1E2087FF20006B910A /* MockupProcessor.swift */,
 				B5C9DE202087FF20006B910A /* MockupAcount.swift */,
+				02FF055523D984310058E6E7 /* MockupFileManager.swift */,
 				B5C9DE212087FF20006B910A /* MockupSite.swift */,
 				B5A01CA020D19C4700E3207E /* MockupStorage.swift */,
 				B53A569F211245E0000776C9 /* MockupStorage+Sample.swift */,
@@ -767,6 +818,7 @@
 		B5F2AE9320EBAD5200FEDC59 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				02FF055723D984500058E6E7 /* Media */,
 				02E262BE238CE7EA00B79588 /* ShippingSettings */,
 				B54EAF2021188C470029C35E /* EntityListenerTests.swift */,
 				B5F2AE9420EBAD6000FEDC59 /* ResultsControllerTests.swift */,
@@ -961,6 +1013,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7492FADD217FAF5C00ED2C69 /* SettingStore.swift in Sources */,
+				02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */,
 				B52E0032211A440D00700FDE /* Order+ReadOnlyType.swift in Sources */,
 				02E262BD238CE46A00B79588 /* ShippingSettingsService.swift in Sources */,
 				B5C9DE152087FF0E006B910A /* Dispatcher.swift in Sources */,
@@ -972,6 +1025,7 @@
 				74685D4E20F7EFA7008958C1 /* OrderItem+ReadOnlyConvertible.swift in Sources */,
 				7471401121877668009A11CC /* NotificationAction.swift in Sources */,
 				CE4FD4522350FB5400A16B31 /* OrderItemTaxRefund+ReadOnlyConvertible.swift in Sources */,
+				02FF055223D983F30058E6E7 /* MediaExportService.swift in Sources */,
 				45010695239A6CDE00E24722 /* TaxClassAction.swift in Sources */,
 				CE4FD4562350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift in Sources */,
 				74FD596F216FB6ED00A5AE83 /* OrderStatsItem+ReadOnlyConvertible.swift in Sources */,
@@ -993,14 +1047,18 @@
 				CE3B7AD52225EBF10050FE4B /* OrderStatusAction.swift in Sources */,
 				7493750C224987D9007D85D1 /* ProductAttribute+ReadOnlyConvertible.swift in Sources */,
 				744A3219216D55F80051439B /* SiteVisitStatsItem+ReadOnlyConvertible.swift in Sources */,
+				02FF055423D983F30058E6E7 /* MediaExport.swift in Sources */,
 				74643EE1221F567E00EDC51A /* ShipmentAction.swift in Sources */,
+				02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */,
 				CE01014F2368C41600783459 /* Refund+ReadOnlyType.swift in Sources */,
 				D8736B6D22F0CE0900A14A29 /* OrderCount+ReadOnlyConvertible.swift in Sources */,
+				02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */,
 				B56C1EC220EAE2E500D749F9 /* ReadOnlyConvertible.swift in Sources */,
 				74A18C562113827E00DCF8A8 /* StatsStore.swift in Sources */,
 				D8C11A5022DF2D9400D4A88D /* StatsStoreV4.swift in Sources */,
 				D87F614A22657A690031A13B /* AppSettingsAction.swift in Sources */,
 				744A321B216D57D40051439B /* SiteVisitStats+ReadOnlyType.swift in Sources */,
+				02FF055023D983F30058E6E7 /* ExportableAsset.swift in Sources */,
 				7493750E224988DE007D85D1 /* ProductImage+ReadOnlyConvertible.swift in Sources */,
 				D80F758C223F74B6002F4A3B /* ShipmentTrackingProvider+ReadOnlyConvertible.swift in Sources */,
 				021C7BF22386332C00A3BCBD /* ProductUpdater.swift in Sources */,
@@ -1016,6 +1074,7 @@
 				D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */,
 				D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */,
 				CE4FD4502350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift in Sources */,
+				02FF055123D983F30058E6E7 /* MediaAssetExporter.swift in Sources */,
 				025CA2CA238F515600B05C81 /* ProductShippingClassStore.swift in Sources */,
 				74937508224985BB007D85D1 /* ProductDimensions+ReadOnlyConvertible.swift in Sources */,
 				45010693239A6C9F00E24722 /* TaxClassStore.swift in Sources */,
@@ -1026,6 +1085,7 @@
 				74A7689020D45F9300F9D437 /* OrderAction.swift in Sources */,
 				74FD596E216FB6ED00A5AE83 /* OrderStats+ReadOnlyConvertible.swift in Sources */,
 				D8736B6F22F0CE5200A14A29 /* OrderCountItem+ReadOnlyConvertible.swift in Sources */,
+				02FF055323D983F30058E6E7 /* URL+Media.swift in Sources */,
 				7499936620EFBC7200CF01CD /* OrderNoteStore.swift in Sources */,
 				74858DB421C02B5A00754F3E /* OrderNote+ReadOnlyType.swift in Sources */,
 				02E262C2238CF74D00B79588 /* StorageShippingSettingsService.swift in Sources */,
@@ -1085,6 +1145,7 @@
 				7495C5292114979D00CDD33B /* StatsStoreTests.swift in Sources */,
 				7499A9ED2220527500D8FDFA /* ShipmentStoreTests.swift in Sources */,
 				0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsVisibility.swift in Sources */,
+				02FF055623D984310058E6E7 /* MockupFileManager.swift in Sources */,
 				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,
 				025CA2D0238F54E800B05C81 /* ProductShippingClassStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
@@ -1103,12 +1164,14 @@
 				B5A01CA120D19C4700E3207E /* MockupStorage.swift in Sources */,
 				7455263022305F88003F8932 /* OrderStatusStoreTests.swift in Sources */,
 				B5C9DE242087FF20006B910A /* StoreTests.swift in Sources */,
+				02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */,
 				B5C9DE252087FF20006B910A /* MockupProcessor.swift in Sources */,
 				D8C11A5A22DFC21600D4A88D /* StatsStoreV4Tests.swift in Sources */,
 				B54EAF2121188C470029C35E /* EntityListenerTests.swift in Sources */,
 				021C7BF52386362A00A3BCBD /* Product+UpdaterTestCases.swift in Sources */,
 				CECC504023675DF4004540EA /* RefundStoreTests.swift in Sources */,
 				D831E2E8230E74EF000037D0 /* ProductReviewStoreTests.swift in Sources */,
+				02FF055B23D9846A0058E6E7 /* MediaDirectoryTests.swift in Sources */,
 				741F34842195F752005F5BD9 /* CommentStoreTests.swift in Sources */,
 				B5C9DE282087FF20006B910A /* MockupSite.swift in Sources */,
 				B5BC736820D1AA8F00B5B6FA /* AccountStoreTests.swift in Sources */,
@@ -1118,6 +1181,7 @@
 				028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */,
 				B5F2AE9520EBAD6000FEDC59 /* ResultsControllerTests.swift in Sources */,
 				B5BC736E20D1AB3600B5B6FA /* Constants.swift in Sources */,
+				02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */,
 				748525AC218A45360036DF75 /* NotificationStoreTests.swift in Sources */,
 				7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */,
 			);

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		02FF055B23D9846A0058E6E7 /* MediaDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055823D9846A0058E6E7 /* MediaDirectoryTests.swift */; };
 		02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */; };
 		02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */; };
+		02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF055E23D985710058E6E7 /* URL+MediaTests.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
@@ -235,6 +236,7 @@
 		02FF055823D9846A0058E6E7 /* MediaDirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaDirectoryTests.swift; sourceTree = "<group>"; };
 		02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManagerTests.swift; sourceTree = "<group>"; };
 		02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+URLTests.swift"; sourceTree = "<group>"; };
+		02FF055E23D985710058E6E7 /* URL+MediaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+MediaTests.swift"; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -506,6 +508,7 @@
 				02FF055A23D9846A0058E6E7 /* FileManager+URLTests.swift */,
 				02FF055823D9846A0058E6E7 /* MediaDirectoryTests.swift */,
 				02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */,
+				02FF055E23D985710058E6E7 /* URL+MediaTests.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -1147,6 +1150,7 @@
 				0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsVisibility.swift in Sources */,
 				02FF055623D984310058E6E7 /* MockupFileManager.swift in Sources */,
 				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,
+				02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */,
 				025CA2D0238F54E800B05C81 /* ProductShippingClassStoreTests.swift in Sources */,
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockupAcount.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -110,3 +110,7 @@ public typealias StorageSiteVisitStatsItem = Storage.SiteVisitStatsItem
 public typealias StorageTopEarnerStats = Storage.TopEarnerStats
 public typealias StorageTopEarnerStatsItem = Storage.TopEarnerStatsItem
 public typealias StorageTaxClass = Storage.TaxClass
+
+// MARK: - Internal ReadOnly Models
+
+typealias UploadableMedia = Networking.UploadableMedia

--- a/Yosemite/Yosemite/Tools/Media/ExportableAsset.swift
+++ b/Yosemite/Yosemite/Tools/Media/ExportableAsset.swift
@@ -1,0 +1,5 @@
+import Photos
+
+public protocol ExportableAsset {}
+
+extension PHAsset: ExportableAsset {}

--- a/Yosemite/Yosemite/Tools/Media/FileManager+URL.swift
+++ b/Yosemite/Yosemite/Tools/Media/FileManager+URL.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension FileManager {
+    /// Returns a URL with an incremental file name, if a file already exists at the given URL.
+    ///
+    func createIncrementalFilenameIfNeeded(url originalURL: URL) -> URL {
+        var url = originalURL
+        let pathExtension = url.pathExtension
+        let filename = url.deletingPathExtension().lastPathComponent
+        var index = 1
+        while fileExists(atPath: url.path) {
+            let incrementedName = "\(filename)-\(index)"
+            url.deleteLastPathComponent()
+            url.appendPathComponent(incrementedName, isDirectory: false)
+            url.appendPathExtension(pathExtension)
+            index += 1
+        }
+        return url
+    }
+}

--- a/Yosemite/Yosemite/Tools/Media/ImageSourceWriter.swift
+++ b/Yosemite/Yosemite/Tools/Media/ImageSourceWriter.swift
@@ -99,6 +99,7 @@ extension ImageSourceWriter {
         case imageSourceDestinationWithURLFailed
         case imageSourceThumbnailGenerationFailed
         case imageSourceDestinationWriteFailed
+
         var description: String {
             switch self {
             default:

--- a/Yosemite/Yosemite/Tools/Media/ImageSourceWriter.swift
+++ b/Yosemite/Yosemite/Tools/Media/ImageSourceWriter.swift
@@ -1,0 +1,110 @@
+/// Writes an image to a URL from a CGImageSource, via CGImageDestination, particular to the needs of a `MediaImageExporter`.
+///
+struct ImageSourceWriter {
+
+    /// File URL where the image should be written.
+    ///
+    private let url: URL
+
+    /// The UTType of the image source.
+    ///
+    private let sourceUTType: CFString
+
+    init(url: URL, sourceUTType: CFString) {
+        self.url = url
+        self.sourceUTType = sourceUTType
+    }
+
+    /// Struct for returned result from writing an image, and any properties worth keeping track of.
+    ///
+    struct WriteResultProperties {
+        let width: CGFloat?
+        let height: CGFloat?
+    }
+
+    /// Write a given image source, succeeds unless an error is thrown, returns the resulting properties if available.
+    ///
+    func writeImageSource(_ source: CGImageSource, options: MediaImageExportOptions) throws -> WriteResultProperties {
+        // Create the destination with the URL, or error
+        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, sourceUTType, 1, nil) else {
+            throw ImageSourceWriterError.imageSourceDestinationWithURLFailed
+        }
+
+        // Configure image properties for the image source and image destination methods
+        // Preserve any existing properties from the source.
+        var imageProperties: [NSString: Any] = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? Dictionary) ?? [:]
+        // Configure destination properties
+        imageProperties[kCGImageDestinationLossyCompressionQuality] = options.imageCompressionQuality
+
+        // Keep track of the image's width and height
+        var width: CGFloat?
+        var height: CGFloat?
+
+        // Configure orientation properties to default .up or 1
+        imageProperties[kCGImagePropertyOrientation] = Int(CGImagePropertyOrientation.up.rawValue) as CFNumber
+        if var tiffProperties = imageProperties[kCGImagePropertyTIFFDictionary] as? [NSString: Any] {
+            // Remove TIFF orientation value
+            tiffProperties.removeValue(forKey: kCGImagePropertyTIFFOrientation)
+            imageProperties[kCGImagePropertyTIFFDictionary] = tiffProperties
+        }
+        if var iptcProperties = imageProperties[kCGImagePropertyIPTCDictionary] as? [NSString: Any] {
+            // Remove IPTC orientation value
+            iptcProperties.removeValue(forKey: kCGImagePropertyIPTCImageOrientation)
+            imageProperties[kCGImagePropertyIPTCDictionary] = iptcProperties
+        }
+
+        // Configure options for generating the thumbnail, such as the maximum size.
+        var thumbnailOptions: [NSString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCache: false,
+            kCGImageSourceTypeIdentifierHint: sourceUTType,
+            kCGImageSourceCreateThumbnailWithTransform: true ]
+
+        if let maximumSize = options.maximumImageSize {
+            thumbnailOptions[kCGImageSourceThumbnailMaxPixelSize] = maximumSize as CFNumber
+        }
+
+        // Create a thumbnail of the image source.
+        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary) else {
+            throw ImageSourceWriterError.imageSourceThumbnailGenerationFailed
+        }
+
+        if options.stripsGeoLocationIfNeeded == true {
+            // When removing GPS data for a thumbnail, we have to remove the dictionary
+            // itself for the CGImageDestinationAddImage method.
+            imageProperties.removeValue(forKey: kCGImagePropertyGPSDictionary)
+        }
+
+        // Add the thumbnail image as the destination's image.
+        CGImageDestinationAddImage(destination, image, imageProperties as CFDictionary?)
+
+        // Get the dimensions from the CGImage itself
+        width = CGFloat(image.width)
+        height = CGFloat(image.height)
+
+        // Write the image to the file URL
+        let written = CGImageDestinationFinalize(destination)
+        guard written == true else {
+            throw ImageSourceWriterError.imageSourceDestinationWriteFailed
+        }
+
+        // Return the result with any interesting properties.
+        return WriteResultProperties(width: width,
+                                     height: height)
+    }
+}
+
+extension ImageSourceWriter {
+    enum ImageSourceWriterError: Error {
+        case imageSourceDestinationWithURLFailed
+        case imageSourceThumbnailGenerationFailed
+        case imageSourceDestinationWriteFailed
+        var description: String {
+            switch self {
+            default:
+                return NSLocalizedString("The image could not be added to the Media Library.",
+                                         comment: "Message shown when an image failed to load while trying to add it to the Media library.")
+            }
+        }
+    }
+}

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -1,0 +1,187 @@
+import Foundation
+import MobileCoreServices
+import AVFoundation
+import Photos
+
+/// Media export handling of PHAssets
+///
+final class MediaAssetExporter: MediaExporter {
+
+    let mediaDirectoryType: MediaDirectory
+
+    private let imageOptions: MediaImageExporter.Options
+
+    private let allowableFileExtensions: Set<String>
+
+    private let asset: PHAsset
+
+    /// Default shared instance of the PHImageManager
+    ///
+    private lazy var imageManager = PHImageManager.default()
+
+    init(asset: PHAsset, imageOptions: MediaImageExporter.Options, allowableFileExtensions: Set<String>, mediaDirectoryType: MediaDirectory = .uploads) {
+        self.asset = asset
+        self.imageOptions = imageOptions
+        self.allowableFileExtensions = allowableFileExtensions
+        self.mediaDirectoryType = mediaDirectoryType
+    }
+
+    func export(onCompletion: @escaping MediaExportCompletion) {
+        switch asset.mediaType {
+        case .image:
+            return exportImage(forAsset: asset, onCompletion: onCompletion)
+        default:
+            onCompletion(nil, AssetExportError.unsupportedPHAssetMediaType)
+        }
+    }
+
+    private func exportImage(forAsset asset: PHAsset, onCompletion: @escaping MediaExportCompletion) {
+        guard asset.mediaType == .image else {
+            onCompletion(nil, AssetExportError.expectedPHAssetImageType)
+            return
+        }
+        var filename = UUID().uuidString + ".jpg"
+        var resourceAvailableLocally = false
+        // Get the resource matching the type, to export.
+        let resources = PHAssetResource.assetResources(for: asset).filter({ $0.type == .photo })
+        if let resource = resources.first {
+            resourceAvailableLocally = true
+            filename = resource.originalFilename
+            if UTTypeEqual(resource.uniformTypeIdentifier as CFString, kUTTypeGIF) {
+                // Handles GIF export differently from images.
+                exportGIF(forAsset: asset, resource: resource, onCompletion: onCompletion)
+                return
+            }
+        }
+
+        // Configure the options for requesting the image.
+        let options = PHImageRequestOptions()
+        options.version = .current
+        options.deliveryMode = .highQualityFormat
+        options.resizeMode = .exact
+        options.isNetworkAccessAllowed = true
+        // If we have a resource object that means we have a local copy of the asset so we can request the image in sync mode.
+        options.isSynchronous = resourceAvailableLocally
+
+        // Configure an error handler for the image request.
+        let onImageRequestError: (Error?) -> Void = { (error) in
+            guard let error = error else {
+                onCompletion(nil, AssetExportError.failedLoadingPHImageManagerRequest)
+                return
+            }
+            onCompletion(nil, error)
+        }
+
+        // Request the image.
+        imageManager.requestImageData(for: asset,
+                                      options: options,
+                                      resultHandler: { [weak self] (data, uti, orientation, info) in
+                                        guard let self = self else {
+                                            return
+                                        }
+
+                                        guard let imageData = data else {
+                                            onImageRequestError(info?[PHImageErrorKey] as? Error)
+                                            return
+                                        }
+
+                                        var exportImageType = self.imageOptions.exportImageType
+                                        if self.imageOptions.exportImageType == nil, let utiToUse = uti {
+                                            exportImageType = self.preferredExportTypeFor(uti: utiToUse)
+                                        }
+                                        let options = MediaImageExporter.Options(maximumImageSize: self.imageOptions.maximumImageSize,
+                                                                                        imageCompressionQuality: self.imageOptions.imageCompressionQuality,
+                                                                                        exportImageType: exportImageType,
+                                                                                        stripsGeoLocationIfNeeded: self.imageOptions.stripsGeoLocationIfNeeded)
+
+                                        // Hands off the image export to a shared image writer.
+                                        let exporter = MediaImageExporter(data: imageData,
+                                                                          filename: filename,
+                                                                          typeHint: uti,
+                                                                          options: options,
+                                                                          mediaDirectoryType: self.mediaDirectoryType)
+                                        exporter.export(onCompletion: onCompletion)
+        })
+    }
+}
+
+private extension MediaAssetExporter {
+    func preferredExportTypeFor(uti: String) -> String? {
+        guard allowableFileExtensions.isEmpty == false,
+            let extensionType = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue() as String?
+            else {
+                return nil
+        }
+        if allowableFileExtensions.contains(extensionType) {
+            return uti
+        } else {
+            return kUTTypeJPEG as String
+        }
+    }
+
+    /// Exports and writes an asset's GIF data to a local Media URL.
+    ///
+    /// - parameter onCompletion: Called on successful export, with the local file URL of the exported asset.
+    /// - parameter onError: Called if an error was encountered during export.
+    ///
+    private func exportGIF(forAsset asset: PHAsset, resource: PHAssetResource, onCompletion: @escaping MediaExportCompletion) {
+        guard UTTypeEqual(resource.uniformTypeIdentifier as CFString, kUTTypeGIF) else {
+            onCompletion(nil, AssetExportError.expectedPHAssetGIFType)
+            return
+        }
+        let url: URL
+        do {
+            url = try mediaFileManager.createLocalMediaURL(withFilename: resource.originalFilename,
+                                                           fileExtension: "gif")
+        } catch {
+            onCompletion(nil, error)
+            return
+        }
+        let options = PHAssetResourceRequestOptions()
+        options.isNetworkAccessAllowed = true
+        let manager = PHAssetResourceManager.default()
+        manager.writeData(for: resource,
+                          toFile: url,
+                          options: options,
+                          completionHandler: { (error) in
+                            guard error == nil else {
+                                onCompletion(nil, error)
+                                return
+                            }
+                            let exported = MediaUploadable(localURL: url,
+                                                           filename: url.lastPathComponent,
+                                                           mimeType: url.mimeTypeForPathExtension)
+                            onCompletion(exported, nil)
+        })
+    }
+}
+
+extension MediaAssetExporter {
+    enum AssetExportError: Error {
+        case unsupportedPHAssetMediaType
+        case expectedPHAssetImageType
+        case expectedPHAssetVideoType
+        case expectedPHAssetGIFType
+        case failedLoadingPHImageManagerRequest
+        case unavailablePHAssetImageResource
+        case unavailablePHAssetVideoResource
+        case failedRequestingVideoExportSession
+
+        var description: String {
+            switch self {
+            case .unsupportedPHAssetMediaType:
+                return NSLocalizedString("The item could not be added to the Media Library.", comment: "Message shown when an asset failed to load while trying to add it to the Media library.")
+            case .expectedPHAssetImageType,
+                 .failedLoadingPHImageManagerRequest,
+                 .unavailablePHAssetImageResource:
+                return NSLocalizedString("The image could not be added to the Media Library.", comment: "Message shown when an image failed to load while trying to add it to the Media library.")
+            case .expectedPHAssetVideoType,
+                 .unavailablePHAssetVideoResource,
+                 .failedRequestingVideoExportSession:
+                return NSLocalizedString("The video could not be added to the Media Library.", comment: "Message shown when a video failed to load while trying to add it to the Media library.")
+            case .expectedPHAssetGIFType:
+                return NSLocalizedString("The GIF could not be added to the Media Library.", comment: "Message shown when a GIF failed to load while trying to add it to the Media library.")
+            }
+        }
+    }
+}

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -148,7 +148,7 @@ private extension MediaAssetExporter {
                                 onCompletion(nil, error)
                                 return
                             }
-                            let exported = MediaUploadable(localURL: url,
+                            let exported = UploadableMedia(localURL: url,
                                                            filename: url.lastPathComponent,
                                                            mimeType: url.mimeTypeForPathExtension)
                             onCompletion(exported, nil)

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -159,27 +159,23 @@ extension MediaAssetExporter {
     enum AssetExportError: Error {
         case unsupportedPHAssetMediaType
         case expectedPHAssetImageType
-        case expectedPHAssetVideoType
         case expectedPHAssetGIFType
         case failedLoadingPHImageManagerRequest
         case unavailablePHAssetImageResource
-        case unavailablePHAssetVideoResource
-        case failedRequestingVideoExportSession
 
         var description: String {
             switch self {
             case .unsupportedPHAssetMediaType:
-                return NSLocalizedString("The item could not be added to the Media Library.", comment: "Message shown when an asset failed to load while trying to add it to the Media library.")
+                return NSLocalizedString("The item could not be added to the Media Library.",
+                                         comment: "Message shown when an asset failed to load while trying to add it to the Media library.")
             case .expectedPHAssetImageType,
                  .failedLoadingPHImageManagerRequest,
                  .unavailablePHAssetImageResource:
-                return NSLocalizedString("The image could not be added to the Media Library.", comment: "Message shown when an image failed to load while trying to add it to the Media library.")
-            case .expectedPHAssetVideoType,
-                 .unavailablePHAssetVideoResource,
-                 .failedRequestingVideoExportSession:
-                return NSLocalizedString("The video could not be added to the Media Library.", comment: "Message shown when a video failed to load while trying to add it to the Media library.")
+                return NSLocalizedString("The image could not be added to the Media Library.",
+                                         comment: "Message shown when an image failed to load while trying to add it to the Media library.")
             case .expectedPHAssetGIFType:
-                return NSLocalizedString("The GIF could not be added to the Media Library.", comment: "Message shown when a GIF failed to load while trying to add it to the Media library.")
+                return NSLocalizedString("The GIF could not be added to the Media Library.",
+                                         comment: "Message shown when a GIF failed to load while trying to add it to the Media library.")
             }
         }
     }

--- a/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -3,7 +3,7 @@ import MobileCoreServices
 import AVFoundation
 import Photos
 
-/// Media export handling of PHAssets
+/// Exports a media item of `PHAsset` type to be uploadable.
 ///
 final class MediaAssetExporter: MediaExporter {
 

--- a/Yosemite/Yosemite/Tools/Media/MediaExport.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExport.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Networking
+
+typealias MediaUploadable = Networking.UploadableMedia
+
+/// Completion block when a media item is exported.
+///
+typealias MediaExportCompletion = (MediaUploadable?, Error?) -> Void
+
+/// Exports media to the local file system for remote upload.
+///
+protocol MediaExporter {
+
+    /// The type of MediaDirectory to use for the export destination URL.
+    ///
+    /// - Note: This would generally be set to .uploads or .cache, but for unit testing we use .temporary.
+    ///
+    var mediaDirectoryType: MediaDirectory { get }
+
+    /// Export a media to another format
+    ///
+    /// - Parameters:
+    ///   - onCompletion: a callback to invoke when the export finishes.
+    ///
+    func export(onCompletion: @escaping MediaExportCompletion)
+}
+
+/// Extension providing generic helper implementation particular to a MediaExporter.
+///
+extension MediaExporter {
+
+    /// A MediaFileManager configured with the exporter's set MediaDirectory type.
+    ///
+    var mediaFileManager: MediaFileManager {
+        return MediaFileManager(directory: mediaDirectoryType)
+    }
+}
+
+/// Protocol of general options available for an export, typically corresponding to a user setting.
+///
+protocol MediaExportingOptions {
+
+    /// Strip the geoLocation from exported media, if needed.
+    ///
+    var stripsGeoLocationIfNeeded: Bool { get }
+}

--- a/Yosemite/Yosemite/Tools/Media/MediaExport.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExport.swift
@@ -1,11 +1,11 @@
 import Foundation
 import Networking
 
-typealias MediaUploadable = Networking.UploadableMedia
+typealias UploadableMedia = Networking.UploadableMedia
 
 /// Completion block when a media item is exported.
 ///
-typealias MediaExportCompletion = (MediaUploadable?, Error?) -> Void
+typealias MediaExportCompletion = (UploadableMedia?, Error?) -> Void
 
 /// Exports media to the local file system for remote upload.
 ///

--- a/Yosemite/Yosemite/Tools/Media/MediaExport.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExport.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Networking
 
-typealias UploadableMedia = Networking.UploadableMedia
-
 /// Completion block when a media item is exported.
 ///
 typealias MediaExportCompletion = (UploadableMedia?, Error?) -> Void

--- a/Yosemite/Yosemite/Tools/Media/MediaExport.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExport.swift
@@ -35,12 +35,3 @@ extension MediaExporter {
         return MediaFileManager(directory: mediaDirectoryType)
     }
 }
-
-/// Protocol of general options available for an export, typically corresponding to a user setting.
-///
-protocol MediaExportingOptions {
-
-    /// Strip the geoLocation from exported media, if needed.
-    ///
-    var stripsGeoLocationIfNeeded: Bool { get }
-}

--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -2,9 +2,7 @@ import Foundation
 import CocoaLumberjack
 import Photos
 
-/// Encapsulates exporting assets such as PHAssets, images, videos, or files at URLs to `MediaUploadable`.
-///
-/// - Note: Methods with escaping closures will call back via its corresponding thread.
+/// Encapsulates exporting assets such as PHAssets, images, videos, or files at URLs to `UploadableMedia`.
 ///
 final class MediaExportService {
     /// Completion handler for a created Media object.
@@ -12,7 +10,7 @@ final class MediaExportService {
     typealias MediaExportCompletion = (UploadableMedia?, Error?) -> Void
 
     private lazy var exportQueue: DispatchQueue = {
-        return DispatchQueue(label: "org.wordpress.mediaExportService", autoreleaseFrequency: .workItem)
+        return DispatchQueue(label: "com.woocommerce.mediaExportService", autoreleaseFrequency: .workItem)
     }()
 
     // MARK: - Instance methods

--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -1,0 +1,85 @@
+import Foundation
+import CocoaLumberjack
+import Photos
+
+/// Encapsulates exporting assets such as PHAssets, images, videos, or files at URLs to `MediaUploadable`.
+///
+/// - Note: Methods with escaping closures will call back via its corresponding thread.
+///
+final class MediaExportService {
+    /// Completion handler for a created Media object.
+    ///
+    typealias MediaExportCompletion = (MediaUploadable?, Error?) -> Void
+
+    private lazy var exportQueue: DispatchQueue = {
+        return DispatchQueue(label: "org.wordpress.mediaExportService", autoreleaseFrequency: .workItem)
+    }()
+
+    // MARK: - Instance methods
+
+    /// Exports a media asset to the local file system so that it is uploadable, asynchronously.
+    ///
+    /// - Parameters:
+    ///     - exportable: the exportable resource where data will be read from.
+    ///     - onCompletion: Called when the Media export finishes.
+    ///
+    func export(_ exportable: ExportableAsset, onCompletion: @escaping MediaExportCompletion) {
+        exportQueue.async {
+            guard let exporter = self.createExporter(for: exportable) else {
+                preconditionFailure("An exporter needs to be availale for asset: \(exportable)")
+            }
+            exporter.export(onCompletion: { [weak self] (exported, error) in
+                guard let media = exported, error == nil else {
+                    self?.handleExportError(error, onCompletion: onCompletion)
+                    return
+                }
+                onCompletion(media, error)
+            })
+        }
+    }
+}
+
+// MARK: MediaExporter
+//
+private extension MediaExportService {
+    func createExporter(for exportable: ExportableAsset) -> MediaExporter? {
+        switch exportable {
+        case let asset as PHAsset:
+            let exporter = MediaAssetExporter(asset: asset,
+                                              imageOptions: Defaults.imageExportOptions,
+                                              allowableFileExtensions: Defaults.allowableFileExtensions)
+            return exporter
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: Error handling
+//
+private extension MediaExportService {
+    /// Handles and logs any error encountered.
+    ///
+    func handleExportError(_ error: Error?, onCompletion: MediaExportCompletion) {
+        guard let error = error else {
+            onCompletion(nil, nil)
+            return
+        }
+        DDLogError("Error occurred exporting to Media: \(error)")
+        onCompletion(nil, error)
+    }
+}
+
+private extension MediaExportService {
+    enum Defaults {
+        ///
+        /// - Note: This value may or may not be honored, depending on the export implementation and underlying data.
+        ///
+        static let imageExportOptions = MediaImageExporter.Options(maximumImageSize: 3000,
+                                                                   imageCompressionQuality: 0.85,
+                                                                   exportImageType: nil,
+                                                                   stripsGeoLocationIfNeeded: false)
+
+        static let allowableFileExtensions = Set<String>(["jpg", "jpeg", "png", "gif", "pdf"])
+    }
+}

--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -75,10 +75,9 @@ private extension MediaExportService {
         ///
         /// - Note: This value may or may not be honored, depending on the export implementation and underlying data.
         ///
-        static let imageExportOptions = MediaImageExporter.Options(maximumImageSize: 3000,
-                                                                   imageCompressionQuality: 0.85,
-                                                                   exportImageType: nil,
-                                                                   stripsGeoLocationIfNeeded: false)
+        static let imageExportOptions = MediaImageExportOptions(maximumImageSize: 3000,
+                                                                imageCompressionQuality: 0.85,
+                                                                stripsGeoLocationIfNeeded: false)
 
         static let allowableFileExtensions = Set<String>(["jpg", "jpeg", "png", "gif"])
     }

--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -9,7 +9,7 @@ import Photos
 final class MediaExportService {
     /// Completion handler for a created Media object.
     ///
-    typealias MediaExportCompletion = (MediaUploadable?, Error?) -> Void
+    typealias MediaExportCompletion = (UploadableMedia?, Error?) -> Void
 
     private lazy var exportQueue: DispatchQueue = {
         return DispatchQueue(label: "org.wordpress.mediaExportService", autoreleaseFrequency: .workItem)
@@ -80,6 +80,6 @@ private extension MediaExportService {
                                                                    exportImageType: nil,
                                                                    stripsGeoLocationIfNeeded: false)
 
-        static let allowableFileExtensions = Set<String>(["jpg", "jpeg", "png", "gif", "pdf"])
+        static let allowableFileExtensions = Set<String>(["jpg", "jpeg", "png", "gif"])
     }
 }

--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -9,9 +9,8 @@ final class MediaExportService {
     ///
     typealias MediaExportCompletion = (UploadableMedia?, Error?) -> Void
 
-    private lazy var exportQueue: DispatchQueue = {
-        return DispatchQueue(label: "com.woocommerce.mediaExportService", autoreleaseFrequency: .workItem)
-    }()
+    private lazy var exportQueue: DispatchQueue = DispatchQueue(label: "com.woocommerce.mediaExportService",
+                                                                autoreleaseFrequency: .workItem)
 
     // MARK: - Instance methods
 

--- a/Yosemite/Yosemite/Tools/Media/MediaFileManager.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaFileManager.swift
@@ -1,0 +1,99 @@
+import Foundation
+import CocoaLumberjack
+
+/// Type of the local Media directory URL in implementation.
+///
+enum MediaDirectory {
+    /// Default, system Documents directory, for persisting media files for upload.
+    case uploads
+    /// System Caches directory, for creating discardable media files, such as thumbnails.
+    case cache
+    /// System temporary directory, used for unit testing or temporary media files.
+    case temporary
+
+    /// Returns the directory URL for the directory type.
+    ///
+    /// - Parameter name: the name of the directory.
+    ///
+    func directoryURL(name: String) -> URL {
+        let fileManager = FileManager.default
+        // Gets a parent directory, based on the type.
+        let parentDirectory: URL
+        switch self {
+        case .uploads:
+            parentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        case .cache:
+            parentDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        case .temporary:
+            parentDirectory = fileManager.temporaryDirectory
+        }
+        return parentDirectory.appendingPathComponent(name, isDirectory: true)
+    }
+}
+
+/// Encapsulates Media functions related to the local Media directory.
+///
+final class MediaFileManager {
+
+    private let directory: MediaDirectory
+
+    private let fileManager: FileManager
+
+    /// Init with default directory of .uploads.
+    ///
+    /// - Note: This is particularly because the original Media directory was in the NSFileManager's documents directory.
+    ///   We shouldn't change this default directory lightly as older versions of the app may rely on Media files being in
+    ///   the documents directory for upload.
+    ///
+    init(directory: MediaDirectory = .uploads, fileManager: FileManager = FileManager.default) {
+        self.directory = directory
+        self.fileManager = fileManager
+    }
+
+    /// Returns a unique filesystem URL for a Media filename and extension, within the local Media directory.
+    ///
+    /// - Note: if a file already exists with the same name, the file name is appended with a number
+    ///   and incremented until a unique filename is found.
+    ///
+    func createLocalMediaURL(withFilename filename: String, fileExtension: String?) throws -> URL {
+        let baseURL = try createDirectoryURL()
+        let url: URL
+        if let fileExtension = fileExtension {
+            let basename = (filename as NSString).deletingPathExtension.lowercased()
+            url = baseURL.appendingPathComponent(basename, isDirectory: false)
+                .appendingPathExtension(fileExtension)
+        } else {
+            url = baseURL.appendingPathComponent(filename, isDirectory: false)
+        }
+
+        // Increments the filename as needed to ensure we're not providing a URL for an existing file of the same name.
+        return fileManager.createIncrementalFilenameIfNeeded(url: url)
+    }
+
+    /// Removes a media file given the local file URL.
+    ///
+    func removeLocalMedia(at url: URL) throws {
+        try fileManager.removeItem(at: url)
+    }
+
+    /// Returns filesystem URL for the local Media directory.
+    ///
+    private func createDirectoryURL() throws -> URL {
+        let mediaDirectory = directory.directoryURL(name: Defaults.mediaDirectoryName)
+
+        // Checks whether or not the file path exists for the Media directory.
+        // If the filepath does not exist, or if the filepath does exist but it is not a directory, try creating the directory.
+        // Note: This way, if unexpectedly a file exists but it is not a dir, an error will throw when trying to create the dir.
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: mediaDirectory.path, isDirectory: &isDirectory) == false || isDirectory.boolValue == false {
+            try fileManager.createDirectory(at: mediaDirectory, withIntermediateDirectories: true, attributes: nil)
+        }
+        return mediaDirectory
+    }
+}
+
+private extension MediaFileManager {
+    enum Defaults {
+        static let mediaDirectoryName = "Media"
+    }
+}

--- a/Yosemite/Yosemite/Tools/Media/MediaFileManager.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaFileManager.swift
@@ -55,7 +55,7 @@ final class MediaFileManager {
     /// - Note: if a file already exists with the same name, the file name is appended with a number
     ///   and incremented until a unique filename is found.
     ///
-    func createLocalMediaURL(withFilename filename: String, fileExtension: String?) throws -> URL {
+    func createLocalMediaURL(filename: String, fileExtension: String?) throws -> URL {
         let baseURL = try createDirectoryURL()
         let url: URL
         if let fileExtension = fileExtension {

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -120,7 +120,7 @@ final class MediaImageExporter: MediaExporter {
             writer.nullifyGPSData = options.stripsGeoLocationIfNeeded
             _ = try writer.writeImageSource(source)
 
-            let exported = MediaUploadable(localURL: url,
+            let exported = UploadableMedia(localURL: url,
                                            filename: url.lastPathComponent,
                                            mimeType: url.mimeTypeForPathExtension)
             onCompletion(exported, nil)

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 import MobileCoreServices
 

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -2,48 +2,38 @@ import AVFoundation
 import Foundation
 import MobileCoreServices
 
+/// Available options for an image export.
+///
+struct MediaImageExportOptions {
+    /// Set a maximumImageSize for resizing images, or nil for exporting the full images.
+    ///
+    let maximumImageSize: CGFloat?
+
+    /// Compression quality if the image type supports compression, defaults to no compression or maximum quality.
+    ///
+    let imageCompressionQuality: Double
+
+    /// If the original asset contains geo location information, enabling this option will remove it.
+    let stripsGeoLocationIfNeeded: Bool
+
+    init(maximumImageSize: CGFloat?,
+         imageCompressionQuality: Double,
+         stripsGeoLocationIfNeeded: Bool) {
+        self.maximumImageSize = maximumImageSize
+        self.imageCompressionQuality = imageCompressionQuality
+        self.stripsGeoLocationIfNeeded = stripsGeoLocationIfNeeded
+    }
+}
+
 /// Media export handling of UIImages.
 ///
 final class MediaImageExporter: MediaExporter {
-
-    /// Available options for an image export.
-    ///
-    struct Options: MediaExportingOptions {
-        /// Set a maximumImageSize for resizing images, or nil for exporting the full images.
-        ///
-        let maximumImageSize: CGFloat?
-
-        /// Compression quality if the image type supports compression, defaults to no compression or maximum quality.
-        ///
-        let imageCompressionQuality: Double
-
-        /// The target UTType of the exported image, typically a UTTypeJPEG or UTTypePNG,
-        /// or nil if the original image's format should be used.
-        ///
-        /// - Note: The exporter may not support exporting the original image as
-        ///   the set type, and will throw an error if it fails.
-        ///
-        let exportImageType: String?
-
-        /// If the original asset contains geo location information, enabling this option will remove it.
-        let stripsGeoLocationIfNeeded: Bool
-
-        init(maximumImageSize: CGFloat?,
-             imageCompressionQuality: Double,
-             exportImageType: String?,
-             stripsGeoLocationIfNeeded: Bool) {
-            self.maximumImageSize = maximumImageSize
-            self.imageCompressionQuality = imageCompressionQuality
-            self.exportImageType = exportImageType
-            self.stripsGeoLocationIfNeeded = stripsGeoLocationIfNeeded
-        }
-    }
 
     let mediaDirectoryType: MediaDirectory
 
     /// Export options.
     ///
-    private let options: Options
+    private let options: MediaImageExportOptions
 
     /// Default filename used when writing media images locally, which may be appended with "-1" or "-thumbnail".
     ///
@@ -53,7 +43,11 @@ final class MediaImageExporter: MediaExporter {
     private let filename: String?
     private let typeHint: String?
 
-    init(data: Data, filename: String?, typeHint: String? = nil, options: Options, mediaDirectoryType: MediaDirectory = .uploads) {
+    init(data: Data,
+         filename: String?,
+         typeHint: String? = nil,
+         options: MediaImageExportOptions,
+         mediaDirectoryType: MediaDirectory = .uploads) {
         self.filename = filename
         self.data = data
         self.typeHint = typeHint
@@ -87,8 +81,7 @@ final class MediaImageExporter: MediaExporter {
             }
             exportImageSource(source,
                               filename: fileName,
-                              // TODO: refactor this
-                              type: options.exportImageType ?? utType as String,
+                              type: utType as String,
                               onCompletion: onCompletion)
         } catch {
             onCompletion(nil, error)
@@ -107,18 +100,13 @@ final class MediaImageExporter: MediaExporter {
     private func exportImageSource(_ source: CGImageSource, filename: String?, type: String, onCompletion: @escaping MediaExportCompletion) {
         do {
             let filename = filename ?? defaultImageFilename
-            // Make a new URL within the local Media directory
-            let url = try mediaFileManager.createLocalMediaURL(withFilename: filename,
+            // Makes a new URL within the local Media directory
+            let url = try mediaFileManager.createLocalMediaURL(filename: filename,
                                                                fileExtension: URL.fileExtensionForUTType(type))
 
-            // Check MediaSettings and configure the image writer as needed.
-            var writer = ImageSourceWriter(url: url, sourceUTType: type as CFString)
-            if let maximumImageSize = options.maximumImageSize {
-                writer.maximumSize = maximumImageSize as CFNumber
-            }
-            writer.lossyCompressionQuality = options.imageCompressionQuality
-            writer.nullifyGPSData = options.stripsGeoLocationIfNeeded
-            _ = try writer.writeImageSource(source)
+            // Checks export options and configures the image writer as needed.
+            let writer = ImageSourceWriter(url: url, sourceUTType: type as CFString)
+            _ = try writer.writeImageSource(source, options: options)
 
             let exported = UploadableMedia(localURL: url,
                                            filename: url.lastPathComponent,
@@ -144,116 +132,6 @@ extension MediaImageExporter {
                 return NSLocalizedString("The image could not be added to the Media Library.",
                                          comment: "Message shown when an image failed to load while trying to add it to the Media library.")
             }
-        }
-    }
-}
-
-private extension MediaImageExporter {
-    /// Configurable struct for writing an image to a URL from a CGImageSource, via CGImageDestination, particular to the needs of a MediaImageExporter.
-    ///
-    struct ImageSourceWriter {
-
-        /// File URL where the image should be written
-        ///
-        var url: URL
-
-        /// The UTType of the image source
-        ///
-        var sourceUTType: CFString
-
-        /// The Compression quality used, defaults to 1.0 or full
-        ///
-        var lossyCompressionQuality = 1.0
-
-        /// Whether or not GPS data should be nullified.
-        ///
-        var nullifyGPSData = false
-
-        /// A maximum size required for the image to be written, or nil.
-        ///
-        var maximumSize: CFNumber?
-
-        init(url: URL, sourceUTType: CFString) {
-            self.url = url
-            self.sourceUTType = sourceUTType
-        }
-
-        /// Struct for returned result from writing an image, and any properties worth keeping track of.
-        ///
-        struct WriteResultProperties {
-            let width: CGFloat?
-            let height: CGFloat?
-        }
-
-        /// Write a given image source, succeeds unless an error is thrown, returns the resulting properties if available.
-        ///
-        func writeImageSource(_ source: CGImageSource) throws -> WriteResultProperties {
-            // Create the destination with the URL, or error
-            guard let destination = CGImageDestinationCreateWithURL(url as CFURL, sourceUTType, 1, nil) else {
-                throw ImageExportError.imageSourceDestinationWithURLFailed
-            }
-
-            // Configure image properties for the image source and image destination methods
-            // Preserve any existing properties from the source.
-            var imageProperties: [NSString: Any] = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? Dictionary) ?? [:]
-            // Configure destination properties
-            imageProperties[kCGImageDestinationLossyCompressionQuality] = lossyCompressionQuality
-
-            // Keep track of the image's width and height
-            var width: CGFloat?
-            var height: CGFloat?
-
-            // Configure orientation properties to default .up or 1
-            imageProperties[kCGImagePropertyOrientation] = Int(CGImagePropertyOrientation.up.rawValue) as CFNumber
-            if var tiffProperties = imageProperties[kCGImagePropertyTIFFDictionary] as? [NSString: Any] {
-                // Remove TIFF orientation value
-                tiffProperties.removeValue(forKey: kCGImagePropertyTIFFOrientation)
-                imageProperties[kCGImagePropertyTIFFDictionary] = tiffProperties
-            }
-            if var iptcProperties = imageProperties[kCGImagePropertyIPTCDictionary] as? [NSString: Any] {
-                // Remove IPTC orientation value
-                iptcProperties.removeValue(forKey: kCGImagePropertyIPTCImageOrientation)
-                imageProperties[kCGImagePropertyIPTCDictionary] = iptcProperties
-            }
-
-            // Configure options for generating the thumbnail, such as the maximum size.
-            var thumbnailOptions: [NSString: Any] = [
-                kCGImageSourceCreateThumbnailFromImageAlways: true,
-                kCGImageSourceShouldCache: false,
-                kCGImageSourceTypeIdentifierHint: sourceUTType,
-                kCGImageSourceCreateThumbnailWithTransform: true ]
-
-            if let maximumSize = maximumSize {
-                thumbnailOptions[kCGImageSourceThumbnailMaxPixelSize] = maximumSize
-            }
-
-            // Create a thumbnail of the image source.
-            guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary) else {
-                throw ImageExportError.imageSourceThumbnailGenerationFailed
-            }
-
-            if nullifyGPSData == true {
-                // When removing GPS data for a thumbnail, we have to remove the dictionary
-                // itself for the CGImageDestinationAddImage method.
-                imageProperties.removeValue(forKey: kCGImagePropertyGPSDictionary)
-            }
-
-            // Add the thumbnail image as the destination's image.
-            CGImageDestinationAddImage(destination, image, imageProperties as CFDictionary?)
-
-            // Get the dimensions from the CGImage itself
-            width = CGFloat(image.width)
-            height = CGFloat(image.height)
-
-            // Write the image to the file URL
-            let written = CGImageDestinationFinalize(destination)
-            guard written == true else {
-                throw ImageExportError.imageSourceDestinationWriteFailed
-            }
-
-            // Return the result with any interesting properties.
-            return WriteResultProperties(width: width,
-                                         height: height)
         }
     }
 }

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -1,0 +1,259 @@
+import AVFoundation
+import Foundation
+import MobileCoreServices
+
+/// Media export handling of UIImages.
+///
+final class MediaImageExporter: MediaExporter {
+
+    /// Available options for an image export.
+    ///
+    struct Options: MediaExportingOptions {
+        /// Set a maximumImageSize for resizing images, or nil for exporting the full images.
+        ///
+        let maximumImageSize: CGFloat?
+
+        /// Compression quality if the image type supports compression, defaults to no compression or maximum quality.
+        ///
+        let imageCompressionQuality: Double
+
+        /// The target UTType of the exported image, typically a UTTypeJPEG or UTTypePNG,
+        /// or nil if the original image's format should be used.
+        ///
+        /// - Note: The exporter may not support exporting the original image as
+        ///   the set type, and will throw an error if it fails.
+        ///
+        let exportImageType: String?
+
+        /// If the original asset contains geo location information, enabling this option will remove it.
+        let stripsGeoLocationIfNeeded: Bool
+
+        init(maximumImageSize: CGFloat?,
+             imageCompressionQuality: Double,
+             exportImageType: String?,
+             stripsGeoLocationIfNeeded: Bool) {
+            self.maximumImageSize = maximumImageSize
+            self.imageCompressionQuality = imageCompressionQuality
+            self.exportImageType = exportImageType
+            self.stripsGeoLocationIfNeeded = stripsGeoLocationIfNeeded
+        }
+    }
+
+    let mediaDirectoryType: MediaDirectory
+
+    /// Export options.
+    ///
+    private let options: Options
+
+    /// Default filename used when writing media images locally, which may be appended with "-1" or "-thumbnail".
+    ///
+    private let defaultImageFilename = "image"
+
+    private let data: Data
+    private let filename: String?
+    private let typeHint: String?
+
+    init(data: Data, filename: String?, typeHint: String? = nil, options: Options, mediaDirectoryType: MediaDirectory = .uploads) {
+        self.filename = filename
+        self.data = data
+        self.typeHint = typeHint
+        self.options = options
+        self.mediaDirectoryType = mediaDirectoryType
+    }
+
+    func export(onCompletion: @escaping MediaExportCompletion) {
+        exportImage(withData: data, fileName: filename, typeHint: typeHint, onCompletion: onCompletion)
+    }
+
+    /// Exports and writes an image's data, expected as PNG or JPEG format, to a local Media URL.
+    ///
+    /// - Parameters:
+    ///     - fileName: Filename if it's known.
+    ///     - typeHint: Hint towards the UTType of data, such as PNG or JPEG.
+    ///     - onCompletion: Called on successful export, with the local file URL of the exported UIImage.
+    ///     - onError: Called if an error was encountered during creation.
+    ///
+    /// - Returns: a progress object that report the current state of the export process.
+    ///
+    private func exportImage(withData data: Data, fileName: String?, typeHint: String?, onCompletion: @escaping MediaExportCompletion) {
+        do {
+            let hint = typeHint ?? kUTTypeJPEG as String
+            let sourceOptions: [String: Any] = [kCGImageSourceTypeIdentifierHint as String: hint as CFString]
+            guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
+                throw ImageExportError.imageSourceCreationWithDataFailed
+            }
+            guard let utType = CGImageSourceGetType(source) else {
+                throw ImageExportError.imageSourceIsAnUnknownType
+            }
+            exportImageSource(source,
+                              filename: fileName,
+                              // TODO: refactor this
+                              type: options.exportImageType ?? utType as String,
+                              onCompletion: onCompletion)
+        } catch {
+            onCompletion(nil, error)
+        }
+    }
+
+    /// Exports and writes an image source, to a local Media URL.
+    ///
+    /// - Parameters:
+    ///     - fileName: Filename if it's known.
+    ///     - onCompletion: Called on successful export, with the local file URL of the exported UIImage.
+    ///     - onError: Called if an error was encountered during creation.
+    ///
+    /// - Returns: a progress object that report the current state of the export process.
+    ///
+    private func exportImageSource(_ source: CGImageSource, filename: String?, type: String, onCompletion: @escaping MediaExportCompletion) {
+        do {
+            let filename = filename ?? defaultImageFilename
+            // Make a new URL within the local Media directory
+            let url = try mediaFileManager.createLocalMediaURL(withFilename: filename,
+                                                               fileExtension: URL.fileExtensionForUTType(type))
+
+            // Check MediaSettings and configure the image writer as needed.
+            var writer = ImageSourceWriter(url: url, sourceUTType: type as CFString)
+            if let maximumImageSize = options.maximumImageSize {
+                writer.maximumSize = maximumImageSize as CFNumber
+            }
+            writer.lossyCompressionQuality = options.imageCompressionQuality
+            writer.nullifyGPSData = options.stripsGeoLocationIfNeeded
+            _ = try writer.writeImageSource(source)
+
+            let exported = MediaUploadable(localURL: url,
+                                           filename: url.lastPathComponent,
+                                           mimeType: url.mimeTypeForPathExtension)
+            onCompletion(exported, nil)
+        } catch {
+            onCompletion(nil, error)
+        }
+    }
+}
+
+extension MediaImageExporter {
+    enum ImageExportError: Error {
+        case imageSourceCreationWithDataFailed
+        case imageSourceCreationWithURLFailed
+        case imageSourceIsAnUnknownType
+        case imageSourceDestinationWithURLFailed
+        case imageSourceThumbnailGenerationFailed
+        case imageSourceDestinationWriteFailed
+        var description: String {
+            switch self {
+            default:
+                return NSLocalizedString("The image could not be added to the Media Library.",
+                                         comment: "Message shown when an image failed to load while trying to add it to the Media library.")
+            }
+        }
+    }
+}
+
+private extension MediaImageExporter {
+    /// Configurable struct for writing an image to a URL from a CGImageSource, via CGImageDestination, particular to the needs of a MediaImageExporter.
+    ///
+    struct ImageSourceWriter {
+
+        /// File URL where the image should be written
+        ///
+        var url: URL
+
+        /// The UTType of the image source
+        ///
+        var sourceUTType: CFString
+
+        /// The Compression quality used, defaults to 1.0 or full
+        ///
+        var lossyCompressionQuality = 1.0
+
+        /// Whether or not GPS data should be nullified.
+        ///
+        var nullifyGPSData = false
+
+        /// A maximum size required for the image to be written, or nil.
+        ///
+        var maximumSize: CFNumber?
+
+        init(url: URL, sourceUTType: CFString) {
+            self.url = url
+            self.sourceUTType = sourceUTType
+        }
+
+        /// Struct for returned result from writing an image, and any properties worth keeping track of.
+        ///
+        struct WriteResultProperties {
+            let width: CGFloat?
+            let height: CGFloat?
+        }
+
+        /// Write a given image source, succeeds unless an error is thrown, returns the resulting properties if available.
+        ///
+        func writeImageSource(_ source: CGImageSource) throws -> WriteResultProperties {
+            // Create the destination with the URL, or error
+            guard let destination = CGImageDestinationCreateWithURL(url as CFURL, sourceUTType, 1, nil) else {
+                throw ImageExportError.imageSourceDestinationWithURLFailed
+            }
+
+            // Configure image properties for the image source and image destination methods
+            // Preserve any existing properties from the source.
+            var imageProperties: [NSString: Any] = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? Dictionary) ?? [:]
+            // Configure destination properties
+            imageProperties[kCGImageDestinationLossyCompressionQuality] = lossyCompressionQuality
+
+            // Keep track of the image's width and height
+            var width: CGFloat?
+            var height: CGFloat?
+
+            // Configure orientation properties to default .up or 1
+            imageProperties[kCGImagePropertyOrientation] = Int(CGImagePropertyOrientation.up.rawValue) as CFNumber
+            if var tiffProperties = imageProperties[kCGImagePropertyTIFFDictionary] as? [NSString: Any] {
+                // Remove TIFF orientation value
+                tiffProperties.removeValue(forKey: kCGImagePropertyTIFFOrientation)
+                imageProperties[kCGImagePropertyTIFFDictionary] = tiffProperties
+            }
+            if var iptcProperties = imageProperties[kCGImagePropertyIPTCDictionary] as? [NSString: Any] {
+                // Remove IPTC orientation value
+                iptcProperties.removeValue(forKey: kCGImagePropertyIPTCImageOrientation)
+                imageProperties[kCGImagePropertyIPTCDictionary] = iptcProperties
+            }
+
+            // Configure options for generating the thumbnail, such as the maximum size.
+            var thumbnailOptions: [NSString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceShouldCache: false,
+                kCGImageSourceTypeIdentifierHint: sourceUTType,
+                kCGImageSourceCreateThumbnailWithTransform: true ]
+
+            if let maximumSize = maximumSize {
+                thumbnailOptions[kCGImageSourceThumbnailMaxPixelSize] = maximumSize
+            }
+
+            // Create a thumbnail of the image source.
+            guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions as CFDictionary) else {
+                throw ImageExportError.imageSourceThumbnailGenerationFailed
+            }
+
+            if nullifyGPSData == true {
+                // When removing GPS data for a thumbnail, we have to remove the dictionary
+                // itself for the CGImageDestinationAddImage method.
+                imageProperties.removeValue(forKey: kCGImagePropertyGPSDictionary)
+            }
+
+            // Add the thumbnail image as the destination's image.
+            CGImageDestinationAddImage(destination, image, imageProperties as CFDictionary?)
+
+            // Get the dimensions from the CGImage itself
+            width = CGFloat(image.width)
+            height = CGFloat(image.height)
+
+            // Write the image to the file URL
+            let written = CGImageDestinationFinalize(destination)
+            guard written == true else {
+                throw ImageExportError.imageSourceDestinationWriteFailed
+            }
+
+            // Return the result with any interesting properties.
+            return WriteResultProperties(width: width,
+                                         height: height)
+        }
+    }
+}

--- a/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaImageExporter.swift
@@ -56,20 +56,21 @@ final class MediaImageExporter: MediaExporter {
     }
 
     func export(onCompletion: @escaping MediaExportCompletion) {
-        exportImage(withData: data, fileName: filename, typeHint: typeHint, onCompletion: onCompletion)
+        exportImage(data: data, fileName: filename, typeHint: typeHint, onCompletion: onCompletion)
     }
 
     /// Exports and writes an image's data, expected as PNG or JPEG format, to a local Media URL.
     ///
     /// - Parameters:
+    ///     - data: Image data.
     ///     - fileName: Filename if it's known.
-    ///     - typeHint: Hint towards the UTType of data, such as PNG or JPEG.
-    ///     - onCompletion: Called on successful export, with the local file URL of the exported UIImage.
-    ///     - onError: Called if an error was encountered during creation.
+    ///     - typeHint: The UTType of data, if it's known.
+    ///     - onCompletion: Called when the image export completes.
     ///
-    /// - Returns: a progress object that report the current state of the export process.
-    ///
-    private func exportImage(withData data: Data, fileName: String?, typeHint: String?, onCompletion: @escaping MediaExportCompletion) {
+    private func exportImage(data: Data,
+                             fileName: String?,
+                             typeHint: String?,
+                             onCompletion: @escaping MediaExportCompletion) {
         do {
             let hint = typeHint ?? kUTTypeJPEG as String
             let sourceOptions: [String: Any] = [kCGImageSourceTypeIdentifierHint as String: hint as CFString]
@@ -88,7 +89,7 @@ final class MediaImageExporter: MediaExporter {
         }
     }
 
-    /// Exports and writes an image source, to a local Media URL.
+    /// Exports and writes an image source to a local Media URL.
     ///
     /// - Parameters:
     ///     - fileName: Filename if it's known.
@@ -97,7 +98,10 @@ final class MediaImageExporter: MediaExporter {
     ///
     /// - Returns: a progress object that report the current state of the export process.
     ///
-    private func exportImageSource(_ source: CGImageSource, filename: String?, type: String, onCompletion: @escaping MediaExportCompletion) {
+    private func exportImageSource(_ source: CGImageSource,
+                                   filename: String?,
+                                   type: String,
+                                   onCompletion: @escaping MediaExportCompletion) {
         do {
             let filename = filename ?? defaultImageFilename
             // Makes a new URL within the local Media directory
@@ -121,11 +125,8 @@ final class MediaImageExporter: MediaExporter {
 extension MediaImageExporter {
     enum ImageExportError: Error {
         case imageSourceCreationWithDataFailed
-        case imageSourceCreationWithURLFailed
         case imageSourceIsAnUnknownType
-        case imageSourceDestinationWithURLFailed
-        case imageSourceThumbnailGenerationFailed
-        case imageSourceDestinationWriteFailed
+
         var description: String {
             switch self {
             default:

--- a/Yosemite/Yosemite/Tools/Media/URL+Media.swift
+++ b/Yosemite/Yosemite/Tools/Media/URL+Media.swift
@@ -2,13 +2,12 @@ import MobileCoreServices
 
 extension URL {
     var mimeTypeForPathExtension: String {
-        if
-            let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, lastPathComponent as CFString, nil)?.takeRetainedValue(),
-            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() {
-            return contentType as String
+        guard
+            let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension as CFString, nil)?.takeRetainedValue(),
+            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() else {
+                return "application/octet-stream"
         }
-
-        return "application/octet-stream"
+        return contentType as String
     }
 
     /// The expected file extension string for a given UTType identifier string.

--- a/Yosemite/Yosemite/Tools/Media/URL+Media.swift
+++ b/Yosemite/Yosemite/Tools/Media/URL+Media.swift
@@ -1,0 +1,23 @@
+import MobileCoreServices
+
+extension URL {
+    var mimeTypeForPathExtension: String {
+        if
+            let id = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, lastPathComponent as CFString, nil)?.takeRetainedValue(),
+            let contentType = UTTypeCopyPreferredTagWithClass(id, kUTTagClassMIMEType)?.takeRetainedValue() {
+            return contentType as String
+        }
+
+        return "application/octet-stream"
+    }
+
+    /// The expected file extension string for a given UTType identifier string.
+    ///
+    /// - param type: The UTType identifier string.
+    /// - returns: The expected file extension or nil if unknown.
+    ///
+    static func fileExtensionForUTType(_ type: String) -> String? {
+        let fileExtension = UTTypeCopyPreferredTagWithClass(type as CFString, kUTTagClassFilenameExtension)?.takeRetainedValue()
+        return fileExtension as String?
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A subclass of `FileManager` where the file existence is based on a dictionary whose key is the file path.
+///
+final class MockupFileManager: FileManager {
+    var dataByFilePath: [String: Data] = [:]
+
+    override func fileExists(atPath path: String) -> Bool {
+        return dataByFilePath[path] != nil
+    }
+
+    override func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
+        dataByFilePath[path] = data
+        return true
+    }
+
+    override func removeItem(at URL: URL) throws {
+        dataByFilePath.removeValue(forKey: URL.path)
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
@@ -9,7 +9,7 @@ final class MockupFileManager: FileManager {
         return dataByFilePath[path] != nil
     }
 
-    override func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
+    override func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey: Any]? = nil) -> Bool {
         dataByFilePath[path] = data
         return true
     }

--- a/Yosemite/YosemiteTests/Tools/Media/FileManager+URLTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/FileManager+URLTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Yosemite
+
+final class FileManager_URLTests: XCTestCase {
+    private lazy var fileManager = MockupFileManager()
+
+    func testCreatingIncrementalFilenames() {
+        let filename = "hello"
+        let fileExtension = "txt"
+
+        let url = fileManager.temporaryDirectory.appendingPathComponent(filename, isDirectory: false)
+            .appendingPathExtension(fileExtension)
+        let originalURL = fileManager.createIncrementalFilenameIfNeeded(url: url)
+        XCTAssertEqual(originalURL.lastPathComponent, "\(filename).\(fileExtension)")
+
+        createMockData(at: url)
+
+        let urlCopy1 = fileManager.createIncrementalFilenameIfNeeded(url: url)
+        XCTAssertEqual(urlCopy1.lastPathComponent, "\(filename)-1.\(fileExtension)")
+
+        createMockData(at: urlCopy1)
+
+        let urlCopy2 = fileManager.createIncrementalFilenameIfNeeded(url: url)
+        XCTAssertEqual(urlCopy2.lastPathComponent, "\(filename)-2.\(fileExtension)")
+    }
+}
+
+private extension FileManager_URLTests {
+    func createMockData(at fileURL: URL) {
+        _ = fileManager.createFile(atPath: fileURL.path, contents: Data())
+    }
+}

--- a/Yosemite/YosemiteTests/Tools/Media/MediaDirectoryTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaDirectoryTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Yosemite
+
+final class MediaDirectoryTests: XCTestCase {
+    func testMediaDirectoryURLWithUploadsDirectory() {
+        let name = "Media"
+        let url = MediaDirectory.uploads.directoryURL(name: name)
+        XCTAssertEqual(url.lastPathComponent, name)
+        XCTAssertTrue(url.hasDirectoryPath)
+
+        // The .uploads directory should be within the system Documents directory.
+        let parentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        XCTAssert(url.absoluteString.hasPrefix(parentDirectory.absoluteString), "Media uploads directory URL has unexpected path.")
+    }
+
+    func testMediaDirectoryURLWithCacheDirectory() {
+        let name = "Media"
+        let url = MediaDirectory.cache.directoryURL(name: name)
+        XCTAssertEqual(url.lastPathComponent, name)
+        XCTAssertTrue(url.hasDirectoryPath)
+
+        // The .cache directory should be within the system Caches directory.
+        let parentDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        XCTAssert(url.absoluteString.hasPrefix(parentDirectory.absoluteString), "Media uploads directory URL has unexpected path.")
+    }
+
+    func testMediaDirectoryURLWithTemporaryDirectory() {
+        let name = "Media"
+        let url = MediaDirectory.temporary.directoryURL(name: name)
+        XCTAssertEqual(url.lastPathComponent, name)
+        XCTAssertTrue(url.hasDirectoryPath)
+
+        // The .temporary directory should be within the system tmp directory.
+        let parentDirectory = FileManager.default.temporaryDirectory
+        XCTAssert(url.absoluteString.hasPrefix(parentDirectory.absoluteString), "Media uploads directory URL has unexpected path.")
+    }
+}

--- a/Yosemite/YosemiteTests/Tools/Media/MediaFileManagerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaFileManagerTests.swift
@@ -10,19 +10,19 @@ final class MediaFileManagerTests: XCTestCase {
 
             let fileManager = MediaFileManager()
 
-            var url = try fileManager.createLocalMediaURL(withFilename: basename, fileExtension: pathExtension)
+            var url = try fileManager.createLocalMediaURL(filename: basename, fileExtension: pathExtension)
             XCTAssertEqual(url.lastPathComponent, expected)
 
-            url = try fileManager.createLocalMediaURL(withFilename: expected, fileExtension: pathExtension)
+            url = try fileManager.createLocalMediaURL(filename: expected, fileExtension: pathExtension)
             XCTAssertEqual(url.lastPathComponent, expected)
 
-            url = try fileManager.createLocalMediaURL(withFilename: basename + ".png", fileExtension: pathExtension)
+            url = try fileManager.createLocalMediaURL(filename: basename + ".png", fileExtension: pathExtension)
             XCTAssertEqual(url.lastPathComponent, expected)
 
-            url = try fileManager.createLocalMediaURL(withFilename: basename, fileExtension: nil)
+            url = try fileManager.createLocalMediaURL(filename: basename, fileExtension: nil)
             XCTAssertEqual(url.lastPathComponent, basename)
 
-            url = try fileManager.createLocalMediaURL(withFilename: expected, fileExtension: nil)
+            url = try fileManager.createLocalMediaURL(filename: expected, fileExtension: nil)
             XCTAssertEqual(url.lastPathComponent, expected)
         } catch {
             XCTFail("Error creating local media URL: \(error)")
@@ -34,7 +34,7 @@ final class MediaFileManagerTests: XCTestCase {
             let fileManager = MockupFileManager()
             let data = Data()
             let mediaFileManager = MediaFileManager(fileManager: fileManager)
-            let localURL = try mediaFileManager.createLocalMediaURL(withFilename: "hello", fileExtension: "txt")
+            let localURL = try mediaFileManager.createLocalMediaURL(filename: "hello", fileExtension: "txt")
 
             XCTAssertTrue(fileManager.createFile(atPath: localURL.path, contents: data))
             XCTAssertTrue(fileManager.fileExists(atPath: localURL.path))

--- a/Yosemite/YosemiteTests/Tools/Media/MediaFileManagerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/MediaFileManagerTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Yosemite
+
+final class MediaFileManagerTests: XCTestCase {
+    func testCreatingLocalMediaURL() {
+        do {
+            let basename = "media-service-test-sample"
+            let pathExtension = "jpg"
+            let expected = "\(basename).\(pathExtension)"
+
+            let fileManager = MediaFileManager()
+
+            var url = try fileManager.createLocalMediaURL(withFilename: basename, fileExtension: pathExtension)
+            XCTAssertEqual(url.lastPathComponent, expected)
+
+            url = try fileManager.createLocalMediaURL(withFilename: expected, fileExtension: pathExtension)
+            XCTAssertEqual(url.lastPathComponent, expected)
+
+            url = try fileManager.createLocalMediaURL(withFilename: basename + ".png", fileExtension: pathExtension)
+            XCTAssertEqual(url.lastPathComponent, expected)
+
+            url = try fileManager.createLocalMediaURL(withFilename: basename, fileExtension: nil)
+            XCTAssertEqual(url.lastPathComponent, basename)
+
+            url = try fileManager.createLocalMediaURL(withFilename: expected, fileExtension: nil)
+            XCTAssertEqual(url.lastPathComponent, expected)
+        } catch {
+            XCTFail("Error creating local media URL: \(error)")
+        }
+    }
+
+    func testRemovingLocalMediaAtURL() {
+        do {
+            let fileManager = MockupFileManager()
+            let data = Data()
+            let mediaFileManager = MediaFileManager(fileManager: fileManager)
+            let localURL = try mediaFileManager.createLocalMediaURL(withFilename: "hello", fileExtension: "txt")
+
+            XCTAssertTrue(fileManager.createFile(atPath: localURL.path, contents: data))
+            XCTAssertTrue(fileManager.fileExists(atPath: localURL.path))
+
+            try mediaFileManager.removeLocalMedia(at: localURL)
+            XCTAssertFalse(fileManager.fileExists(atPath: localURL.path))
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/URL+MediaTests.swift
@@ -1,0 +1,49 @@
+import MobileCoreServices
+import XCTest
+@testable import Yosemite
+
+final class URL_MediaTests: XCTestCase {
+
+    // MARK: tests for `mimeTypeForPathExtension`
+
+    func testMimeTypeForJPEGFileURL() {
+        let url = URL(string: "/test/product.jpeg")
+        let expectedMimeType = "image/jpeg"
+        XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
+    }
+
+    func testMimeTypeForJPGFileURL() {
+        let url = URL(string: "/test/product.jpg")
+        let expectedMimeType = "image/jpeg"
+        XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
+    }
+
+    func testMimeTypeForGIFFileURL() {
+        let url = URL(string: "/test/product.gif")
+        let expectedMimeType = "image/gif"
+        XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
+    }
+
+    func testMimeTypeForPNGFileURL() {
+        let url = URL(string: "/test/product.png")
+        let expectedMimeType = "image/png"
+        XCTAssertEqual(url?.mimeTypeForPathExtension, expectedMimeType)
+    }
+
+    // MARK: tests for `fileExtensionForUTType`
+
+    func testFileExtensionForJPEGType() {
+        let expectedFileExtension = "jpeg"
+        XCTAssertEqual(URL.fileExtensionForUTType(kUTTypeJPEG as String), expectedFileExtension)
+    }
+
+    func testFileExtensionForGIFType() {
+        let expectedFileExtension = "gif"
+        XCTAssertEqual(URL.fileExtensionForUTType(kUTTypeGIF as String), expectedFileExtension)
+    }
+
+    func testFileExtensionForPNGType() {
+        let expectedFileExtension = "png"
+        XCTAssertEqual(URL.fileExtensionForUTType(kUTTypePNG as String), expectedFileExtension)
+    }
+}


### PR DESCRIPTION
"Export image assets to local file system" part for #1713 

First, I apologize for the size of the PR 🙇🏻‍♀️ The tests are about 200 diffs. A lot of the export code is based on WPiOS, simplified to our use cases. In addition to the PR branch, I have a [`spike/media-library` branch](https://github.com/woocommerce/woocommerce-ios/compare/spike/media-library?expand=1) that includes the changes in this PR with WIP UI for initial integrated testing. I wasn't sure how to test the actual media and image export, lemme know if you have any ideas!

## Background

Also mentioned in p99K0U-2mN-p2, when the user picks an image from the device media library or took a picture from the device camera, we have to first save it in the app file system and then upload the image given the file URL. The image from the device media library or camera is of type `PHAsset`, and before we save it for future upload, we'd first export the raw `PHAsset` to an image with some optimization options (`MediaImageExportOptions`) (defaults following WCAndroid):
- `maximumImageSize`: max file size - default is 3MB
- `imageCompressionQuality`: compression quality - default is 85%
- `stripsGeoLocationIfNeeded`: whether to remove location info - default is false

## Changes

I made all the media export changes in `Yosemite` layer, lemme know if you think another layer (like the app layer) might be more suitable!

- Created an empty protocol `ExportableAsset`, with just `PHAsset` implementing it (if we add more media types in the future, more types could conform to the protocol with potential shared properties)
- Added `ImageSourceWriter` that writes the raw image source to a local file URL
- In `MediaExport.swift`, added a `MediaExporter` protocol which has a configurable media directory type (e.g. `Documents`/`Temporary`), and a function that exports the media with a completion block
  - Added `MediaAssetExporter` that implements the `MediaExporter` protocol for a `PHAsset` media
  - Added `MediaImageExporter` that implements the `MediaExporter` protocol for an image
    - `MediaImageExporter` then uses `ImageSourceWriter` to writes the image source to the file system
- Created `MediaExportService` that encapsulates the whole media export process with a dispatch queue and decides which `MediaExporter` implementation to export the media based on the media type
- Created `MediaFileManager` with two main features:
  - Generates the media destination file URL given the media directory type, filename, and extension. This handles the case when a file of the same URL already exists, and automatically increments the filename
  - Removes a media locally given the media file URL
- Some extension helpers for `URL` and `FileManager` + unit tests

## Testing

There are already so many changes with the export itself, so still no user-facing changes yet. The next PR should have testable UI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
