### PR TITLE
Edit Product: ability to share the product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -63,12 +63,7 @@ private extension ProductFormViewController {
                                      style: .plain,
                                      target: self,
                                      action: #selector(presentMoreOptionsActionSheet))
-        moreButton.accessibilityTraits = .button
-        moreButton.accessibilityLabel = NSLocalizedString("Show more options", comment: "Accessibility label for the Edit Product More Options action sheet")
-        moreButton.accessibilityHint = NSLocalizedString(
-            "Action for show the More Options action sheet in Edit Product.",
-            comment: "VoiceOver accessibility hint, informing the user the button can be used to show the More Options action sheet."
-        )
+        moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
         moreButton.accessibilityIdentifier = "edit-product-more-options-button"
         return moreButton
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -62,7 +62,7 @@ private extension ProductFormViewController {
         let moreButton = UIBarButtonItem(image: .moreImage,
                                      style: .plain,
                                      target: self,
-                                     action: #selector(updateProduct))
+                                     action: #selector(presentMoreActionSheet))
         moreButton.accessibilityTraits = .button
         moreButton.accessibilityLabel = NSLocalizedString("Show more", comment: "Accessibility label for the Edit Product More action sheet")
         moreButton.accessibilityHint = NSLocalizedString(
@@ -419,6 +419,35 @@ private extension ProductFormViewController {
                                                                stockQuantity: data.stockQuantity,
                                                                backordersSetting: data.backordersSetting,
                                                                stockStatus: data.stockStatus)
+    }
+}
+
+// MARK: Action Sheet
+//
+private extension ProductFormViewController {
+
+    /// More Action Sheet
+    ///
+    @objc func presentMoreActionSheet() {
+        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.view.tintColor = .text
+
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { _ in
+        }
+
+        actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel) { _ in
+        }
+
+        let popoverController = actionSheet.popoverPresentationController
+        popoverController?.sourceView = view
+        popoverController?.sourceRect = view.bounds
+
+        present(actionSheet, animated: true)
+    }
+
+    enum ActionSheetStrings {
+        static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Action Sheet")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Action Sheet")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -166,6 +166,14 @@ private extension ProductFormViewController {
 
         present(alert, animated: true, completion: nil)
     }
+
+    func shareProduct() {
+        guard let url = URL(string: product.permalink) else {
+            return
+        }
+
+        SharingHelper.shareURL(url: url, title: product.name, from: view, in: self)
+    }
 }
 
 extension ProductFormViewController: UITableViewDelegate {
@@ -432,7 +440,8 @@ private extension ProductFormViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
-        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { _ in
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { [weak self] _ in
+            self?.shareProduct()
         }
 
         actionSheet.addCancelActionWithTitle(ActionSheetStrings.cancel) { _ in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -50,8 +50,27 @@ final class ProductFormViewController: UIViewController {
 private extension ProductFormViewController {
     func configureNavigationBar() {
         let updateTitle = NSLocalizedString("Update", comment: "Action for updating a Product remotely")
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))
+        navigationItem.rightBarButtonItems = [UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))]
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2) {
+            navigationItem.rightBarButtonItems?.insert(moreBarButton(), at: 0)
+        }
         removeNavigationBackBarButtonText()
+    }
+
+    func moreBarButton() -> UIBarButtonItem {
+        let moreButton = UIBarButtonItem(image: .moreImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(updateProduct))
+        moreButton.accessibilityTraits = .button
+        moreButton.accessibilityLabel = NSLocalizedString("Show more", comment: "Accessibility label for the Edit Product More action sheet")
+        moreButton.accessibilityHint = NSLocalizedString(
+            "Action for show the More action sheet in Edit Product.",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to show the More action sheet."
+        )
+        moreButton.accessibilityIdentifier = "edit-product-more-button"
+        return moreButton
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -53,23 +53,23 @@ private extension ProductFormViewController {
         navigationItem.rightBarButtonItems = [UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))]
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2) {
-            navigationItem.rightBarButtonItems?.insert(moreBarButton(), at: 0)
+            navigationItem.rightBarButtonItems?.insert(moreOptionsBarButton(), at: 0)
         }
         removeNavigationBackBarButtonText()
     }
 
-    func moreBarButton() -> UIBarButtonItem {
+    func moreOptionsBarButton() -> UIBarButtonItem {
         let moreButton = UIBarButtonItem(image: .moreImage,
                                      style: .plain,
                                      target: self,
-                                     action: #selector(presentMoreActionSheet))
+                                     action: #selector(presentMoreOptionsActionSheet))
         moreButton.accessibilityTraits = .button
-        moreButton.accessibilityLabel = NSLocalizedString("Show more", comment: "Accessibility label for the Edit Product More action sheet")
+        moreButton.accessibilityLabel = NSLocalizedString("Show more options", comment: "Accessibility label for the Edit Product More Options action sheet")
         moreButton.accessibilityHint = NSLocalizedString(
-            "Action for show the More action sheet in Edit Product.",
-            comment: "VoiceOver accessibility hint, informing the user the button can be used to show the More action sheet."
+            "Action for show the More Options action sheet in Edit Product.",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to show the More Options action sheet."
         )
-        moreButton.accessibilityIdentifier = "edit-product-more-button"
+        moreButton.accessibilityIdentifier = "edit-product-more-options-button"
         return moreButton
     }
 
@@ -426,9 +426,9 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
 
-    /// More Action Sheet
+    /// More Options Action Sheet
     ///
-    @objc func presentMoreActionSheet() {
+    @objc func presentMoreOptionsActionSheet() {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
@@ -446,8 +446,8 @@ private extension ProductFormViewController {
     }
 
     enum ActionSheetStrings {
-        static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Action Sheet")
-        static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Action Sheet")
+        static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Options Action Sheet")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Options Action Sheet")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -53,12 +53,12 @@ private extension ProductFormViewController {
         navigationItem.rightBarButtonItems = [UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))]
 
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2) {
-            navigationItem.rightBarButtonItems?.insert(moreOptionsBarButton(), at: 0)
+            navigationItem.rightBarButtonItems?.insert(createMoreOptionsBarButtonItem(), at: 0)
         }
         removeNavigationBackBarButtonText()
     }
 
-    func moreOptionsBarButton() -> UIBarButtonItem {
+    func createMoreOptionsBarButtonItem() -> UIBarButtonItem {
         let moreButton = UIBarButtonItem(image: .moreImage,
                                      style: .plain,
                                      target: self,


### PR DESCRIPTION
Fixes #1820 

## Description
Implemented the ability to share the product using the name and the permalink URL. Part of the Product release 2.

## Testing
1) Navigate to a product detail
2) Press the more button
3) Press share
4) Make sure you are able to share the product on your favorite apps 📱 

## Screenshots
| More options action sheet             |  Share button pressed |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-06 at 18 21 49](https://user-images.githubusercontent.com/495617/73962512-e3e49680-490e-11ea-9056-179f54a3a3c1.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-06 at 18 21 52](https://user-images.githubusercontent.com/495617/73962530-e941e100-490e-11ea-8bc7-3804aa268007.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
