### PR TITLE
[Order List Redesign] Move OrdersViewController out of the storyboard

### DIFF
--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -10,6 +10,10 @@ public struct Order: Decodable {
     public let customerID: Int64
 
     public let number: String
+    /// The Order status.
+    ///
+    /// Maps to `OrderStatus.slug`.
+    ///
     public let statusKey: String
     public let currency: String
     public let customerNote: String?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -39,6 +39,14 @@ final class OrderDetailsViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
+    /// Create an instance of `Self` from its corresponding storyboard.
+    ///
+    static func instantiatedViewControllerFromStoryboard() -> Self? {
+        let storyboard = UIStoryboard.orders
+        let identifier = "OrderDetailsViewController"
+        return storyboard.instantiateViewController(withIdentifier: identifier) as? Self
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigation()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -181,8 +181,7 @@ private extension OrderLoaderViewController {
     /// Presents the OrderDetailsViewController, as a childViewController, for a given Order.
     ///
     func presentOrderDetails(for order: Order) {
-        let identifier = OrderDetailsViewController.classNameWithoutNamespaces
-        guard let detailsViewController = UIStoryboard.orders.instantiateViewController(withIdentifier: identifier) as? OrderDetailsViewController else {
+        guard let detailsViewController = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
             fatalError()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
+++ b/WooCommerce/Classes/ViewRelated/Orders/Orders.storyboard
@@ -1,53 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QmM-AQ-tMl">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Orders-->
-        <scene sceneID="7nC-1d-Ldd">
-            <objects>
-                <viewController storyboardIdentifier="OrdersViewController" title="Orders" id="KgN-oM-7t8" customClass="OrdersViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="ZY5-tq-E2x">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="grouped" rowHeight="-1" estimatedRowHeight="86" sectionHeaderHeight="18" estimatedSectionHeaderHeight="12" sectionFooterHeight="18" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yra-Ak-zW1">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                                <connections>
-                                    <outlet property="dataSource" destination="KgN-oM-7t8" id="Fl9-M6-voo"/>
-                                    <outlet property="delegate" destination="KgN-oM-7t8" id="fOY-vu-tTB"/>
-                                </connections>
-                            </tableView>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="E6h-Ba-TOy" firstAttribute="trailing" secondItem="yra-Ak-zW1" secondAttribute="trailing" id="9ac-rk-gQQ"/>
-                            <constraint firstItem="yra-Ak-zW1" firstAttribute="leading" secondItem="E6h-Ba-TOy" secondAttribute="leading" id="Pbf-Ko-7AY"/>
-                            <constraint firstItem="yra-Ak-zW1" firstAttribute="top" secondItem="ZY5-tq-E2x" secondAttribute="top" id="eKs-kw-euY"/>
-                            <constraint firstItem="E6h-Ba-TOy" firstAttribute="bottom" secondItem="yra-Ak-zW1" secondAttribute="bottom" id="zge-w1-X4a"/>
-                        </constraints>
-                        <viewLayoutGuide key="safeArea" id="E6h-Ba-TOy"/>
-                    </view>
-                    <tabBarItem key="tabBarItem" title="Item" id="XVK-lO-zfz"/>
-                    <navigationItem key="navigationItem" title="Orders" id="qom-sz-Uvu"/>
-                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <connections>
-                        <outlet property="tableView" destination="yra-Ak-zW1" id="o3y-1L-wtB"/>
-                        <segue destination="IgL-pI-DQK" kind="show" identifier="ShowOrderDetailsViewController" id="2Hx-kK-8Yt"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Vy0-WI-j6l" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1846" y="543"/>
-        </scene>
         <!--Single Order-->
         <scene sceneID="p5z-EU-84P">
             <objects>
@@ -57,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="hBh-xf-Cby">
-                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
@@ -88,11 +48,11 @@
             <objects>
                 <viewController id="gjo-lx-M5d" customClass="ProductListViewController" customModule="WooCommerce" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="K91-GD-PbX">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="eY7-vI-1cr">
-                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="gjo-lx-M5d" id="ABK-8R-DTb"/>
@@ -116,25 +76,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="S5R-n9-NaZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3780" y="543"/>
-        </scene>
-        <!--Orders-->
-        <scene sceneID="KDy-5N-CLG">
-            <objects>
-                <navigationController storyboardIdentifier="Orders" title="Orders" automaticallyAdjustsScrollViewInsets="NO" id="QmM-AQ-tMl" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Orders" id="B5W-UW-TCS"/>
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="6fZ-Y8-AS4">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="KgN-oM-7t8" kind="relationship" relationship="rootViewController" id="zHO-oX-B1V"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="gxa-i4-CH0" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="864.79999999999995" y="542.87856071964018"/>
         </scene>
     </scenes>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -191,9 +191,10 @@ private extension OrdersMasterViewController {
     /// Creates an `OrdersViewController` and attaches its view to `self.view`.
     ///
     func createAndAttachOrdersViewController() -> OrdersViewController? {
-        guard let ordersViewController = OrdersViewController.instantiatedViewControllerFromStoryboard(),
-            let ordersView = ordersViewController.view else {
-                return nil
+        let ordersViewController = OrdersViewController()
+
+        guard let ordersView = ordersViewController.view else {
+            return nil
         }
 
         ordersView.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -280,7 +280,7 @@ extension OrdersViewController {
 // MARK: - Actions
 //
 extension OrdersViewController {
-    @IBAction func pullToRefresh(sender: UIRefreshControl) {
+    @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.ordersViewControllerWillSynchronizeOrders(self)
         syncingCoordinator.synchronizeFirstPage {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -584,7 +584,12 @@ extension OrdersViewController: UITableViewDelegate {
             return
         }
 
-        performSegue(withIdentifier: Segues.orderDetails, sender: detailsViewModel(at: indexPath))
+        guard let orderDetailsVC = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
+            return
+        }
+        orderDetailsVC.viewModel = detailsViewModel(at: indexPath)
+
+        navigationController?.pushViewController(orderDetailsVC, animated: true)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -685,10 +690,6 @@ private extension OrdersViewController {
         static let estimatedHeaderHeight = CGFloat(43)
         static let estimatedRowHeight = CGFloat(86)
         static let placeholderRowsPerSection = [3]
-    }
-
-    enum Segues {
-        static let orderDetails = "ShowOrderDetailsViewController"
     }
 
     enum State {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -127,20 +127,12 @@ class OrdersViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    /// Create an instance of `Self` from its corresponding storyboard.
-    ///
-    static func instantiatedViewControllerFromStoryboard() -> Self? {
-        let storyboard = UIStoryboard.orders
-        let identifier = "OrdersViewController"
-        return storyboard.instantiateViewController(withIdentifier: identifier) as? Self
-    }
-
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        fatalError()
+    init() {
+        super.init(nibName: Self.nibName, bundle: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+        fatalError("Not supported")
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -570,6 +570,7 @@ extension OrdersViewController: UITableViewDelegate {
         }
 
         guard let orderDetailsVC = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
+            assertionFailure("Expected OrderDetailsViewController to be instantiated")
             return
         }
         orderDetailsVC.viewModel = detailsViewModel(at: indexPath)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -267,13 +267,6 @@ extension OrdersViewController {
     func startListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
-        nc.addObserver(self, selector: #selector(stopListeningToNotifications), name: .logOutEventReceived, object: nil)
-    }
-
-    /// Stops listening to all related Notifications
-    ///
-    @objc func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     /// Runs whenever the default Account is updated.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.xib
@@ -8,7 +8,12 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrdersViewController" customModule="WooCommerce" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrdersViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="tSU-S6-bpa" id="SUj-Aq-VLj"/>
+                <outlet property="view" destination="NNG-9N-nnk" id="1P0-fq-dfE"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="NNG-9N-nnk">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
@@ -17,6 +22,10 @@
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="grouped" rowHeight="-1" estimatedRowHeight="86" sectionHeaderHeight="18" estimatedSectionHeaderHeight="12" sectionFooterHeight="18" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tSU-S6-bpa">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                     <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="LOk-AW-wqG"/>
+                        <outlet property="delegate" destination="-1" id="BKx-1d-bU8"/>
+                    </connections>
                 </tableView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.xib
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OrdersViewController" customModule="WooCommerce" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="NNG-9N-nnk">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="grouped" rowHeight="-1" estimatedRowHeight="86" sectionHeaderHeight="18" estimatedSectionHeaderHeight="12" sectionFooterHeight="18" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tSU-S6-bpa">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="tSU-S6-bpa" firstAttribute="top" secondItem="NNG-9N-nnk" secondAttribute="top" id="67x-AH-fgm"/>
+                <constraint firstItem="tSU-S6-bpa" firstAttribute="leading" secondItem="7gb-yg-2g9" secondAttribute="leading" id="6qp-ll-6Be"/>
+                <constraint firstItem="7gb-yg-2g9" firstAttribute="bottom" secondItem="tSU-S6-bpa" secondAttribute="bottom" id="E65-rY-PBF"/>
+                <constraint firstItem="7gb-yg-2g9" firstAttribute="trailing" secondItem="tSU-S6-bpa" secondAttribute="trailing" id="Iwe-kx-18G"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="7gb-yg-2g9"/>
+            <point key="canvasLocation" x="139" y="153"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -61,11 +61,9 @@ final class OrderSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Order, from viewController: UIViewController) {
-        let identifier = OrderDetailsViewController.classNameWithoutNamespaces
-        guard let detailsViewController = UIStoryboard.orders.instantiateViewController(withIdentifier: identifier) as? OrderDetailsViewController else {
+        guard let detailsViewController = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
             fatalError()
         }
-
         detailsViewController.viewModel = OrderDetailsViewModel(order: model)
 
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
+		57AE0B0123ECD6D400237009 /* OrdersViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57AE0B0023ECD6D400237009 /* OrdersViewController.xib */; };
 		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
@@ -886,6 +887,7 @@
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
+		57AE0B0023ECD6D400237009 /* OrdersViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersViewController.xib; sourceTree = "<group>"; };
 		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
@@ -2439,6 +2441,7 @@
 				CEE006022077D0F80079161F /* Cells */,
 				CEE005F52076C4040079161F /* Orders.storyboard */,
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
+				57AE0B0023ECD6D400237009 /* OrdersViewController.xib */,
 				57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */,
 				57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */,
 				57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */,
@@ -3152,6 +3155,7 @@
 				B5D1AFC820BC7B9600DB0E8C /* StorePickerViewController.xib in Resources */,
 				CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */,
 				B57C744320F54F1C00EEFC87 /* AccountHeaderView.xib in Resources */,
+				57AE0B0123ECD6D400237009 /* OrdersViewController.xib in Resources */,
 				D843D5D422485009001BFA55 /* ShipmentProvidersViewController.xib in Resources */,
 				028BAC4522F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib in Resources */,
 				CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */,


### PR DESCRIPTION
Refs #956. This is a continuation of #1816.  

## Goals

Like #1816, the goal is still to support the transition from picking a filter and showing a list of filtered Orders. 

![image](https://user-images.githubusercontent.com/198826/73874110-21162f00-4810-11ea-9dd6-37d67b2f95c1.png)

To move towards that, I'm planning to pass the `OrderStatus` to `OrdersViewController`. We can _technically_ do that like this right now:

```swift
let ordersVC = OrdersViewController.instantiatedViewControllerFromStoryboard()
ordersVC.statusFilter = theSelectedFilter
```

But I'd like to make it safer. I want to make `statusFilter` a `let` instead of `var` so `OrdersViewController` itself will never be able to change it again. 

```swift
let ordersVC = OrdersViewController(statusFilter: theSelectedFilter)
```

## Changes

To support the `init(statusFilter:)`, I moved `OrdersViewController` out of the `Orders.storyboard`. 

![image](https://user-images.githubusercontent.com/198826/73989375-cad5e880-4902-11ea-9970-1822f4a7426b.png)

![image](https://user-images.githubusercontent.com/198826/73989351-b72a8200-4902-11ea-8774-46582036272f.png)

### Bonus

I removed the logout event listener in 525a3f3. As pointed out by @jaclync in https://github.com/woocommerce/woocommerce-ios/pull/1816#discussion_r375616763, we don't want to stop receiving notifications because `OrdersViewController` is never deallocated. 

## Testing 

Please test for regressions. Please test that the previous behaviors of the Orders tab still work like: 

1. Searching
2. Filtering
3. Empty List → Clear Filter button
4. Accepting New Order push notification and showing the Order details.
5. Logging in a new device should still show the correct Orders and statuses.
6. Switching to another Store should update the Orders list.
7. Tapping on an Order will show the Order Details page.
8. You can still see the Products List from the Order Details page.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] Merge #1816 first.
- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

