### PR TITLE
Generate Screenshots in CI

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -131,3 +131,48 @@ jobs:
         cd fastlane && mkdir $GITHUB_RUN_ID && mv screenshots $GITHUB_RUN_ID
         aws s3 cp $GITHUB_RUN_ID s3://$S3_BUCKET/$GITHUB_RUN_ID --recursive --exclude "*.html"
 
+  process:
+    name: "Process Screenshots"
+    needs: capture
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6.x'
+    
+    - name: Install Bundler
+      run: gem install bundler
+    
+    - name: Restore Ruby Dependency Cache
+      id: restore-ruby-dependency-cache
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+    
+    - name: Install Ruby Dependencies
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+
+    - name: Install Fastlane Dependencies
+      run: bundle exec fastlane run configure_apply
+
+    - name: Download Generated Screenshots
+      run: |
+        brew install awscli
+        cd fastlane
+        aws s3 cp s3://$S3_BUCKET/$GITHUB_RUN_ID/screenshots screenshots/  --recursive --exclude "*.html"
+    
+    - name: Generate and Upload Screenshot Summary
+      run: |
+        bundle exec fastlane create_screenshot_summary
+        aws s3 cp fastlane/screenshots/screenshots.html s3://$S3_BUCKET/$GITHUB_RUN_ID/screenshots/screenshots.html
+
+    - name: Archive Raw Screenshots
+      uses: actions/upload-artifact@v1
+      with:
+        name: raw-screenshots
+        path: fastlane/screenshots

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -62,4 +62,72 @@ jobs:
         name: screenshot-runner
         path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerceScreenshots-Runner.app
 
