### PR TITLE
Docs: Add links 

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -326,7 +326,7 @@ into a ReadOnly instance:
         C.      "Weak Entities" are okay not to conform to this protocol. In turn, their parent (strong entities) can be observed.
 
 
-## **WooCommerce**
+## WooCommerce
 
 The outer layer is where the UI and the business logic associated to it belongs to. 
 
@@ -334,6 +334,6 @@ It is important to note that at the moment there is not a global unified archite
 
 That being said, there are some high-level abstractions that are starting to pop up.
 
-### Global depdencies
+### Global Dependencies
 
-Global dependencies are provided by an implementation of the Service Locator pattern. In WooCommerce, a `ServiceLocator` is just a set of static getters to the high-level global abstractions (i.e. stats, stores manager) and set of setters that allow overriding the actual implementation of those abstractions for better testability. 
+Global dependencies are provided by an implementation of the Service Locator pattern. In WooCommerce, a [`ServiceLocator`](../WooCommerce/Classes/ServiceLocator/ServiceLocator.swift) is just a set of static getters to the high-level global abstractions (i.e. stats, stores manager) and set of setters that allow overriding the actual implementation of those abstractions for better testability. 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -4,8 +4,8 @@
 ## High level class diagram
 ![Networking high level class diagram](images/networking.png)
 
-## Remote
-A [`Remote`](../Networking/Networking/Remote/Remote.swift) performs network requests. This is the core of this module.  
+## [Remote](../Networking/Networking/Remote/Remote.swift)
+A `Remote` performs network requests. This is the core of this module.  
 
 The base implementation of `Remote`  is provided an implementation of the [`Network`](../Networking/Networking/Network/Network.swift) protocol, and enqueues pairs of `Request` and [`Mapper`](../Networking/Networking/Mapper/Mapper.swift), executing that request on the provided `Network` and delegating the parsing of the response to the `Mapper` provided. 
 
@@ -29,33 +29,33 @@ At the time of writing this document, these are the subclasses of `Remote`:
 * `TaxClassesRemote` fetches tax classes for a given site.
 * `TopEarnersStatsRemote`fetches the top earner stats for a given site.
 
-## Network
+## [Network](../Networking/Networking/Network/Network.swift)
 A protocol that abstracts the networking stack. 
 
