### PR TITLE
[Order List Redesign] Link Search Filtering to OrdersViewController

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -92,6 +92,14 @@ class OrdersViewController: UIViewController {
         }
     }
 
+    /// If `true`, the "Remove Filters" action will be shown on the Filtered Empty View.
+    ///
+    /// Defaults to `true`.
+    ///
+    /// - SeeAlso: displayEmptyFilteredOverlay
+    ///
+    private let showsRemoveFilterActionOnFilteredEmptyView: Bool
+
     /// The current list of order statuses for the default site
     ///
     private var currentSiteStatuses: [OrderStatus] {
@@ -133,8 +141,10 @@ class OrdersViewController: UIViewController {
     ///
     /// - Parameter statusFilter The filter to use.
     ///
-    init(statusFilter: OrderStatus? = nil) {
+    init(statusFilter: OrderStatus? = nil,
+         showsRemoveFilterActionOnFilteredEmptyView: Bool = true) {
         self.statusFilter = statusFilter
+        self.showsRemoveFilterActionOnFilteredEmptyView = showsRemoveFilterActionOnFilteredEmptyView
         super.init(nibName: Self.nibName, bundle: nil)
     }
 
@@ -484,6 +494,8 @@ private extension OrdersViewController {
                 self.delegate?.ordersViewControllerRequestsToClearStatusFilter(self)
             }
         }
+
+        overlayView.actionVisible = showsRemoveFilterActionOnFilteredEmptyView
 
         overlayView.attach(to: view)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -76,6 +76,8 @@ class OrdersViewController: UIViewController {
     /// This is set and changed by `OrdersMasterViewModel`. This shouldn't be updated internally
     /// by `self`.
     ///
+    /// TODO Make this `let`.
+    ///
     var statusFilter: OrderStatus? {
         didSet {
             guard isViewLoaded else {
@@ -127,7 +129,12 @@ class OrdersViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
-    init() {
+    /// Designated initializer.
+    ///
+    /// - Parameter statusFilter The filter to use.
+    ///
+    init(statusFilter: OrderStatus? = nil) {
+        self.statusFilter = statusFilter
         super.init(nibName: Self.nibName, bundle: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -43,7 +43,10 @@ extension OrderSearchStarterViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let orderStatus = viewModel.orderStatus(at: indexPath)
+
         let ordersViewController = OrdersViewController(statusFilter: orderStatus)
+        ordersViewController.title =
+            orderStatus.name ?? NSLocalizedString("Orders", comment: "Default title for Orders List shown when tapping on the Search filter.")
 
         navigationController?.pushViewController(ordersViewController, animated: true)
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -51,7 +51,10 @@ extension OrderSearchStarterViewController: UITableViewDelegate {
 
         analytics.trackSelectionOf(orderStatus: orderStatus)
 
-        let ordersViewController = OrdersViewController(statusFilter: orderStatus)
+        let ordersViewController = OrdersViewController(
+            statusFilter: orderStatus,
+            showsRemoveFilterActionOnFilteredEmptyView: false
+        )
         ordersViewController.title =
             orderStatus.name ?? NSLocalizedString("Orders", comment: "Default title for Orders List shown when tapping on the Search filter.")
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -1,12 +1,15 @@
 
 import Foundation
 import UIKit
+import struct Yosemite.OrderStatus
 
 /// The view shown in Orders Search if there is no search keyword entered.
 ///
 /// This shows a list of `OrderStatus` that the user can pick to filter Orders by status.
 ///
 final class OrderSearchStarterViewController: UIViewController {
+    private lazy var analytics = ServiceLocator.analytics
+
     @IBOutlet private var tableView: UITableView!
 
     private lazy var viewModel = OrderSearchStarterViewModel()
@@ -39,10 +42,14 @@ final class OrderSearchStarterViewController: UIViewController {
     }
 }
 
+// MARK: - UITableViewDelegate
+
 extension OrderSearchStarterViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let orderStatus = viewModel.orderStatus(at: indexPath)
+
+        analytics.trackSelectionOf(orderStatus: orderStatus)
 
         let ordersViewController = OrdersViewController(statusFilter: orderStatus)
         ordersViewController.title =
@@ -54,8 +61,21 @@ extension OrderSearchStarterViewController: UITableViewDelegate {
     }
 }
 
+// MARK: - KeyboardScrollable
+
 extension OrderSearchStarterViewController: KeyboardScrollable {
     var scrollable: UIScrollView {
         tableView
+    }
+}
+
+// MARK: - Analytics
+
+private extension Analytics {
+    /// Submit events depicting selection of an `OrderStatus` in the UI.
+    ///
+    func trackSelectionOf(orderStatus: OrderStatus) {
+        track(.filterOrdersOptionSelected, withProperties: ["status": orderStatus.slug])
+        track(.ordersListFilterOrSearch, withProperties: ["filter": orderStatus.slug, "search": ""])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -42,13 +42,12 @@ final class OrderSearchStarterViewController: UIViewController {
 extension OrderSearchStarterViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let alertController = UIAlertController(title: "Not available",
-                                                message: "This is still under development.",
-                                                preferredStyle: .alert)
-        alertController.addActionWithTitle("Fine, I guess", style: .default) { _ in
-            tableView.deselectSelectedRowWithAnimation(true)
-        }
-        present(alertController, animated: true, completion: nil)
+        let orderStatus = viewModel.orderStatus(at: indexPath)
+        let ordersViewController = OrdersViewController(statusFilter: orderStatus)
+
+        navigationController?.pushViewController(ordersViewController, animated: true)
+
+        tableView.deselectSelectedRowWithAnimation(true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -25,6 +25,12 @@ final class OrderSearchStarterViewModel {
 
         try? dataSource.performFetch()
     }
+
+    /// The `OrderStatus` located at `indexPath`.
+    ///
+    func orderStatus(at indexPath: IndexPath) -> OrderStatus {
+        dataSource.orderStatus(at: indexPath)
+    }
 }
 
 
@@ -66,6 +72,12 @@ private extension OrderSearchStarterViewModel {
                                forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
         }
 
+        /// The `OrderStatus` located at `indexPath`.
+        ///
+        func orderStatus(at indexPath: IndexPath) -> OrderStatus {
+            resultsController.object(at: indexPath)
+        }
+
         func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
             resultsController.numberOfObjects
         }
@@ -73,7 +85,7 @@ private extension OrderSearchStarterViewModel {
         func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
             let cell = tableView.dequeueReusableCell(withIdentifier: BasicTableViewCell.reuseIdentifier,
                                                      for: indexPath)
-            let orderStatus = resultsController.object(at: indexPath)
+            let orderStatus = self.orderStatus(at: indexPath)
 
             cell.accessoryType = .disclosureIndicator
             cell.selectionStyle = .default


### PR DESCRIPTION
Refs #1845. This implements filtering by Order Statuses from the Search view.

![](https://user-images.githubusercontent.com/198826/73874110-21162f00-4810-11ea-9dd6-37d67b2f95c1.png)

## Screenshots

Behavior | Empty Screen 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/74068044-db946600-49b7-11ea-98c5-f800c04a88c9.gif" width="320">    | <img src="https://user-images.githubusercontent.com/198826/74068178-35952b80-49b8-11ea-8ab1-d6addb7e0cf5.PNG" width="320">

## Changes 

This builds upon the changes in #1835. The linking works by injecting `OrderStatus` to the `OrderStatusViewController.init`. 

https://github.com/woocommerce/woocommerce-ios/blob/cbc13db244977dcb5a95886762f71447550c0415/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift#L54-L57

### `statusFilter` is still `var`

I have not been able to change `OrdersViewController.statusFilter` to a `let` yet. The controller is still currently being used for filtering in `OrdersMasterViewController`. 

### Empty View

The empty view, by default, shows a "Remove Filter" button. I hid that by passing a new argument, `showsRemoveFilterActionOnFilteredEmptyView`, to the `OrdersViewController.init`. 

There are probably better ways to do this but I thought I'd wait until I've confirmed how the empty states should look like. 

## Design Review

@Garance91540 The only changes in the UI here is the navigation from Search and the Empty States. I just realized as I was finishing this that I couldn't find what the empty states should look like for them. What do you think of the Empty State screenshot above? Is that good enough for now? 

## Testing

1. Navigate to Orders → Search.
2. Tap on the filter buttons (e.g. Completed). 
3. Confirm that the pushed Orders List is filtered by what you picked. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

