### PR TITLE
[Order Notes] Fixing strange character in note to customer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/OrderNoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/OrderNoteTableViewCell.swift
@@ -82,7 +82,7 @@ private extension OrderNoteTableViewCell {
         if isCustomerNote {
             iconButton.backgroundColor = .primary
             let template =
-                NSLocalizedString("%1$@ - %@$@ (To Customer)",
+                NSLocalizedString("%1$@ - %2$@ (To Customer)",
                                   comment: "Labels an order note. The user know it's visible to the customer. Reads like 05:30 PM - username (To Customer)")
             statusLabel.text = String.localizedStringWithFormat(template, dateOfCreation, theAuthor)
         } else if isSystemAuthor {


### PR DESCRIPTION
This PR fixes issue #1809 

The issue was that when adding a public note on an order it was showing some strange characters near the date/time field.

| Before | After |
| :-----: | :------: |
| ![image](https://user-images.githubusercontent.com/2797522/73708887-b43d5f00-4753-11ea-8b48-3608befc3163.png) | ![image](https://user-images.githubusercontent.com/2797522/73708781-75a7a480-4753-11ea-8226-64a1f3580dee.png) |



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
