### PR TITLE
Edit Product Title: fixed background safe area when in dark mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -61,6 +61,7 @@ final class TextViewViewController: UIViewController {
         super.viewDidLoad()
 
         configureNavigation()
+        configureView()
         configureTextView()
         configurePlaceholderLabel()
         refreshPlaceholderVisibility()
@@ -113,6 +114,10 @@ private extension TextViewViewController {
         title = navigationTitle
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeEditing))
+    }
+    
+    func configureView() {
+        view.backgroundColor = .basicBackground
     }
 
     func configureTextView() {

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -115,7 +115,7 @@ private extension TextViewViewController {
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeEditing))
     }
-    
+
     func configureView() {
         view.backgroundColor = .basicBackground
     }


### PR DESCRIPTION
Fixes #1799 

## Description
The safe area has a different color on the Edit Product Title screen when dark mode is enabled. This PR fixes this bug.
I changed the background view color, since changing the text field which is pinned to the safe area bottom create a wrong behavior with long text.

## Testing
1) Enable dark mode
2) Navigate to a product detail
3) Tap the Title
4) Make sure the safe area si dark, like the rest of the screen. 

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-04 at 12 18 00](https://user-images.githubusercontent.com/495617/73741471-97e8f480-474a-11ea-8740-5d210e12eb57.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-04 at 12 25 07](https://user-images.githubusercontent.com/495617/73741479-9b7c7b80-474a-11ea-8692-f49a6c8ded65.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
