### PR TITLE
Image Upload: weak self when passing closures

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -10,7 +10,9 @@ final class ProductFormViewController: UIViewController {
         didSet {
             viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
             tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel)
-            tableViewDataSource.configureActions(onAddImage: showProductImages)
+            tableViewDataSource.configureActions(onAddImage: { [weak self] in
+                self?.showProductImages()
+            })
             tableView.dataSource = tableViewDataSource
             tableView.reloadData()
         }
@@ -31,7 +33,9 @@ final class ProductFormViewController: UIViewController {
         self.viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
         self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel)
         super.init(nibName: nil, bundle: nil)
-        tableViewDataSource.configureActions(onAddImage: showProductImages)
+        tableViewDataSource.configureActions(onAddImage: { [weak self] in
+            self?.showProductImages()
+        })
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -125,7 +125,9 @@ extension ProductImagesCollectionViewController {
         let status = productImageStatuses[indexPath.row]
         switch status {
         case .remote(let productImage):
-            let productImageViewController = ProductImageViewController(productImage: productImage, onDeletion: onDeletion)
+            let productImageViewController = ProductImageViewController(productImage: productImage, onDeletion: { [weak self] productImage in
+                self?.onDeletion(productImage)
+            })
             navigationController?.pushViewController(productImageViewController, animated: true)
         default:
             return

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -36,13 +36,18 @@ final class ProductImagesViewController: UIViewController {
     // Child view controller.
     private lazy var imagesViewController: ProductImagesCollectionViewController = {
         let viewController = ProductImagesCollectionViewController(imageStatuses: productImageStatuses,
-                                                                   onDeletion: onDeletion)
+                                                                   onDeletion: { [weak self] productImage in
+                                                                    self?.onDeletion(productImage: productImage)
+        })
         return viewController
     }()
 
     private lazy var mediaPickingCoordinator: MediaPickingCoordinator = {
-        return MediaPickingCoordinator(onCameraCaptureCompletion: self.onCameraCaptureCompletion,
-                                       onDeviceMediaLibraryPickerCompletion: self.onDeviceMediaLibraryPickerCompletion(assets:))
+        return MediaPickingCoordinator(onCameraCaptureCompletion: { [weak self] asset, error in
+            self?.onCameraCaptureCompletion(asset: asset, error: error)
+            }, onDeviceMediaLibraryPickerCompletion: { [weak self] assets in
+                self?.onDeviceMediaLibraryPickerCompletion(assets: assets)
+        })
     }()
 
     private let onCompletion: Completion
@@ -205,11 +210,11 @@ private extension ProductImagesViewController {
     func addMediaToProduct(mediaItems: [Media]) {
         let newProductImageStatuses = mediaItems.map({
             ProductImage(imageID: $0.mediaID,
-            dateCreated: Date(),
-            dateModified: nil,
-            src: $0.src,
-            name: $0.name,
-            alt: $0.alt)
+                         dateCreated: Date(),
+                         dateModified: nil,
+                         src: $0.src,
+                         name: $0.name,
+                         alt: $0.alt)
         }).map({ ProductImageStatus.remote(image: $0) })
         self.productImageStatuses = newProductImageStatuses + productImageStatuses
     }


### PR DESCRIPTION
Part of #1713 

## Changes
- Used `weak self` for the closures passed to another class that it owns
  - Lemme know if you know any more concise ways to pass self's function with weak self!

## Testing

Note: memory debugger works better on the simulators

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header to edit images
- Tap "Add Photos"
- Add an image
- Go back to the Edit Product screen
- Go back to the Products tab (whether saving the Product or not)
- Run the memory debugger and search by "product" --> there should be no `ProductImage*` classes in the memory (feel free to check if you see some `ProductImage*` classes on `develop` after the same steps)

<img width="820" alt="Screen Shot 2020-02-20 at 3 00 55 PM" src="https://user-images.githubusercontent.com/1945542/74912142-04c1e700-53f9-11ea-9fcb-495f987bf171.png">


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
