### PR TITLE
WP media library: Networking & Yosemite layers

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
 		02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
 		02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */; };
+		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		450106852399A7CB00E24722 /* TaxClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106842399A7CB00E24722 /* TaxClass.swift */; };
 		4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068E2399B19500E24722 /* TaxClassRemote.swift */; };
@@ -345,6 +346,7 @@
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
 		02BDB83423EA98C800BCC63E /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLTests.swift"; sourceTree = "<group>"; };
+		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
 		450106842399A7CB00E24722 /* TaxClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClass.swift; sourceTree = "<group>"; };
 		4501068E2399B19500E24722 /* TaxClassRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemote.swift; sourceTree = "<group>"; };
 		450106902399B2C800E24722 /* TaxClassListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapper.swift; sourceTree = "<group>"; };
@@ -947,6 +949,7 @@
 				B524194621AC643900D6FC0A /* device-settings.json */,
 				B505F6D420BEE4E600BB1B69 /* me.json */,
 				93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */,
+				02F096C12406691100C0C1D5 /* media-library.json */,
 				020D07C123D858BB00FD9580 /* media-upload.json */,
 				B58D10C92114D22E00107ED4 /* new-order-note.json */,
 				022902D322E2436400059692 /* no_stats_permission_error.json */,
@@ -1371,6 +1374,7 @@
 				020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */,
 				457FC68C2382B2FD00B41B02 /* product-update.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,
+				02F096C22406691100C0C1D5 /* media-library.json in Resources */,
 				74159628224D63CE003C21CF /* settings-product-alt.json in Resources */,
 				020D07C223D858BB00FD9580 /* media-upload.json in Resources */,
 				74ABA1CA213F19FE00FFAD30 /* top-performers-year.json in Resources */,

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -4,6 +4,7 @@ import Foundation
 ///
 public class MediaRemote: Remote {
     /// Loads an array of media from the site's WP Media Library.
+    /// API reference: https://developer.wordpress.com/docs/api/1.2/get/sites/%24site/media/
     ///
     /// - Parameters:
     ///   - siteID: Site for which we'll load the media from.
@@ -16,11 +17,11 @@ public class MediaRemote: Remote {
                                  pageFirstIndex: Int = Constants.pageFirstIndex,
                                  pageNumber: Int = Constants.pageFirstIndex,
                                  pageSize: Int = 25,
-                                 context: String? = nil,
+                                 context: String = Default.context,
                                  completion: @escaping (_ mediaItems: [Media]?, _ error: Error?) -> Void) {
         let parameters: [String: Any] = [
-            ParameterKey.contextKey: context ?? Default.context,
-            ParameterKey.perPage: pageSize,
+            ParameterKey.contextKey: context,
+            ParameterKey.pageSize: pageSize,
             ParameterKey.pageNumber: pageNumber - pageFirstIndex + Constants.pageFirstIndex,
             ParameterKey.fields: "ID,date,URL,thumbnails,title,alt,extension,mime_type",
             ParameterKey.mimeType: "image"
@@ -54,7 +55,7 @@ public class MediaRemote: Remote {
         ]
 
         let path = "sites/\(siteID)/media/new"
-        let request = DotcomRequest(wordpressApiVersion: .mark1_1,
+        let request = DotcomRequest(wordpressApiVersion: .mark1_2,
                                     method: .post,
                                     path: path,
                                     parameters: parameters)
@@ -85,7 +86,7 @@ public extension MediaRemote {
 
     private enum ParameterKey {
         static let pageNumber: String = "page"
-        static let perPage: String    = "number"
+        static let pageSize: String   = "number"
         static let fields: String     = "fields"
         static let mimeType: String   = "mime_type"
         static let contextKey: String = "context"

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -3,6 +3,39 @@ import Foundation
 /// Media: Remote Endpoints
 ///
 public class MediaRemote: Remote {
+    /// Loads an array of media from the site's WP Media Library.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll load the media from.
+    ///   - pageFirstIndex: The index of the first page from the caller's perspective.
+    ///   - pageNumber: The index of the page of media data to load from.
+    ///   - pageSize: The number of media items to return.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadMediaLibrary(for siteID: Int64,
+                                 pageFirstIndex: Int = Constants.pageFirstIndex,
+                                 pageNumber: Int = Constants.pageFirstIndex,
+                                 pageSize: Int = 25,
+                                 context: String? = nil,
+                                 completion: @escaping (_ mediaItems: [Media]?, _ error: Error?) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKey.contextKey: context ?? Default.context,
+            ParameterKey.perPage: pageSize,
+            ParameterKey.pageNumber: pageNumber - pageFirstIndex + Constants.pageFirstIndex,
+            ParameterKey.fields: "ID,date,URL,thumbnails,title,alt,extension,mime_type",
+            ParameterKey.mimeType: "image"
+        ]
+
+        let path = "sites/\(siteID)/media"
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1,
+                                    method: .get,
+                                    path: path,
+                                    parameters: parameters)
+        let mapper = MediaListMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+
     /// Uploads an array of media in the local file system.
     ///
     /// - Parameters:
@@ -46,7 +79,15 @@ public extension MediaRemote {
         public static let context: String = "display"
     }
 
+    enum Constants {
+        public static let pageFirstIndex = 1
+    }
+
     private enum ParameterKey {
+        static let pageNumber: String = "page"
+        static let perPage: String    = "number"
+        static let fields: String     = "fields"
+        static let mimeType: String   = "mime_type"
         static let contextKey: String = "context"
     }
 }

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -7,7 +7,7 @@ public class MediaRemote: Remote {
     ///
     /// - Parameters:
     ///   - siteID: Site for which we'll load the media from.
-    ///   - pageFirstIndex: The index of the first page from the caller's perspective.
+    ///   - pageFirstIndex: The index of the first page from the caller's perspective, which `pageNumber` is based on.
     ///   - pageNumber: The index of the page of media data to load from.
     ///   - pageSize: The number of media items to return.
     ///   - completion: Closure to be executed upon completion.

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -8,21 +8,19 @@ public class MediaRemote: Remote {
     ///
     /// - Parameters:
     ///   - siteID: Site for which we'll load the media from.
-    ///   - pageFirstIndex: The index of the first page from the caller's perspective, which `pageNumber` is based on.
-    ///   - pageNumber: The index of the page of media data to load from.
+    ///   - pageNumber: The index of the page of media data to load from, starting from 1.
     ///   - pageSize: The number of media items to return.
     ///   - completion: Closure to be executed upon completion.
     ///
     public func loadMediaLibrary(for siteID: Int64,
-                                 pageFirstIndex: Int = Constants.pageFirstIndex,
-                                 pageNumber: Int = Constants.pageFirstIndex,
+                                 pageNumber: Int = Default.pageNumber,
                                  pageSize: Int = 25,
                                  context: String = Default.context,
                                  completion: @escaping (_ mediaItems: [Media]?, _ error: Error?) -> Void) {
         let parameters: [String: Any] = [
             ParameterKey.contextKey: context,
             ParameterKey.pageSize: pageSize,
-            ParameterKey.pageNumber: pageNumber - pageFirstIndex + Constants.pageFirstIndex,
+            ParameterKey.pageNumber: pageNumber,
             ParameterKey.fields: "ID,date,URL,thumbnails,title,alt,extension,mime_type",
             ParameterKey.mimeType: "image"
         ]
@@ -78,10 +76,7 @@ public class MediaRemote: Remote {
 public extension MediaRemote {
     enum Default {
         public static let context: String = "display"
-    }
-
-    enum Constants {
-        public static let pageFirstIndex = 1
+        public static let pageNumber = 1
     }
 
     private enum ParameterKey {

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -17,6 +17,41 @@ final class MediaRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
+    // MARK: - Load Media From Media Library `loadMediaLibrary`
+
+    /// Verifies that `loadMediaLibrary` properly parses the `media-library` sample response.
+    ///
+    func testLoadMediaLibraryProperlyReturnsParsedMedia() {
+        let remote = MediaRemote(network: network)
+        let expectation = self.expectation(description: "Load Media Library")
+
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library")
+
+        remote.loadMediaLibrary(for: sampleSiteID) { mediaItems, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(mediaItems)
+            XCTAssertEqual(mediaItems!.count, 5)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `loadMediaLibrary` properly relays Networking Layer errors.
+    ///
+    func testLoadMediaLibraryProperlyRelaysNetwokingErrors() {
+        let remote = MediaRemote(network: network)
+        let expectation = self.expectation(description: "Load Media Library")
+
+        remote.loadMediaLibrary(for: sampleSiteID) { mediaItems, error in
+            XCTAssertNil(mediaItems)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     // MARK: - uploadMedia
 
     /// Verifies that `uploadMedia` properly parses the `media-upload` sample response.

--- a/Networking/NetworkingTests/Responses/media-library.json
+++ b/Networking/NetworkingTests/Responses/media-library.json
@@ -1,0 +1,123 @@
+{
+    "media": [
+        {
+            "ID": 2352,
+            "URL": "https://test.com/wp-content/uploads/2020/02/img_0002-8.jpeg",
+            "date": "2020-02-21T12:15:38+08:00",
+            "mime_type": "image/jpeg",
+            "extension": "jpeg",
+            "title": "DSC_0010",
+            "alt": "",
+            "thumbnails": {
+                "medium": "https://test.com/wp-content/uploads/2020/02/img_0002-8-300x199.jpeg",
+                "large": "https://test.com/wp-content/uploads/2020/02/img_0002-8-1024x680.jpeg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0002-8-150x150.jpeg",
+                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0002-8-768x510.jpeg",
+                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0002-8-1536x1020.jpeg",
+                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0002-8-2048x1361.jpeg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0002-8-350x350.jpeg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0002-8-685x455.jpeg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0002-8-100x100.jpeg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0002-8-350x350.jpeg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0002-8-685x455.jpeg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0002-8-100x100.jpeg"
+            }
+        },
+        {
+            "ID": 2351,
+            "URL": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13.jpeg",
+            "date": "2020-02-21T12:14:44+08:00",
+            "mime_type": "image/jpeg",
+            "extension": "jpeg",
+            "title": "img_0111-1",
+            "alt": "",
+            "thumbnails": {
+                "medium": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-300x225.jpeg",
+                "large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-1024x768.jpeg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-150x150.jpeg",
+                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-768x576.jpeg",
+                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-1536x1152.jpeg",
+                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-2048x1536.jpeg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-350x350.jpeg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-685x514.jpeg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-100x100.jpeg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-350x350.jpeg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-685x514.jpeg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-13-100x100.jpeg"
+            }
+        },
+        {
+            "ID": 2350,
+            "URL": "https://test.com/wp-content/uploads/2020/02/img_0005-15.jpeg",
+            "date": "2020-02-21T12:00:50+08:00",
+            "mime_type": "image/jpeg",
+            "extension": "jpeg",
+            "title": "img_0005",
+            "alt": "",
+            "thumbnails": {
+                "medium": "https://test.com/wp-content/uploads/2020/02/img_0005-15-300x200.jpeg",
+                "large": "https://test.com/wp-content/uploads/2020/02/img_0005-15-1024x683.jpeg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-15-150x150.jpeg",
+                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0005-15-768x513.jpeg",
+                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0005-15-1536x1025.jpeg",
+                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0005-15-2048x1367.jpeg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-15-350x350.jpeg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0005-15-685x457.jpeg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-15-100x100.jpeg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0005-15-350x350.jpeg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0005-15-685x457.jpeg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-15-100x100.jpeg"
+            }
+        },
+        {
+            "ID": 2349,
+            "URL": "https://test.com/wp-content/uploads/2020/02/img_0005-14.jpeg",
+            "date": "2020-02-21T11:59:53+08:00",
+            "mime_type": "image/jpeg",
+            "extension": "jpeg",
+            "title": "img_0005",
+            "alt": "",
+            "thumbnails": {
+                "medium": "https://test.com/wp-content/uploads/2020/02/img_0005-14-300x200.jpeg",
+                "large": "https://test.com/wp-content/uploads/2020/02/img_0005-14-1024x683.jpeg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-14-150x150.jpeg",
+                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0005-14-768x513.jpeg",
+                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0005-14-1536x1025.jpeg",
+                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0005-14-2048x1367.jpeg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-14-350x350.jpeg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0005-14-685x457.jpeg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-14-100x100.jpeg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0005-14-350x350.jpeg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0005-14-685x457.jpeg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0005-14-100x100.jpeg"
+            }
+        },
+        {
+            "ID": 2348,
+            "URL": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12.jpeg",
+            "date": "2020-02-21T11:58:24+08:00",
+            "mime_type": "image/jpeg",
+            "extension": "jpeg",
+            "title": "img_0111-1",
+            "alt": "",
+            "thumbnails": {
+                "medium": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-300x225.jpeg",
+                "large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-1024x768.jpeg",
+                "thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-150x150.jpeg",
+                "medium_large": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-768x576.jpeg",
+                "1536x1536": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-1536x1152.jpeg",
+                "2048x2048": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-2048x1536.jpeg",
+                "woocommerce_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-350x350.jpeg",
+                "woocommerce_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-685x514.jpeg",
+                "woocommerce_gallery_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-100x100.jpeg",
+                "shop_catalog": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-350x350.jpeg",
+                "shop_single": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-685x514.jpeg",
+                "shop_thumbnail": "https://test.com/wp-content/uploads/2020/02/img_0111-1-12-100x100.jpeg"
+            }
+        }
+    ],
+    "found": 185,
+    "meta": {
+        "next_page": "value=2020-02-21T11%3A58%3A24%2B08%3A00&id=2348"
+    }
+}

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262BF238CE80100B79588 /* StorageShippingSettingsServiceTests.swift */; };
 		02E262C2238CF74D00B79588 /* StorageShippingSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C1238CF74D00B79588 /* StorageShippingSettingsService.swift */; };
 		02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */; };
+		02F096C4240670A400C0C1D5 /* Media+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F096C3240670A400C0C1D5 /* Media+Equatable.swift */; };
 		02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054523D983F30058E6E7 /* MediaFileManager.swift */; };
 		02FF054E23D983F30058E6E7 /* MediaImageExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054623D983F30058E6E7 /* MediaImageExporter.swift */; };
 		02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054723D983F30058E6E7 /* FileManager+URL.swift */; };
@@ -53,10 +54,10 @@
 		02FF056323DE9C490058E6E7 /* MediaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056223DE9C490058E6E7 /* MediaAction.swift */; };
 		02FF056523DE9C8B0058E6E7 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056423DE9C8B0058E6E7 /* MediaStore.swift */; };
 		02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056623DEB2180058E6E7 /* MediaStoreTests.swift */; };
-		02FF056F23E04F320058E6E7 /* MockMediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */; };
 		02FF056923DECD5B0058E6E7 /* MediaImageExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056823DECD5B0058E6E7 /* MediaImageExporterTests.swift */; };
 		02FF056B23DED3670058E6E7 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 02FF056A23DED3670058E6E7 /* Media.xcassets */; };
 		02FF056D23DEDCB90058E6E7 /* MockImageSourceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */; };
