### PR TITLE
Product Price Settings: handled zero values on regular and sale price textfields

### DIFF
--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -37,7 +37,7 @@ struct PriceInputFormatter: UnitInputFormatter {
 
     func format(input text: String?) -> String {
         guard let text = text, text.isEmpty == false else {
-            return "0"
+            return ""
         }
 
         // Replace any characters not in the set of 0-9 with the current decimal separator configured on website

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -70,12 +70,14 @@ private extension DefaultProductFormTableViewModel {
         var priceDetails = [String]()
 
         // Regular price and sale price are both available only when a sale price is set.
-        if let regularPrice = product.regularPrice, !regularPrice.isEmpty,
-            let salePrice = product.salePrice, !salePrice.isEmpty {
+        if let regularPrice = product.regularPrice, regularPrice.isNotEmpty {
             let formattedRegularPrice = currencyFormatter.formatAmount(regularPrice, with: currency) ?? ""
-            let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
             priceDetails.append(String.localizedStringWithFormat(Constants.regularPriceFormat, formattedRegularPrice))
-            priceDetails.append(String.localizedStringWithFormat(Constants.salePriceFormat, formattedSalePrice))
+
+            if let salePrice = product.salePrice, salePrice.isNotEmpty {
+                let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
+                priceDetails.append(String.localizedStringWithFormat(Constants.salePriceFormat, formattedSalePrice))
+            }
 
             if let dateOnSaleStart = product.dateOnSaleStart, let dateOnSaleEnd = product.dateOnSaleEnd {
                 let dateIntervalFormatter = DateIntervalFormatter.mediumLengthLocalizedDateIntervalFormatter

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -9,7 +9,7 @@ extension Product {
         let currencyFormatter = CurrencyFormatter()
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
-        var value = currencyFormatter.formatAmount(regularPrice ?? "", with: unit) ?? "0"
+        var value = currencyFormatter.formatAmount(regularPrice ?? "", with: unit) ?? ""
         value = value.replacingOccurrences(of: unit, with: "")
         return UnitInputViewModel(title: title,
                                   unit: unit,
@@ -28,7 +28,7 @@ extension Product {
         let currencyFormatter = CurrencyFormatter()
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
-        var value = currencyFormatter.formatAmount(salePrice ?? "", with: unit) ?? "0"
+        var value = currencyFormatter.formatAmount(salePrice ?? "", with: unit) ?? ""
         value = value.replacingOccurrences(of: unit, with: "")
         return UnitInputViewModel(title: title,
                                   unit: unit,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -14,6 +14,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)
@@ -32,6 +33,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -1,9 +1,9 @@
 import Yosemite
 
 extension Product {
-    
+
     private static let placeholder = "0"
-    
+
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                        onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -1,6 +1,9 @@
 import Yosemite
 
 extension Product {
+    
+    private static let placeholder = "0"
+    
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                        onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
@@ -14,7 +17,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)
@@ -33,7 +36,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -180,6 +180,12 @@ extension ProductPriceSettingsViewController {
     @objc private func completeUpdating() {
         let newSalePrice = salePrice == "0" ? nil : salePrice
 
+        // Check if the sale price is populated, and the regular price is not.
+        if getDecimalPrice(salePrice) != nil, getDecimalPrice(regularPrice) == nil {
+            displaySalePriceWithoutRegularPriceErrorNotice()
+            return
+        }
+
         // Check if the sale price is less of the regular price, else show an error.
         if let decimalSalePrice = getDecimalPrice(salePrice), let decimalRegularPrice = getDecimalPrice(regularPrice) {
             let comparison = decimalSalePrice.compare(decimalRegularPrice)
@@ -216,6 +222,17 @@ private extension ProductPriceSettingsViewController {
 // MARK: - Error handling
 //
 private extension ProductPriceSettingsViewController {
+
+    /// Displays a Notice onscreen, indicating that you can't add a sale price without adding before the regular price
+    ///
+    func displaySalePriceWithoutRegularPriceErrorNotice() {
+        UIApplication.shared.keyWindow?.endEditing(true)
+        let message = NSLocalizedString("The sale price can't be added without the regular price.",
+                                        comment: "Product price error notice message, when the sale price is added but the regular price is not")
+
+        let notice = Notice(title: message, feedbackType: .error)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
 
     /// Displays a Notice onscreen, indicating that the sale price need to be higher than the regular price
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -16,6 +16,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: "",
                                   value: "\(stockQuantity ?? 0)",
+                                  placeholder: "0",
                                   keyboardType: .numberPad,
                                   inputFormatter: IntegerInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -306,7 +306,6 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-
         guard regularPrice != product.regularPrice ||
             salePrice != product.salePrice ||
             dateOnSaleStart != product.dateOnSaleStart ||

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -6,10 +6,11 @@ extension Product {
                                               onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Weight", comment: "Title of the cell in Product Shipping Settings > Weight")
         let unit = shippingSettingsService.weightUnit ?? ""
-        let value = weight == nil || weight?.isEmpty == true ? "0": weight
+        let value = weight == nil || weight?.isEmpty == true ? "": weight
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -22,7 +23,8 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: length.isEmpty ? "0": length,
+                                  value: length.isEmpty ? "": length,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -35,7 +37,8 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: width.isEmpty ? "0": width,
+                                  value: width.isEmpty ? "": width,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -48,7 +51,8 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: height.isEmpty ? "0": height,
+                                  value: height.isEmpty ? "": height,
+                                  placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,6 +1,9 @@
 import Yosemite
 
 extension Product {
+    
+    private static let placeholder = "0"
+    
     static func createShippingWeightViewModel(weight: String?,
                                               using shippingSettingsService: ShippingSettingsService,
                                               onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
@@ -10,7 +13,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -24,7 +27,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: length,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -38,7 +41,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: width,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -52,7 +55,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: height,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -23,7 +23,7 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: length.isEmpty ? "": length,
+                                  value: length,
                                   placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
@@ -37,7 +37,7 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: width.isEmpty ? "": width,
+                                  value: width,
                                   placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
@@ -51,7 +51,7 @@ extension Product {
         let unit = shippingSettingsService.dimensionUnit ?? ""
         return UnitInputViewModel(title: title,
                                   unit: unit,
-                                  value: height.isEmpty ? "": height,
+                                  value: height,
                                   placeholder: "0",
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,9 +1,9 @@
 import Yosemite
 
 extension Product {
-    
+
     private static let placeholder = "0"
-    
+
     static func createShippingWeightViewModel(weight: String?,
                                               using shippingSettingsService: ShippingSettingsService,
                                               onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -4,6 +4,7 @@ struct UnitInputViewModel {
     let title: String
     let unit: String
     let value: String?
+    let placeholder: String?
     let keyboardType: UIKeyboardType
     let inputFormatter: UnitInputFormatter
     let onInputChange: ((_ input: String?) -> Void)?
@@ -36,6 +37,7 @@ final class UnitInputTableViewCell: UITableViewCell {
         unitLabel.text = viewModel.unit
         unitLabel.isHidden = viewModel.unit.isEmpty
         inputTextField.text = viewModel.value
+        inputTextField.placeholder = viewModel.placeholder
         inputTextField.keyboardType = viewModel.keyboardType
         inputFormatter = viewModel.inputFormatter
         onInputChange = viewModel.onInputChange

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -46,6 +46,11 @@ final class PriceInputFormatterTests: XCTestCase {
 
     func testFormattingEmptyInput() {
         let input = ""
+        XCTAssertEqual(formatter.format(input: input), "")
+    }
+
+    func testFormattingZeroInput() {
+        let input = "0"
         XCTAssertEqual(formatter.format(input: input), "0")
     }
 


### PR DESCRIPTION
Fixes #1786 

## Description
Previously, we always show zero `0` when a field is empty on the web, which is a wrong information.
This PR allows the fields (regular price and sale price textfields) to be empty and to show a `0` placeholder, and show an error if the user adds a sale price without the regular price.

## Testing
1) Go to a product detail
2) Tap edit
3) Tap Price Settings
4) Try to update a product with all the fields empty. Now it should work (if you use WC 3.9.1).
5) Every empty field shows a placeholder `0`.
6) Try to add a sale price without adding a regular price. You will see an error alert.

Feel free to suggest a better error message.

## Screenshot
| Empty fields             |  Error sale price without regular price |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-01-29 at 12 53 35](https://user-images.githubusercontent.com/495617/73354605-637ebf80-4296-11ea-9ee5-9d86a7c5c2a2.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-01-29 at 14 53 37](https://user-images.githubusercontent.com/495617/73364459-ec9ff180-42aa-11ea-8160-831cfd6f2322.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
