### PR TITLE
Localize order item quantity

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,8 @@
 - Order Details & Product UI: if a Product name has HTML escape characters, they should be decoded in the app.
 - Order Details: if the Order has multiple Products, tapping on any Product should open the same Product now.
 - bugfix: the orders badge on tab bar now is correctly refreshed after switching to a store with badge count equal to zero.
+- The orders tab now localizes item quantities and the order badge.
+
 
 3.5
 -----

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -47,7 +47,7 @@ struct ProductDetailsCellViewModel {
     /// Item Quantity as a String
     ///
     var quantity: String {
-        return positiveQuantity.description
+        return NumberFormatter.localizedString(from: positiveQuantity as NSDecimalNumber, number: .decimal)
     }
 
     /// Refunded Product Price


### PR DESCRIPTION
@astralbodies' [comment](https://github.com/woocommerce/woocommerce-ios/pull/1829#issuecomment-582697942) on #1829 caused me to go back and take a look at the other screenshots to see if there were any more places numbers weren't localized. There was one!

**The change:**
The item list within an order will now localize the quantity for locales that use non-english numerals.

**How to test**
You'll need to set your device to Arabic to see this change work – just changing the app locale doesn't work. Once you've changed the locale, open up a specific order's details and observe the item quantities.

**Screenshots**
| Before        | After           | 
| ------------- |-------------| 
| ![before](https://user-images.githubusercontent.com/1123407/74060902-2c03c780-49a8-11ea-8f92-9fa269c70bd3.png) | ![after](https://user-images.githubusercontent.com/1123407/74060919-31611200-49a8-11ea-8968-02ed84a4cf69.png) |

**Update release notes:**

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
