### PR TITLE
Decode Order Item & Product's name

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */ = {isa = PBXBuildFile; fileRef = 0282DD90233A120A006A5FDB /* products-search-photo.json */; };
 		02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */; };
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
+		02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
+		02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
@@ -341,6 +343,8 @@
 		0282DD90233A120A006A5FDB /* products-search-photo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-search-photo.json"; sourceTree = "<group>"; };
 		02BA23C722EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-deactivated.json"; sourceTree = "<group>"; };
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
+		02BDB83423EA98C800BCC63E /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
+		02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLTests.swift"; sourceTree = "<group>"; };
 		450106842399A7CB00E24722 /* TaxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClass.swift; sourceTree = "<group>"; };
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
@@ -1094,6 +1098,7 @@
 				B53EF5312180F21C003E146F /* Dictionary+Woo.swift */,
 				B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */,
 				021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */,
+				02BDB83423EA98C800BCC63E /* String+HTML.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1103,6 +1108,7 @@
 			children = (
 				CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */,
 				B5C6FCC720A32E4800A4F8E4 /* DateFormatterWooTests.swift */,
+				02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1575,6 +1581,7 @@
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
 				B567AF2B20A0FA4200AB6C62 /* OrderListMapper.swift in Sources */,
+				02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */,
 				B505F6CF20BEE38B00BB1B69 /* Account.swift in Sources */,
 				743E84EA22171C5800FAC9D7 /* ShipmentsRemote.swift in Sources */,
 				B59325D5217E4206000B0E8E /* NoteRange.swift in Sources */,
@@ -1591,6 +1598,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				74749B9522413119005C4CF2 /* ProductsRemoteTests.swift in Sources */,
 				B524194321AC622500D6FC0A /* DotcomDeviceMapperTests.swift in Sources */,

--- a/Networking/Networking/Extensions/String+HTML.swift
+++ b/Networking/Networking/Extensions/String+HTML.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+
+/// String: HTML Stripping
+///
+extension String {
+
+    /// Returns the HTML Stripped version of the receiver.
+    ///
+    /// NOTE: I can be very slow ⏳ — using it in a background thread is strongly recommended.
+    ///
+    public var strippedHTML: String {
+        guard let data = data(using: .utf8) else {
+            return self
+        }
+
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+
+        guard let attributedString = try? NSAttributedString(data: data, options: options, documentAttributes: nil) else {
+            return self
+        }
+
+        return attributedString.string
+    }
+}

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -59,7 +59,7 @@ public struct OrderItem: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let itemID = try container.decode(Int64.self, forKey: .itemID)
-        let name = try container.decode(String.self, forKey: .name)
+        let name = try container.decode(String.self, forKey: .name).strippedHTML
         let productID = try container.decode(Int64.self, forKey: .productID)
         let variationID = try container.decode(Int64.self, forKey: .variationID)
 

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -237,7 +237,7 @@ public struct Product: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let productID = try container.decode(Int64.self, forKey: .productID)
-        let name = try container.decode(String.self, forKey: .name)
+        let name = try container.decode(String.self, forKey: .name).strippedHTML
         let slug = try container.decode(String.self, forKey: .slug)
         let permalink = try container.decode(String.self, forKey: .permalink)
 

