### PR TITLE
Update App Store Headers for localization

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -60,8 +60,8 @@ msgstr ""
 #. No specified characters limit here, but try to keep as short as the source one. 
 msgctxt "app_store_screenshot-1"
 msgid ""
-"Your Store\n"
-"in Your Pocket\n"
+"Track sales and high\n"
+"performing products\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
@@ -75,27 +75,33 @@ msgstr ""
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
 #. No specified characters limit here, but try to keep as short as the source one. 
 msgctxt "app_store_screenshot-2"
-msgid "View and manage orders"
+msgid ""
+"View and manage\n"
+"orders on the go\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
 #. No specified characters limit here, but try to keep as short as the source one. 
 msgctxt "app_store_screenshot-3"
-msgid "Track order status"
+msgid ""
+"Review order details\n"
+"and payments\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
 #. No specified characters limit here, but try to keep as short as the source one. 
 msgctxt "app_store_screenshot-4"
 msgid ""
-"Scroll through, filter,\n"
-"or look up specific orders\n"
+"View products and\n"
+"check inventory\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.
 #. No specified characters limit here, but try to keep as short as the source one. 
 msgctxt "app_store_screenshot-5"
-msgid "Track sales data and high performing products"
+msgid ""
+"Get notified about\n"
+"new reviews\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,13 +95,10 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       app_store_keywords: File.join(source_metadata_folder, "keywords.txt"),
       "app_store_promo_text" => File.join(source_metadata_folder, "app_store_promo_text.txt"),
       "app_store_screenshot-1" => File.join(source_metadata_folder, "promo_screenshot_1.txt"),
-      "app_store_screenshot-1_b" => File.join(source_metadata_folder, "promo_screenshot_1_b.txt"),
       "app_store_screenshot-2" => File.join(source_metadata_folder, "promo_screenshot_2.txt"),
       "app_store_screenshot-3" => File.join(source_metadata_folder, "promo_screenshot_3.txt"),
       "app_store_screenshot-4" => File.join(source_metadata_folder, "promo_screenshot_4.txt"),
       "app_store_screenshot-5" => File.join(source_metadata_folder, "promo_screenshot_5.txt"),
-      "app_store_screenshot-6" => File.join(source_metadata_folder, "promo_screenshot_6.txt"),
-      "app_store_screenshot-7" => File.join(source_metadata_folder, "promo_screenshot_7.txt"),
     }
 
     ios_update_metadata_source(po_file_path: prj_folder + "/WooCommerce/Resources/AppStoreStrings.pot", 

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
@@ -1,2 +1,2 @@
-Your Store
-in Your Pocket
+Track sales and high
+performing products

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_1_b.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_1_b.txt
@@ -1,2 +1,0 @@
-Made with 💜
-at Automattic

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
@@ -1,1 +1,2 @@
-View and manage orders
+View and manage
+orders on the go

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
@@ -1,1 +1,2 @@
-Track order status
+Review order details
+and payments

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
@@ -1,2 +1,2 @@
-Scroll through, filter,
-or look up specific orders
+View products and
+check inventory

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
@@ -1,1 +1,2 @@
-Track sales data and high performing products
+Get notified about
+new reviews

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
@@ -1,2 +1,0 @@
-Get notified about new
-customer reviews

--- a/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
+++ b/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
@@ -1,1 +1,0 @@
-Create and manage products


### PR DESCRIPTION
Updates the strings to match the new screenshots for localization.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
