### PR TITLE
Zendesk: limit log size to 64k characters

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 -----
 - bugfix: when the app is in the foreground while receiving a push notification, the badge on the Orders tab and Reviews tab should be updated correctly based on the type of the notification.
 - bugfix: after logging out and in, the Product list should be loaded to the correct store instead of being empty.
+- bugfix: in Contact Support, a message should always be sent successfully now.
 
 3.4
 -----

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -548,6 +548,11 @@ private extension ZendeskManager {
                 return ""
         }
 
+        // Truncates the log text so it fits in the ticket field.
+        if logText.count > Constants.logFieldCharacterLimit {
+            return String(logText.suffix(Constants.logFieldCharacterLimit))
+        }
+
         return logText
     }
 
@@ -798,6 +803,7 @@ private extension ZendeskManager {
         static let blogSeperator = "\n----------\n"
         static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"
+        static let logFieldCharacterLimit = 64000
         static let networkWiFi = "WiFi"
         static let networkWWAN = "Mobile"
         static let networkTypeLabel = "Network Type:"


### PR DESCRIPTION
Fixes #1509 

## Changes

- Truncated the log file size to the last 64k characters if needed
(I meant to add unit tests for this change, but there's no public interface for this info right now, since the log file is embedded in the Zendesk view controller of `UIViewController` type)

## Testing

Prerequisite: the app log file exceeds ~64k characters. Generally, after using the app for a while the file goes over 64k characters). You can double check the log file while logged in to a store under **Settings > Help & Support > View Application Log** and look for the first file.

- Build from `develop`
- While logged in to a store, go to Settings > Help & Support > Contact Support 
- Submit a ticket --> the ticket will fail to send if the log file is over the limit
- Build the PR branch
- Go to Settings > Help & Support > Contact Support
- Submit a ticket --> the ticket should be sent successfully (can be further verified on Zendesk)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
