### PR TITLE
Product Shipping Settings: use the right input formatter that accepts web string

### DIFF
--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// `UnitInputFormatter` implementation for shipping input.
+/// `UnitInputFormatter` implementation for shipping input, like weight and dimensions (width/height/length)
 ///
 struct ShippingInputFormatter: UnitInputFormatter {
 

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// `UnitInputFormatter` implementation for shipping input.
+///
+struct ShippingInputFormatter: UnitInputFormatter {
+
+    // Match all the characters not included in the set: numbers between 0 and 9, and - . , %
+    let regex = "[^-0-9%.,]"
+
+    func isValid(input: String) -> Bool {
+        guard input.isEmpty == false else {
+            // Allows empty input to be replaced by 0.
+            return true
+        }
+
+        return input.range(of: regex, options: .regularExpression) == nil
+    }
+
+    func format(input text: String?) -> String {
+        guard let text = text, text.isEmpty == false else {
+            return "0"
+        }
+
+        let formattedText = text
+            // Removes leading 0s before the digits.
+            .replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
+            // Maximum one leading 0.
+            .replacingOccurrences(of: "^(0+)", with: "0", options: .regularExpression)
+            // Replace all the occurrences of regex
+            .replacingOccurrences(of: regex, with: "", options: .regularExpression)
+        return formattedText
+    }
+}

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -4,8 +4,8 @@ import Foundation
 ///
 struct ShippingInputFormatter: UnitInputFormatter {
 
-    // Match all the characters not included in the set: numbers between 0 and 9, and - . , %
-    private let regex = "[^-0-9%.,]"
+    // Match all the characters not included in the set: numbers between 0 and 9, and - . ,
+    private let regex = "[^-0-9.,]"
 
     func isValid(input: String) -> Bool {
         guard input.isEmpty == false else {

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -26,8 +26,8 @@ struct ShippingInputFormatter: UnitInputFormatter {
             .replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
             // Maximum one leading 0.
             .replacingOccurrences(of: "^(0+)", with: "0", options: .regularExpression)
-            // Replace all the occurrences of regex
-            .replacingOccurrences(of: regex, with: "", options: .regularExpression)
+            // Replace all the occurrences of regex plus all the points or comma (but not the last `.` or `,`)
+            .replacingOccurrences(of: "(?:[.,](?=.*[.,])|" + regex + ")+", with: "$1", options: .regularExpression)
         return formattedText
     }
 }

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -18,7 +18,7 @@ struct ShippingInputFormatter: UnitInputFormatter {
 
     func format(input text: String?) -> String {
         guard let text = text, text.isEmpty == false else {
-            return "0"
+            return ""
         }
 
         let formattedText = text

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -5,7 +5,7 @@ import Foundation
 struct ShippingInputFormatter: UnitInputFormatter {
 
     // Match all the characters not included in the set: numbers between 0 and 9, and - . , %
-    let regex = "[^-0-9%.,]"
+    private let regex = "[^-0-9%.,]"
 
     func isValid(input: String) -> Bool {
         guard input.isEmpty == false else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -11,7 +11,7 @@ extension Product {
                                   unit: unit,
                                   value: value,
                                   keyboardType: .decimalPad,
-                                  inputFormatter: DecimalInputFormatter(),
+                                  inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
     }
 
@@ -24,7 +24,7 @@ extension Product {
                                   unit: unit,
                                   value: length.isEmpty ? "0": length,
                                   keyboardType: .decimalPad,
-                                  inputFormatter: DecimalInputFormatter(),
+                                  inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
     }
 
@@ -37,7 +37,7 @@ extension Product {
                                   unit: unit,
                                   value: width.isEmpty ? "0": width,
                                   keyboardType: .decimalPad,
-                                  inputFormatter: DecimalInputFormatter(),
+                                  inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
     }
 
@@ -50,7 +50,7 @@ extension Product {
                                   unit: unit,
                                   value: height.isEmpty ? "0": height,
                                   keyboardType: .decimalPad,
-                                  inputFormatter: DecimalInputFormatter(),
+                                  inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -217,6 +217,8 @@
 		45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */; };
 		45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */; };
 		45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FD23D0FB25005F87D0 /* Throttler.swift */; };
+		45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */; };
+		45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */; };
 		45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */; };
 		45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2C238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift */; };
 		45FBDF34238D33F100127F77 /* MockProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF33238D33F100127F77 /* MockProduct.swift */; };