+  capture:
+    name: Capture
+    needs: build
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        language: [ar, de-DE, en-US, es-ES, fr-FR, he, id, it, ja, ko, nl-NL, pt-BR, ru, sv, tr, zh-Hans, zh-Hant]
+        mode: [dark, light]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6.x'
+    
+    - name: Install Bundler
+      run: gem install bundler
+    
+    - name: Restore Ruby Dependency Cache
+      id: restore-ruby-dependency-cache
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+    
+    - name: Install Ruby Dependencies
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+
+    - name: Install Fastlane Dependencies
+      run: bundle exec fastlane run configure_apply
+    
+    - name: Download Screenshot App
+      uses: actions/download-artifact@v1
+      with:
+        name: screenshot-app
+        path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app
+
+    - name: Download Screenshot Runner
+      uses: actions/download-artifact@v1
+      with:
+        name: screenshot-runner
+        path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerceScreenshots-Runner.app
+
+    - name: Start Mocks
+      run: rake mocks &
+
+    - name: Generate Screenshots
+      run: |
+        bundle exec fastlane take_screenshots languages:${{ matrix.language }} mode:${{ matrix.mode }}
+
+    - name: Move Test Result Bundle to Logs
+      if: always()
+      run: cp -Rv fastlane/screenshots/test_output fastlane/logs && rm -rf fastlane/screenshots/test_output
+
+    - name: Store Logs
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: "screenshot-log-${{ matrix.language }}-${{ matrix.mode }}"
+        path: fastlane/logs
+
+    - name: Archive Generated Screenshots
+      run: |
+        brew install awscli
+        cd fastlane && mkdir $GITHUB_RUN_ID && mv screenshots $GITHUB_RUN_ID
+        aws s3 cp $GITHUB_RUN_ID s3://$S3_BUCKET/$GITHUB_RUN_ID --recursive --exclude "*.html"
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,65 @@
+name: Screenshots
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+env:
+  S3_BUCKET: ${{ secrets.S3_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  CONFIGURE_ENCRYPTION_KEY: ${{ secrets.CONFIGURE_ENCRYPTION_KEY }}
+
+jobs:
+  build:
+    name: Build Application
+    if: contains(github.event.pull_request.labels.*.name, 'Needs Screenshots')
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6.x'
+    
+    - name: Install Bundler
+      run: gem install bundler
+    
+    - name: Restore Ruby Dependency Cache
+      id: restore-ruby-dependency-cache
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+    
+    - name: Install Ruby Dependencies
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    
+    - name: Restore CocoaPods Dependency Cache
+      id: restore-cocoapods-dependency-cache
+      uses: actions/cache@v1
+      with:
+        path: Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+
+    - name: Install App Dependencies
+      run: bundle exec rake dependencies
+    
+    - name: Compile the App
+      run: bundle exec fastlane build_screenshots
+
+    - name: Archive App
+      uses: actions/upload-artifact@v1
+      with:
+        name: screenshot-app
+        path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerce.app
+
+    - name: Archive Runner
+      uses: actions/upload-artifact@v1
+      with:
+        name: screenshot-runner
+        path: fastlane/DerivedData/Build/Products/Debug-iphonesimulator/WooCommerceScreenshots-Runner.app
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,10 @@ Carthage/Build
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
+fastlane/promo_screenshots
 fastlane/test_output
 fastlane/README.md
+fastlane/logs
 Preview.html
 default.profraw
 
@@ -82,7 +84,6 @@ default.profraw
 
 # Ignore Local Configuration files (like the ones used for Fastlane)
 .env
-/fastlane/promo_screenshots
 
 # All secrets should be stored under .configure-files
 # Everything without a .enc extension is ignored

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -6,11 +6,7 @@ class WooCommerceScreenshots: XCTestCase {
 
         continueAfterFailure = false
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
-        } else {
-            XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
-        }
+        XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
     }
 
     func testScreenshots() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -295,24 +295,9 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   ########################################################################
   # Screenshot Lanes
   ########################################################################  
-  desc "Take Screenshots"
-  lane :screenshots do | options |
-
-    fastlane_directory = File.expand_path File.dirname(__FILE__)
-    derived_data_path = File.join(fastlane_directory, "DerivedData")
-    screenshots_directory = File.join(fastlane_directory, "screenshots")
-
-    # By default, clear previous screenshots
-    should_clear_previous_screenshots = true
-    languages = "ar de-DE es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant en-US".split()
-
-    if options[:languages] != nil
-      languages = languages & options[:languages].split()
-      should_clear_previous_screenshots = false
-    end
-
-    puts "Creating screenshots for #{languages}"
-
+  desc "Build Screenshots"
+  lane :build_screenshots do
+    
     # Ensure we're using the latest Pods
     sh('bundle exec pod install')
 
@@ -320,49 +305,112 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       workspace: File.join(fastlane_directory, "../WooCommerce.xcworkspace"),
       scheme: "WooCommerceScreenshots",
       build_for_testing: true,
-      derived_data_path: derived_data_path,
+      derived_data_path: derived_data_directory,
     )
+  end
 
-    devices = [
-      "iPhone 11 Pro Max",
-      "iPhone 8 Plus",
-      "iPad Pro (12.9-inch) (2nd generation)",
-      "iPad Pro (12.9-inch) (3rd generation)",
-    ]
+  desc "Take Screenshots"
+  lane :take_screenshots do | options |
+
+    # By default, clear previous screenshots
+    languages = "ar de-DE es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant en-US".split()
+
+    if options[:languages] != nil
+      languages = languages & options[:languages].split()
+    end
+
+    puts "Creating screenshots for #{languages}"
+
+    devices = screenshot_devices.map { |device| device[:name] }
 
     if options[:devices] != nil
       devices = devices & options[:devices].split()
-      should_clear_previous_screenshots = false
     end
 
-    FileUtils.rm_f(screenshots_directory) unless !should_clear_previous_screenshots
+    # Erase the simulator between runs in order to get everything back to a default state
+    rebuild_screenshot_devices
 
