### PR TITLE
Hotfix: fixed orders badge count when you switch between two stores (one with badge count = 0)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - Orders tab: The full total amount is now shown.
 - Order Details & Product UI: if a Product name has HTML escape characters, they should be decoded in the app.
 - Order Details: if the Order has multiple Products, tapping on any Product should open the same Product now.
+- bugfix: the orders badge on tab bar now is correctly refreshed after switching to a store with badge count equal to zero.
 
 3.5
 -----

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -390,8 +390,7 @@ private extension MainTabBarController {
 private extension MainTabBarController {
     func startListeningToOrdersBadge() {
         viewModel.onBadgeReload = { [weak self] countReadableString in
-            guard let self = self,
-            let badgeText = countReadableString else {
+            guard let self = self else {
                 return
             }
 
@@ -402,7 +401,7 @@ private extension MainTabBarController {
                 return
             }
 
-            orderTab.badgeValue = badgeText
+            orderTab.badgeValue = countReadableString
             orderTab.badgeColor = .primary
         }
 


### PR DESCRIPTION
Fixes #1373 

We discovered a new bug with the orders badge refresh when you switch from a store with a count > 0 to a store with count zero. Basically, also if the store has a badge count equal to zero, we don't update the count, which is related to the count of the old store.

The bug was caused by a wrong check on the closure that is responsible of the badge refresh. When a count is zero, we sent `nil`, and the old check returned without updating the badge value.

![tabbar](https://user-images.githubusercontent.com/495617/74437147-f65b5480-4e67-11ea-895c-1a2714fa461e.png)


## Testing
1) Make sure to have two stores: the first one with orders to fulfill, and the second one without orders to fulfill.
2) Switch between the two stores, and make sure that the badge in the tab "Orders" is updated correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