+		02FF056F23E04F320058E6E7 /* MockMediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */; };
 		0E67B79585034C4DD75C8117 /* Pods_Yosemite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25501C7F936D2FD32FAF3F4 /* Pods_Yosemite.framework */; };
 		36941EA7B9242CAB1FF828BC /* Pods_YosemiteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 991BBCE6E4A92F0A028885D8 /* Pods_YosemiteTests.framework */; };
 		450106872399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */; };
@@ -232,6 +233,7 @@
 		02E262BF238CE80100B79588 /* StorageShippingSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageShippingSettingsServiceTests.swift; sourceTree = "<group>"; };
 		02E262C1238CF74D00B79588 /* StorageShippingSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageShippingSettingsService.swift; sourceTree = "<group>"; };
 		02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSOrderedSet+Array.swift"; sourceTree = "<group>"; };
+		02F096C3240670A400C0C1D5 /* Media+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+Equatable.swift"; sourceTree = "<group>"; };
 		02FF054523D983F30058E6E7 /* MediaFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManager.swift; sourceTree = "<group>"; };
 		02FF054623D983F30058E6E7 /* MediaImageExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImageExporter.swift; sourceTree = "<group>"; };
 		02FF054723D983F30058E6E7 /* FileManager+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+URL.swift"; sourceTree = "<group>"; };
@@ -249,10 +251,10 @@
 		02FF056223DE9C490058E6E7 /* MediaAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaAction.swift; sourceTree = "<group>"; };
 		02FF056423DE9C8B0058E6E7 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		02FF056623DEB2180058E6E7 /* MediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStoreTests.swift; sourceTree = "<group>"; };
-		02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaExportService.swift; sourceTree = "<group>"; };
 		02FF056823DECD5B0058E6E7 /* MediaImageExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageExporterTests.swift; sourceTree = "<group>"; };
 		02FF056A23DED3670058E6E7 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		02FF056C23DEDCB90058E6E7 /* MockImageSourceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageSourceWriter.swift; sourceTree = "<group>"; };
+		02FF056E23E04F320058E6E7 /* MockMediaExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediaExportService.swift; sourceTree = "<group>"; };
 		35381AA86D039850A916E336 /* Pods-YosemiteTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YosemiteTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-YosemiteTests/Pods-YosemiteTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		450106862399AB3F00E24722 /* TaxClass+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45010692239A6C9F00E24722 /* TaxClassStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStore.swift; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 				02FF055923D9846A0058E6E7 /* MediaFileManagerTests.swift */,
 				02FF055E23D985710058E6E7 /* URL+MediaTests.swift */,
 				02FF056823DECD5B0058E6E7 /* MediaImageExporterTests.swift */,
