### PR TITLE
Makes crash reports opt-in by default to match Android

### DIFF
--- a/WooCommerce/Classes/Tools/Logging/CrashLogging.swift
+++ b/WooCommerce/Classes/Tools/Logging/CrashLogging.swift
@@ -44,7 +44,8 @@ class WCCrashLoggingDataProvider: CrashLoggingDataProvider {
 struct CrashLoggingSettings {
     static var didOptIn: Bool {
         get {
-            return UserDefaults.standard.object(forKey: .userOptedInCrashLogging) ?? false
+            // By default, opt the user into crash reporting
+            return UserDefaults.standard.object(forKey: .userOptedInCrashLogging) ?? true
         }
         set {
             if newValue {


### PR DESCRIPTION
New installs will have crash reports turned on default.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
