### PR TITLE
[Order List Redesign] Add dates to each cell

### DIFF
--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -67,6 +67,18 @@ extension Date {
 
         return calendar.date(byAdding: dayComponent, to: today)
     }
+
+    /// Returns `true` if `self` is in the same year as `other`.
+    ///
+    func isSameYear(as otherDate: Date) -> Bool {
+        let calendar = Calendar.current
+        guard let selfYear = calendar.dateComponents([.year], from: self).year,
+            let otherYear = calendar.dateComponents([.year], from: otherDate).year else {
+                return false
+        }
+
+        return selfYear == otherYear
+    }
 }
 
 

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -73,11 +73,9 @@ extension DateFormatter {
         ///
         /// Example Output: "Dec 30" or "12月30日"
         ///
-        public static let chartMarkerDayFormatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.setLocalizedDateFormatFromTemplate("MMM d")
-            return formatter
-        }()
+        public static var chartMarkerDayFormatter: DateFormatter {
+            monthAndDayFormatter
+        }
 
         /// Date formatter used for creating a **localized** date string displayed on a chart marker for **week** granularity.
         ///
@@ -120,6 +118,16 @@ extension DateFormatter {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("MMM d yyyy")
 
+        return formatter
+    }()
+
+    /// Date formatter used for creating a **localized** string containing the month and day.
+    ///
+    /// Example Output: "Dec 30" or "12月30日"
+    ///
+    public static let monthAndDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
         return formatter
     }()
 }

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -103,11 +103,9 @@ extension DateFormatter {
         ///
         /// Example Output: "2018" or "2017"
         ///
-        public static let chartMarkerYearFormatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.setLocalizedDateFormatFromTemplate("yyyy")
-            return formatter
-        }()
+        public static var chartMarkerYearFormatter: DateFormatter {
+            yearFormatter
+        }
     }
 
     /// Date formatter used for creating a medium-length **localized** date string to be displayed anywhere.
@@ -125,9 +123,19 @@ extension DateFormatter {
     ///
     /// Example Output: "Dec 30" or "12月30日"
     ///
-    public static let monthAndDayFormatter: DateFormatter = {
+    static let monthAndDayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return formatter
+    }()
+
+    /// Date formatter used for creating a **localized** string of the year only.
+    ///
+    /// Example Output: "2018" or "2017"
+    ///
+    static let yearFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("yyyy")
         return formatter
     }()
 }