+				02F096C3240670A400C0C1D5 /* Media+Equatable.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -1188,6 +1191,7 @@
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,
 				45ED4F16239E939A004F1BE3 /* TaxClassStoreTests.swift in Sources */,
 				0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */,
+				02F096C4240670A400C0C1D5 /* Media+Equatable.swift in Sources */,
 				020B2F9623BDE4DD00BD79AD /* ProductStoreTests+Validation.swift in Sources */,
 				02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */,
 				B5C9DE222087FF20006B910A /* DispatcherTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -7,13 +7,11 @@ public enum MediaAction: Action {
     ///
     /// - Parameters:
     ///   - siteID: Site for which we'll load the media from.
-    ///   - pageFirstIndex: The index of the first page from the caller's perspective, which `pageNumber` is based on.
-    ///   - pageNumber: The index of the page of media data to load from.
+    ///   - pageNumber: The index of the page of media data to load from, starting from 1.
     ///   - pageSize: The maximum number of media items to return per page.
     ///   - onCompletion: Closure to be executed upon completion.
     ///
     case retrieveMediaLibrary(siteID: Int64,
-        pageFirstIndex: Int,
         pageNumber: Int,
         pageSize: Int,
         onCompletion: (_ mediaItems: [Media], _ error: Error?) -> Void)

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -5,6 +5,13 @@ import Foundation
 public enum MediaAction: Action {
     /// Retrieves media from the site's WP Media Library.
     ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll load the media from.
+    ///   - pageFirstIndex: The index of the first page from the caller's perspective, which `pageNumber` is based on.
+    ///   - pageNumber: The index of the page of media data to load from.
+    ///   - pageSize: The maximum number of media items to return per page.
+    ///   - onCompletion: Closure to be executed upon completion.
+    ///
     case retrieveMediaLibrary(siteID: Int64,
         pageFirstIndex: Int,
         pageNumber: Int,

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -3,6 +3,14 @@ import Foundation
 // MARK: - MediaAction: Defines media operations (supported by the MediaStore).
 //
 public enum MediaAction: Action {
+    /// Retrieves media from the site's WP Media Library.
+    ///
+    case retrieveMediaLibrary(siteID: Int64,
+        pageFirstIndex: Int,
+        pageNumber: Int,
+        pageSize: Int,
+        onCompletion: (_ mediaItems: [Media], _ error: Error?) -> Void)
+
     /// Uploads an exportable media asset to the site's WP Media Library.
     ///
     case uploadMedia(siteID: Int64, mediaAsset: ExportableAsset, onCompletion: (_ uploadedMedia: Media?, _ error: Error?) -> Void)

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -34,8 +34,8 @@ public final class MediaStore: Store {
         }
 
         switch action {
-        case .retrieveMediaLibrary(let siteID, let pageFirstIndex, let pageNumber, let pageSize, let onCompletion):
-            retrieveMediaLibrary(siteID: siteID, pageFirstIndex: pageFirstIndex, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .retrieveMediaLibrary(let siteID, let pageNumber, let pageSize, let onCompletion):
+            retrieveMediaLibrary(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .uploadMedia(let siteID, let mediaAsset, let onCompletion):
             uploadMedia(siteID: siteID, mediaAsset: mediaAsset, onCompletion: onCompletion)
         }
@@ -44,13 +44,11 @@ public final class MediaStore: Store {
 
 private extension MediaStore {
     func retrieveMediaLibrary(siteID: Int64,
-                              pageFirstIndex: Int,
                               pageNumber: Int,
                               pageSize: Int,
                               onCompletion: @escaping (_ mediaItems: [Media], _ error: Error?) -> Void) {
         let remote = MediaRemote(network: network)
         remote.loadMediaLibrary(for: siteID,
-                                pageFirstIndex: pageFirstIndex,
                                 pageNumber: pageNumber,
                                 pageSize: pageSize) { (mediaItems, error) in
                                     onCompletion(mediaItems ?? [], error)

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -53,11 +53,7 @@ private extension MediaStore {
                                 pageFirstIndex: pageFirstIndex,
                                 pageNumber: pageNumber,
                                 pageSize: pageSize) { (mediaItems, error) in
-                                    guard let mediaItems = mediaItems, error == nil else {
-                                        onCompletion([], error)
-                                        return
-                                    }
-                                    onCompletion(mediaItems, nil)
+                                    onCompletion(mediaItems ?? [], error)
         }
     }
 

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -34,6 +34,8 @@ public final class MediaStore: Store {
         }
 
         switch action {
+        case .retrieveMediaLibrary(let siteID, let pageFirstIndex, let pageNumber, let pageSize, let onCompletion):
+            retrieveMediaLibrary(siteID: siteID, pageFirstIndex: pageFirstIndex, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .uploadMedia(let siteID, let mediaAsset, let onCompletion):
             uploadMedia(siteID: siteID, mediaAsset: mediaAsset, onCompletion: onCompletion)
         }
@@ -41,6 +43,24 @@ public final class MediaStore: Store {
 }
 
 private extension MediaStore {
+    func retrieveMediaLibrary(siteID: Int64,
+                              pageFirstIndex: Int,
+                              pageNumber: Int,
+                              pageSize: Int,
+                              onCompletion: @escaping (_ mediaItems: [Media], _ error: Error?) -> Void) {
+        let remote = MediaRemote(network: network)
+        remote.loadMediaLibrary(for: siteID,
+                                pageFirstIndex: pageFirstIndex,
+                                pageNumber: pageNumber,
+                                pageSize: pageSize) { (mediaItems, error) in
+                                    guard let mediaItems = mediaItems, error == nil else {
+                                        onCompletion([], error)
+                                        return
+                                    }
+                                    onCompletion(mediaItems, nil)
+        }
+    }
+
     /// Uploads an exportable media asset to the site's WP Media Library with 2 steps:
     /// 1) Exports the media asset to a uploadable type
     /// 2) Uploads the exported media file to the server

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -50,7 +50,6 @@ final class MediaStoreTests: XCTestCase {
                                   width: nil)
 
         let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
-                                                      pageFirstIndex: 1,
                                                       pageNumber: 1,
                                                       pageSize: 20) { mediaItems, error in
                                                         XCTAssertNil(error)
@@ -75,7 +74,6 @@ final class MediaStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "media", filename: "generic_error")
         let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
-                                                      pageFirstIndex: 1,
                                                       pageNumber: 1,
                                                       pageSize: 20) { mediaItems, error in
                                                         XCTAssertNotNil(error)
@@ -97,7 +95,6 @@ final class MediaStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve media library")
 
         let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
-                                                      pageFirstIndex: 1,
                                                       pageNumber: 1,
                                                       pageSize: 20) { mediaItems, error in
                                                         XCTAssertNotNil(error)

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -79,6 +79,8 @@ final class MediaStoreTests: XCTestCase {
                                                       pageNumber: 1,
                                                       pageSize: 20) { mediaItems, error in
                                                         XCTAssertNotNil(error)
+                                                        XCTAssertNotNil(mediaItems)
+                                                        XCTAssertTrue(mediaItems.isEmpty)
                                                         expectation.fulfill()
         }
 

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -29,6 +29,86 @@ final class MediaStoreTests: XCTestCase {
         network = MockupNetwork()
     }
 
+    // MARK: test cases for `MediaAction.retrieveMediaLibrary`
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns the expected response.
+    ///
+    func testRetrieveMediaLibraryUponSuccessfulResponse() {
+        let expectation = self.expectation(description: "Retrieve media library")
+
+        network.simulateResponse(requestUrlSuffix: "media", filename: "media-library")
+
+        let expectedMedia = Media(mediaID: 2352,
+                                  date: date(with: "2020-02-21T12:15:38+08:00"),
+                                  fileExtension: "jpeg",
+                                  mimeType: "image/jpeg",
+                                  src: "https://test.com/wp-content/uploads/2020/02/img_0002-8.jpeg",
+                                  thumbnailURL: "https://test.com/wp-content/uploads/2020/02/img_0002-8-150x150.jpeg",
+                                  name: "DSC_0010",
+                                  alt: "",
+                                  height: nil,
+                                  width: nil)
+
+        let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
+                                                      pageFirstIndex: 1,
+                                                      pageNumber: 1,
+                                                      pageSize: 20) { mediaItems, error in
+                                                        XCTAssertNil(error)
+                                                        XCTAssertEqual(mediaItems.count, 5)
+                                                        XCTAssertEqual(mediaItems.first, expectedMedia)
+
+
+                                                        expectation.fulfill()
+        }
+
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+        mediaStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is an error response from the backend.
+    ///
+    func testRetrieveMediaLibraryReturnsErrorUponReponseError() {
+        let expectation = self.expectation(description: "Retrieve media library")
+
+        network.simulateResponse(requestUrlSuffix: "media", filename: "generic_error")
+        let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
+                                                      pageFirstIndex: 1,
+                                                      pageNumber: 1,
+                                                      pageSize: 20) { mediaItems, error in
+                                                        XCTAssertNotNil(error)
+                                                        expectation.fulfill()
+        }
+
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+        mediaStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    /// Verifies that `MediaAction.retrieveMediaLibrary` returns an error whenever there is no backend response.
+    ///
+    func testRetrieveMediaLibraryReturnsErrorUponEmptyResponse() {
+        let expectation = self.expectation(description: "Retrieve media library")
+
+        let action = MediaAction.retrieveMediaLibrary(siteID: sampleSiteID,
+                                                      pageFirstIndex: 1,
+                                                      pageNumber: 1,
+                                                      pageSize: 20) { mediaItems, error in
+                                                        XCTAssertNotNil(error)
+                                                        expectation.fulfill()
+        }
+
+        let mediaStore = MediaStore(dispatcher: dispatcher,
+                                    storageManager: storageManager,
+                                    network: network)
+        mediaStore.onAction(action)
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
     // MARK: test cases for `MediaAction.uploadMedia`
 
     func testUploadingMedia() {
@@ -125,5 +205,12 @@ private extension MediaStoreTests {
         return UploadableMedia(localURL: targetURL,
                                filename: "test.jpg",
                                mimeType: "image/jpeg")
+    }
+
+    func date(with dateString: String) -> Date {
+        guard let date = DateFormatter.Defaults.iso8601.date(from: dateString) else {
+            return Date()
+        }
+        return date
     }
 }

--- a/Yosemite/YosemiteTests/Tools/Media/Media+Equatable.swift
+++ b/Yosemite/YosemiteTests/Tools/Media/Media+Equatable.swift
@@ -1,0 +1,18 @@
+@testable import Yosemite
+
+// MARK: - Equatable Conformance
+//
+extension Media: Equatable {
+    public static func == (lhs: Media, rhs: Media) -> Bool {
+        return lhs.mediaID == rhs.mediaID &&
+            lhs.date == rhs.date &&
+            lhs.fileExtension == rhs.fileExtension &&
+            lhs.mimeType == rhs.mimeType &&
+            lhs.src == rhs.src &&
+            lhs.thumbnailURL == rhs.thumbnailURL &&
+            lhs.name == rhs.name &&
+            lhs.alt == rhs.alt &&
+            lhs.height == rhs.height &&
+            lhs.width == rhs.width
+    }
+}


### PR DESCRIPTION
Networking & Yosemite layers for #1875 

## Changes

- In Networking layer, added `loadMediaLibrary` to `MediaRemote` to load media given a page number and page size from the site's WP media library ([API reference](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/))
  - Added unit tests with mock response `media-library.json`
- In Yosemite layer, added `retrieveMediaLibrary` to `MediaAction` to retrieve media given a page number and page size from the site's WP media library using `MediaRemote`
  - Added unit tests

## Testing

No user-facing changes yet, just CI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
