### PR TITLE
Edit Products M1: update WIP banner message & experimental features copy

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -181,9 +181,16 @@ private extension BetaFeaturesViewController {
     func configureProductsSwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
 
-        let statsVersionTitle = NSLocalizedString("Products",
-                                                  comment: "My Store > Settings > Experimental features > Switch Products")
-        cell.title = statsVersionTitle
+        let title: String
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts) {
+            title = NSLocalizedString("Product editing",
+                                      comment: "My Store > Settings > Experimental features > Product editing")
+        } else {
+            title = NSLocalizedString("Products",
+                                      comment: "My Store > Settings > Experimental features > Switch Products")
+        }
+
+        cell.title = title
 
         let action = AppSettingsAction.loadProductsVisibility() { isVisible in
             cell.isOn = isVisible
@@ -202,8 +209,16 @@ private extension BetaFeaturesViewController {
 
     func configureProductsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
-        cell.textLabel?.text = NSLocalizedString("Test out the new products section as we get ready to launch",
-                                                 comment: "My Store > Settings > Experimental features > Products description")
+
+        let description: String
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts) {
+            description = NSLocalizedString("Test out the new product editing functionality as we get ready to launch",
+                                            comment: "My Store > Settings > Experimental features > Product editing")
+        } else {
+            description = NSLocalizedString("Test out the new products section as we get ready to launch",
+                                            comment: "My Store > Settings > Experimental features > Switch Products")
+        }
+        cell.textLabel?.text = description
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -229,10 +229,21 @@ private extension ProductsViewController {
     }
 
     func createTopBannerView() -> TopBannerView {
-        let title = NSLocalizedString("Work in progress!",
+        let title: String
+        let infoText: String
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts) {
+            title = NSLocalizedString("Limited editing available",
                                       comment: "The title of the Work In Progress top banner on the Products tab")
-        let infoText = NSLocalizedString("We’re hard at work on this new Products section, so you may see some changes as we get ready for launch 🚀",
+            infoText = NSLocalizedString("We’ve added editing functionality to simple products. Keep an eye out for editing on other product types soon",
                                          comment: "The info of the Work In Progress top banner on the Products tab")
+        } else {
+            title = NSLocalizedString("Work in progress!",
+                                      comment: "The title of the Work In Progress top banner on the Products tab")
+            infoText = NSLocalizedString("We’re hard at work on this new Products section, so you may see some changes as we get ready for launch 🚀",
+                                         comment: "The info of the Work In Progress top banner on the Products tab")
+        }
+
         let viewModel = TopBannerViewModel(title: title,
                                            infoText: infoText,
                                            icon: .workInProgressBanner) { [weak self] in


### PR DESCRIPTION
Fixes #1678 

## Changes

Depending on whether the Edit Products feature flag is on:
- Updated the copy in Settings > Experimental Features > Products
- Updated title and message in the Products tab WIP banner

## Example screenshots

screen | Edit Products feature on | Edit Products feature off
-- | -- | --
Settings > Experimental Features | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-24 at 13 03 21](https://user-images.githubusercontent.com/1945542/75130006-f3355380-5706-11ea-92bd-a9bed5ae5f52.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-24 at 13 08 03](https://user-images.githubusercontent.com/1945542/75130013-fa5c6180-5706-11ea-90a6-1414b770d154.png)
Products tab WIP banner | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-24 at 13 04 51](https://user-images.githubusercontent.com/1945542/75130009-f8929e00-5706-11ea-8f0e-e52b82d548e8.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-02-24 at 13 08 06](https://user-images.githubusercontent.com/1945542/75130014-faf4f800-5706-11ea-8f7d-813713097ca9.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
