### PR TITLE
Product List: fix Product list not loading after logging out and in

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 3.5
 -----
 - bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.
-- bugfix: when logging out and in to the same store, the Product list should be loaded instead of empty.
+- bugfix: after logging out and in, the Product list should be loaded to the correct store instead of being empty.
 
 3.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 3.5
 -----
 - bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.
- 
+- bugfix: when logging out and in to the same store, the Product list should be loaded instead of empty.
+
 3.4
 -----
 - bugfix: on the Order Details screen, the product quantity title in the 2-column header view aligns to the right now

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -119,13 +119,6 @@ private extension ProductsViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
         nc.addObserver(self, selector: #selector(defaultSiteWasUpdated), name: .StoresManagerDidUpdateDefaultSite, object: nil)
-        nc.addObserver(self, selector: #selector(stopListeningToNotifications), name: .logOutEventReceived, object: nil)
-    }
-
-    /// Stops listening to all related Notifications
-    ///
-    @objc func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Runs whenever the default Account is updated.


### PR DESCRIPTION
Fixes #1737 

## Cause of the issue

Right now, we only sync and load the Product list in these 3 scenarios:
- `viewDidLoad` (once per app lifetime)
- when the site is updated, notified via `NotificationCenter`
- pulled to refresh
when logging out, we remove the view controller from listening to `NotificationCenter`, and thus after logging in again, the second scenario above isn't working anymore.

## Changes

- Removed handling `logOutEventReceived` notification that removes the view controller from listening to the default `NotificationCenter`

## Testing

- Launch the app while logged in to a store
- Go to the Products tab and make sure the list is loaded properly
- Log out
- Log in again to any store
- Go to the Products tab --> the list should be loaded properly instead of being empty as on `develop`

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
