### PR TITLE
Product Shipping Settings: handled zero values on weight and dimensions textfields

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -14,6 +14,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)
@@ -32,6 +33,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -16,6 +16,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: "",
                                   value: "\(stockQuantity ?? 0)",
+                                  placeholder: "0",
                                   keyboardType: .numberPad,
                                   inputFormatter: IntegerInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -6,10 +6,11 @@ extension Product {
                                               onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Weight", comment: "Title of the cell in Product Shipping Settings > Weight")
         let unit = shippingSettingsService.weightUnit ?? ""
-        let value = weight == nil || weight?.isEmpty == true ? "0": weight
+        let value = weight == nil || weight?.isEmpty == true ? "": weight
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -22,7 +23,8 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: length.isEmpty ? "0": length,
+                                  value: length.isEmpty ? "": length,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -35,7 +37,8 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: width.isEmpty ? "0": width,
+                                  value: width.isEmpty ? "": width,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -48,7 +51,8 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: height.isEmpty ? "0": height,
+                                  value: height.isEmpty ? "": height,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -23,7 +23,7 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: length.isEmpty ? "": length,
+                                  value: length,
                                   placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
@@ -37,7 +37,7 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: width.isEmpty ? "": width,
+                                  value: width,
                                   placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
@@ -51,7 +51,7 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: height.isEmpty ? "": height,
+                                  value: height,
                                   placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -4,6 +4,7 @@ struct UnitInputViewModel {
     let title: String
     let unit: String
     let value: String?
+    let placeholder: String?
     let keyboardType: UIKeyboardType
     let inputFormatter: UnitInputFormatter
     let onInputChange: ((_ input: String?) -> Void)?
@@ -36,6 +37,7 @@ final class UnitInputTableViewCell: UITableViewCell {
         unitLabel.text = viewModel.unit
         unitLabel.isHidden = viewModel.unit.isEmpty
         inputTextField.text = viewModel.value
+        inputTextField.placeholder = viewModel.placeholder
         inputTextField.keyboardType = viewModel.keyboardType
         inputFormatter = viewModel.inputFormatter
         onInputChange = viewModel.onInputChange


### PR DESCRIPTION
Fixes #1785 

## Description
Previously, we always show zero 0 when a field is empty on the web, which is a wrong information.
This PR allows the fields (weight and dimensions textfields) to be empty and to show a `0` placeholder.

## Testing
1) Go to a product detail
2) Tap edit
3) Tap Shipping Settings
4) Try to update a product with all the fields empty. Now it should work (if you use WC 3.9.1).
5) Every empty field shows a placeholder `0`.

## Screenshot
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-29 at 12 21 53](https://user-images.githubusercontent.com/495617/73353250-3ed51880-4293-11ea-8dbb-cff6f0f40251.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
