### PR TITLE
Merge 3.7 release notes into develop

### DIFF
--- a/WooCommerce/Resources/AppStoreStrings.pot
+++ b/WooCommerce/Resources/AppStoreStrings.pot
@@ -47,13 +47,10 @@ msgctxt "app_store_promo_text"
 msgid "Run your store wherever you are. The WooCommerce app makes it easy to manage orders and inventory, track sales, and monitor store activity like new orders and reviews."
 msgstr ""
 
-msgctxt "v3.6-whats-new"
+msgctxt "v3.7-whats-new"
 msgid ""
-"- You can now view refunds on an order.\n"
-"- The “orders to fulfill” badge now maxes at 99, showing 99+ for anything over 99. Previously, it was 9+.\n"
-"- Fixed a bug where long product names could make the product quantity disappear when viewing an order.\n"
-"- Product names with HTML escape characters should display correctly now.\n"
-"- If an order has multiple products, tapping on any product should open the correct product.\n"
+"- In the dashboard, tapping on a product in the “Top Performers” section opens the product detail.\n"
+"- The orders tab now localizes both item quantities and the order badge.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of a screenshot in the App Store.

--- a/WooCommerce/Resources/release_notes.txt
+++ b/WooCommerce/Resources/release_notes.txt
@@ -1,5 +1,2 @@
-- You can now view refunds on an order.
-- The “orders to fulfill” badge now maxes at 99, showing 99+ for anything over 99. Previously, it was 9+.
-- Fixed a bug where long product names could make the product quantity disappear when viewing an order.
-- Product names with HTML escape characters should display correctly now.
-- If an order has multiple products, tapping on any product should open the correct product.
+- In the dashboard, tapping on a product in the “Top Performers” section opens the product detail.
+- The orders tab now localizes both item quantities and the order badge.


### PR DESCRIPTION
Just what it says on the tin – merges the release notes to be picked up by GlotPress.