### PR TITLE
Use stock date and time for screenshots

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceScreenshots.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerceScreenshots.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1130"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -11,6 +11,24 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "IPHONE_TIME=$(ruby -e &quot;require &apos;time&apos;;puts Time.new(2007, 1, 9, 9, 41, 0).iso8601&quot;)&#10;&#10;xcrun simctl boot &quot;${TARGET_DEVICE_IDENTIFIER}&quot;&#10;&#10;xcrun simctl status_bar &quot;${TARGET_DEVICE_IDENTIFIER}&quot; override \&#10;    --time $IPHONE_TIME \&#10;    --dataNetwork wifi \&#10;    --wifiMode active \&#10;    --wifiBars 3 \&#10;    --cellularMode active \&#10;    --batteryState charged \&#10;    --batteryLevel 100&#10;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "F997170123DBB97500592D8E"
+                     BuildableName = "WooCommerceScreenshots.xctest"
+                     BlueprintName = "WooCommerceScreenshots"
+                     ReferencedContainer = "container:WooCommerce.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
**To Test:**
1. Check out this PR
2. Run `bundle exec pod install`
3. Run `bundle exec fastlane screenshots languages:en-US`
4. When complete, ensure that:
  - The time is set to 9:41 am in all screenshots
  - The battery is full in all screenshots
  - 5 bars of cellular signal are displayed (on iPhone devices)
  - Full bars of wifi signal are displayed (on iPad devices)
  - Jan 9 is displayed as the date on all devices (iPads should include the day of the week)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
