### PR TITLE
Enabled the refunds feature for all the users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
  
 3.6
 -----
+- Order Details: see a list of issued refunds inside the order detail screen
 - Orders tab: Orders to fulfill badge shows numbers 1-99, and now 99+ for anything over 99. Previously, it was 9+.
 - Orders tab: The full total amount is now shown.
 - Order Details & Product UI: if a Product name has HTML escape characters, they should be decoded in the app.

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -12,7 +12,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         case .stats:
             return true
         case .refunds:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .orderListRedesign:
             return BuildConfiguration.current == .localDeveloper
         default:


### PR DESCRIPTION
This PR enables the Refunds feature in the next release 3.6 for all the users.

## Testing
Make sure that Refunds and partial refunds are showed correctly inside an Order Detail, and that everything works like expected (no empty actions, no placeholder or strange things).

## Screenshots

| Screen 1             |  Screen 2 | Screen 3 | Screen 4
:-------------------------:|:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-11 at 15 35 03](https://user-images.githubusercontent.com/495617/74246076-3e516e80-4ce4-11ea-9459-3b74adc70609.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-11 at 15 35 05](https://user-images.githubusercontent.com/495617/74246091-427d8c00-4ce4-11ea-8167-09ecd9a3e2f9.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-11 at 15 35 19](https://user-images.githubusercontent.com/495617/74246100-44dfe600-4ce4-11ea-89f5-852fb3534fbc.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-11 at 15 35 59](https://user-images.githubusercontent.com/495617/74246105-46111300-4ce4-11ea-8f5b-a0614995adcc.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
