### PR TITLE
Dashboard: tapping on a product on "top performer" section will present the product detail screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 3.7
 -----
- 
+- Dashboard: now tapping on a product on "Top Performers" section open the product detail
+
 3.6
 -----
 - Orders tab: Orders to fulfill badge shows numbers 1-99, and now 99+ for anything over 99. Previously, it was 9+.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -146,7 +146,6 @@ private extension TopPerformerDataViewController {
     func configureTableView() {
         tableView.backgroundColor = .basicBackground
         tableView.separatorColor = .systemColor(.separator)
-        tableView.allowsSelection = false
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.tableFooterView = Constants.emptyView
@@ -231,6 +230,14 @@ extension TopPerformerDataViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate Conformance
 //
 extension TopPerformerDataViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let statsItem = statsItem(at: indexPath), let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return
+        }
+        presentProductDetails(for: statsItem.productID, siteID: siteID)
+    }
+
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         return Constants.estimatedSectionHeight
     }
@@ -245,6 +252,23 @@ extension TopPerformerDataViewController: UITableViewDelegate {
     }
 }
 
+// MARK: Navigation Actions
+//
+
+private extension TopPerformerDataViewController {
+
+    /// Presents the ProductDetailsViewController or the ProductFormViewController, as a childViewController, for a given Product.
+    ///
+    func presentProductDetails(for productID: Int64, siteID: Int64) {
+        let currencyCode = CurrencySettings.shared.currencyCode
+        let currency = CurrencySettings.shared.symbol(from: currencyCode)
+        let loaderViewController = ProductLoaderViewController(productID: productID,
+                                                               siteID: siteID,
+                                                               currency: currency)
+        let navController = WooNavigationController(rootViewController: loaderViewController)
+        self.present(navController, animated: true, completion: nil)
+    }
+}
 
 // MARK: - Private Helpers
 //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -266,7 +266,7 @@ private extension TopPerformerDataViewController {
                                                                siteID: siteID,
                                                                currency: currency)
         let navController = WooNavigationController(rootViewController: loaderViewController)
-        self.present(navController, animated: true, completion: nil)
+        present(navController, animated: true, completion: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +19,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" style="plain" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="quh-Rf-B3R" customClass="IntrinsicTableView" customModule="WooCommerce" customModuleProvider="target">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="quh-Rf-B3R" customClass="IntrinsicTableView" customModule="WooCommerce" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>


### PR DESCRIPTION
Fixes #1850 
Fixes #1034 

## Description
When tapping a simple Product from the "Top Performer" section inside the Dashboard, navigate to the Edit Product screen or product detail (if flag `editProducts` is not enabled).

## Testing case 1
1) Navigate to Dashboard
2) Tap on a simple product on Top Performer section
3) Make sure that the view showed is the new Edit Product

## Testing case 2
1) Disable the `editProducts` flag
2) Navigate to Dashboard
3) Tap on a simple product on Top Performer section
4) Make sure that the view showed is the old product detail

## Screenshots
| From the Top Performer section tap a product             |  will open the product detail |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-02-12 at 18 39 04](https://user-images.githubusercontent.com/495617/74361647-99a85d00-4dc7-11ea-9976-cb06b119cedd.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-12 at 18 39 07](https://user-images.githubusercontent.com/495617/74361661-a036d480-4dc7-11ea-944a-9c072743df2f.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
