### PR TITLE
Add lane to update certs and profiles

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -405,6 +405,26 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
      )
   end
 
+########################################################################
+# Configure Lanes
+########################################################################
+  #####################################################################################
+  # update_certs_and_profiles
+  # -----------------------------------------------------------------------------------
+  # This lane downloads all the required certs and profiles and, 
+  # if not run on CI it creates the missing ones.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane update_certs_and_profiles 
+  #
+  # Example:
+  # bundle exec fastlane update_certs_and_profiles 
+  #####################################################################################
+  lane :update_certs_and_profiles do | options |
+    alpha_code_signing
+    appstore_code_signing
+  end
+
   ########################################################################
   # Fastlane match code signing
   ########################################################################


### PR DESCRIPTION
This PR adds a simple public lane that can be used by developers to generate new Match handled profiles for new components.

## To test:
1. Run `bundle exec fastlane update_certs_and_profiles` and verify that the provisioning profiles for alpha, internal and production builds are installed (develop certs and profiles are not handled yet).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
