### PR TITLE
Image Upload: keep the spinner animating after backgrounding the app

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/CircleSpinnerView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/CircleSpinnerView.swift
@@ -57,7 +57,13 @@ final class CircleSpinnerView: UIView {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
+
+        guard window != nil else {
+            return
+        }
+
         animate()
+        startListeningToNotifications()
     }
 
     // MARK: Public interface
@@ -86,6 +92,19 @@ private extension CircleSpinnerView {
         layer.fillColor = nil
         layer.lineWidth = Constants.lineWidth
         layer.strokeEnd = Constants.strokeEnd
+    }
+}
+
+// MARK: Notifications
+//
+private extension CircleSpinnerView {
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(onAppDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    @objc func onAppDidBecomeActive() {
+        animate()
     }
 }
 


### PR DESCRIPTION
"The spinner stops after backgrounding the app" part for #1713 

## Changes

- In `CircleSpinnerView`, listened for `UIApplication.didBecomeActiveNotification` to keep the spinner animating

## Testing

Note: feel free to disable the image upload action so that the spinner stays for the whole time (e.g. return early here https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesService.swift#L14)

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera --> there should be a spinner cell after picking a photo
- Background the app and come back --> the spinner should keep spinning (vs. the spinner stops before this PR)

## Example screenshot

<img src="https://user-images.githubusercontent.com/1945542/75013689-bcb9c780-54bf-11ea-828c-e0cb1db1e0f6.png" width="320" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
