### PR TITLE
Order Details: navigate to Edit Product when tapping on a simple Product in the Order 

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -80,6 +80,12 @@ extension UIImage {
         return Gridicon.iconOfType(.chevronUp)
     }
 
+    /// Close bar button item
+    ///
+    static var closeButton: UIImage {
+        return Gridicon.iconOfType(.cross)
+    }
+    
     /// Cog Icon
     ///
     static var cogImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -85,7 +85,7 @@ extension UIImage {
     static var closeButton: UIImage {
         return Gridicon.iconOfType(.cross)
     }
-    
+
     /// Cog Icon
     ///
     static var cogImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -17,13 +17,13 @@ extension UIViewController {
     func removeNavigationBackBarButtonText() {
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
-    
+
     /// Show the X close button on the left bar button item position
     ///
     func addLeftCloseNavigationBarButton() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: self, action: #selector(dismiss))
     }
-    
+
 //    private func dismiss() {
 //        dismiss(animated: true, completion: nil)
 //    }

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -17,4 +17,14 @@ extension UIViewController {
     func removeNavigationBackBarButtonText() {
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
+    
+    /// Show the X close button on the left bar button item position
+    ///
+    func addLeftCloseNavigationBarButton() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: self, action: #selector(dismiss))
+    }
+    
+//    private func dismiss() {
+//        dismiss(animated: true, completion: nil)
+//    }
 }

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -20,11 +20,19 @@ extension UIViewController {
 
     /// Show the X close button on the left bar button item position
     ///
-    func addLeftCloseNavigationBarButton() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: self, action: #selector(dismiss))
+    func addCloseNavigationBarButton() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: self, action: #selector(dismissVC))
     }
 
-//    private func dismiss() {
-//        dismiss(animated: true, completion: nil)
-//    }
+}
+
+/// Private methods
+///
+private extension UIViewController {
+
+    /// Dismiss method
+    ///
+    @objc func dismissVC() {
+        dismiss(animated: true, completion: nil)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -56,7 +56,7 @@ final class ProductLoaderViewController: UIViewController {
         configureNavigationTitle()
         configureSpinner()
         configureMainView()
-        configureDismissButton()
+        addCloseNavigationBarButton()
         loadProduct()
     }
 }
@@ -86,17 +86,6 @@ private extension ProductLoaderViewController {
         activityIndicator.hidesWhenStopped = true
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
     }
-
-    /// Setup: Dismiss Button
-    ///
-    func configureDismissButton() {
-        let dismissButtonTitle = NSLocalizedString("Dismiss", comment: "Product details screen - button title for closing the view")
-        let leftBarButton = UIBarButtonItem(title: dismissButtonTitle,
-                                            style: .plain,
-                                            target: self,
-                                            action: #selector(dismissButtonTapped))
-        navigationItem.setLeftBarButton(leftBarButton, animated: false)
-    }
 }
 
 
@@ -123,10 +112,6 @@ private extension ProductLoaderViewController {
 
         state = .loading
         ServiceLocator.stores.dispatch(action)
-    }
-
-    @objc func dismissButtonTapped() {
-        dismiss(animated: true, completion: nil)
     }
 }
 
@@ -169,19 +154,29 @@ private extension ProductLoaderViewController {
         }
     }
 
-    /// Presents the ProductDetailsViewController, as a childViewController, for a given Product.
+    /// Presents the ProductDetailsViewController or the ProductFormViewController, as a childViewController, for a given Product.
     ///
     func presentProductDetails(for product: Product) {
-        let detailsViewModel = ProductDetailsViewModel(product: product, currency: currency)
-        let detailsViewController = ProductDetailsViewController(viewModel: detailsViewModel)
+
+        let isFeatureFlagOn = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts)
+        let viewController: UIViewController
+        if product.productType == .simple && isFeatureFlagOn {
+            viewController = ProductFormViewController(product: product, currency: currency)
+            // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
+        } else {
+            let viewModel = ProductDetailsViewModel(product: product, currency: currency)
+            viewController = ProductDetailsViewController(viewModel: viewModel)
+        }
 
         // Attach
-        addChild(detailsViewController)
-        attachSubview(detailsViewController.view)
-        detailsViewController.didMove(toParent: self)
+        addChild(viewController)
+        attachSubview(viewController.view)
+        viewController.didMove(toParent: self)
 
-        // And, of course, borrow the Child's Title
-        title = detailsViewController.title
+
+        // And, of course, borrow the Child's Title + right nav bar items
+        title = viewController.title
+        navigationItem.rightBarButtonItems = viewController.navigationItem.rightBarButtonItems
     }
 
     /// Removes all of the children UIViewControllers

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -162,7 +162,6 @@ private extension ProductLoaderViewController {
         let viewController: UIViewController
         if product.productType == .simple && isFeatureFlagOn {
             viewController = ProductFormViewController(product: product, currency: currency)
-            // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         } else {
             let viewModel = ProductDetailsViewModel(product: product, currency: currency)
             viewController = ProductDetailsViewController(viewModel: viewModel)

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -45,7 +45,7 @@ final class IconsTests: XCTestCase {
     func testChevronUpImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.chevronUpImage)
     }
-    
+
     func testCloseButtonIconIsNotNil() {
         XCTAssertNotNil(UIImage.closeButton)
     }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -45,6 +45,10 @@ final class IconsTests: XCTestCase {
     func testChevronUpImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.chevronUpImage)
     }
+    
+    func testCloseButtonIconIsNotNil() {
+        XCTAssertNotNil(UIImage.closeButton)
+    }
 
     func testCogImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.cogImage)


### PR DESCRIPTION
Fixes #1837 

## Description
When tapping a simple Product from the Order Details, let's navigate to the Edit Product screen with a dismiss button in the left navigation bar. This feature is behind the `editProducts` feature flag.

## Changes
- Added the new `closeButton` icon + tests
- Implemented the method to add the close button in the navigation bar inside `UIViewController+Helpers`
- Cleaned `ProductLoaderViewController` from the old method for adding the Dismiss textual button.
- Managed the presentation of `ProductFormViewController` when the `editProducts` flag is enabled, inside `ProductLoaderViewController`

## Testing case 1
1) Navigate to an order detail
2) Tap on a simple product
3) Make sure that the view showed is the new Edit Product
4) Make sure you are able to make all the edit actions on a Product.
5) Tap save
6) Make sure the product name in the order detail is not updated (this is the right behavior).

## Testing case 2
1) Disable the `editProducts` flag
2) Navigate to an order detail
3) Tap on a simple product
3) Make sure that the view showed is the old product detail

## Screenshot
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-10 at 13 13 26](https://user-images.githubusercontent.com/495617/74149078-32dc4580-4c07-11ea-8651-34aced0abf4c.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
