### PR TITLE
Edit Product: short description

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -447,6 +447,9 @@ public struct Product: Codable {
         try container.encode(stockQuantity, forKey: .stockQuantity)
         try container.encode(backordersKey, forKey: .backordersKey)
         try container.encode(stockStatusKey, forKey: .stockStatusKey)
+
+        // Brief description (short description).
+        try container.encode(briefDescription, forKey: .briefDescription)
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -33,6 +33,12 @@ extension UIImage {
         return Gridicon.iconOfType(.bell)
     }
 
+    /// Brief Description Icon
+    ///
+    static var briefDescriptionImage: UIImage {
+        return Gridicon.iconOfType(.alignLeft, withSize: CGSize(width: 24, height: 24))
+    }
+
     /// Camera Icon
     ///
     static var cameraImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -19,4 +19,14 @@ final class EditorFactory {
         editor.onContentSave = onContentSave
         return editor
     }
+
+    func productBriefDescriptionEditor(product: Product,
+                                       onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
+        let navigationTitle = NSLocalizedString("Short description",
+                                                comment: "The navigation bar title of the edit short description screen.")
+        let viewProperties = EditorViewProperties(navigationTitle: navigationTitle, showSaveChangesActionSheet: true)
+        let editor = AztecEditorViewController(content: product.briefDescription, viewProperties: viewProperties)
+        editor.onContentSave = onContentSave
+        return editor
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -8,4 +8,12 @@ extension Product {
         }
         return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    /// Returns the brief description (short description) without the HTML tags and leading/trailing white spaces and new lines.
+    var trimmedBriefDescription: String? {
+        guard let description = briefDescription else {
+            return nil
+        }
+        return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -52,7 +52,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
 extension ProductFormSection.SettingsRow: ReusableTableRow {
     var cellTypes: [UITableViewCell.Type] {
         switch self {
-        case .price, .inventory, .shipping:
+        case .price, .inventory, .shipping, .briefDescription:
             return [ImageAndTitleAndTextTableViewCell.self]
         }
     }
@@ -63,7 +63,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
 
     private var cellType: UITableViewCell.Type {
         switch self {
-        case .price, .inventory, .shipping:
+        case .price, .inventory, .shipping, .briefDescription:
             return ImageAndTitleAndTextTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -155,7 +155,7 @@ private extension ProductFormTableViewDataSource {
             fatalError()
         }
         switch row {
-        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel):
+        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel), .briefDescription(let viewModel):
             configureSettings(cell: cell, viewModel: viewModel)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -15,6 +15,7 @@ enum ProductFormSection {
         case price(viewModel: ViewModel)
         case shipping(viewModel: ViewModel)
         case inventory(viewModel: ViewModel)
+        case briefDescription(viewModel: ViewModel)
 
         struct ViewModel {
             let icon: UIImage
@@ -67,6 +68,8 @@ extension ProductFormSection.SettingsRow: Equatable {
         case (let .shipping(viewModel1), let .shipping(viewModel2)):
             return viewModel1 == viewModel2
         case (let .inventory(viewModel1), let .inventory(viewModel2)):
+            return viewModel1 == viewModel2
+        case (let .briefDescription(viewModel1), let .briefDescription(viewModel2)):
             return viewModel1 == viewModel2
         default:
             return false

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -201,6 +201,10 @@ extension ProductFormViewController: UITableViewDelegate {
             case .inventory:
                 ServiceLocator.analytics.track(.productDetailViewInventorySettingsTapped)
                 editInventorySettings()
+            case .briefDescription:
+                // TODO-1879: Edit Products M2 analytics
+                editBriefDescription()
+                break
             }
         }
     }
@@ -423,6 +427,30 @@ private extension ProductFormViewController {
                                                                stockQuantity: data.stockQuantity,
                                                                backordersSetting: data.backordersSetting,
                                                                stockStatus: data.stockStatus)
+    }
+}
+
+// MARK: Action - Edit Product Brief Description (Short Description)
+//
+private extension ProductFormViewController {
+    func editBriefDescription() {
+        let editorViewController = EditorFactory().productBriefDescriptionEditor(product: product) { [weak self] content in
+            self?.onEditBriefDescriptionCompletion(newBriefDescription: content)
+        }
+        navigationController?.pushViewController(editorViewController, animated: true)
+    }
+
+    func onEditBriefDescriptionCompletion(newBriefDescription: String) {
+        defer {
+            navigationController?.popViewController(animated: true)
+        }
+        let hasChangedData = newBriefDescription != product.briefDescription
+        // TODO-1879: Edit Products M2 analytics
+
+        guard hasChangedData else {
+            return
+        }
+        self.product = productUpdater.briefDescriptionUpdated(briefDescription: newBriefDescription)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -152,6 +152,8 @@
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
 		029D444E22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */; };
+		02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */; };
+		02A275C823FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
 		02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */; };
@@ -813,6 +815,8 @@
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
 		029D444D22F141CD00DEFA8A /* DashboardStatsV3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsV3ViewController.swift; sourceTree = "<group>"; };
+		02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureFlagService.swift; sourceTree = "<group>"; };
+		02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultProductFormTableViewModel+EditProductsM2Tests.swift"; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
 		02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SystemColors.swift"; sourceTree = "<group>"; };
@@ -1381,6 +1385,7 @@
 			isa = PBXGroup;
 			children = (
 				020B2F9823BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift */,
+				02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -1913,6 +1918,7 @@
 				B509FED421C052D1000076A9 /* MockupSupportManager.swift */,
 				B555531221B57E8800449E71 /* MockupUserNotificationsCenterAdapter.swift */,
 				02404EE32315151400FF1170 /* MockupStatsVersionStoresManager.swift */,
+				02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */,
 			);
 			path = Mockups;
 			sourceTree = "<group>";
@@ -3884,6 +3890,7 @@
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,
 				02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */,
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
+				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,
 				453904F523BB8BD5007C4956 /* ProductTaxClassListSelectorDataSourceTests.swift in Sources */,
@@ -3910,6 +3917,7 @@
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,
 				CE50345A21B1F8F7007573C6 /* ZendeskManagerTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,
+				02A275C823FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,
 				CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -18,6 +18,10 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.bellImage)
     }
 
+    func testBriefDescriptionImageIconIsNotNil() {
+        XCTAssertNotNil(UIImage.briefDescriptionImage)
+    }
+
     func testCameraIconIsNotNil() {
         XCTAssertNotNil(UIImage.cameraImage)
     }

--- a/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
@@ -1,0 +1,23 @@
+@testable import WooCommerce
+
+struct MockFeatureFlagService: FeatureFlagService {
+    private let isProductListFeatureOn: Bool
+    private let isEditProductsRelease2On: Bool
+
+    init(isProductListFeatureOn: Bool = true,
+         isEditProductsRelease2On: Bool = false) {
+        self.isProductListFeatureOn = isProductListFeatureOn
+        self.isEditProductsRelease2On = isEditProductsRelease2On
+    }
+
+    func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
+        switch featureFlag {
+        case .productList:
+            return isProductListFeatureOn
+        case .editProductsRelease2:
+            return isEditProductsRelease2On
+        default:
+            return false
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests+ProductListFeatureFlag.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests+ProductListFeatureFlag.swift
@@ -54,20 +54,3 @@ class MainTabBarControllerTests: XCTestCase {
     }
 
 }
-
-private struct MockFeatureFlagService: FeatureFlagService {
-    var isProductListFeatureOn: Bool = false
-
-    init(isProductListFeatureOn: Bool) {
-        self.isProductListFeatureOn = isProductListFeatureOn
-    }
-
-    func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
-        switch featureFlag {
-        case .productList:
-            return isProductListFeatureOn
-        default:
-            return false
-        }
-    }
-}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM2Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM2Tests.swift
@@ -3,8 +3,12 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-final class DefaultProductFormTableViewModelTests: XCTestCase {
-    private let mockFeatureFlagService = MockFeatureFlagService(isEditProductsRelease2On: false)
+/// The same tests as `DefaultProductFormTableViewModelTests`, but with Edit Products M2 feature flag on.
+/// When we fully launch Edit Products M2, we can replace `DefaultProductFormTableViewModelTests` with the test cases here.
+///
+final class DefaultProductFormTableViewModel_EditProductsM2Tests: XCTestCase {
+
+    private let mockFeatureFlagService = MockFeatureFlagService(isEditProductsRelease2On: true)
 
     func testViewModelForSimplePhysicalProductWithoutImagesWhenM2FeatureFlagIsOff() {
         let product = MockProduct().product(downloadable: false,
@@ -15,6 +19,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                          currency: "$",
                                                          featureFlagService: mockFeatureFlagService)
         let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
             .name(name: product.name),
             .description(description: product.trimmedFullDescription)
         ])
@@ -23,7 +28,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let settingFieldsSection = viewModel.sections[1]
         switch settingFieldsSection {
         case .settings(let rows):
-            XCTAssertEqual(rows.count, 3)
+            XCTAssertEqual(rows.count, 4)
 
             if case .price(_) = rows[0] {} else {
                 XCTFail("Unexpected setting section: \(rows[0])")
@@ -32,6 +37,9 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                 XCTFail("Unexpected setting section: \(rows[1])")
             }
             if case .inventory(_) = rows[2] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .briefDescription(_) = rows[3] {} else {
                 XCTFail("Unexpected setting section: \(rows[1])")
             }
         default:
@@ -58,12 +66,15 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let settingFieldsSection = viewModel.sections[1]
         switch settingFieldsSection {
         case .settings(let rows):
-            XCTAssertEqual(rows.count, 2)
+            XCTAssertEqual(rows.count, 3)
 
             if case .price(_) = rows[0] {} else {
                 XCTFail("Unexpected setting section: \(rows[0])")
             }
             if case .inventory(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .briefDescription(_) = rows[2] {} else {
                 XCTFail("Unexpected setting section: \(rows[1])")
             }
         default:
@@ -79,6 +90,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                          currency: "$",
                                                          featureFlagService: mockFeatureFlagService)
         let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
             .name(name: product.name),
             .description(description: product.trimmedFullDescription)
         ])
@@ -87,11 +99,14 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let settingFieldsSection = viewModel.sections[1]
         switch settingFieldsSection {
         case .settings(let rows):
-            XCTAssertEqual(rows.count, 2)
+            XCTAssertEqual(rows.count, 3)
             if case .price(_) = rows[0] {} else {
                 XCTFail("Unexpected setting section: \(rows[0])")
             }
             if case .inventory(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .briefDescription(_) = rows[2] {} else {
                 XCTFail("Unexpected setting section: \(rows[1])")
             }
         default:
@@ -108,6 +123,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                          currency: "$",
                                                          featureFlagService: mockFeatureFlagService)
         let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
             .name(name: product.name),
             .description(description: product.trimmedFullDescription)
         ])
@@ -116,11 +132,14 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let settingFieldsSection = viewModel.sections[1]
         switch settingFieldsSection {
         case .settings(let rows):
-            XCTAssertEqual(rows.count, 2)
+            XCTAssertEqual(rows.count, 3)
             if case .price(_) = rows[0] {} else {
                 XCTFail("Unexpected setting section: \(rows[0])")
             }
             if case .inventory(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .briefDescription(_) = rows[2] {} else {
                 XCTFail("Unexpected setting section: \(rows[1])")
             }
         default:
@@ -129,7 +148,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
     }
 }
 
-private extension DefaultProductFormTableViewModelTests {
+private extension DefaultProductFormTableViewModel_EditProductsM2Tests {
     func sampleImages() -> [ProductImage] {
         let image1 = ProductImage(imageID: 19,
                                   dateCreated: Date(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -11,11 +11,18 @@ class Product_ProductFormTests: XCTestCase {
         let expectedDescription = "This is the party room!"
         XCTAssertEqual(product.trimmedFullDescription, expectedDescription)
     }
+
+    func testTrimmedBriefDescriptionWithLeadingNewLinesAndHTMLTags() {
+        let description = "\n\n\n  <p>This is the party room!</p>\n"
+        let product = sampleProduct(briefDescription: description)
+        let expectedDescription = "This is the party room!"
+        XCTAssertEqual(product.trimmedBriefDescription, expectedDescription)
+    }
 }
 
 private extension Product_ProductFormTests {
 
-    func sampleProduct(description: String?) -> Product {
+    func sampleProduct(description: String? = "", briefDescription: String? = "") -> Product {
         return Product(siteID: 109,
                        productID: 177,
                        name: "Book the Green Room",
@@ -30,12 +37,7 @@ private extension Product_ProductFormTests {
                        featured: false,
                        catalogVisibilityKey: "visible",
                        fullDescription: description,
-                       briefDescription: """
-                       [contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. \
-                       We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us \
-                       know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests \
-                       for $100.</p>\n
-                       """,
+                       briefDescription: briefDescription,
                        sku: "",
                        price: "0",
                        regularPrice: "",

--- a/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
+++ b/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
@@ -17,6 +17,7 @@ public protocol ProductUpdater {
                                   backordersSetting: ProductBackordersSetting?,
                                   stockStatus: ProductStockStatus?) -> Product
     func imagesUpdated(images: [ProductImage]) -> Product
+    func briefDescriptionUpdated(briefDescription: String) -> Product
 }
 
 extension Product: ProductUpdater {
@@ -346,6 +347,69 @@ extension Product: ProductUpdater {
     }
 
     public func imagesUpdated(images: [ProductImage]) -> Product {
+        return Product(siteID: siteID,
+                       productID: productID,
+                       name: name,
+                       slug: slug,
+                       permalink: permalink,
+                       dateCreated: dateCreated,
+                       dateModified: dateModified,
+                       dateOnSaleStart: dateOnSaleStart,
+                       dateOnSaleEnd: dateOnSaleEnd,
+                       productTypeKey: productTypeKey,
+                       statusKey: statusKey,
+                       featured: featured,
+                       catalogVisibilityKey: catalogVisibilityKey,
+                       fullDescription: fullDescription,
+                       briefDescription: briefDescription,
+                       sku: sku,
+                       price: price,
+                       regularPrice: regularPrice,
+                       salePrice: salePrice,
+                       onSale: onSale,
+                       purchasable: purchasable,
+                       totalSales: totalSales,
+                       virtual: virtual,
+                       downloadable: downloadable,
+                       downloads: downloads,
+                       downloadLimit: downloadLimit,
+                       downloadExpiry: downloadExpiry,
+                       externalURL: externalURL,
+                       taxStatusKey: taxStatusKey,
+                       taxClass: taxClass,
+                       manageStock: manageStock,
+                       stockQuantity: stockQuantity,
+                       stockStatusKey: stockStatusKey,
+                       backordersKey: backordersKey,
+                       backordersAllowed: backordersAllowed,
+                       backordered: backordered,
+                       soldIndividually: soldIndividually,
+                       weight: weight,
+                       dimensions: dimensions,
+                       shippingRequired: shippingRequired,
+                       shippingTaxable: shippingTaxable,
+                       shippingClass: shippingClass,
+                       shippingClassID: shippingClassID,
+                       productShippingClass: productShippingClass,
+                       reviewsAllowed: reviewsAllowed,
+                       averageRating: averageRating,
+                       ratingCount: ratingCount,
+                       relatedIDs: relatedIDs,
+                       upsellIDs: upsellIDs,
+                       crossSellIDs: crossSellIDs,
+                       parentID: parentID,
+                       purchaseNote: purchaseNote,
+                       categories: categories,
+                       tags: tags,
+                       images: images,
+                       attributes: attributes,
+                       defaultAttributes: defaultAttributes,
+                       variations: variations,
+                       groupedProducts: groupedProducts,
+                       menuOrder: menuOrder)
+    }
+
+    public func briefDescriptionUpdated(briefDescription: String) -> Product {
         return Product(siteID: siteID,
                        productID: productID,
                        name: name,

--- a/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
+++ b/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
@@ -105,6 +105,15 @@ final class Product_UpdaterTestCases: XCTestCase {
         // Images.
         XCTAssertEqual(updatedProduct.images, newImages)
     }
+
+    func testUpdatingBriefDescription() {
+        let product = sampleProduct()
+        let newBriefDescription = "<p> deal of the day! </p>"
+        let updatedProduct = product.briefDescriptionUpdated(briefDescription: newBriefDescription)
+        XCTAssertEqual(updatedProduct.briefDescription, newBriefDescription)
+        XCTAssertEqual(updatedProduct.fullDescription, product.fullDescription)
+        XCTAssertEqual(updatedProduct.name, product.name)
+    }
 }
 
 // MARK: - Private Helpers


### PR DESCRIPTION
Fixes #1831 

## Changes

- In Networking layer, encoded `briefDescription` field
- Added a `UIImage` icon `briefDescriptionImage` + test case in `IconsTests`
- In `EditorFactory`, created an editor factory method for editing Product brief description
- In `DefaultProductFormTableViewModel` where we set up the sections and rows for Product Form UI, DI'ed `FeatureFlagService` for a flag that indicates whether Edit Products M2 flag is on
  - Added configuration for the brief description row
  - Showed the brief description row if Edit Products M2 flag is on
  - Used `trimmedBriefDescription` to trim HTML tags for brief description data for this row
- In `ProductFormViewController`, handled the edit brief description action by navigating to the Aztec editor
- Added unit tests

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "Short description" row
- Tap "<" in the navigation bar --> should navigate back to the Edit Product screen
- Tap on the "Short description" row
- Enter some content that is different from before
- Tap "<" in the navigation bar --> should see an action sheet about whether to discard the changes
- Tap "Cancel" on the action sheet
- Tap "Done" in the navigation bar --> should navigate back to the Edit Product screen, and the short description updated
- Tap "Update"  in the navigation bar --> after the remote update is complete, check on the website to see if the short description is updated

## Example screenshots

no short description yet | edit short description | short description updated
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2020-02-20 at 20 30 37](https://user-images.githubusercontent.com/1945542/74998268-4acb8900-5493-11ea-907b-dc2c0e9ab41a.png) | ![Simulator Screen Shot - iPhone 11 - 2020-02-20 at 20 30 45](https://user-images.githubusercontent.com/1945542/74998277-4ef7a680-5493-11ea-9252-121994dd350d.png) | ![Simulator Screen Shot - iPhone 11 - 2020-02-20 at 20 30 50](https://user-images.githubusercontent.com/1945542/74998281-4f903d00-5493-11ea-86c6-c0c854904361.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
