### PR TITLE
Product Price Settings: fixed regular and sale price with thousand separators

### DIFF
--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -40,11 +40,12 @@ struct PriceInputFormatter: UnitInputFormatter {
             return ""
         }
 
-        // Replace any characters not in the set of 0-9 with the current decimal separator configured on website
-        let formattedText = text.replacingOccurrences(of: "[^0-9]", with: CurrencySettings.shared.decimalSeparator, options: .regularExpression)
+        let formattedText = text
+            // Replace any characters not in the set of 0-9 with the current decimal separator configured on website
+            .replacingOccurrences(of: "[^0-9]", with: CurrencySettings.shared.decimalSeparator, options: .regularExpression)
             // Remove any initial zero number in the string. Es. 00224.30 will be 2224.30
             .replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
-            // Replace all the occurrences of regex plus all the points or comma (but not the last `.` or `,`)
+            // Replace all the occurrences of regex plus all the points or comma (but not the last `.` or `,`) like thousand separators
             .replacingOccurrences(of: "(?:[.,](?=.*[.,])|)+", with: "$1", options: .regularExpression)
         return formattedText
     }

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -37,7 +37,7 @@ struct PriceInputFormatter: UnitInputFormatter {
 
     func format(input text: String?) -> String {
         guard let text = text, text.isEmpty == false else {
-            return "0"
+            return ""
         }
 
         // Replace any characters not in the set of 0-9 with the current decimal separator configured on website

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -41,10 +41,11 @@ struct PriceInputFormatter: UnitInputFormatter {
         }
 
         // Replace any characters not in the set of 0-9 with the current decimal separator configured on website
-        var formattedText = text.replacingOccurrences(of: "[^0-9]", with: CurrencySettings.shared.decimalSeparator, options: .regularExpression)
-
-        // Remove any initial zero number in the string. Es. 00224.30 will be 2224.30
-        formattedText = formattedText.replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
+        let formattedText = text.replacingOccurrences(of: "[^0-9]", with: CurrencySettings.shared.decimalSeparator, options: .regularExpression)
+            // Remove any initial zero number in the string. Es. 00224.30 will be 2224.30
+            .replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
+            // Replace all the occurrences of regex plus all the points or comma (but not the last `.` or `,`)
+            .replacingOccurrences(of: "(?:[.,](?=.*[.,])|)+", with: "$1", options: .regularExpression)
         return formattedText
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -70,12 +70,14 @@ private extension DefaultProductFormTableViewModel {
         var priceDetails = [String]()
 
         // Regular price and sale price are both available only when a sale price is set.
-        if let regularPrice = product.regularPrice, !regularPrice.isEmpty,
-            let salePrice = product.salePrice, !salePrice.isEmpty {
+        if let regularPrice = product.regularPrice, regularPrice.isNotEmpty {
             let formattedRegularPrice = currencyFormatter.formatAmount(regularPrice, with: currency) ?? ""
-            let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
             priceDetails.append(String.localizedStringWithFormat(Constants.regularPriceFormat, formattedRegularPrice))
-            priceDetails.append(String.localizedStringWithFormat(Constants.salePriceFormat, formattedSalePrice))
+
+            if let salePrice = product.salePrice, salePrice.isNotEmpty {
+                let formattedSalePrice = currencyFormatter.formatAmount(salePrice, with: currency) ?? ""
+                priceDetails.append(String.localizedStringWithFormat(Constants.salePriceFormat, formattedSalePrice))
+            }
 
             if let dateOnSaleStart = product.dateOnSaleStart, let dateOnSaleEnd = product.dateOnSaleEnd {
                 let dateIntervalFormatter = DateIntervalFormatter.mediumLengthLocalizedDateIntervalFormatter

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -1,6 +1,12 @@
 import Yosemite
 
 extension Product {
+
+    // Regex that match all the occurrences of the thousand separators.
+    // All the points or comma (but not the last `.` or `,`)
+    //
+    private static let regexThousandSeparators = "(?:[.,](?=.*[.,])|)+"
+
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                        onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
@@ -10,7 +16,9 @@ extension Product {
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
         var value = currencyFormatter.formatAmount(regularPrice ?? "", with: unit) ?? ""
-        value = value.replacingOccurrences(of: unit, with: "")
+        value = value
+            .replacingOccurrences(of: unit, with: "")
+            .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
@@ -29,7 +37,9 @@ extension Product {
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
         var value = currencyFormatter.formatAmount(salePrice ?? "", with: unit) ?? ""
-        value = value.replacingOccurrences(of: unit, with: "")
+        value = value
+            .replacingOccurrences(of: unit, with: "")
+            .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -9,7 +9,7 @@ extension Product {
         let currencyFormatter = CurrencyFormatter()
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
-        var value = currencyFormatter.formatAmount(regularPrice ?? "", with: unit) ?? "0"
+        var value = currencyFormatter.formatAmount(regularPrice ?? "", with: unit) ?? ""
         value = value.replacingOccurrences(of: unit, with: "")
         return UnitInputViewModel(title: title,
                                   unit: unit,
@@ -28,7 +28,7 @@ extension Product {
         let currencyFormatter = CurrencyFormatter()
         let currencyCode = CurrencySettings.shared.currencyCode
         let unit = CurrencySettings.shared.symbol(from: currencyCode)
-        var value = currencyFormatter.formatAmount(salePrice ?? "", with: unit) ?? "0"
+        var value = currencyFormatter.formatAmount(salePrice ?? "", with: unit) ?? ""
         value = value.replacingOccurrences(of: unit, with: "")
         return UnitInputViewModel(title: title,
                                   unit: unit,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -1,9 +1,9 @@
 import Yosemite
 
 extension Product {
-    
+
     private static let placeholder = "0"
-    
+
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                        onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -1,6 +1,9 @@
 import Yosemite
 
 extension Product {
+    
+    private static let placeholder = "0"
+    
     static func createRegularPriceViewModel(regularPrice: String?,
                                             using currencySettings: CurrencySettings,
                                        onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
@@ -14,7 +17,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)
@@ -33,7 +36,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: PriceInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -180,6 +180,12 @@ extension ProductPriceSettingsViewController {
     @objc private func completeUpdating() {
         let newSalePrice = salePrice == "0" ? nil : salePrice
 
+        // Check if the sale price is populated, and the regular price is not.
+        if getDecimalPrice(salePrice) != nil, getDecimalPrice(regularPrice) == nil {
+            displaySalePriceWithoutRegularPriceErrorNotice()
+            return
+        }
+
         // Check if the sale price is less of the regular price, else show an error.
         if let decimalSalePrice = getDecimalPrice(salePrice), let decimalRegularPrice = getDecimalPrice(regularPrice) {
             let comparison = decimalSalePrice.compare(decimalRegularPrice)
@@ -216,6 +222,17 @@ private extension ProductPriceSettingsViewController {
 // MARK: - Error handling
 //
 private extension ProductPriceSettingsViewController {
+
+    /// Displays a Notice onscreen, indicating that you can't add a sale price without adding before the regular price
+    ///
+    func displaySalePriceWithoutRegularPriceErrorNotice() {
+        UIApplication.shared.keyWindow?.endEditing(true)
+        let message = NSLocalizedString("The sale price can't be added without the regular price.",
+                                        comment: "Product price error notice message, when the sale price is added but the regular price is not")
+
+        let notice = Notice(title: message, feedbackType: .error)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
 
     /// Displays a Notice onscreen, indicating that the sale price need to be higher than the regular price
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -306,7 +306,6 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-
         guard regularPrice != product.regularPrice ||
             salePrice != product.salePrice ||
             dateOnSaleStart != product.dateOnSaleStart ||

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,6 +1,9 @@
 import Yosemite
 
 extension Product {
+    
+    private static let placeholder = "0"
+    
     static func createShippingWeightViewModel(weight: String?,
                                               using shippingSettingsService: ShippingSettingsService,
                                               onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
@@ -10,7 +13,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: value,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -24,7 +27,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: length,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -38,7 +41,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: width,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)
@@ -52,7 +55,7 @@ extension Product {
         return UnitInputViewModel(title: title,
                                   unit: unit,
                                   value: height,
-                                  placeholder: "0",
+                                  placeholder: placeholder,
                                   keyboardType: .decimalPad,
                                   inputFormatter: ShippingInputFormatter(),
                                   onInputChange: onInputChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/Product+ShippingSettingsViewModels.swift
@@ -1,9 +1,9 @@
 import Yosemite
 
 extension Product {
-    
+
     private static let placeholder = "0"
-    
+
     static func createShippingWeightViewModel(weight: String?,
                                               using shippingSettingsService: ShippingSettingsService,
                                               onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -41,7 +41,7 @@ final class PriceInputFormatterTests: XCTestCase {
         let input = ","
         XCTAssertFalse(formatter.isValid(input: input))
     }
-    
+
     func testBigPriceInputWithThousandSeparators() {
         let input = "189,293,891,203.20"
         XCTAssertTrue(formatter.isValid(input: input))
@@ -78,12 +78,12 @@ final class PriceInputFormatterTests: XCTestCase {
         let input = "314200"
         XCTAssertEqual(formatter.format(input: input), "314200")
     }
-    
+
     func testFormattingBigPriceInput() {
         let input = "189293891203.20"
         XCTAssertEqual(formatter.format(input: input), "189293891203.20".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
     }
-    
+
     func testFormattingBigPriceInputWithThousandSeparators() {
         let input = "189,293,891,203.20"
         XCTAssertEqual(formatter.format(input: input), "189293891203.20".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -41,6 +41,11 @@ final class PriceInputFormatterTests: XCTestCase {
         let input = ","
         XCTAssertFalse(formatter.isValid(input: input))
     }
+    
+    func testBigPriceInputWithThousandSeparators() {
+        let input = "189,293,891,203.20"
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
 
     // MARK: test cases for `format(input:)`
 
@@ -72,5 +77,15 @@ final class PriceInputFormatterTests: XCTestCase {
     func testFormattingIntegerInput() {
         let input = "314200"
         XCTAssertEqual(formatter.format(input: input), "314200")
+    }
+    
+    func testFormattingBigPriceInput() {
+        let input = "189293891203.20"
+        XCTAssertEqual(formatter.format(input: input), "189293891203.20".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
+    }
+    
+    func testFormattingBigPriceInputWithThousandSeparators() {
+        let input = "189,293,891,203.20"
+        XCTAssertEqual(formatter.format(input: input), "189293891203.20".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -46,6 +46,11 @@ final class PriceInputFormatterTests: XCTestCase {
 
     func testFormattingEmptyInput() {
         let input = ""
+        XCTAssertEqual(formatter.format(input: input), "")
+    }
+
+    func testFormattingZeroInput() {
+        let input = "0"
         XCTAssertEqual(formatter.format(input: input), "0")
     }
 


### PR DESCRIPTION
Fixes #1794

## Description
This PR fixes a bug that happens when a regular or sale price has one or more thousand separators: the two price text fields became no longer editable, and when you save the price with thousand separators when you re-open the price settings screen, you will see the price truncated.

This is a GIF of the bug:
![pricing bug](https://user-images.githubusercontent.com/495617/73373407-dbf67800-42b8-11ea-8f9d-b1dccc03322b.gif)

## Testing
1) Tap Products tab
2) Navigate to a product detail
3) Tap price settings
4) Add a big price number, like `32934567890.45`. Press the done button.
5) Make sure that the product detail now shows the new price as `39,394,567,890.45` followed by the currency symbol of your website (like $). Tap update.
6) Reopen the edit price settings screen. Make sure you see the new price `32934567890.45` and make sure you can edit it.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
