### PR TITLE
[Order List Redesign] Add border to the bottom bar

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -134,6 +134,26 @@ private extension OrdersMasterViewController {
             oldCell?.label.textColor = .textSubtle
             newCell?.label.textColor = .primary
         }
+
+        addBottomBorderToTabStripButtonBarView(buttonBarView)
+    }
+
+    /// Helper for `configureTabStrip()`.
+    ///
+    func addBottomBorderToTabStripButtonBarView(_ buttonBarView: ButtonBarView) {
+        guard let superView = buttonBarView.superview else {
+            return
+        }
+
+        let border = UIView.createBorderView()
+
+        superView.addSubview(border)
+
+        NSLayoutConstraint.activate([
+            border.topAnchor.constraint(equalTo: buttonBarView.bottomAnchor),
+            border.leadingAnchor.constraint(equalTo: buttonBarView.leadingAnchor),
+            border.trailingAnchor.constraint(equalTo: buttonBarView.trailingAnchor)
+        ])
     }
 
     enum TabStripDimensions {


### PR DESCRIPTION
Refs #956. 

This adds a border underneath the "Processing" and "All Orders" tabs. This is the last design issue to fix from #1851. 

I used the standard `UIView.createBorderView()` that we have which seems to use the separator color. 

## Changes

Before | After  | After (Dark)
--------|-------|---
  <img width="545" alt="before" src="https://user-images.githubusercontent.com/198826/75489429-6f31d480-596f-11ea-987e-6b45784ddfcd.png">      |       <img width="545" alt="after" src="https://user-images.githubusercontent.com/198826/75489425-6e993e00-596f-11ea-905f-5bd25ce91e14.png">|<img width="545" alt="after-dark" src="https://user-images.githubusercontent.com/198826/75489415-6b05b700-596f-11ea-9f9e-04a384333806.png">        | 

| After (Landscape) |
|-------|
|![image](https://user-images.githubusercontent.com/198826/75489531-a607ea80-596f-11ea-91c8-2a5e5ab0aa7a.png)|

## Testing

1. Navigate to Orders
2. Confirm the border is there.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.





 