-There are two implementations of this protocol: `AlamofireNetwork` which manages a networking stack based on the third party library [Alamofire](https://github.com/Alamofire), and `MockupNetwork` which is a mock networking stack that does not actually hit the network, to be used in the unit tests.
+There are two implementations of this protocol: [`AlamofireNetwork`](../Networking/Networking/Network/AlamofireNetwork.swift) which manages a networking stack based on the third party library [Alamofire](https://github.com/Alamofire), and [`MockupNetwork`](../Networking/Networking/Network/MockupNetwork.swift) which is a mock networking stack that does not actually hit the network, to be used in the unit tests.
 
 ## URLRequestConvertible
 A protocol the abstracts the actual URL requests. 
 
 At the moment, we provide three implementations of `URLRequestConvertible`:
-* `DotcomRequest` models requests to WordPress.com
-* `JetpackRequest` represents a Jetpack-Tunneled WordPress.com 
-* `AuthenticatedRequest` Wraps up a URLRequestConvertible Instance, and injects credentials (username and token) when required
+* [`DotcomRequest`](../Networking/Networking/Requests/DotcomRequest.swift) models requests to WordPress.com
+* [`JetpackRequest`](../Networking/Networking/Requests/JetpackRequest.swift) represents a Jetpack-Tunneled WordPress.com 
+* [`AuthenticatedRequest`](../Networking/Networking/Requests/AuthenticatedRequest.swift) Wraps up a `URLRequestConvertible` instance, and injects credentials (username and token) when required
 
-## Mapper
+## [Mapper](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Mapper/Mapper.swift)
 A protocol that abstracts the different parsers.
 
-There are several implementations of this protocol, roughly one per Remote, although in some cases there is more than one implementation per remote (roughly, one for a single model object, and another for a collection of the same model object). 
+There are several implementations of this protocol, roughly one per `Remote`, although in some cases there is more than one implementation per remote (roughly, one for a single model object, and another for a collection of the same model object). 
 
 Mappers receive an instance of `Data` and return  the result of parsing that data as a model object or a collection of model objects.
 
 ## Model objects
-Model objects declared in `Networking` are immutable, and modelled as value types (structs) that typically implement `Decodable`
+Model objects declared in `Networking` are immutable, and modelled as value types (structs) that typically implement `Decodable`.
 
-Model objects should implement `Comparable` .
+Model objects should implement `Comparable`.
 
 ## Unit tests
-As mentioned previously, there is an implementation of the `Network` protocol called `MockupNetwork` used to mock network requests in the unit tests. This way we prevent the tests from hitting the actual network.
+As mentioned previously, there is an implementation of the `Network` protocol called [`MockupNetwork`](../Networking/Networking/Network/MockupNetwork.swift) used to mock network requests in the unit tests. This way we prevent the tests from hitting the actual network.
 
 `MockupNetwork` stubs responses (in the form of  the name of a json file) for a given endpoint. Those stubs can be either stored in a FIFO queue, used once and then removed from the queue, or stored to be reused multiple times, according to a value passed as a parameter of this class’ constructor.
 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -4,7 +4,7 @@
 ## High level class diagram
 ![Networking high level class diagram](images/networking.png)
 
-## [Remote](../Networking/Networking/Remote/Remote.swift)
+## [`Remote`](../Networking/Networking/Remote/Remote.swift)
 A `Remote` performs network requests. This is the core of this module.  
 
 The base implementation of `Remote`  is provided an implementation of the [`Network`](../Networking/Networking/Network/Network.swift) protocol, and enqueues pairs of `Request` and [`Mapper`](../Networking/Networking/Mapper/Mapper.swift), executing that request on the provided `Network` and delegating the parsing of the response to the `Mapper` provided. 
@@ -29,12 +29,12 @@ At the time of writing this document, these are the subclasses of `Remote`:
 * `TaxClassesRemote` fetches tax classes for a given site.
 * `TopEarnersStatsRemote`fetches the top earner stats for a given site.
 
-## [Network](../Networking/Networking/Network/Network.swift)
+## [`Network`](../Networking/Networking/Network/Network.swift)
 A protocol that abstracts the networking stack. 
 
 There are two implementations of this protocol: [`AlamofireNetwork`](../Networking/Networking/Network/AlamofireNetwork.swift) which manages a networking stack based on the third party library [Alamofire](https://github.com/Alamofire), and [`MockupNetwork`](../Networking/Networking/Network/MockupNetwork.swift) which is a mock networking stack that does not actually hit the network, to be used in the unit tests.
 
-## URLRequestConvertible
+## `URLRequestConvertible`
 A protocol the abstracts the actual URL requests. 
 
 At the moment, we provide three implementations of `URLRequestConvertible`:
@@ -42,7 +42,7 @@ At the moment, we provide three implementations of `URLRequestConvertible`:
 * [`JetpackRequest`](../Networking/Networking/Requests/JetpackRequest.swift) represents a Jetpack-Tunneled WordPress.com 
 * [`AuthenticatedRequest`](../Networking/Networking/Requests/AuthenticatedRequest.swift) Wraps up a `URLRequestConvertible` instance, and injects credentials (username and token) when required
 
-## [Mapper](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Mapper/Mapper.swift)
+## [`Mapper`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Mapper/Mapper.swift)
 A protocol that abstracts the different parsers.
 
 There are several implementations of this protocol, roughly one per `Remote`, although in some cases there is more than one implementation per remote (roughly, one for a single model object, and another for a collection of the same model object). 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -42,7 +42,7 @@ At the moment, we provide three implementations of `URLRequestConvertible`:
 * [`JetpackRequest`](../Networking/Networking/Requests/JetpackRequest.swift) represents a Jetpack-Tunneled WordPress.com 
 * [`AuthenticatedRequest`](../Networking/Networking/Requests/AuthenticatedRequest.swift) Wraps up a `URLRequestConvertible` instance, and injects credentials (username and token) when required
 
-## [`Mapper`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Mapper/Mapper.swift)
+## [`Mapper`](../Networking/Networking/Mapper/Mapper.swift)
 A protocol that abstracts the different parsers.
 
 There are several implementations of this protocol, roughly one per `Remote`, although in some cases there is more than one implementation per remote (roughly, one for a single model object, and another for a collection of the same model object). 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -5,9 +5,9 @@
 ![Networking high level class diagram](images/networking.png)
 
 ## Remote
-A `Remote` performs network requests. This is the core of this module.  
+A [`Remote`](../Networking/Networking/Remote/Remote.swift) performs network requests. This is the core of this module.  
 
-The base implementation of `Remote`  is provided an implementation of the `Network` protocol, and enqueues pairs of `Request` and `Mapper`, executing that request on the provided `Network` and delegating the parsing of the response to the `Mapper` provided. 
+The base implementation of `Remote`  is provided an implementation of the [`Network`](../Networking/Networking/Network/Network.swift) protocol, and enqueues pairs of `Request` and [`Mapper`](../Networking/Networking/Mapper/Mapper.swift), executing that request on the provided `Network` and delegating the parsing of the response to the `Mapper` provided. 
 
 There is a subclass of `Remote` for each relevant concern. Each of these subclasses provide public methods for each of the networking operations relevant to that concern.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,4 +3,4 @@
 - [Architecture](ARCHITECTURE.md)
 - [Networking](NETWORKING.md)
 - [Storage](STORAGE.md)
-- [Yosemite](Yosemite.md)
+- [Yosemite](YOSEMITE.md)

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -6,23 +6,23 @@
 ![Storage high level class diagram](images/storage.png)
 
 ## Public interface
-The Storage module exposes its functionality via the `StorageManagerType` protocol. 
+The Storage module exposes its functionality via the [`StorageManagerType`](../Storage/Storage/Protocols/StorageManagerType.swift) protocol. 
 
-This protocol declares getters to `StorageType` and methods to save or perform an operation on a `StorageType` 
+This protocol declares getters to [`StorageType`](../Storage/Storage/Protocols/StorageType.swift) and methods to save or perform an operation on a `StorageType` 
 
 ## The CoreData stack
 The default implementation of the `StorageManagerType` and `StorageType` protocols is based on CoreData.
 
- `StorageManagerType` is implemented by the `CoreDataManager` class. As the name implies, this class manages a CoreData stack, aggregating a `NSPersistentContainer` .
+ `StorageManagerType` is implemented by the [`CoreDataManager`](../Storage/Storage/CoreData/CoreDataManager.swift) class. As the name implies, this class manages a CoreData stack, aggregating a `NSPersistentContainer`.
 
-When clients of this class request a `StorageType`, `CoreDataManager` will return the a `NSManagedObjectContext`. 
+When clients of this class request a `StorageType`, `CoreDataManager` will return an `NSManagedObjectContext`. 
 
 When `CoreDataManager` is requested a  `viewContext`, it will provide  the persistent container’s `viewContext` . When it is requested a `newDerivedStorage` it will return a new child context with  a private dispatch queue.
 
 ## File storage
-The Storage module also exposes a protocol, called `FileStorage` to abstract saving and reading data to and from local storage. 
+The Storage module also exposes a protocol, called [`FileStorage`](../Storage/Storage/Protocols/FileStorage.swift) to abstract saving and reading data to and from local storage. 
 
-The default implementation of this protocol, `PListFileStorage` provided support for `.plist` files.  
+The default implementation of this protocol, [`PListFileStorage`](../Storage/Storage/Tools/PListFileStorage.swift) provides support for `.plist` files.  
 
 ## Model objects
 This module also provides extensions to make the model objects declared in the `Networking` module coredata-compliant.  

--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -76,17 +76,17 @@ The sequence for the UI layer to trigger a request to fetch data would be:
 
 The full listing:
 
-```
-    func syncTopPerformers(onCompletion: ((Error?) -> Void)? = nil) {
-        let action = StatsAction.retrieveTopEarnerStats(siteID: siteID,
-                                                        granularity: granularity,
-                                                        latestDateToInclude: Date()) { [weak self] error in
-			// Error handling removed for brevity
-            onCompletion?(error)
-        }
-
-        ServiceLocator.storesManager.dispatch(action)
+```swift
+func syncTopPerformers(onCompletion: ((Error?) -> Void)? = nil) {
+    let action = StatsAction.retrieveTopEarnerStats(siteID: siteID,
+                                                    granularity: granularity,
+                                                    latestDateToInclude: Date()) { [weak self] error in
+        // Error handling removed for brevity
+        onCompletion?(error)
     }
+
+    ServiceLocator.storesManager.dispatch(action)
+}
 ```
 
 ## Rationale?

--- a/docs/YOSEMITE.md
+++ b/docs/YOSEMITE.md
@@ -5,11 +5,11 @@
 ![Yosemite high level class diagram](images/yosemite_general.png)
 
 ## Application state. StoresManagerState
-Business logic is broken down into different subclasses of   [`Store`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Base/Store.swift).   A `Store` encapsulates the business logic related to one and only one of the domain level concerns (i.e. Notifications, Orders, Shipment…).
+Business logic is broken down into different subclasses of   [`Store`](../Yosemite/Yosemite/Base/Store.swift).   A `Store` encapsulates the business logic related to one and only one of the domain level concerns (i.e. Notifications, Orders, Shipment…).
 
-Some of these concerns require a valid user session (a user to be logged into the system) while some others don’t require a session.  To handle that, `Store`s are aggregated by a [`StoresManager`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ServiceLocator/StoresManager.swift).
+Some of these concerns require a valid user session (a user to be logged into the system) while some others don’t require a session.  To handle that, `Store`s are aggregated by a [`StoresManager`](../WooCommerce/Classes/ServiceLocator/StoresManager.swift).
 
-`StoresManager` is a state machine, that manages two states. Those states are implementations of the `StoresManagerState` protocol. Currently, we have two implementations, [`AuthenticatedState`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Yosemite/AuthenticatedState.swift) and [`DeauthenticatedState`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift).
+`StoresManager` is a state machine, that manages two states. Those states are implementations of the `StoresManagerState` protocol. Currently, we have two implementations, [`AuthenticatedState`](../WooCommerce/Classes/Yosemite/AuthenticatedState.swift) and [`DeauthenticatedState`](../WooCommerce/Classes/Yosemite/DeauthenticatedState.swift).
 
 Each of the implementations of the `StoresManagerState` aggregates a collection of subclasses of `Store` protocol. That’s how we enforce certain concerns (i.e. Orders) to require users to be authenticated.
 
@@ -24,7 +24,7 @@ As mentioned in the previous section, the business logic pertaining each domain 
 
 `Store` is an implementation of the `ActionsProcessor` protocol. We will discuss this protocol later, but for now, let’s say it is _something that can process an action_.
 
-`Store` is injected with a reference to a [`Dispatcher`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Base/Dispatcher.swift), an implementation of the  [`StorageManagerType`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Storage/Storage/Protocols/StorageManagerType.swift)  protocol (the storage stack) and an implementation of the [`Network`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Networking/Networking/Network/Network.swift) protocol (the networking stack).
+`Store` is injected with a reference to a [`Dispatcher`](../Yosemite/Yosemite/Base/Dispatcher.swift), an implementation of the  [`StorageManagerType`](../Storage/Storage/Protocols/StorageManagerType.swift)  protocol (the storage stack) and an implementation of the [`Network`](../Networking/Networking/Network/Network.swift) protocol (the networking stack).
 
 As a quick aside, please note this pattern: dependencies are usually injected.
 


### PR DESCRIPTION
I added links to the class files as I was reading the docs. I only added links to where it made sense. 

This should help in understanding the doc quickly. I don't have to find the class/file in Xcode manually.

I also fixed some typos along the way.

## Testing

1. View all the docs [here](https://github.com/woocommerce/woocommerce-ios/tree/update/docs/docs). 
2. Tap on the links to make sure they work. No need to go through everything. I suggest `STORAGE.md`. 

You can also try opening the files on your local editor like Visual Studio Code. CMD+tapping on a link in VS Code will open the file. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