-    [true, false].each { | dark_mode_enabled |
-      capture_ios_screenshots(
-        scheme: "WooCommerceScreenshots",
+    capture_ios_screenshots(
+      scheme: "WooCommerceScreenshots",
 
-        localize_simulator: true,
-        languages: languages,
+      localize_simulator: true,
+      languages: languages,
 
-        devices: devices,
+      devices: devices,
 
-        # Don't rebuild the app for every new locale / device type, and specify where to find the binaries
-        test_without_building: true,
-        derived_data_path: derived_data_path,
+      # Don't rebuild the app for every new locale / device type, and specify where to find the binaries
+      test_without_building: true,
+      derived_data_path: derived_data_directory,
 
-        # Where should the screenshots go, and should we delete them before starting?
-        output_directory: "./fastlane/screenshots",
+      # Where should the screenshots go, and should we delete them before starting?
+      output_directory: screenshots_directory,
 
-        concurrent_simulators: false,
+      # Output the simulator logs for debugging
+      buildlog_path: "./fastlane/logs",
+      output_simulator_logs: true,
+      result_bundle: true,
+      namespace_log_files: true,
 
-        # Retry a few times if something is a little flaky
-        number_of_retries: 3,
+      concurrent_simulators: false,
 
-        # Allow the caller to invoke dark mode
-        dark_mode: dark_mode_enabled
-      )
+      # Explicitly set the iOS version to ensure we match the created simulators
+      ios_version: simulator_version,
+
+      # Erase the simulator prior to booting the app
+      erase_simulator: true,
+
+      # Retry a few times if something is a little flaky
+      number_of_retries: 3,
+
+      # But fail completely after those 3 retries
+      stop_after_first_error: true,
+
+      # Allow the caller to invoke dark mode
+      dark_mode: options[:mode].to_s.downcase == "dark"
+    )
+
+  end
+
+  desc "Create Screenshots Locally"
+  lane :screenshots do | options |
+
+    FileUtils.rm_f(screenshots_directory)
+
+    build_screenshots(options)
+    take_screenshots(options.merge({ mode: 'light' }))
+    take_screenshots(options.merge({ mode: 'dark' }))
+  end
+
+  desc "Rebuild Screenshot Devices"
+  lane :rebuild_screenshot_devices do
+    require 'simctl'
+
+    device_names = screenshot_devices.map { |device| device[:name] }
+
+    SimCtl.list_devices.each { |device|
+      next unless device_names.include? device.name
+      device.delete
     }
 
+    screenshot_devices.each { | device |
+      runtime = SimCtl.runtime(name: "iOS #{simulator_version}")
+      devicetype = SimCtl.devicetype(name: device[:device_id])
+
+      device = SimCtl.create_device device[:name], devicetype, runtime
+    }
+  end
+
+  desc "Create Screenshot Summary"
+  lane :create_screenshot_summary do
+    fastlane_require 'snapshot'
+
+    # Provide enough information to bootstrap the configuration and generate the HTML report
+    Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
+      "workspace": "../WooCommerce.xcworkspace",
+      "scheme": "WooCommerceScreenshots"
+    })
+
+    Snapshot::ReportsGenerator.new.generate
   end
 
   desc "Download App Store Translations"
@@ -510,3 +558,40 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     end
   end
 end
+
+  def fastlane_directory()
+    File.expand_path File.dirname(__FILE__)
+  end
+
+  def derived_data_directory()
+    File.join(fastlane_directory, "DerivedData")
+  end
+
+  def screenshots_directory()
+    File.join(fastlane_directory, "screenshots")
+  end
+
+  def screenshot_devices()
+    [
+      {
+        name: "iPhone 11 Pro Max (screenshots)",
+        device_id: "iPhone 11 Pro Max"
+      },
+      {
+        name: "iPhone 8 Plus (screenshots)",
+        device_id: "iPhone 8 Plus"
+      },
+      {
+        name: "iPad Pro (12.9-inch) (2nd generation) (screenshots)",
+        device_id: "iPad Pro (12.9-inch) (2nd generation)"
+      },
+      {
+        name: "iPad Pro (12.9-inch) (3rd generation) (screenshots)",
+        device_id: "iPad Pro (12.9-inch) (3rd generation)"
+      }
+    ]
+  end
+
+  def simulator_version()
+    return '13.3'
+  end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -316,16 +316,18 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     languages = "ar de-DE es-ES fr-FR he id it ja ko nl-NL pt-BR ru sv tr zh-Hans zh-Hant en-US".split()
 
     if options[:languages] != nil
