### PR TITLE
Remove a duplicate call to sync the first page of reviews

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
@@ -132,7 +132,6 @@ final class ReviewsViewController: UIViewController {
     }
 
     func presentDetails(for noteID: Int64) {
-        syncingCoordinator.synchronizeFirstPage()
         viewModel.loadReview(for: noteID) { [weak self] in
             guard let self = self else {
                 return


### PR DESCRIPTION
Fixes #1812 

## Changes

- Removed a call to sync the first page of reviews when presenting Review Details from a push notification, which is also called in the following `viewModel.loadReview(for:)`

## Testing

We can test it with Wormholy!

Prerequisites: the app can receive push notifications in dev builds (p99K0U-1qz-p2 might be helpful) or already has a push notification for a new Review (like from a TestFlight build)

- Launch the app from PR branch
- Go to Settings > OTHER > Launch Wormholy debug
- Tap More > Clear to remove all logs
- Go back to "My store" tab
- Background the app
- Tap on a new Review push notification either from a new Review or a pre-existing push notification --> after a bit (sometimes it takes a few seconds), the app should open the Reviews tab and then present the Review Details. Go to Settings > OTHER > Launch Wormholy debug, filter by "reviews" and there should be only 2 requests made
  - Note: ideally only 1 request is made, but the other one is triggered by `viewWillAppear` and I didn't want to affect this behavior for this PR

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