@@ -829,6 +831,8 @@
 		45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatusListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D685FD23D0FB25005F87D0 /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
+		45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputFormatter.swift; sourceTree = "<group>"; };
+		45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputFormatterTests.swift; sourceTree = "<group>"; };
 		45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FBDF2C238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		45FBDF33238D33F100127F77 /* MockProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProduct.swift; sourceTree = "<group>"; };
@@ -1577,6 +1581,7 @@
 				45B9C64223A91CB6007FC4C5 /* PriceInputFormatter.swift */,
 				021E2A1D23AA24C600B1DE07 /* StringInputFormatter.swift */,
 				020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */,
+				45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */,
 			);
 			path = UnitInputFormatter;
 			sourceTree = "<group>";
@@ -1915,6 +1920,7 @@
 				D8053BCD231F98DA00CE60C2 /* ReviewAgeTests.swift */,
 				D85136DC231E613900DD0539 /* ReviewsViewModelTests.swift */,
 				D88D5A3C230B5E85007B6E01 /* ServiceLocatorTests.swift */,
+				45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */,
 				B517EA19218B2D2600730EC4 /* StringFormatterTests.swift */,
 				B56BBD15214820A70053A32D /* SyncCoordinatorTests.swift */,
 				D83A6A7923792B2400419D48 /* UIColor+Muriel-Tests.swift */,
@@ -3468,6 +3474,7 @@
 				934CB123224EAB150005CCB9 /* main.swift in Sources */,
 				02F4F50F237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.swift in Sources */,
 				021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorDataSource.swift in Sources */,
+				45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */,
 				45C8B2582313FA570002FA77 /* CustomerNoteTableViewCell.swift in Sources */,
 				7493BB8E2149852A003071A9 /* TopPerformersHeaderView.swift in Sources */,
 				D88CA756237CE515005D2F44 /* UITabBar+Appearance.swift in Sources */,
