### PR TITLE
Edit Products: removed "Save changes" from action sheet

### DIFF
--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -7,14 +7,10 @@ extension UIAlertController {
 
     /// Save Changes Action Sheet
     ///
-    static func presentSaveChangesActionSheet(viewController: UIViewController, onSave: (() -> Void)?,
+    static func presentDiscardChangesActionSheet(viewController: UIViewController,
                                               onDiscard: (() -> Void)?, onCancel: (() -> Void)? = nil) {
         let actionSheet = UIAlertController(title: nil, message: ActionSheetStrings.message, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
-
-        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.save) { _ in
-            onSave?()
-        }
 
         actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.discard) { _ in
             onDiscard?()
@@ -35,8 +31,6 @@ extension UIAlertController {
 private enum ActionSheetStrings {
     static let message = NSLocalizedString("Are you sure you want to discard these changes?",
                                            comment: "Message title for Save Changes Action Sheet")
-    static let save = NSLocalizedString("Save changes",
-                                        comment: "Button title for Save Changes Action Sheet")
     static let discard = NSLocalizedString("Discard changes",
                                           comment: "Button title Discard Changes in Save Changes Action Sheet")
     static let cancel = NSLocalizedString("Cancel",

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -5,7 +5,7 @@ import UIKit
 ///
 extension UIAlertController {
 
-    /// Save Changes Action Sheet
+    /// Discard Changes Action Sheet
     ///
     static func presentDiscardChangesActionSheet(viewController: UIViewController,
                                               onDiscard: (() -> Void)?, onCancel: (() -> Void)? = nil) {
@@ -30,9 +30,9 @@ extension UIAlertController {
 
 private enum ActionSheetStrings {
     static let message = NSLocalizedString("Are you sure you want to discard these changes?",
-                                           comment: "Message title for Save Changes Action Sheet")
+                                           comment: "Message title for Discard Changes Action Sheet")
     static let discard = NSLocalizedString("Discard changes",
-                                          comment: "Button title Discard Changes in Save Changes Action Sheet")
+                                          comment: "Button title Discard Changes in Discard Changes Action Sheet")
     static let cancel = NSLocalizedString("Cancel",
-                                          comment: "Button title Cancel in Save Changes Action Sheet")
+                                          comment: "Button title Cancel in Discard Changes Action Sheet")
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -242,9 +242,7 @@ extension AztecEditorViewController {
     }
 
     private func presentBackNavigationActionSheet() {
-        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
-            self?.saveButtonTapped()
-        }, onDiscard: { [weak self] in
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -199,9 +199,7 @@ extension ProductPriceSettingsViewController {
     }
 
     private func presentBackNavigationActionSheet() {
-        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
-            self?.completeUpdating()
-        }, onDiscard: { [weak self] in
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -189,9 +189,7 @@ extension ProductInventorySettingsViewController {
     }
 
     private func presentBackNavigationActionSheet() {
-        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
-            self?.completeUpdating()
-        }, onDiscard: { [weak self] in
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -131,9 +131,7 @@ extension ProductShippingSettingsViewController {
     }
 
     private func presentBackNavigationActionSheet() {
-        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
-            self?.completeUpdating()
-        }, onDiscard: { [weak self] in
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -100,9 +100,7 @@ extension TextViewViewController {
     }
 
     private func presentBackNavigationActionSheet() {
-        UIAlertController.presentSaveChangesActionSheet(viewController: self, onSave: { [weak self] in
-            self?.completeEditing()
-        }, onDiscard: { [weak self] in
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         })
     }


### PR DESCRIPTION
Fixes #1798 

## Description
This PR removes the "Save changes" action from the action sheet when tapping the back navigation button on edit product settings.

## Testing
1) Navigate to a product detail
2) Try to edit one thing in every product settings
3) Press back
4) Make sure that the action sheet now shows only "Discard changes" and "Cancel"

## Reference screenshots (this represent only the Title)
| Before             |  After |
:-------------------------:|:-------------------------:
![before](https://user-images.githubusercontent.com/495617/73675593-067a7380-46b3-11ea-9832-2b4d2dc8382b.png) | ![after](https://user-images.githubusercontent.com/495617/73675609-0d08eb00-46b3-11ea-8139-57ce9f9691af.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
