### PR TITLE
[Order List Redesign] Fix Order List Design 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -117,7 +117,7 @@ private extension OrderTableViewCell {
     /// Setup: Labels
     ///
     func configureLabels() {
-        titleLabel.applyHeadlineStyle()
+        titleLabel.applyBodyStyle()
         totalLabel.applyBodyStyle()
         totalLabel.numberOfLines = 0
         paymentStatusLabel.applyFootnoteStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -58,7 +58,6 @@
                     <constraint firstAttribute="bottomMargin" secondItem="w2s-RF-ahH" secondAttribute="bottom" constant="8" id="YAb-lm-rXp"/>
                 </constraints>
             </tableViewCellContentView>
-            <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="contentStackView" destination="w2s-RF-ahH" id="ULq-Dn-l9Q"/>
                 <outlet property="dateCreatedLabel" destination="ylK-xx-FWE" id="gKt-XQ-tYq"/>


### PR DESCRIPTION
Refs #956. 

This fixes some of the design issues found in https://github.com/woocommerce/woocommerce-ios/pull/1851#pullrequestreview-357598719. This is targeting `develop` since the design changes are not dependent on #1851. 

## Changes 

### Indented Separator

> G: Similarly as for the product list, the bottom divider between each order row should not span the full width, but have a 16px left padding

Fixed by removing the manually set `0` inset and keeping it as automatic in 191c7e4a50d3cfd64df9a99183041c2497420e59.

Before | After | After (Dark)
--------|-------|---
![image](https://user-images.githubusercontent.com/198826/74477492-9fa24a80-4e68-11ea-8bcb-3af902c88d78.png)| ![image](https://user-images.githubusercontent.com/198826/74477372-6e297f00-4e68-11ea-8abc-09215ba0ce93.png) |![image](https://user-images.githubusercontent.com/198826/74477427-86999980-4e68-11ea-8be2-fbc1e83d31ee.png)|

### Title Font Weight

> G: Order row: the font weight of the customer name is Body (it looks bold here)

Fixed by using the body style in e629d4b1fff158e894cae4329a7d737741dec054.

Before | After | After (Dark)
--------|-------|---
![image](https://user-images.githubusercontent.com/198826/74477852-50104e80-4e69-11ea-8839-3f2117708d1d.png)|![image](https://user-images.githubusercontent.com/198826/74477931-88179180-4e69-11ea-9410-9aa4e58b27ed.png)|![image](https://user-images.githubusercontent.com/198826/74477877-63231e80-4e69-11ea-9367-88e9be502355.png)


## Testing

1. Navigate to Orders list
2. Confirm that the fixes above have been applied. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