-      languages = languages & options[:languages].split()
+      languages = languages & options[:languages].split(",")
     end
 
-    puts "Creating screenshots for #{languages}"
-
-    devices = screenshot_devices.map { |device| device[:name] }
+    devices = screenshot_devices
 
     if options[:devices] != nil
-      devices = devices & options[:devices].split()
+      devices = devices & options[:devices].split(",")
     end
+
+    UI.user_error!("Unable to run on devices: \"#{devices}\"") unless !devices.empty?
+
+    puts "Creating screenshots for #{languages} on #{devices}"
 
     # Erase the simulator between runs in order to get everything back to a default state
     rebuild_screenshot_devices
@@ -351,7 +353,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       result_bundle: true,
       namespace_log_files: true,
 
-      concurrent_simulators: false,
+      concurrent_simulators: true,
 
       # Explicitly set the iOS version to ensure we match the created simulators
       ios_version: simulator_version,
@@ -385,18 +387,19 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   lane :rebuild_screenshot_devices do
     require 'simctl'
 
-    device_names = screenshot_devices.map { |device| device[:name] }
+    device_names = screenshot_devices
 
     SimCtl.list_devices.each { |device|
       next unless device_names.include? device.name
+      puts "Deleting #{device.name} because it already exists."
       device.delete
     }
 
     screenshot_devices.each { | device |
       runtime = SimCtl.runtime(name: "iOS #{simulator_version}")
-      devicetype = SimCtl.devicetype(name: device[:device_id])
+      devicetype = SimCtl.devicetype(name: device)
 
-      device = SimCtl.create_device device[:name], devicetype, runtime
+      device = SimCtl.create_device device, devicetype, runtime
     }
   end
 
@@ -573,22 +576,10 @@ end
 
   def screenshot_devices()
     [
-      {
-        name: "iPhone 11 Pro Max (screenshots)",
-        device_id: "iPhone 11 Pro Max"
-      },
-      {
-        name: "iPhone 8 Plus (screenshots)",
-        device_id: "iPhone 8 Plus"
-      },
-      {
-        name: "iPad Pro (12.9-inch) (2nd generation) (screenshots)",
-        device_id: "iPad Pro (12.9-inch) (2nd generation)"
-      },
-      {
-        name: "iPad Pro (12.9-inch) (3rd generation) (screenshots)",
-        device_id: "iPad Pro (12.9-inch) (3rd generation)"
-      }
+      "iPhone 11 Pro Max",
+      "iPhone 8 Plus",
+      "iPad Pro (12.9-inch) (2nd generation)",
+      "iPad Pro (12.9-inch) (3rd generation)",
     ]
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -299,7 +299,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   lane :build_screenshots do
     
     # Ensure we're using the latest Pods
-    sh('bundle exec pod install')
+    sh('bundle exec pod install --verbose')
 
     scan(
       workspace: File.join(fastlane_directory, "../WooCommerce.xcworkspace"),


### PR DESCRIPTION
**To Test:**

**Part 1:**
- See that the Checks list shows that all jobs are passing – that means the screenshots were generated successfully.

**Part 2:**
- Create a new branch from this one, and create a PR for it. 
- Note that the PR by default doesn't create screenshots.
- Add the "Needs Screenshots" label to the PR – that'll cause the process to start.
- Verify that it succeeds (it usually takes about an hour, give or take)

**Cleanup:**
- Close down your test PR and delete the test branch.

**Note:**
This functionality can still be a little flaky at times – based on the logs and automated screenshots captured during failures, this seems to be an issue on Xcode's part – it sometimes can't properly launch and communicate with the app in the simulator. Because it's so intermittent, and there's not much we can do about it, IMHO the functionality offered by this PR is good enough that we ought to ship it – if we want to re-run the screenshot generation code, we can do so by removing and re-adding the label, and it's still often faster than running this all locally. 