### PR TITLE
Creation of a boolean property isNotEmpty for String and Array

### DIFF
--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -14,7 +14,7 @@ extension Array {
         return removeFirst()
     }
 
-    /// A Boolean value indicating whether an array has characters.
+    /// A Boolean value indicating whether a collection is not empty.
     var isNotEmpty: Bool {
         return !isEmpty
     }

--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -13,6 +13,11 @@ extension Array {
 
         return removeFirst()
     }
+    
+    /// A Boolean value indicating whether an array has characters.
+    var isNotEmpty: Bool {
+        return !isEmpty
+    }
 }
 
 

--- a/WooCommerce/Classes/Extensions/Array+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/Array+Helpers.swift
@@ -13,7 +13,7 @@ extension Array {
 
         return removeFirst()
     }
-    
+
     /// A Boolean value indicating whether an array has characters.
     var isNotEmpty: Bool {
         return !isEmpty

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -64,7 +64,7 @@ extension String {
         return newText
     }
 
-    /// A Boolean value indicating whether a string  has characters.
+    /// A Boolean value indicating whether a string has characters.
     var isNotEmpty: Bool {
         return !isEmpty
     }

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -63,4 +63,9 @@ extension String {
 
         return newText
     }
+
+    /// A Boolean value indicating whether a string  has characters.
+    var isNotEmpty: Bool {
+        return !isEmpty
+    }
 }


### PR DESCRIPTION
This PR adds the property 'isNotEmpty' for Strings and Arrays.

Properties were created at:
WooCommerce/Classes/Extensions/Array+Helpers.swift
WooCommerce/Classes/Extensions/String+Helpers.swift

Please feel free to let me know whether I placed it in the right file, otherwise I can move it to the right one.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