--- a/Networking/NetworkingTests/Extensions/String+HTMLTests.swift
+++ b/Networking/NetworkingTests/Extensions/String+HTMLTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Networking
+
+final class String_HTMLTests: XCTestCase {
+
+    /// Verifies that regular HTML Tags are effectively nuked
+    ///
+    func testRegularTagsAreCleanedUp() {
+        let sampleHTML1 = "<a href='www.automattic.com'><b><i>LINK</i></b></a>"
+        let sampleStripped1 = "LINK"
+
+        XCTAssertEqual(sampleHTML1.strippedHTML, sampleStripped1)
+    }
+
+    /// Verifies that Hexa Entities are converted into plain Characters
+    ///
+    func testHexaCharactersAreConvertedIntoSimpleCharacters() {
+        let sampleHTML2 = "&lt;&gt;&amp;&quot;&apos;"
+        let sampleStripped2 = "<>&\"'"
+
+        XCTAssertEqual(sampleHTML2.strippedHTML, sampleStripped2)
+    }
+
+    /// Verifies that Line Breaks are effectively converted into `\n` characters
+    ///
+    func testLineBreaksAreConvertedIntoNewlines() {
+        let sampleHTML3 = "<br><br/>"
+        let sampleStripped3 = "\n\n"
+
+        XCTAssertEqual(sampleHTML3.strippedHTML, sampleStripped3)
+    }
+
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Orders tab: Orders to fulfill badge shows numbers 1-99, and now 99+ for anything over 99. Previously, it was 9+.
 - Orders tab: The full total amount is now shown.
+- Order Details & Product UI: if a Product name has HTML escape characters, they should be decoded in the app.
 
 3.5
 -----

--- a/WooCommerce/Classes/Extensions/String+HTML.swift
+++ b/WooCommerce/Classes/Extensions/String+HTML.swift
@@ -5,27 +5,6 @@ import Foundation
 ///
 extension String {
 
-    /// Returns the HTML Stripped version of the receiver.
-    ///
-    /// NOTE: I can be very slow ⏳ — please be careful when using me (i.e. tableview cells are probably a bad idea).
-    ///
-    var strippedHTML: String {
-        guard let data = data(using: .utf8) else {
-            return self
-        }
-
-        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
-            .documentType: NSAttributedString.DocumentType.html,
-            .characterEncoding: String.Encoding.utf8.rawValue
-        ]
-
-        guard let attributedString = try? NSAttributedString(data: data, options: options, documentAttributes: nil) else {
-            return self
-        }
-
-        return attributedString.string
-    }
-
     /// Convert HTML to an attributed string
     ///
     var htmlToAttributedString: NSAttributedString {

--- a/WooCommerce/WooCommerceTests/Extensions/StringHTMLTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/StringHTMLTests.swift
@@ -6,33 +6,6 @@ import XCTest
 ///
 class StringHTMLTests: XCTestCase {
 
-    /// Verifies that regular HTML Tags are effectively nuked
-    ///
-    func testRegularTagsAreCleanedUp() {
-        let sampleHTML1 = "<a href='www.automattic.com'><b><i>LINK</i></b></a>"
-        let sampleStripped1 = "LINK"
-
-        XCTAssertEqual(sampleHTML1.strippedHTML, sampleStripped1)
-    }
-
-    /// Verifies that Hexa Entities are converted into plain Characters
-    ///
-    func testHexaCharactersAreConvertedIntoSimpleCharacters() {
-        let sampleHTML2 = "&lt;&gt;&amp;&quot;&apos;"
-        let sampleStripped2 = "<>&\"'"
-
-        XCTAssertEqual(sampleHTML2.strippedHTML, sampleStripped2)
-    }
-
-    /// Verifies that Line Breaks are effectively converted into `\n` characters
-    ///
-    func testLineBreaksAreConvertedIntoNewlines() {
-        let sampleHTML3 = "<br><br/>"
-        let sampleStripped3 = "\n\n"
-
-        XCTAssertEqual(sampleHTML3.strippedHTML, sampleStripped3)
-    }
-
     func testHTMLTagsRemovedWithHTMLText() {
         let sampleHTML = "<a href='www.automattic.com'><b><i>LINK</i></b></a>"
         let expectedString = "LINK"


### PR DESCRIPTION
Fixes #1808 

When a user who is not an admin edits a Product (or Post) in `wp-admin`, we don't allow special characters in the Product/Post's name. Thus, the raw Product name could contain the escape characters that we want to decode in the app.

## Changes

- Moved `String`'s `strippedHTML` extension to the Networking framework
- Applied `strippedHTML` to `OrderItem` and `Product`'s `name` field during decoding in the Networking layer

## Testing

Prerequisites:
- have a Product whose name has some HTML escape characters (like `&amp;`, `&quot;`)
- have an order with the Product above
---
- Launch the app
- Go to the Products tab and scroll to the Product whose name has HTML escape characters --> the Product name UI should not have the escape characters
- Tap on the Product and navigate around --> the Product name UI should not have the escape characters
- Go to the Orders tab and scroll to the Order from the prerequisites --> the Order Item name UI should not have the escape characters
  - Note: pull down to refresh if the Order Item name hasn't got updated
- In the Order Details, tap on the Product from the prerequisites --> the Product name UI should not have the escape characters

## Example screenshots

\ | before | after
-- | -- | --
Product | ![Simulator Screen Shot - iPhone 11 - 2020-02-05 at 15 35 39](https://user-images.githubusercontent.com/1945542/73820990-e622f400-482d-11ea-8887-a8deb5f446b9.png) | ![Simulator Screen Shot - iPhone 11 - 2020-02-05 at 15 31 02](https://user-images.githubusercontent.com/1945542/73821011-f044f280-482d-11ea-820d-41f04be0395b.png)
Order Details | ![Simulator Screen Shot - iPhone 11 - 2020-02-05 at 15 35 45](https://user-images.githubusercontent.com/1945542/73821002-ec18d500-482d-11ea-9997-4f9f6017b7ee.png) | ![Simulator Screen Shot - iPhone 11 - 2020-02-05 at 15 33 51](https://user-images.githubusercontent.com/1945542/73821026-f76c0080-482d-11ea-8603-78cd30849039.png)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
