### PR TITLE
Allow WordPress.com API Base URL to be overriden with launch argument

### DIFF
--- a/Networking/Networking/Requests/DotcomRequest.swift
+++ b/Networking/Networking/Requests/DotcomRequest.swift
@@ -6,10 +6,6 @@ import Alamofire
 ///
 struct DotcomRequest: URLRequestConvertible {
 
-    /// WordPress.com Base URL
-    ///
-    let wordpressApiBaseURL: String
-
     /// WordPress.com API Version
     ///
     let wordpressApiVersion: WordPressAPIVersion
@@ -40,13 +36,12 @@ struct DotcomRequest: URLRequestConvertible {
         self.method = method
         self.path = path
         self.parameters = parameters ?? [:]
-        self.wordpressApiBaseURL = UserDefaults.standard.string(forKey: "wpcom-api-base-url") ?? "https://public-api.wordpress.com/"
     }
 
     /// Returns a URLRequest instance representing the current WordPress.com Request.
     ///
     func asURLRequest() throws -> URLRequest {
-        let dotcomURL = URL(string: wordpressApiBaseURL + wordpressApiVersion.path + path)!
+        let dotcomURL = URL(string: Settings.wordpressApiBaseURL + wordpressApiVersion.path + path)!
         let dotcomRequest = try URLRequest(url: dotcomURL, method: method, headers: nil)
 
         return try URLEncoding.default.encode(dotcomRequest, with: parameters)

--- a/Networking/Networking/Requests/DotcomRequest.swift
+++ b/Networking/Networking/Requests/DotcomRequest.swift
@@ -8,7 +8,7 @@ struct DotcomRequest: URLRequestConvertible {
 
     /// WordPress.com Base URL
     ///
-    static let wordpressApiBaseURL = "https://public-api.wordpress.com/"
+    let wordpressApiBaseURL: String
 
     /// WordPress.com API Version
     ///
@@ -40,12 +40,13 @@ struct DotcomRequest: URLRequestConvertible {
         self.method = method
         self.path = path
         self.parameters = parameters ?? [:]
+        self.wordpressApiBaseURL = UserDefaults.standard.string(forKey: "wpcom-api-base-url") ?? "https://public-api.wordpress.com/"
     }
 
     /// Returns a URLRequest instance representing the current WordPress.com Request.
     ///
     func asURLRequest() throws -> URLRequest {
-        let dotcomURL = URL(string: DotcomRequest.wordpressApiBaseURL + wordpressApiVersion.path + path)!
+        let dotcomURL = URL(string: wordpressApiBaseURL + wordpressApiVersion.path + path)!
         let dotcomRequest = try URLRequest(url: dotcomURL, method: method, headers: nil)
 
         return try URLEncoding.default.encode(dotcomRequest, with: parameters)

--- a/Networking/Networking/Settings/Settings.swift
+++ b/Networking/Networking/Settings/Settings.swift
@@ -8,4 +8,14 @@ public struct Settings {
     /// UserAgent to be used for every Networking Request
     ///
     public static var userAgent = "WooCommerce iOS"
+
+    /// WordPress.com API Base URL
+    ///
+    public static var wordpressApiBaseURL: String {
+        if ProcessInfo.processInfo.arguments.contains("mocked-wpcom-api") {
+            return "http://localhost:8282/"
+        }
+
+        return "https://public-api.wordpress.com/"
+    }
 }

--- a/Networking/Networking/Settings/Settings.swift
+++ b/Networking/Networking/Settings/Settings.swift
@@ -11,11 +11,11 @@ public struct Settings {
 
     /// WordPress.com API Base URL
     ///
-    public static var wordpressApiBaseURL: String {
+    public static var wordpressApiBaseURL: String = {
         if ProcessInfo.processInfo.arguments.contains("mocked-wpcom-api") {
             return "http://localhost:8282/"
         }
 
         return "https://public-api.wordpress.com/"
-    }
+    }()
 }

--- a/Networking/NetworkingTests/Requests/DotcomRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/DotcomRequestTests.swift
@@ -34,7 +34,7 @@ class DotcomRequestTests: XCTestCase {
     func testRequestUrlContainsExpectedComponents() {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: sampleRPC)
 
-        let expectedURL = URL(string: request.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
+        let expectedURL = URL(string: Settings.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
         let generatedURL = try! request.asURLRequest().url!
         XCTAssertEqual(expectedURL, generatedURL)
     }
@@ -44,7 +44,7 @@ class DotcomRequestTests: XCTestCase {
     func testParametersAreSerializedAsPartOfTheUrlQueryWhenMethodIsSetToGet() {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: sampleRPC, parameters: sampleParameters)
 
-        let expectedURL = URL(string: request.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC + sampleParametersForQuery)!
+        let expectedURL = URL(string: Settings.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC + sampleParametersForQuery)!
         let generatedURL = try! request.asURLRequest().url!
 
         /// Note: Why not compare URL's directly?. As of iOS 12, URLQueryItem's serialization to string can result in swizzled entries.
@@ -68,7 +68,7 @@ class DotcomRequestTests: XCTestCase {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: sampleRPC, parameters: sampleParameters)
 
         let generatedURL = try! request.asURLRequest().url!
-        let expectedURL = URL(string: request.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
+        let expectedURL = URL(string: Settings.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
         XCTAssertEqual(expectedURL, generatedURL)
     }
 

--- a/Networking/NetworkingTests/Requests/DotcomRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/DotcomRequestTests.swift
@@ -34,7 +34,7 @@ class DotcomRequestTests: XCTestCase {
     func testRequestUrlContainsExpectedComponents() {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: sampleRPC)
 
-        let expectedURL = URL(string: DotcomRequest.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
+        let expectedURL = URL(string: request.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
         let generatedURL = try! request.asURLRequest().url!
         XCTAssertEqual(expectedURL, generatedURL)
     }
@@ -44,7 +44,7 @@ class DotcomRequestTests: XCTestCase {
     func testParametersAreSerializedAsPartOfTheUrlQueryWhenMethodIsSetToGet() {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .get, path: sampleRPC, parameters: sampleParameters)
 
-        let expectedURL = URL(string: DotcomRequest.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC + sampleParametersForQuery)!
+        let expectedURL = URL(string: request.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC + sampleParametersForQuery)!
         let generatedURL = try! request.asURLRequest().url!
 
         /// Note: Why not compare URL's directly?. As of iOS 12, URLQueryItem's serialization to string can result in swizzled entries.
@@ -68,7 +68,7 @@ class DotcomRequestTests: XCTestCase {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: sampleRPC, parameters: sampleParameters)
 
         let generatedURL = try! request.asURLRequest().url!
-        let expectedURL = URL(string: DotcomRequest.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
+        let expectedURL = URL(string: request.wordpressApiBaseURL + request.wordpressApiVersion.path + sampleRPC)!
         XCTAssertEqual(expectedURL, generatedURL)
     }
 

--- a/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/JetpackRequestTests.swift
@@ -25,7 +25,7 @@ final class JetpackRequestTests: XCTestCase {
     /// Base URL: Mapping the Sample Site + Jetpack Tunneling API
     ///
     private var jetpackEndpointBaseURL: String {
-        return DotcomRequest.wordpressApiBaseURL + JetpackRequest.wordpressApiVersion.path + "jetpack-blogs/" + String(sampleSiteID) + "/rest-api/"
+        return Settings.wordpressApiBaseURL + JetpackRequest.wordpressApiVersion.path + "jetpack-blogs/" + String(sampleSiteID) + "/rest-api/"
     }
 
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressAuthenticator
 import Yosemite
-import Networking
+import struct Networking.Settings
 
 
 /// Encapsulates all of the interactions with the WordPress Authenticator

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -14,10 +14,13 @@ class AuthenticationManager: Authentication {
     /// Initializes the WordPress Authenticator.
     ///
     func initialize() {
+        let wordpressApiBaseURL = UserDefaults.standard.string(forKey: "wpcom-api-base-url") ?? "https://public-api.wordpress.com/"
+
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
                                                                 wpcomTermsOfServiceURL: WooConstants.termsOfServiceUrl.absoluteString,
+                                                                wpcomAPIBaseURL: wordpressApiBaseURL,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressAuthenticator
 import Yosemite
+import Networking
 
 
 /// Encapsulates all of the interactions with the WordPress Authenticator
@@ -14,13 +15,11 @@ class AuthenticationManager: Authentication {
     /// Initializes the WordPress Authenticator.
     ///
     func initialize() {
-        let wordpressApiBaseURL = UserDefaults.standard.string(forKey: "wpcom-api-base-url") ?? "https://public-api.wordpress.com/"
-
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
                                                                 wpcomTermsOfServiceURL: WooConstants.termsOfServiceUrl.absoluteString,
-                                                                wpcomAPIBaseURL: wordpressApiBaseURL,
+                                                                wpcomAPIBaseURL: Settings.wordpressApiBaseURL,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,

--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -101,7 +101,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-wpcom-api-base-url http://localhost:8282/"
+            argument = "mocked-wpcom-api"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce.xcscheme
@@ -99,6 +99,12 @@
             ReferencedContainer = "container:WooCommerce.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-wpcom-api-base-url http://localhost:8282/"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This change allows the WordPress.com API Base URL to be set as `http://localhost:8282/` with the launch argument `mocked-wpcom-api`. If that argument isn't set, it defaults to `https://public-api.wordpress.com/` as before.

This will allow us to mock the network requests in UI testing, using a local WireMock server. The setup for the server and mocks will be done in a later PR.

Note: After discussing options with @jkmassel I went ahead and imported `Networking` in `AuthenticationManager` to use the base URL setting in the Authenticator configuration. I know this goes against the [architectural](https://github.com/woocommerce/woocommerce-ios/blob/develop/docs/ARCHITECTURE.md) goal to avoid importing `Networking` and only interact with the Yosemite framework, but I wasn't sure how to nicely avoid this. I'm open to suggestions for how to do this differently if this isn't something we want to do here.

To test:

* Build and run the app. Confirm network requests work as expected, hitting the live API.
* In the `WooCommerce` scheme (under WooCommerce -> Edit Scheme -> Run -> Arguments), enable the `mocked-wpcom-api` launch argument. Build and run the app again, and confirm the app tries to reach `http://localhost:8282/` for network requests. (Note that it won't be able to reach the server, since there is nothing running at `http://localhost:8282/` yet.)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
