### PR TITLE
Order Details: tapping on a Product doesn't always open the same Product if there are multiple Products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - Orders tab: Orders to fulfill badge shows numbers 1-99, and now 99+ for anything over 99. Previously, it was 9+.
 - Orders tab: The full total amount is now shown.
 - Order Details & Product UI: if a Product name has HTML escape characters, they should be decoded in the app.
+- Order Details: if the Order has multiple Products, tapping on any Product should open the same Product now.
 
 3.5
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -236,8 +236,10 @@ private extension OrderDetailsDataSource {
             configureRefund(cell: cell, at: indexPath)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .netAmount:
             configureNetAmount(cell: cell)
-        case let cell as ProductDetailsTableViewCell:
+        case let cell as ProductDetailsTableViewCell where row == .orderItem:
             configureOrderItem(cell: cell, at: indexPath)
+        case let cell as ProductDetailsTableViewCell where row == .aggregateOrderItem:
+            configureAggregateOrderItem(cell: cell, at: indexPath)
         case let cell as FulfillButtonTableViewCell:
             configureFulfillmentButton(cell: cell)
         case let cell as OrderTrackingTableViewCell:
@@ -389,16 +391,16 @@ private extension OrderDetailsDataSource {
     private func configureOrderItem(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
         cell.selectionStyle = .default
 
-        let refundsEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.refunds)
-        guard aggregateOrderItems.count > 0 && refundsEnabled else {
-            let item = items[indexPath.row]
-            let product = lookUpProduct(by: item.productOrVariationID)
-            let itemViewModel = ProductDetailsCellViewModel(item: item,
-                                                            currency: order.currency,
-                                                            product: product)
-            cell.configure(item: itemViewModel, imageService: imageService)
-            return
-        }
+        let item = items[indexPath.row]
+        let product = lookUpProduct(by: item.productOrVariationID)
+        let itemViewModel = ProductDetailsCellViewModel(item: item,
+                                                        currency: order.currency,
+                                                        product: product)
+        cell.configure(item: itemViewModel, imageService: imageService)
+    }
+
+    private func configureAggregateOrderItem(cell: ProductDetailsTableViewCell, at indexPath: IndexPath) {
+        cell.selectionStyle = .default
 
         let aggregateItem = aggregateOrderItems[indexPath.row]
         let product = lookUpProduct(by: aggregateItem.productOrVariationID)
@@ -580,7 +582,9 @@ extension OrderDetailsDataSource {
             }
 
             var rows = [Row]()
-            if refundedProductsCount > 0 {
+
+            let refundsEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.refunds)
+            if refundedProductsCount > 0 && refundsEnabled {
                 rows = Array(repeating: .aggregateOrderItem, count: aggregateOrderItems.count)
             } else {
                 rows = Array(repeating: .orderItem, count: items.count)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -101,7 +101,9 @@ final class OrderDetailsDataSource: NSObject {
     /// Yosemite.OrderItem
     /// The original list of order items a user purchased
     ///
-    private(set) var items: [OrderItem]
+    var items: [OrderItem] {
+        return order.items
+    }
 
     /// Combine refunded order items to show refunded products
     ///
@@ -152,7 +154,6 @@ final class OrderDetailsDataSource: NSObject {
     init(order: Order) {
         self.order = order
         self.couponLines = order.coupons
-        self.items = order.items
 
         super.init()
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -19,6 +19,7 @@ final class OrderDetailsViewModel {
 
     func update(order newOrder: Order) {
         self.order = newOrder
+        dataSource.update(order: order)
     }
 
     /// The date displayed on the Orders List.
@@ -56,7 +57,7 @@ final class OrderDetailsViewModel {
     /// Sorted order items
     ///
     private var items: [OrderItem] {
-        return order.items
+        return dataSource.items
     }
 
     /// Refunded products from an Order
@@ -138,7 +139,6 @@ extension OrderDetailsViewModel {
 
     func updateOrderStatus(order: Order) {
         update(order: order)
-        dataSource.update(order: order)
     }
 }
 


### PR DESCRIPTION
Fixes #1839

## Cause of the issue

Because `Order` is mutable in both `OrderDetailsDataSource` (that renders each cell) and `OrderDetailsViewModel` (that owns `OrderDetailsDataSource` and handles the cell tap event), it's easy to miss updating the data (Order and Order Items) everywhere and make sure they are the same. For this bug, the order's `items` somehow got out of sync between the data source and view model.

Perhaps we could refactor these two to have immutable `Order` in the future. Also, the `Order`'s `items` are currently not ordered in the schema, we probably want to keep them in the same order as in the API response?

## Changes

- In `OrderDetailsDataSource`, updated `items: [OrderItem]` variable to derive from its `Order`
- In `OrderDetailsViewModel`:
  - updated `items: [OrderItem]` variable to derive from its data source (`OrderDetailsDataSource`)'s `items`
  - whenever we update its `Order`, also updated its data source's `Order`

## Testing

- I'd recommend disabling the Refunds feature flag for testing, or testing both cases since the data could be different.
- You can try reproducing this issue on `develop` first
---
Prerequisite: the site has an Order with multiple Products
- Go to the Orders tab
- Tap on the Order with multiple Products (can also do so from Search)
- Tap on each Product under the "PRODUCT" section --> it should open the correct Product
- Pull down to refresh and repeat the previous step --> it should open the correct Product

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
