### PR TITLE
Upload dSYMs to Sentry for installable builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -289,6 +289,15 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       notify_testers: false 
     )
 
+    # Install SentryCLI prior to trying to upload dSYMs
+    sh("curl -sL https://sentry.io/get-cli/ | bash")
+
+    sentry_upload_dsym(
+      auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
+      org_slug: 'a8c',
+      project_slug: 'woocommerce-ios',
+      dsym_path: "./build/WooCommerce.app.dSYM.zip",
+    )
 
     download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]
     UI.message("Successfully built and uploaded installable build here: #{download_url}")


### PR DESCRIPTION
This PR adds support for uploading dSYMs to Sentry as part of an installable build.

**To Test**

- In this PR, I've already generated an installable build. In [the CI log](https://circleci.com/gh/woocommerce/woocommerce-ios/6380?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link), under the `Build` phase, you can verify that the symbols were uploading by searching for `Starting sentry-cli` in the log. You can choose a file UUID at random, and search for it in the [Sentry debug file list](https://sentry.io/settings/a8c/projects/woocommerce-ios/debug-symbols/). It will be present in the list.
- If you'd like to be extra-sure this works, you can create your own branch from this one, open a PR, and run the installable build action yourself. Following the steps above will provide confirmation!