--- a/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/DateFormatter+Helpers.swift
@@ -114,7 +114,7 @@ extension DateFormatter {
 
     /// Date formatter used for creating a medium-length **localized** date string to be displayed anywhere.
     ///
-    /// Example output: "Jan 28 2018"
+    /// Example output in English: "Jan 28, 2018"
     ///
     public static let mediumLengthLocalizedDateFormatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UILabel+Helpers.swift
@@ -74,4 +74,10 @@ extension UILabel {
     func applyActionableStyle() {
         textColor = .accent
     }
+
+    func applyCaption1Style() {
+        adjustsFontForContentSizeCategory = true
+        font = .caption1
+        textColor = .textSubtle
+    }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -18,6 +18,12 @@ final class OrderDetailsViewModel {
         self.order = newOrder
     }
 
+    /// The date displayed on the Orders List
+    /// 
+    var formattedDateCreated: String? {
+        DateFormatter.mediumLengthLocalizedDateFormatter.string(from: order.dateCreated)
+    }
+
     var summaryTitle: String? {
         return dataSource.summaryTitle
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -18,10 +18,14 @@ final class OrderDetailsViewModel {
         self.order = newOrder
     }
 
-    /// The date displayed on the Orders List
-    /// 
-    var formattedDateCreated: String? {
-        DateFormatter.mediumLengthLocalizedDateFormatter.string(from: order.dateCreated)
+    /// The date displayed on the Orders List.
+    ///
+    /// The value will only include the year if the `createdDate` is not from the current year.
+    ///
+    var formattedDateCreated: String {
+        let isSameYear = order.dateCreated.isSameYear(as: Date())
+        let formatter: DateFormatter = isSameYear ? .monthAndDayFormatter : .mediumLengthLocalizedDateFormatter
+        return formatter.string(from: order.dateCreated)
     }
 
     var summaryTitle: String? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -41,6 +41,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     func configureCell(viewModel: OrderDetailsViewModel, orderStatus: OrderStatus?) {
         titleLabel.text = viewModel.summaryTitle
         totalLabel.text = viewModel.totalFriendlyString
+        dateCreatedLabel.text = viewModel.formattedDateCreated
 
         if let orderStatus = orderStatus {
             paymentStatusLabel.applyStyle(for: orderStatus.status)

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -121,5 +121,7 @@ private extension OrderTableViewCell {
         totalLabel.numberOfLines = 0
         paymentStatusLabel.applyFootnoteStyle()
         paymentStatusLabel.numberOfLines = 0
+
+        dateCreatedLabel.applyCaption1Style()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -15,6 +15,10 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     ///
     @IBOutlet private var totalLabel: UILabel!
 
+    /// Order's Creation Date
+    ///
+    @IBOutlet private var dateCreatedLabel: UILabel!
+
     /// Payment
     ///
     @IBOutlet private var paymentStatusLabel: PaddedLabel!

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -22,19 +22,19 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
                                 <rect key="frame" x="0.0" y="0.0" width="106" height="48"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" ambiguous="YES" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
                                         <rect key="frame" x="0.0" y="0.0" width="26.5" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" ambiguous="YES" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
                                         <rect key="frame" x="0.0" y="20.5" width="106" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" ambiguous="YES" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" verticalCompressionResistancePriority="749" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="47" width="97.5" height="1"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -61,6 +61,7 @@
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="contentStackView" destination="w2s-RF-ahH" id="ULq-Dn-l9Q"/>
+                <outlet property="dateCreatedLabel" destination="ylK-xx-FWE" id="gKt-XQ-tYq"/>
                 <outlet property="paymentStatusLabel" destination="6EE-dX-ERE" id="9ur-nE-PKb"/>
                 <outlet property="titleLabel" destination="Nzo-QV-IP1" id="c4l-JL-JKc"/>
                 <outlet property="totalLabel" destination="9oo-9a-Tey" id="OzG-Y4-pOm"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -9,18 +9,18 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="OrderTableViewCell" rowHeight="86" id="fpH-Wv-Xy6" userLabel="OrderTableViewCell" customClass="OrderTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="86"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="OrderTableViewCell" rowHeight="107" id="fpH-Wv-Xy6" userLabel="OrderTableViewCell" customClass="OrderTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="107"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fpH-Wv-Xy6" id="C8B-hF-50d">
-                <rect key="frame" x="0.0" y="0.0" width="348" height="86"/>
+                <rect key="frame" x="0.0" y="0.0" width="348" height="107"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="w2s-RF-ahH">
-                        <rect key="frame" x="15" y="19" width="326" height="48"/>
+                        <rect key="frame" x="15" y="19" width="326" height="69"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
-                                <rect key="frame" x="0.0" y="0.0" width="106" height="48"/>
+                                <rect key="frame" x="0.0" y="0.0" width="106" height="69"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
                                         <rect key="frame" x="0.0" y="0.0" width="26.5" height="14.5"/>
@@ -29,13 +29,13 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
-                                        <rect key="frame" x="0.0" y="20.5" width="106" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="21.5" width="106" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" verticalCompressionResistancePriority="749" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="47" width="97.5" height="1"/>
+                                        <rect key="frame" x="0.0" y="48.5" width="97.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -43,7 +43,7 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" text="$75,894.63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oo-9a-Tey">
-                                <rect key="frame" x="237" y="0.0" width="89" height="48"/>
+                                <rect key="frame" x="237" y="0.0" width="89" height="69"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -65,7 +65,7 @@
                 <outlet property="titleLabel" destination="Nzo-QV-IP1" id="c4l-JL-JKc"/>
                 <outlet property="totalLabel" destination="9oo-9a-Tey" id="OzG-Y4-pOm"/>
             </connections>
-            <point key="canvasLocation" x="130" y="154"/>
+            <point key="canvasLocation" x="128.80000000000001" y="163.26836581709148"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -22,8 +22,8 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
                                 <rect key="frame" x="0.0" y="0.0" width="106" height="69"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
-                                        <rect key="frame" x="0.0" y="0.0" width="26.5" height="14.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Date Created" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="75" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="86"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fpH-Wv-Xy6" id="C8B-hF-50d">
-                <rect key="frame" x="0.0" y="0.0" width="341" height="85.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="348" height="86"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="w2s-RF-ahH">
@@ -22,14 +22,20 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
                                 <rect key="frame" x="0.0" y="0.0" width="106" height="48"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
-                                        <rect key="frame" x="0.0" y="0.0" width="106" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" ambiguous="YES" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="26.5" height="14.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" ambiguous="YES" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
+                                        <rect key="frame" x="0.0" y="20.5" width="106" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="27.5" width="97.5" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" ambiguous="YES" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="47" width="97.5" height="1"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -125,4 +125,37 @@ final class DateWooTests: XCTestCase {
         let futureDate2 = Calendar.current.date(byAdding: .year, value: 1, to: Date())!
         XCTAssertEqual(futureDate2.relativelyFormattedUpdateString, momentsAgo)
     }
+
+    func testIsSameYearReturnsTrueIfTheDatesAreFromTheSameYear() {
+        let calendar = Calendar.current
+        let thisDate: Date = {
+            let components = DateComponents(calendar: calendar, year: 2018, month: 12, day: 25)
+            return calendar.date(from: components)!
+        }()
+        let thatDate: Date = {
+            let components = DateComponents(calendar: calendar, year: 2018, month: 1, day: 1)
+            return calendar.date(from: components)!
+        }()
+
+        let isSameYear = thisDate.isSameYear(as: thatDate)
+
+        XCTAssertTrue(isSameYear)
+    }
+
+    func testIsSameYearReturnsFalseIfTheDatesAreNotFromTheSameYear() {
+        let calendar = Calendar.current
+        let thisDate: Date = {
+            let components = DateComponents(calendar: calendar, year: 2018, month: 12, day: 25)
+            return calendar.date(from: components)!
+        }()
+        let thatDate: Date = {
+            let components = DateComponents(calendar: calendar, year: 2019, month: 1, day: 1)
+            return calendar.date(from: components)!
+        }()
+
+        let isSameYear = thisDate.isSameYear(as: thatDate)
+
+        XCTAssertFalse(isSameYear)
+    }
 }
+

--- a/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/DateWooTests.swift
@@ -158,4 +158,3 @@ final class DateWooTests: XCTestCase {
         XCTAssertFalse(isSameYear)
     }
 }
-

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -31,6 +31,33 @@ final class MockOrders {
                      refunds: [])
     }
 
+    func sampleOrderCreatedInCurrentYear() -> Networking.Order {
+        return Order(siteID: siteID,
+                     orderID: orderID,
+                     parentID: 0,
+                     customerID: 11,
+                     number: "963",
+                     statusKey: "processing",
+                     currency: "USD",
+                     customerNote: "",
+                     dateCreated: Date(),
+                     dateModified: Date(),
+                     datePaid: Date(),
+                     discountTotal: "30.00",
+                     discountTax: "1.20",
+                     shippingTotal: "0.00",
+                     shippingTax: "0.00",
+                     total: "31.20",
+                     totalTax: "1.20",
+                     paymentMethodTitle: "Credit Card (Stripe)",
+                     items: [],
+                     billingAddress: sampleAddress(),
+                     shippingAddress: sampleAddress(),
+                     shippingLines: sampleShippingLines(),
+                     coupons: [],
+                     refunds: [])
+    }
+
     func sampleShippingLines() -> [Networking.ShippingLine] {
         return [ShippingLine(shippingID: 123,
         methodTitle: "International Priority Mail Express Flat Rate",

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -36,4 +36,24 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         XCTAssert(receivedEvents.contains(WooAnalyticsStat.orderTrackingDelete.rawValue))
     }
+
+    func testFormattedDateCreatedDoesNotIncludeTheYearForDatesWithTheSameYear() {
+        let order = MockOrders().sampleOrderCreatedInCurrentYear()
+        let viewModel = OrderDetailsViewModel(order: order)
+        let expectedYearString = DateFormatter.yearFormatter.string(from: order.dateCreated)
+
+        let formatted = viewModel.formattedDateCreated
+
+        XCTAssertFalse(formatted.contains(expectedYearString))
+    }
+
+    func testFormattedDateCreatedIncludesTheYearForDatesThatAreNotInTheSameYear() {
+        let order = MockOrders().sampleOrder()
+        let viewModel = OrderDetailsViewModel(order: order)
+        let expectedYearString = DateFormatter.yearFormatter.string(from: order.dateCreated)
+
+        let formatted = viewModel.formattedDateCreated
+
+        XCTAssertTrue(formatted.contains(expectedYearString))
+    }
 }


### PR DESCRIPTION
Refs #956. 

This adds the creation date of the order in the Order List.  

## Changes

### Light Mode

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/73112304-146a1080-3ecb-11ea-9531-932b3bfe7e05.png)        |       ![image](https://user-images.githubusercontent.com/198826/73112312-1af88800-3ecb-11ea-9746-24111bd2f572.png) 

### Dark Mode

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/73112356-51ce9e00-3ecb-11ea-996c-168b5521b95a.png)        |       ![image](https://user-images.githubusercontent.com/198826/73112363-585d1580-3ecb-11ea-9d15-62c4824f0a3f.png)

### Different Year

If the order was created from a different year, the year will be shown. If not, only the month and day.

<img src="https://user-images.githubusercontent.com/198826/73112426-87738700-3ecb-11ea-8914-d2b266be8d47.png" width="320">

## Testing

1. Navigate to Orders
2. Confirm that the correct creation date is shown.
3. Confirm that if the order was created during the last year, the year will be shown. 

## Design Review

@Garance91540 I'm not sure if the spacing is too much. I only used the existing spacing of 6 pts between the labels. 

![image](https://user-images.githubusercontent.com/198826/73112639-a32b5d00-3ecc-11ea-9cc0-6b6b2a0396c9.png)


## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 


