### PR TITLE
[Order List Redesign] Decrease header height

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -243,6 +243,7 @@ private extension OrdersViewController {
         tableView.tableFooterView = footerSpinnerView
         tableView.estimatedSectionHeaderHeight = Settings.estimatedHeaderHeight
         tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = .leastNonzeroMagnitude
     }
 
     /// Setup: Ghostable TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -241,6 +241,8 @@ private extension OrdersViewController {
         tableView.backgroundColor = .listBackground
         tableView.refreshControl = refreshControl
         tableView.tableFooterView = footerSpinnerView
+        tableView.estimatedSectionHeaderHeight = Settings.estimatedHeaderHeight
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
     }
 
     /// Setup: Ghostable TableView
@@ -564,15 +566,6 @@ extension OrdersViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate Conformance
 //
 extension OrdersViewController: UITableViewDelegate {
-
-    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return Settings.estimatedHeaderHeight
-    }
-
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         return estimatedRowHeights[indexPath] ?? Settings.estimatedRowHeight
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -157,7 +157,7 @@ class OrdersViewController: UIViewController {
 
         refreshResultsPredicate()
         refreshStatusPredicate()
-        registerTableViewCells()
+        registerTableViewHeadersAndCells()
 
         configureSyncingCoordinator()
         configureTableView()
@@ -265,15 +265,18 @@ private extension OrdersViewController {
         ghostableTableView.isScrollEnabled = false
     }
 
-    /// Registers all of the available TableViewCells
+    /// Registers all of the available table view cells and headers
     ///
-    func registerTableViewCells() {
+    func registerTableViewHeadersAndCells() {
         let cells = [ OrderTableViewCell.self ]
 
         for cell in cells {
             tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
             ghostableTableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
         }
+
+        let headerType = TwoColumnSectionHeaderView.self
+        tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
     }
 }
 
@@ -557,9 +560,19 @@ extension OrdersViewController: UITableViewDataSource {
         return cell
     }
 
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        let rawAge = resultsController.sections[section].name
-        return Age(rawValue: rawAge)?.description
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let reuseIdentifier = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) as? TwoColumnSectionHeaderView else {
+            return nil
+        }
+
+        header.leftText = {
+            let rawAge = resultsController.sections[section].name
+            return Age(rawValue: rawAge)?.description
+        }()
+        header.rightText = nil
+
+        return header
     }
 }
 


### PR DESCRIPTION
This fixes the section header height issue described in https://github.com/woocommerce/woocommerce-ios/pull/1851#pullrequestreview-357598719. The other design issues were fixed in #1861. 

This is targeting `develop` since the changes are not dependent on #1851.  

## Screenshots

Before | After (Light)
--------|-------
   <img width="545" alt="before" src="https://user-images.githubusercontent.com/198826/75391059-a8524200-58a6-11ea-9e29-80c25229662c.png">     |       <img width="545" alt="after" src="https://user-images.githubusercontent.com/198826/75391057-a7b9ab80-58a6-11ea-8cd7-664eb44aaa94.png">

After (Dark) | After (Large)
--------|-------
   <img width="545" alt="after-dark" src="https://user-images.githubusercontent.com/198826/75391046-a38d8e00-58a6-11ea-9c56-09e3a4c28019.png">     |       <img width="545" alt="after-large" src="https://user-images.githubusercontent.com/198826/75391055-a7211500-58a6-11ea-83fb-fe1f2a33bc8e.png">

## Solution

I used the `TwoColumnSectionHeaderView` which seems to have the correct height and is used by most parts of the app. 

## Testing

1. Navigate to Orders
2. Confirm the changes to the header above.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

