### PR TITLE
[Order List Redesign] Make OrdersViewController reusable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Base.lproj/Main.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="MVm-eA-hqC">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="MVm-eA-hqC">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +20,6 @@
                     </tabBar>
                     <connections>
                         <segue destination="jeN-XS-2qG" kind="relationship" relationship="viewControllers" id="SC7-CG-XND"/>
-                        <segue destination="eDI-91-edj" kind="relationship" relationship="viewControllers" id="71l-Q1-bEB"/>
                         <segue destination="VMd-nd-2gL" kind="relationship" relationship="viewControllers" id="I5c-0D-HBd"/>
                     </connections>
                 </tabBarController>
@@ -39,16 +36,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lNt-Bh-d2U" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-54" y="133"/>
-        </scene>
-        <!--Orders-->
-        <scene sceneID="LpB-yt-3zf">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Orders" referencedIdentifier="Orders" id="eDI-91-edj" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" enabled="NO" title="Item" id="etY-Vs-MSy"/>
-                </viewControllerPlaceholder>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="W3N-OO-li0" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-83" y="-15"/>
         </scene>
         <!--Dashboard-->
         <scene sceneID="jh0-Br-aHk">

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -309,18 +309,6 @@ extension MainTabBarController {
 //
 extension MainTabBarController {
 
-    /// Displays the Orders List with the specified Filter applied.
-    ///
-    static func presentOrders(statusFilter: OrderStatus) {
-        switchToOrdersTab()
-
-        guard let ordersViewController: OrdersViewController = childViewController() else {
-            return
-        }
-
-        ordersViewController.statusFilter = statusFilter
-    }
-
     /// Syncs the notification given the ID, and handles the notification based on its notification kind.
     ///
     static func presentNotificationDetails(for noteID: Int64) {
@@ -395,6 +383,8 @@ private extension MainTabBarController {
         notificationsBadge.badgeCountWasUpdated(newValue: newValue, tab: tab, in: tabBar, tabIndex: tabIndex)
     }
 }
+
+// MARK: - Orders Tab Badge
 
 private extension MainTabBarController {
     func startListeningToOrdersBadge() {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -325,10 +325,11 @@ extension MainTabBarController {
         switch note.kind {
         case .storeOrder:
             switchToOrdersTab {
-                guard let ordersViewController: OrdersViewController = childViewController() else {
+                guard let ordersMasterVC: OrdersMasterViewController = childViewController() else {
                     return
                 }
-                ordersViewController.presentDetails(for: note)
+
+                ordersMasterVC.presentDetails(for: note)
             }
         case .comment:
             switchToReviewsTab {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -58,7 +58,11 @@ extension WooTab {
 
 
 // MARK: - MainTabBarController
-//
+
+/// A view controller that shows the tabs Store, Orders, Products, and Reviews.
+///
+/// TODO Migrate the `viewControllers` management from `Main.storyboard` to here (as code).
+///
 final class MainTabBarController: UITabBarController {
 
     /// For picking up the child view controller's status bar styling
@@ -101,12 +105,25 @@ final class MainTabBarController: UITabBarController {
         return navController
     }()
 
+    private lazy var ordersTabViewController: UIViewController = {
+        let masterViewController = OrdersMasterViewController()
+        return WooNavigationController(rootViewController: masterViewController)
+    }()
+
 
     // MARK: - Overridden Methods
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setNeedsStatusBarAppearanceUpdate() // call this to refresh status bar changes happening at runtime
+
+        // Add the Orders tab
+        viewControllers = {
+            let index = WooTab.orders.visibleIndex(isProductListFeatureOn: isProductsTabVisible)
+            var controllers = viewControllers ?? []
+            controllers.insert(ordersTabViewController, at: index)
+            return controllers
+        }()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -37,6 +37,7 @@ final class OrdersMasterViewController: UIViewController {
 
         viewModel.activate()
 
+        navigationItem.leftBarButtonItem = createSearchBarButtonItem()
         navigationItem.rightBarButtonItem = createFilterBarButtonItem()
         // Don't show the Order title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
@@ -84,6 +85,22 @@ final class OrdersMasterViewController: UIViewController {
         present(actionSheet, animated: true)
     }
 
+    /// Shows `SearchViewController`.
+    ///
+    @objc private func displaySearchOrders() {
+        guard let storeID = viewModel.storeID else {
+            return
+        }
+
+        analytics.track(.ordersListSearchTapped)
+
+        let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(storeID: storeID,
+                                                                                                  command: OrderSearchUICommand(),
+                                                                                                  cellType: OrderTableViewCell.self)
+        let navigationController = WooNavigationController(rootViewController: searchViewController)
+
+        present(navigationController, animated: true, completion: nil)
+    }
 }
 
 // MARK: - OrdersViewControllerDelegate
@@ -115,6 +132,24 @@ private extension OrdersMasterViewController {
             comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the order list."
         )
         button.accessibilityIdentifier = "order-filter-button"
+
+        return button
+    }
+
+    /// Create a `UIBarButtonItem` to be used as the search button on the top-left.
+    ///
+    func createSearchBarButtonItem() -> UIBarButtonItem {
+        let button = UIBarButtonItem(image: .searchImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(displaySearchOrders))
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = NSLocalizedString("Search orders", comment: "Search Orders")
+        button.accessibilityHint = NSLocalizedString(
+            "Retrieves a list of orders that contain a given keyword.",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to search orders."
+        )
+        button.accessibilityIdentifier = "order-search-button"
 
         return button
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -49,6 +49,16 @@ final class OrdersMasterViewController: UIViewController {
         ordersViewController.didMove(toParent: self)
 
         self.ordersViewController = ordersViewController
+
+        ordersViewController.willSynchronizeOrders = { [weak self] in
+            self?.viewModel.syncOrderStatuses()
+        }
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel.syncOrderStatuses()
     }
 
     /// Show the list of Order statuses can be filtered with.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -1,5 +1,6 @@
 
 import UIKit
+import struct Yosemite.OrderStatus
 
 /// The main Orders view controller that is shown when the Orders tab is accessed.
 ///
@@ -9,7 +10,9 @@ final class OrdersMasterViewController: UIViewController {
 
     private lazy var analytics = ServiceLocator.analytics
 
-    private lazy var viewModel = OrdersMasterViewModel()
+    private lazy var viewModel = OrdersMasterViewModel(statusFilterChanged: { [weak self] (status: OrderStatus?) in
+        self?.statusFilterChanged(status: status)
+    })
 
     /// The view controller that shows the list of Orders.
     ///
@@ -61,6 +64,12 @@ final class OrdersMasterViewController: UIViewController {
         viewModel.syncOrderStatuses()
     }
 
+    /// Called when the ViewModel's `statusFilter` changed.
+    ///
+    private func statusFilterChanged(status: OrderStatus?) {
+        ordersViewController?.statusFilter = status
+    }
+
     /// Show the list of Order statuses can be filtered with.
     ///
     @objc private func displayFiltersAlert() {
@@ -71,12 +80,12 @@ final class OrdersMasterViewController: UIViewController {
 
         actionSheet.addCancelActionWithTitle(FilterAction.dismiss)
         actionSheet.addDefaultActionWithTitle(FilterAction.displayAll) { [weak self] _ in
-            self?.ordersViewController?.statusFilter = nil
+            self?.viewModel.filterBy(orderStatus: nil)
         }
 
         for orderStatus in viewModel.currentSiteStatuses {
             actionSheet.addDefaultActionWithTitle(orderStatus.name) { [weak self] _ in
-                self?.ordersViewController?.statusFilter = orderStatus
+                self?.viewModel.filterBy(orderStatus: orderStatus)
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -7,6 +7,8 @@ import UIKit
 ///
 final class OrdersMasterViewController: UIViewController {
 
+    private lazy var viewModel = OrdersMasterViewModel()
+
     /// The view controller that shows the list of Orders.
     ///
     private var ordersViewController: OrdersViewController?
@@ -27,6 +29,8 @@ final class OrdersMasterViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        viewModel.activate()
 
         navigationItem.rightBarButtonItem = createFilterBarButtonItem()
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -137,8 +137,8 @@ private extension OrdersMasterViewController {
     func configureNavigationButtons() {
         navigationItem.leftBarButtonItem = createSearchBarButtonItem()
         navigationItem.rightBarButtonItem = createFilterBarButtonItem()
-        // Don't show the Order title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+
+        removeNavigationBackBarButtonText()
     }
 
     /// For `viewDidLoad` only, initialize and set up bindings for `self.ordersViewController`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -36,10 +36,7 @@ final class OrdersMasterViewController: UIViewController {
 
         viewModel.activate()
 
-        navigationItem.leftBarButtonItem = createSearchBarButtonItem()
-        navigationItem.rightBarButtonItem = createFilterBarButtonItem()
-        // Don't show the Order title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+        configureNavigationButtons()
 
         ordersViewController = createAndAttachOrdersViewController()
         ordersViewController?.delegate = self
@@ -135,6 +132,15 @@ private extension OrdersMasterViewController {
         tabBarItem.title = title
         tabBarItem.image = .pagesImage
         tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
+    }
+
+    /// For `viewDidLoad` only, set up `navigationItem` buttons.
+    ///
+    func configureNavigationButtons() {
+        navigationItem.leftBarButtonItem = createSearchBarButtonItem()
+        navigationItem.rightBarButtonItem = createFilterBarButtonItem()
+        // Don't show the Order title in the next-view's back button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -7,6 +7,10 @@ import UIKit
 ///
 final class OrdersMasterViewController: UIViewController {
 
+    /// The view controller that shows the list of Orders.
+    ///
+    private var ordersViewController: OrdersViewController?
+
     init() {
         super.init(nibName: Self.nibName, bundle: nil)
 
@@ -35,5 +39,7 @@ final class OrdersMasterViewController: UIViewController {
         view.addSubview(ordersView)
         ordersView.pinSubviewToAllEdges(view)
         ordersViewController.didMove(toParent: self)
+
+        self.ordersViewController = ordersViewController
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -24,9 +24,7 @@ final class OrdersMasterViewController: UIViewController {
 
         title = NSLocalizedString("Orders", comment: "The title of the Orders tab.")
 
-        tabBarItem.title = title
-        tabBarItem.image = .pagesImage
-        tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
+        configureTabBarItem()
     }
 
     required init?(coder: NSCoder) {
@@ -125,6 +123,18 @@ extension OrdersMasterViewController: OrdersViewControllerDelegate {
 
     func ordersViewControllerRequestsToClearStatusFilter(_ viewController: OrdersViewController) {
         viewModel.statusFilter = nil
+    }
+}
+
+// MARK: - Initialization and Loading (Not Reusable)
+
+private extension OrdersMasterViewController {
+    /// Set up properties for `self` as a root tab bar controller.
+    ///
+    func configureTabBarItem() {
+        tabBarItem.title = title
+        tabBarItem.image = .pagesImage
+        tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -38,6 +38,8 @@ final class OrdersMasterViewController: UIViewController {
         viewModel.activate()
 
         navigationItem.rightBarButtonItem = createFilterBarButtonItem()
+        // Don't show the Order title in the next-view's back button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
 
         ordersViewController = createAndAttachOrdersViewController()
         ordersViewController?.delegate = self
@@ -138,6 +140,8 @@ extension OrdersMasterViewController: OrdersViewControllerDelegate {
         viewModel.statusFilter = nil
     }
 }
+
+// MARK: - Optional<OrderStatus> Extension
 
 private extension Optional where Wrapped == OrderStatus {
     /// A localized title to use as the `OrdersMasterViewController`'s navigation title.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -28,6 +28,8 @@ final class OrdersMasterViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationItem.rightBarButtonItem = createFilterBarButtonItem()
+
         guard let ordersViewController = OrdersViewController.instantiatedViewControllerFromStoryboard(),
             let ordersView = ordersViewController.view else {
             return
@@ -41,5 +43,25 @@ final class OrdersMasterViewController: UIViewController {
         ordersViewController.didMove(toParent: self)
 
         self.ordersViewController = ordersViewController
+    }
+
+    @objc private func displayFiltersAlert() {
+
+    }
+
+    private func createFilterBarButtonItem() -> UIBarButtonItem {
+        let button = UIBarButtonItem(image: .filterImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(displayFiltersAlert))
+        button.accessibilityTraits = .button
+        button.accessibilityLabel = NSLocalizedString("Filter orders", comment: "Filter the orders list.")
+        button.accessibilityHint = NSLocalizedString(
+            "Filters the order list by payment status.",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the order list."
+        )
+        button.accessibilityIdentifier = "order-filter-button"
+
+        return button
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -80,12 +80,12 @@ final class OrdersMasterViewController: UIViewController {
 
         actionSheet.addCancelActionWithTitle(FilterAction.dismiss)
         actionSheet.addDefaultActionWithTitle(FilterAction.displayAll) { [weak self] _ in
-            self?.viewModel.filterBy(orderStatus: nil)
+            self?.viewModel.statusFilter = nil
         }
 
         for orderStatus in viewModel.currentSiteStatuses {
             actionSheet.addDefaultActionWithTitle(orderStatus.name) { [weak self] _ in
-                self?.viewModel.filterBy(orderStatus: orderStatus)
+                self?.viewModel.statusFilter = orderStatus
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -10,7 +10,9 @@ final class OrdersMasterViewController: UIViewController {
     init() {
         super.init(nibName: Self.nibName, bundle: nil)
 
-        tabBarItem.title = NSLocalizedString("Orders", comment: "Title of the Orders tab — plural form of Order")
+        title = NSLocalizedString("Orders", comment: "The title of the Orders tab.")
+
+        tabBarItem.title = title
         tabBarItem.image = .pagesImage
         tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -37,9 +37,7 @@ final class OrdersMasterViewController: UIViewController {
         viewModel.activate()
 
         configureNavigationButtons()
-
-        ordersViewController = createAndAttachOrdersViewController()
-        ordersViewController?.delegate = self
+        configureOrdersViewController()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -141,6 +139,13 @@ private extension OrdersMasterViewController {
         navigationItem.rightBarButtonItem = createFilterBarButtonItem()
         // Don't show the Order title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+    }
+
+    /// For `viewDidLoad` only, initialize and set up bindings for `self.ordersViewController`.
+    ///
+    func configureOrdersViewController() {
+        ordersViewController = createAndAttachOrdersViewController()
+        ordersViewController?.delegate = self
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -94,7 +94,7 @@ final class OrdersMasterViewController: UIViewController {
     /// Shows `SearchViewController`.
     ///
     @objc private func displaySearchOrders() {
-        guard let storeID = viewModel.storeID else {
+        guard let storeID = viewModel.siteID else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -124,4 +124,8 @@ extension OrdersMasterViewController: OrdersViewControllerDelegate {
     func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController) {
         viewModel.syncOrderStatuses()
     }
+
+    func ordersViewControllerRequestsToClearStatusFilter(_ viewController: OrdersViewController) {
+        viewModel.statusFilter = nil
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -7,4 +7,11 @@ import UIKit
 ///
 final class OrdersMasterViewController: UIViewController {
 
+    init() {
+        super.init(nibName: Self.nibName, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Not supported")
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -39,20 +39,8 @@ final class OrdersMasterViewController: UIViewController {
 
         navigationItem.rightBarButtonItem = createFilterBarButtonItem()
 
-        guard let ordersViewController = OrdersViewController.instantiatedViewControllerFromStoryboard(),
-            let ordersView = ordersViewController.view else {
-            return
-        }
-
-        ordersView.translatesAutoresizingMaskIntoConstraints = false
-
-        add(ordersViewController)
-        view.addSubview(ordersView)
-        ordersView.pinSubviewToAllEdges(view)
-        ordersViewController.didMove(toParent: self)
-
-        ordersViewController.delegate = self
-        self.ordersViewController = ordersViewController
+        ordersViewController = createAndAttachOrdersViewController()
+        ordersViewController?.delegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -93,6 +81,8 @@ final class OrdersMasterViewController: UIViewController {
         present(actionSheet, animated: true)
     }
 
+    /// Create a `UIBarButtonItem` to be used as the filter button on the top-right.
+    ///
     private func createFilterBarButtonItem() -> UIBarButtonItem {
         let button = UIBarButtonItem(image: .filterImage,
                                      style: .plain,
@@ -107,6 +97,24 @@ final class OrdersMasterViewController: UIViewController {
         button.accessibilityIdentifier = "order-filter-button"
 
         return button
+    }
+
+    /// Creates an `OrdersViewController` and attaches its view to `self.view`.
+    ///
+    private func createAndAttachOrdersViewController() -> OrdersViewController? {
+        guard let ordersViewController = OrdersViewController.instantiatedViewControllerFromStoryboard(),
+            let ordersView = ordersViewController.view else {
+                return nil
+        }
+
+        ordersView.translatesAutoresizingMaskIntoConstraints = false
+
+        add(ordersViewController)
+        view.addSubview(ordersView)
+        ordersView.pinSubviewToAllEdges(view)
+        ordersViewController.didMove(toParent: self)
+
+        return ordersViewController
     }
 
     enum FilterAction {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -1,0 +1,10 @@
+
+import UIKit
+
+/// The main Orders view controller that is shown when the Orders tab is accessed.
+///
+/// TODO This should contain the tabs "Processing" and "All Orders".
+///
+final class OrdersMasterViewController: UIViewController {
+
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -18,4 +18,20 @@ final class OrdersMasterViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("Not supported")
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        guard let ordersViewController = OrdersViewController.instantiatedViewControllerFromStoryboard(),
+            let ordersView = ordersViewController.view else {
+            return
+        }
+
+        ordersView.translatesAutoresizingMaskIntoConstraints = false
+
+        add(ordersViewController)
+        view.addSubview(ordersView)
+        ordersView.pinSubviewToAllEdges(view)
+        ordersViewController.didMove(toParent: self)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -86,7 +86,7 @@ final class OrdersMasterViewController: UIViewController {
 
         let popoverController = actionSheet.popoverPresentationController
         popoverController?.barButtonItem = navigationItem.rightBarButtonItem
-        popoverController?.sourceView = self.view
+        popoverController?.sourceView = view
 
         present(actionSheet, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -53,6 +53,7 @@ final class OrdersMasterViewController: UIViewController {
     ///
     private func statusFilterChanged(status: OrderStatus?) {
         ordersViewController?.statusFilter = status
+        navigationItem.title = status.titleForNavigationItem
     }
 
     /// Show the list of Order statuses can be filtered with.
@@ -135,5 +136,26 @@ extension OrdersMasterViewController: OrdersViewControllerDelegate {
 
     func ordersViewControllerRequestsToClearStatusFilter(_ viewController: OrdersViewController) {
         viewModel.statusFilter = nil
+    }
+}
+
+private extension Optional where Wrapped == OrderStatus {
+    /// A localized title to use as the `OrdersMasterViewController`'s navigation title.
+    ///
+    var titleForNavigationItem: String {
+        guard let filterName = self?.name else {
+            return NSLocalizedString(
+                "Orders",
+                comment: "Title that appears on top of the Order List screen when there is no filter applied to the list (plural form of the word Order)."
+            )
+        }
+
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Orders: %@",
+                comment: "Title that appears on top of the Order List screen when a filter is applied. It reads: Orders: {name of filter}"
+            ),
+            filterName
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -9,6 +9,10 @@ final class OrdersMasterViewController: UIViewController {
 
     init() {
         super.init(nibName: Self.nibName, bundle: nil)
+
+        tabBarItem.title = NSLocalizedString("Orders", comment: "Title of the Orders tab — plural form of Order")
+        tabBarItem.image = .pagesImage
+        tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -84,9 +84,26 @@ final class OrdersMasterViewController: UIViewController {
         present(actionSheet, animated: true)
     }
 
+}
+
+// MARK: - OrdersViewControllerDelegate
+
+extension OrdersMasterViewController: OrdersViewControllerDelegate {
+    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController) {
+        viewModel.syncOrderStatuses()
+    }
+
+    func ordersViewControllerRequestsToClearStatusFilter(_ viewController: OrdersViewController) {
+        viewModel.statusFilter = nil
+    }
+}
+
+// MARK: - Creators
+
+private extension OrdersMasterViewController {
     /// Create a `UIBarButtonItem` to be used as the filter button on the top-right.
     ///
-    private func createFilterBarButtonItem() -> UIBarButtonItem {
+    func createFilterBarButtonItem() -> UIBarButtonItem {
         let button = UIBarButtonItem(image: .filterImage,
                                      style: .plain,
                                      target: self,
@@ -104,7 +121,7 @@ final class OrdersMasterViewController: UIViewController {
 
     /// Creates an `OrdersViewController` and attaches its view to `self.view`.
     ///
-    private func createAndAttachOrdersViewController() -> OrdersViewController? {
+    func createAndAttachOrdersViewController() -> OrdersViewController? {
         guard let ordersViewController = OrdersViewController.instantiatedViewControllerFromStoryboard(),
             let ordersView = ordersViewController.view else {
                 return nil
@@ -126,18 +143,6 @@ final class OrdersMasterViewController: UIViewController {
             "All",
             comment: "Name of the All filter on the Order List screen - it means all orders will be displayed."
         )
-    }
-}
-
-// MARK: - OrdersViewControllerDelegate
-
-extension OrdersMasterViewController: OrdersViewControllerDelegate {
-    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController) {
-        viewModel.syncOrderStatuses()
-    }
-
-    func ordersViewControllerRequestsToClearStatusFilter(_ viewController: OrdersViewController) {
-        viewModel.statusFilter = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -7,6 +7,8 @@ import UIKit
 ///
 final class OrdersMasterViewController: UIViewController {
 
+    private lazy var analytics = ServiceLocator.analytics
+
     private lazy var viewModel = OrdersMasterViewModel()
 
     /// The view controller that shows the list of Orders.
@@ -49,8 +51,30 @@ final class OrdersMasterViewController: UIViewController {
         self.ordersViewController = ordersViewController
     }
 
+    /// Show the list of Order statuses can be filtered with.
+    ///
     @objc private func displayFiltersAlert() {
+        analytics.track(.ordersListFilterTapped)
 
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addCancelActionWithTitle(FilterAction.dismiss)
+        actionSheet.addDefaultActionWithTitle(FilterAction.displayAll) { [weak self] _ in
+            self?.ordersViewController?.statusFilter = nil
+        }
+
+        for orderStatus in viewModel.currentSiteStatuses {
+            actionSheet.addDefaultActionWithTitle(orderStatus.name) { [weak self] _ in
+                self?.ordersViewController?.statusFilter = orderStatus
+            }
+        }
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.barButtonItem = navigationItem.rightBarButtonItem
+        popoverController?.sourceView = self.view
+
+        present(actionSheet, animated: true)
     }
 
     private func createFilterBarButtonItem() -> UIBarButtonItem {
@@ -67,5 +91,13 @@ final class OrdersMasterViewController: UIViewController {
         button.accessibilityIdentifier = "order-filter-button"
 
         return button
+    }
+
+    enum FilterAction {
+        static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the action sheet")
+        static let displayAll = NSLocalizedString(
+            "All",
+            comment: "Name of the All filter on the Order List screen - it means all orders will be displayed."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -1,6 +1,7 @@
 
 import UIKit
 import struct Yosemite.OrderStatus
+import struct Yosemite.Note
 
 /// The main Orders view controller that is shown when the Orders tab is accessed.
 ///
@@ -50,6 +51,18 @@ final class OrdersMasterViewController: UIViewController {
         super.viewWillAppear(animated)
 
         viewModel.syncOrderStatuses()
+    }
+
+    /// Presents the Details for the Notification with the specified Identifier.
+    ///
+    func presentDetails(for note: Note) {
+        guard let orderID = note.meta.identifier(forKey: .order), let siteID = note.meta.identifier(forKey: .site) else {
+            DDLogError("## Notification with [\(note.noteID)] lacks its OrderID!")
+            return
+        }
+
+        let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
+        navigationController?.pushViewController(loaderViewController, animated: true)
     }
 
     /// Called when the ViewModel's `statusFilter` changed.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -51,11 +51,8 @@ final class OrdersMasterViewController: UIViewController {
         ordersView.pinSubviewToAllEdges(view)
         ordersViewController.didMove(toParent: self)
 
+        ordersViewController.delegate = self
         self.ordersViewController = ordersViewController
-
-        ordersViewController.willSynchronizeOrders = { [weak self] in
-            self?.viewModel.syncOrderStatuses()
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -118,5 +115,13 @@ final class OrdersMasterViewController: UIViewController {
             "All",
             comment: "Name of the All filter on the Order List screen - it means all orders will be displayed."
         )
+    }
+}
+
+// MARK: - OrdersViewControllerDelegate
+
+extension OrdersMasterViewController: OrdersViewControllerDelegate {
+    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController) {
+        viewModel.syncOrderStatuses()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.xib
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrdersMasterViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="xuO-pm-Bnd" id="21G-dF-888"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="xuO-pm-Bnd">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="rGE-vr-B04"/>
+            <point key="canvasLocation" x="-317" y="153"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -17,6 +17,12 @@ final class OrdersMasterViewModel {
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, sortedBy: [descriptor])
     }()
 
+    /// The current `storeID`.
+    ///
+    var storeID: Int64? {
+        sessionManager.defaultStoreID
+    }
+
     /// The current list of order statuses for the default site
     ///
     var currentSiteStatuses: [OrderStatus] {
@@ -64,7 +70,7 @@ final class OrdersMasterViewModel {
     func syncOrderStatuses() {
         resetStatusFilterIfNeeded()
 
-        guard let siteID = sessionManager.defaultStoreID else {
+        guard let siteID = storeID else {
             return
         }
 
@@ -108,7 +114,7 @@ final class OrdersMasterViewModel {
                 return
         }
 
-        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", sessionManager.defaultStoreID ?? Int.min)
+        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", storeID ?? Int.min)
     }
 
     /// Reset the current status filter if needed (e.g. when changing stores and the currently

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -17,9 +17,9 @@ final class OrdersMasterViewModel {
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, sortedBy: [descriptor])
     }()
 
-    /// The current `storeID`.
+    /// The current `Site` `siteID`.
     ///
-    var storeID: Int64? {
+    var siteID: Int64? {
         sessionManager.defaultStoreID
     }
 
@@ -70,7 +70,7 @@ final class OrdersMasterViewModel {
     func syncOrderStatuses() {
         resetStatusFilterIfNeeded()
 
-        guard let siteID = storeID else {
+        guard let siteID = siteID else {
             return
         }
 
@@ -114,7 +114,7 @@ final class OrdersMasterViewModel {
                 return
         }
 
-        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", storeID ?? Int.min)
+        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", siteID ?? Int.min)
     }
 
     /// Reset the current status filter if needed (e.g. when changing stores and the currently

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -25,15 +25,16 @@ final class OrdersMasterViewModel {
 
     /// The current `OrderStatus` to filter by.
     ///
-    /// If the this is `nil`, that means that all orders should be shown.
+    /// If the this is `nil`, that means that all orders should be shown. The `statusFilterChanged`
+    /// callback will be called whenever this is changed.
     ///
-    private var statusFilter: OrderStatus? {
+    var statusFilter: OrderStatus? {
         didSet {
             statusFilterChanged(statusFilter)
         }
     }
 
-    /// Called when the selected `OrderStatus` for filtering was changed.
+    /// Called whenever `statusFilter` is changed.
     ///
     private let statusFilterChanged: (OrderStatus?) -> ()
 
@@ -79,16 +80,6 @@ final class OrdersMasterViewModel {
         }
 
         stores.dispatch(action)
-    }
-
-    /// Change the current `OrderStatus` filter.
-    ///
-    /// The `statusFilterChanged` callback will be called after.
-    ///
-    /// - SeeAlso: statusFilter
-    ///
-    func filterBy(orderStatus: OrderStatus?) {
-        statusFilter = orderStatus
     }
 
     /// Runs whenever the default Account is updated.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -27,8 +27,26 @@ final class OrdersMasterViewModel {
     /// This should only be called once in the lifetime of `OrdersMasterViewController`.
     ///
     func activate() {
+        // Initialize `statusResultsController`
         refreshStatusPredicate()
         try? statusResultsController.performFetch()
+
+        // Listen to notifications
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+        nc.addObserver(self, selector: #selector(stopListeningToNotifications), name: .logOutEventReceived, object: nil)
+    }
+
+    /// Runs whenever the default Account is updated.
+    ///
+    @objc private func defaultAccountWasUpdated() {
+        refreshStatusPredicate()
+    }
+
+    /// Stops listening to all related Notifications
+    ///
+    @objc private func stopListeningToNotifications() {
+        NotificationCenter.default.removeObserver(self)
     }
 
     /// Update the `siteID` predicate of `statusResultsController` to the current `siteID`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -61,6 +61,8 @@ final class OrdersMasterViewModel {
     /// Fetch all `OrderStatus` from the API
     ///
     func syncOrderStatuses() {
+        resetStatusFilterIfNeeded()
+
         guard let siteID = sessionManager.defaultStoreID else {
             return
         }
@@ -72,8 +74,8 @@ final class OrdersMasterViewModel {
             if let error = error {
                 DDLogError("⛔️ Order List — Error synchronizing order statuses: \(error)")
             }
-            #warning("restore this feature")
-//            self?.resetStatusFilterIfNeeded()
+
+            self?.resetStatusFilterIfNeeded()
         }
 
         stores.dispatch(action)
@@ -115,5 +117,23 @@ final class OrdersMasterViewModel {
         }
 
         statusResultsController.predicate = NSPredicate(format: "siteID == %lld", sessionManager.defaultStoreID ?? Int.min)
+    }
+
+    /// Reset the current status filter if needed (e.g. when changing stores and the currently
+    /// selected filter does not exist in the new store)
+    ///
+    func resetStatusFilterIfNeeded() {
+        guard let statusFilter = statusFilter else {
+            // "All" is the current filter so bail
+            return
+        }
+        guard currentSiteStatuses.isEmpty == false else {
+            self.statusFilter = nil
+            return
+        }
+
+        if !currentSiteStatuses.contains(where: { $0.name == statusFilter.name && $0.slug == statusFilter.slug }) {
+            self.statusFilter = nil
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -4,6 +4,12 @@ import Yosemite
 
 /// Encapsulates data management for `OrdersMasterViewController`.
 ///
+/// ## Always Active
+///
+/// The corresponding view, `OrdersMaterViewController`, is never deallocated even if the user has
+/// already logged out. There are some considerations in this class like `resetStatusPredicate` to
+/// accommodate this behavior.
+///
 final class OrdersMasterViewModel {
 
     private lazy var storageManager = ServiceLocator.storageManager
@@ -62,7 +68,6 @@ final class OrdersMasterViewModel {
         // Listen to notifications
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
-        nc.addObserver(self, selector: #selector(stopListeningToNotifications), name: .logOutEventReceived, object: nil)
     }
 
     /// Fetch all `OrderStatus` from the API
@@ -93,12 +98,6 @@ final class OrdersMasterViewModel {
     @objc private func defaultAccountWasUpdated() {
         statusFilter = nil
         refreshStatusPredicate()
-    }
-
-    /// Stops listening to all related Notifications
-    ///
-    @objc private func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Update the `siteID` predicate of `statusResultsController` to the current `siteID`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -1,0 +1,23 @@
+
+import Foundation
+import Yosemite
+
+/// Encapsulates data management for `OrdersMasterViewController`.
+///
+final class OrdersMasterViewModel {
+
+    private lazy var storageManager = ServiceLocator.storageManager
+
+    /// ResultsController: Handles all things order status
+    ///
+    private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
+        let descriptor = NSSortDescriptor(key: "slug", ascending: true)
+        return ResultsController<StorageOrderStatus>(storageManager: storageManager, sortedBy: [descriptor])
+    }()
+
+    /// The current list of order statuses for the default site
+    ///
+    var currentSiteStatuses: [OrderStatus] {
+        return statusResultsController.fetchedObjects
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -7,6 +7,7 @@ import Yosemite
 final class OrdersMasterViewModel {
 
     private lazy var storageManager = ServiceLocator.storageManager
+    private lazy var stores = ServiceLocator.stores
 
     /// ResultsController: Handles all things order status
     ///
@@ -23,7 +24,26 @@ final class OrdersMasterViewModel {
 
     /// Start all the operations that this `ViewModel` is responsible for.
     ///
+    /// This should only be called once in the lifetime of `OrdersMasterViewController`.
+    ///
     func activate() {
+        refreshStatusPredicate()
         try? statusResultsController.performFetch()
+    }
+
+    /// Update the `siteID` predicate of `statusResultsController` to the current `siteID`.
+    ///
+    private func refreshStatusPredicate() {
+        // Bugfix for https://github.com/woocommerce/woocommerce-ios/issues/751.
+        // Because we are listening for default account changes,
+        // this will also fire upon logging out, when the account
+        // is set to nil. So let's protect against multi-threaded
+        // access attempts if the account is indeed nil.
+        guard stores.isAuthenticated,
+            stores.needsDefaultStore == false else {
+                return
+        }
+
+        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", stores.sessionManager.defaultStoreID ?? Int.min)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -27,7 +27,11 @@ final class OrdersMasterViewModel {
     ///
     /// If the this is `nil`, that means that all orders should be shown.
     ///
-    private var statusFilter: OrderStatus?
+    private var statusFilter: OrderStatus? {
+        didSet {
+            statusFilterChanged(statusFilter)
+        }
+    }
 
     /// Called when the selected `OrderStatus` for filtering was changed.
     ///
@@ -83,7 +87,6 @@ final class OrdersMasterViewModel {
     ///
     func filterBy(orderStatus: OrderStatus?) {
         statusFilter = orderStatus
-        statusFilterChanged(statusFilter)
     }
 
     /// Runs whenever the default Account is updated.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -20,4 +20,10 @@ final class OrdersMasterViewModel {
     var currentSiteStatuses: [OrderStatus] {
         return statusResultsController.fetchedObjects
     }
+
+    /// Start all the operations that this `ViewModel` is responsible for.
+    ///
+    func activate() {
+        try? statusResultsController.performFetch()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -85,6 +85,7 @@ final class OrdersMasterViewModel {
     /// Runs whenever the default Account is updated.
     ///
     @objc private func defaultAccountWasUpdated() {
+        statusFilter = nil
         refreshStatusPredicate()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -23,6 +23,22 @@ final class OrdersMasterViewModel {
         return statusResultsController.fetchedObjects
     }
 
+    /// The current `OrderStatus` to filter by.
+    ///
+    /// If the this is `nil`, that means that all orders should be shown.
+    ///
+    private var statusFilter: OrderStatus?
+
+    /// Called when the selected `OrderStatus` for filtering was changed.
+    ///
+    private let statusFilterChanged: (OrderStatus?) -> ()
+
+    /// Designated initializer.
+    ///
+    init(statusFilterChanged: @escaping (OrderStatus?) -> ()) {
+        self.statusFilterChanged = statusFilterChanged
+    }
+
     /// Start all the operations that this `ViewModel` is responsible for.
     ///
     /// This should only be called once in the lifetime of `OrdersMasterViewController`.
@@ -57,6 +73,17 @@ final class OrdersMasterViewModel {
         }
 
         stores.dispatch(action)
+    }
+
+    /// Change the current `OrderStatus` filter.
+    ///
+    /// The `statusFilterChanged` callback will be called after.
+    ///
+    /// - SeeAlso: statusFilter
+    ///
+    func filterBy(orderStatus: OrderStatus?) {
+        statusFilter = orderStatus
+        statusFilterChanged(statusFilter)
     }
 
     /// Runs whenever the default Account is updated.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -146,7 +146,6 @@ class OrdersViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        refreshTitle()
         refreshResultsPredicate()
         refreshStatusPredicate()
         registerTableViewCells()
@@ -174,28 +173,6 @@ class OrdersViewController: UIViewController {
 // MARK: - User Interface Initialization
 //
 private extension OrdersViewController {
-
-    /// Setup: Title
-    ///
-    func refreshTitle() {
-        guard let filterName = statusFilter?.name else {
-            navigationItem.title = NSLocalizedString(
-                "Orders",
-                comment: "Title that appears on top of the Order List screen when there is no filter applied to the list (plural form of the word Order)."
-            )
-            return
-        }
-
-        let title = String.localizedStringWithFormat(
-            NSLocalizedString(
-                "Orders: %@",
-                comment: "Title that appears on top of the Order List screen when a filter is applied. It reads: Orders: {name of filter}"
-            ),
-            filterName
-        )
-        navigationItem.title = title
-    }
-
     /// Setup: Order filtering
     ///
     func refreshResultsPredicate() {
@@ -396,8 +373,6 @@ private extension OrdersViewController {
         ServiceLocator.analytics.track(.ordersListFilterOrSearch,
                                   withProperties: ["filter": newFilter?.slug ?? String(),
                                                    "search": ""])
-        // Display the Filter in the Title
-        refreshTitle()
 
         // Filter right away the cached orders
         refreshResultsPredicate()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -234,22 +234,6 @@ private extension OrdersViewController {
             return button
         }()
 
-        navigationItem.rightBarButtonItem = {
-            let button = UIBarButtonItem(image: .filterImage,
-                                                 style: .plain,
-                                                 target: self,
-                                                 action: #selector(displayFiltersAlert))
-            button.accessibilityTraits = .button
-            button.accessibilityLabel = NSLocalizedString("Filter orders", comment: "Filter the orders list.")
-            button.accessibilityHint = NSLocalizedString(
-                "Filters the order list by payment status.",
-                comment: "VoiceOver accessibility hint, informing the user the button can be used to filter the order list."
-            )
-            button.accessibilityIdentifier = "order-filter-button"
-
-            return button
-        }()
-
         // Don't show the Order title in the next-view's back button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
     }
@@ -374,29 +358,6 @@ extension OrdersViewController {
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 
         present(navigationController, animated: true, completion: nil)
-    }
-
-    @IBAction func displayFiltersAlert() {
-        ServiceLocator.analytics.track(.ordersListFilterTapped)
-        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .text
-
-        actionSheet.addCancelActionWithTitle(FilterAction.dismiss)
-        actionSheet.addDefaultActionWithTitle(FilterAction.displayAll) { [weak self] _ in
-            self?.statusFilter = nil
-        }
-
-        for orderStatus in currentSiteStatuses {
-            actionSheet.addDefaultActionWithTitle(orderStatus.name) { [weak self] _ in
-                self?.statusFilter = orderStatus
-            }
-        }
-
-        let popoverController = actionSheet.popoverPresentationController
-        popoverController?.barButtonItem = navigationItem.rightBarButtonItem
-        popoverController?.sourceView = self.view
-
-        present(actionSheet, animated: true)
     }
 
     @IBAction func pullToRefresh(sender: UIRefreshControl) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -227,9 +227,6 @@ private extension OrdersViewController {
 
             return button
         }()
-
-        // Don't show the Order title in the next-view's back button
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
     }
 
     /// Setup: Results Controller

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -681,14 +681,6 @@ private extension OrdersViewController {
 //
 private extension OrdersViewController {
 
-    enum FilterAction {
-        static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss the action sheet")
-        static let displayAll = NSLocalizedString(
-            "All",
-            comment: "Name of the All filter on the Order List screen - it means all orders will be displayed."
-        )
-    }
-
     enum Settings {
         static let estimatedHeaderHeight = CGFloat(43)
         static let estimatedRowHeight = CGFloat(86)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -9,6 +9,16 @@ protocol OrdersViewControllerDelegate: class {
     /// Called when `OrdersViewController` is about to fetch Orders from the API.
     ///
     func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController)
+    /// Called when `OrdersViewController` is requesting to reset the `statusFilter` to `nil`.
+    ///
+    /// `OrdersViewController` does not modify its own `statusFilter`. While it is capable of
+    ///  doing that, we'd rather have that responsibility in the parent
+    ///  `OrdersMasterViewController`.
+    ///
+    ///  TODO There are ways to make secure this intentional behavior. We are keeping this as is
+    ///  for now since we will be significantly refactoring `OrdersViewController` later.
+    ///
+    func ordersViewControllerRequestsToClearStatusFilter(_ viewController: OrdersViewController)
 }
 
 /// OrdersViewController: Displays the list of Orders associated to the active Store / Account.
@@ -561,7 +571,9 @@ private extension OrdersViewController {
         overlayView.messageText = NSLocalizedString("No results for the selected criteria", comment: "Orders List (Empty State + Filters)")
         overlayView.actionText = NSLocalizedString("Remove Filters", comment: "Action: Opens the Store in a browser")
         overlayView.onAction = { [weak self] in
-            self?.statusFilter = nil
+            if let self = self {
+                self.delegate?.ordersViewControllerRequestsToClearStatusFilter(self)
+            }
         }
 
         overlayView.attach(to: view)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -321,7 +321,6 @@ extension OrdersViewController {
     /// Runs whenever the default Account is updated.
     ///
     @objc func defaultAccountWasUpdated() {
-        statusFilter = nil
         refreshStatusPredicate()
         syncingCoordinator.resetInternalState()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -151,7 +151,6 @@ class OrdersViewController: UIViewController {
         registerTableViewCells()
 
         configureSyncingCoordinator()
-        configureNavigation()
         configureTableView()
         configureGhostableTableView()
         configureResultsControllers()
@@ -207,26 +206,6 @@ private extension OrdersViewController {
         }
 
         statusResultsController.predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
-    }
-
-    /// Setup: Navigation Item
-    ///
-    func configureNavigation() {
-        navigationItem.leftBarButtonItem = {
-            let button = UIBarButtonItem(image: .searchImage,
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(displaySearchOrders))
-            button.accessibilityTraits = .button
-            button.accessibilityLabel = NSLocalizedString("Search orders", comment: "Search Orders")
-            button.accessibilityHint = NSLocalizedString(
-                "Retrieves a list of orders that contain a given keyword.",
-                comment: "VoiceOver accessibility hint, informing the user the button can be used to search orders."
-            )
-            button.accessibilityIdentifier = "order-search-button"
-
-            return button
-        }()
     }
 
     /// Setup: Results Controller
@@ -334,22 +313,6 @@ extension OrdersViewController {
 // MARK: - Actions
 //
 extension OrdersViewController {
-
-    @IBAction func displaySearchOrders() {
-        guard let storeID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return
-        }
-
-        ServiceLocator.analytics.track(.ordersListSearchTapped)
-
-        let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(storeID: storeID,
-                                                                                                  command: OrderSearchUICommand(),
-                                                                                                  cellType: OrderTableViewCell.self)
-        let navigationController = WooNavigationController(rootViewController: searchViewController)
-
-        present(navigationController, animated: true, completion: nil)
-    }
-
     @IBAction func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.ordersViewControllerWillSynchronizeOrders(self)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -292,24 +292,6 @@ extension OrdersViewController {
     }
 }
 
-
-// MARK: - Push Notification Handling
-//
-extension OrdersViewController {
-    /// Presents the Details for the Notification with the specified Identifier.
-    ///
-    func presentDetails(for note: Note) {
-        guard let orderID = note.meta.identifier(forKey: .order), let siteID = note.meta.identifier(forKey: .site) else {
-            DDLogError("## Notification with [\(note.noteID)] lacks its OrderID!")
-            return
-        }
-
-        let loaderViewController = OrderLoaderViewController(note: note, orderID: Int64(orderID), siteID: Int64(siteID))
-        navigationController?.pushViewController(loaderViewController, animated: true)
-    }
-}
-
-
 // MARK: - Actions
 //
 extension OrdersViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -74,7 +74,7 @@ class OrdersViewController: UIViewController {
     /// OrderStatus that must be matched by retrieved orders.
     ///
     /// This is set and changed by `OrdersMasterViewModel`. This shouldn't be updated internally
-    /// by this `self`.
+    /// by `self`.
     ///
     var statusFilter: OrderStatus? {
         didSet {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -41,7 +41,7 @@ class OrdersViewController: UIViewController {
         return ResultsController<StorageOrder>(storageManager: storageManager, sectionNameKeyPath: "normalizedAgeAsString", sortedBy: [descriptor])
     }()
 
-    /// ResultsController: Handles all things order status
+    /// Used for looking up the `OrderStatus` to show in the `OrderTableViewCell`.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = ServiceLocator.storageManager
@@ -55,6 +55,9 @@ class OrdersViewController: UIViewController {
     private let syncingCoordinator = SyncingCoordinator()
 
     /// OrderStatus that must be matched by retrieved orders.
+    ///
+    /// This is set and changed by `OrdersMasterViewModel`. This shouldn't be updated internally
+    /// by this `self`.
     ///
     var statusFilter: OrderStatus? {
         didSet {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -122,9 +122,6 @@ class OrdersViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-
-        // This 👇 should be called in init so the tab is correctly localized when the app launches
-        configureTabBarItem()
     }
 
     override func viewDidLoad() {
@@ -272,14 +269,6 @@ private extension OrdersViewController {
     ///
     func configureSyncingCoordinator() {
         syncingCoordinator.delegate = self
-    }
-
-    /// Setup: TabBar Item
-    ///
-    func configureTabBarItem() {
-        tabBarItem.title = NSLocalizedString("Orders", comment: "Title of the Orders tab — plural form of Order")
-        tabBarItem.image = .pagesImage
-        tabBarItem.accessibilityIdentifier = "tab-bar-orders-item"
     }
 
     /// Setup: TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -108,6 +108,14 @@ class OrdersViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
+    /// Create an instance of `Self` from its corresponding storyboard.
+    ///
+    static func instantiatedViewControllerFromStoryboard() -> Self? {
+        let storyboard = UIStoryboard.orders
+        let identifier = "OrdersViewController"
+        return storyboard.instantiateViewController(withIdentifier: identifier) as? Self
+    }
+
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         fatalError()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -147,7 +147,6 @@ class OrdersViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        resetStatusFilterIfNeeded()
         syncingCoordinator.synchronizeFirstPage()
         if AppRatingManager.shared.shouldPromptForAppReview() {
             displayRatingPrompt()
@@ -406,24 +405,6 @@ private extension OrdersViewController {
 
         let action = OrderAction.resetStoredOrders(onCompletion: onCompletion)
         ServiceLocator.stores.dispatch(action)
-    }
-
-    /// Reset the current status filter if needed (e.g. when changing stores and the currently
-    /// selected filter does not exist in the new store)
-    ///
-    func resetStatusFilterIfNeeded() {
-        guard let statusFilter = statusFilter else {
-            // "All" is the current filter so bail
-            return
-        }
-        guard currentSiteStatuses.isEmpty == false else {
-            self.statusFilter = nil
-            return
-        }
-
-        if !currentSiteStatuses.contains(where: { $0.name == statusFilter.name && $0.slug == statusFilter.slug }) {
-            self.statusFilter = nil
-        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
 		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
+		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -887,6 +888,7 @@
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
 		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
+		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -2439,6 +2441,7 @@
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
 				57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */,
 				57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */,
+				57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -3678,6 +3681,7 @@
 				CE21B3DD20FF9BC200A259D5 /* ProductListViewController.swift in Sources */,
 				D83F5930225B269C00626E75 /* DatePickerTableViewCell.swift in Sources */,
 				0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */,
+				57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */,
 				028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */,
 				B59D1EDF219072CC009D1978 /* ProductReviewTableViewCell.swift in Sources */,
 				020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
+		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -883,6 +884,7 @@
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
+		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -2433,6 +2435,7 @@
 				CEE006022077D0F80079161F /* Cells */,
 				CEE005F52076C4040079161F /* Orders.storyboard */,
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
+				57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -3443,6 +3446,7 @@
 				CE1D5A55228A0AD200DF3715 /* TwoColumnTableViewCell.swift in Sources */,
 				74460D4222289C7A00D7316A /* StorePickerCoordinator.swift in Sources */,
 				CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */,
+				57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */,
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
 		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
+		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -885,6 +886,7 @@
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
 		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
+		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -2436,6 +2438,7 @@
 				CEE005F52076C4040079161F /* Orders.storyboard */,
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
 				57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */,
+				57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -3184,6 +3187,7 @@
 				74A95B5821C403EA00FEE953 /* pure-min.css in Resources */,
 				0262DA5423A238460029AF30 /* UnitInputTableViewCell.xib in Resources */,
 				B5BE75DD213F1D3D00909A14 /* OverlayMessageView.xib in Resources */,
+				57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */,
 				02F4F510237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib in Resources */,
 				45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */,
 				D8149F542251CFE60006A245 /* EditableOrderTrackingTableViewCell.xib in Resources */,


### PR DESCRIPTION
Refs #956. 

😱This is more than 500 lines but most it is mostly moving stuff to a different class. 

## Goals

The initial goal was to continue the work in #1805 and support the transition from picking a filter and showing a list of filtered Orders. 

![image](https://user-images.githubusercontent.com/198826/73874110-21162f00-4810-11ea-9dd6-37d67b2f95c1.png)

After some discussion and pair-programming with @pmusolino, we decided that the best way to do this is to repurpose [`OrdersViewController`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift). We can simplify it so that its single responsibility is to **display a list of Orders**. The `OrdersViewController` can then be used in a few places in the Order List Redesign. 

![image](https://user-images.githubusercontent.com/198826/73874869-8159a080-4811-11ea-9210-055c5d9a8135.png)

![image](https://user-images.githubusercontent.com/198826/73875166-08a71400-4812-11ea-9ea3-09237706b52e.png)




## What This PR Changes

There are no new _features_ added in this PR. The changes are:

1. Creating a new container class, [`OrdersMasterViewController`](https://github.com/woocommerce/woocommerce-ios/blob/issue/956-make-orders-vc-reusable/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift). This will _contain_ the `OrdersViewController`. 
2. Simplifying `OrdersViewController` so its only responsibility is to display a list of Orders. All other features that are not related to displaying a list of Orders are moved to the container `OrdersMasterViewController`.

<img src="https://user-images.githubusercontent.com/198826/73876230-e44c3700-4813-11ea-90ac-f0b4b67b4c60.png" height="520">

The following tables show the change of responsibilities. 

### Before

| OrdersViewController | OrdersMasterViewController |
|------------------------------------|----------------------------|
| display a list of Orders |  |
| searching |  |
| filtering |  |
| root `ViewController` for Orders tab |  |
| handling push notifications |  |
| synchronization of `OrderStatus` |  |

### After

| OrdersViewController | OrdersMasterViewController |
|----------------------------------------|-------------------------------------------------------------|
| | owns `OrdersViewController` as a child view | 
| display a list of Orders |  |
|  | searching |
| accepts instructions on what to filter  | filtering (dictates `OrdersViewController` what to filter on) |
|  | root `ViewController` for Orders tab |
|  | handling push notifications |
| fetches `OrderStatus` (for cell display) | synchronization of `OrderStatus` |

## What's Next (The Future)

The new `OrdersMasterViewController` will soon be refactored so it will contain 2 tabs with 2 instances of `OrdersViewController`.

<img src="https://user-images.githubusercontent.com/198826/73880351-815e9e00-481b-11ea-8da1-1138f3b185bf.png" height="520">

## Reviewing 

The commits should show the steps on how the `OrdersViewController` features were transferred to `OrdersMasterViewController`. And also my mistakes. 😄 

Please also check `OrdersViewController` if there's something else that needs to be transferred. 

Only 1 reviewer is needed but anyone can review. 

## Testing

The focus should be on testing for regressions. Please test that the previous behaviors of the Orders tab still work:

1. Searching 
2. Filtering 
3. Empty List → Clear Filter button
4. Accepting _New Order_ push notification and showing the Order details. 
5. Logging in a new device should still show the correct Orders and statuses.
6. Switching to another Store should update the Orders list.

## Unit Tests 

After some rubber-ducking with the team, I might have some ideas on how to add unit tests for this. But I think I'll defer adding unit tests after the `OrdersMasterViewController` is in its _redesigned_ and finalized form.  

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