@@ -3608,6 +3615,7 @@
 				02404EE42315151400FF1170 /* MockupStatsVersionStoresManager.swift in Sources */,
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
+				45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				B555531321B57E8800449E71 /* MockupUserNotificationsCenterAdapter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -29,12 +29,12 @@ final class ShippingInputFormatterTests: XCTestCase {
 
     func testLeadingPointInputIsValid() {
         let input = "."
-        XCTAssertFalse(formatter.isValid(input: input))
+        XCTAssertTrue(formatter.isValid(input: input))
     }
     
     func testNumberDashesAndPercentuageIsValid() {
         let input = "-707--87%.21,22"
-        XCTAssertFalse(formatter.isValid(input: input))
+        XCTAssertTrue(formatter.isValid(input: input))
     }
 
     // MARK: test cases for `format(input:)`

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -32,8 +32,8 @@ final class ShippingInputFormatterTests: XCTestCase {
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func testNumberDashesAndPercentageIsValid() {
-        let input = "-707--87%.2122"
+    func testNumberAndDashesIsValid() {
+        let input = "-707--87.2122"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -32,7 +32,7 @@ final class ShippingInputFormatterTests: XCTestCase {
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
-    func testNumberDashesAndPercentuageIsValid() {
+    func testNumberDashesAndPercentageIsValid() {
         let input = "-707--87%.2122"
         XCTAssertTrue(formatter.isValid(input: input))
     }
@@ -41,7 +41,7 @@ final class ShippingInputFormatterTests: XCTestCase {
 
     func testFormattingEmptyInput() {
         let input = ""
-        XCTAssertEqual(formatter.format(input: input), "0")
+        XCTAssertEqual(formatter.format(input: input), "")
     }
 
     func testFormattingInputWithLeadingZeros() {

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -31,7 +31,7 @@ final class ShippingInputFormatterTests: XCTestCase {
         let input = "."
         XCTAssertTrue(formatter.isValid(input: input))
     }
-    
+
     func testNumberDashesAndPercentuageIsValid() {
         let input = "-707--87%.2122"
         XCTAssertTrue(formatter.isValid(input: input))

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -33,7 +33,7 @@ final class ShippingInputFormatterTests: XCTestCase {
     }
     
     func testNumberDashesAndPercentuageIsValid() {
-        let input = "-707--87%.21,22"
+        let input = "-707--87%.2122"
         XCTAssertTrue(formatter.isValid(input: input))
     }
 

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -49,9 +49,19 @@ final class ShippingInputFormatterTests: XCTestCase {
         XCTAssertEqual(formatter.format(input: input), "123.91")
     }
 
+    func testFormattingInputWithMultipleDecimalSeparator() {
+        let input = "00123.91.232.32"
+        XCTAssertEqual(formatter.format(input: input), "12391232.32")
+    }
+
     func testFormattingInputWithLeadingZerosFollowedByDecimalPoint() {
         let input = "000.91"
         XCTAssertEqual(formatter.format(input: input), "0.91")
+    }
+
+    func testFormattingInputWithEndingDecimalSeparator() {
+        let input = "239."
+        XCTAssertEqual(formatter.format(input: input), "239.")
     }
 
     func testFormattingDecimalInput() {

--- a/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ShippingInputFormatterTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+@testable import WooCommerce
+
+final class ShippingInputFormatterTests: XCTestCase {
+    private let formatter = ShippingInputFormatter()
+
+    // MARK: test cases for `isValid(input:)`
+
+    func testEmptyInputIsValid() {
+        let input = ""
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testAlphanumericInputIsNotValid() {
+        let input = "678two"
+        XCTAssertFalse(formatter.isValid(input: input))
+    }
+
+    func testDecimalInputIsValid() {
+        let input = "9990.52"
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testTrailingPointInputIsValid() {
+        let input = "9990."
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testLeadingPointInputIsValid() {
+        let input = "."
+        XCTAssertFalse(formatter.isValid(input: input))
+    }
+    
+    func testNumberDashesAndPercentuageIsValid() {
+        let input = "-707--87%.21,22"
+        XCTAssertFalse(formatter.isValid(input: input))
+    }
+
+    // MARK: test cases for `format(input:)`
+
+    func testFormattingEmptyInput() {
+        let input = ""
+        XCTAssertEqual(formatter.format(input: input), "0")
+    }
+
+    func testFormattingInputWithLeadingZeros() {
+        let input = "00123.91"
+        XCTAssertEqual(formatter.format(input: input), "123.91")
+    }
+
+    func testFormattingInputWithLeadingZerosFollowedByDecimalPoint() {
+        let input = "000.91"
+        XCTAssertEqual(formatter.format(input: input), "0.91")
+    }
+
+    func testFormattingDecimalInput() {
+        let input = "0.314"
+        XCTAssertEqual(formatter.format(input: input), "0.314")
+    }
+
+    func testFormattingIntegerInput() {
+        let input = "314200"
+        XCTAssertEqual(formatter.format(input: input), "314200")
+    }
+}


### PR DESCRIPTION
Fixes #1635 

## Description
This PR introduces the `ShippingInputFormatter`, which uses the [same regex used in the web admin panel](https://github.com/woocommerce/woocommerce/blob/master/assets/js/admin/woocommerce_admin.js#L96) to validate the input value. In this way, we can handle all the cases where the backend sends to us shipping parameters with a string that contains numbers, dashes, percentages, points, and commas.

## Testing
1) Navigate to a product in the web admin panel.
2) Go to shipping settings and try to use strange dimensions settings, like `-707--87%.2122`. Save it. There are no limits to dashes or negative values.
3) Run the app, go to the product detail > shipping settings
4) If the value is editable and you can add only these values everything is ok: `-`, numbers between `0` and `9`, `%`, `.`, `,`


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
