### PR TITLE
Order Notes > Icon now changes color when activate "Email note to customer"

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -133,7 +133,7 @@ private extension NewNoteViewController {
         }
 
         cell.iconImage = .asideImage
-        cell.iconTint = isCustomerNote ? .listIcon : .textSubtle
+        cell.iconTint = isCustomerNote ? .primary : .textSubtle
         cell.iconImage?.accessibilityLabel = isCustomerNote ?
             NSLocalizedString("Note to customer",
                               comment: "Spoken accessibility label for an icon image that indicates it's a note to the customer.") :


### PR DESCRIPTION
Fixes #1618 

This PR fixes issue #1618.

When activating the "Email note to customer" switch, the note icon in the "Write Note" text area wasn't getting changed to the right color (.primary).

Result after fixing the issue:

"Email note to   customer" not activated | "Email note to   customer" activated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/2797522/73176039-9b371b80-415f-11ea-8f02-e2f207083ead.png)  |  ![image](https://user-images.githubusercontent.com/2797522/73176050-9ffbcf80-415f-11ea-8315-756b4e0e67e8.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
