### PR TITLE
Localize the order count badge

### DIFF
--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -68,7 +68,8 @@ private extension MainTabViewModel {
     }
 
     private func readableCount(_ count: Int) -> String {
-        return count > 99 ? Constants.ninetyNinePlus : String(count)
+        let localizedCount = NumberFormatter.localizedString(from: NSNumber(value: count), number: .none)
+        return count > 99 ? Constants.ninetyNinePlus : localizedCount
     }
 
     private func observeBadgeRefreshNotifications() {


### PR DESCRIPTION
Found this one while doing screenshots – this PR localizes the order count badge for locales that use non-english numerals.

**Before**
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-05 at 15 27 34](https://user-images.githubusercontent.com/1123407/73889257-81b36500-482c-11ea-8baf-cfbffce3a346.png)

**After**
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-02-05 at 15 26 45](https://user-images.githubusercontent.com/1123407/73889275-8d069080-482c-11ea-80d3-6b9785ed945d.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
