### PR TITLE
[Order List Redesign] Do not abbreviate the total amount

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -7,7 +7,6 @@ import Yosemite
 ///
 final class OrderDetailsDataSource: NSObject {
     private(set) var order: Order
-    private let currencyFormatter = CurrencyFormatter()
     private let couponLines: [OrderCouponLine]?
 
     /// Haptic Feedback!
@@ -33,12 +32,6 @@ final class OrderDetailsDataSource: NSObject {
     /// Is the shipment tracking plugin available?
     ///
     var trackingIsReachable: Bool = false
-
-    /// Anything above 999.99 or below -999.99 should display a truncated amount
-    ///
-    var totalFriendlyString: String? {
-        return currencyFormatter.formatHumanReadableAmount(order.total, with: order.currency, roundSmallNumbers: false) ?? String()
-    }
 
     /// For example, #560 Pamela Nguyen
     ///

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -5,7 +5,10 @@ import Yosemite
 import MessageUI
 
 final class OrderDetailsViewModel {
+    private let currencyFormatter = CurrencyFormatter()
+
     private(set) var order: Order
+
     var orderStatus: OrderStatus? {
         return lookUpOrderStatus(for: order)
     }
@@ -36,10 +39,12 @@ final class OrderDetailsViewModel {
 
     let productRightTitle = NSLocalizedString("QTY", comment: "Quantity abbreviation for section title")
 
-    /// Anything above 999.99 or below -999.99 should display a truncated amount
+    /// The localized unabbreviated total which includes the currency.
+    ///
+    /// Example: $48,415,504.20
     ///
     var totalFriendlyString: String? {
-        return dataSource.totalFriendlyString
+        currencyFormatter.formatAmount(order.total, with: order.currency)
     }
 
     /// Products from an Order


### PR DESCRIPTION
Refs #956. This changes the total so that it is no longer abbreviated. The full total amount is now shown with up to 2 decimal numbers.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/73269067-57f99e80-4199-11ea-9cdb-c1518dc66ff2.png)        |     ![image](https://user-images.githubusercontent.com/198826/73269163-89726a00-4199-11ea-9e6d-545f52c1a918.png)

After (Arabic) | After (Large Font)
--------|-------
  ![image](https://user-images.githubusercontent.com/198826/73269082-60ea7000-4199-11ea-9da7-a53afb0b4d2c.png)        |       ![image](https://user-images.githubusercontent.com/198826/73269199-9c853a00-4199-11ea-81b5-6a38dc5f7bae.png)

## Changes

I removed the `totalFriendlyString` from `OrderDetailsDataSource` and just kept it in `OrderDetailsViewModel`. The `OrderDetailsDataSource` location seems like an incorrect placement since that class is used as a [table `dataSource`](https://github.com/woocommerce/woocommerce-ios/blob/f2e3e89ec63c8a84b02b103c88df97e4fbb81c0b/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/OrderDetailsViewController.swift#L89). 

## Testing

1. Navigate to Orders List 
2. Confirm that the totals are no longer abbreviated. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
