### PR TITLE
`ColumnFlowLayout`: fix `UICollectionViewFlowLayout` warnings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
@@ -23,14 +23,14 @@ final class ColumnFlowLayout: UICollectionViewFlowLayout {
     }
 
     override func prepare() {
-        super.prepare()
-
         guard let collectionView = collectionView else { return }
         let marginsAndInsets = sectionInset.left + sectionInset.right
             + collectionView.safeAreaInsets.left + collectionView.safeAreaInsets.right
             + minimumInteritemSpacing * CGFloat(cellsPerRow - 1)
         let itemDimension = ((collectionView.bounds.size.width - marginsAndInsets) / CGFloat(cellsPerRow)).rounded(.down)
         itemSize = CGSize(width: itemDimension, height: itemDimension)
+
+        super.prepare()
     }
 
     override func invalidationContext(forBoundsChange newBounds: CGRect) -> UICollectionViewLayoutInvalidationContext {


### PR DESCRIPTION
Collection view warning part for #1713 

## Changes

More context in https://github.com/woocommerce/woocommerce-ios/pull/1714#pullrequestreview-340526979
- Moved `itemSize` calculation before `super.prepare()` to avoid collection view warning

## Testing

The collection view layout warning is reproducible on iPhone 11 Pro simulator, iOS 13.2

Prerequisite: the store has a simple Product with a few images

- Go to the Products tab
- Tap on the simple Product as in the prerequisite
- Tap on the "+" cell in the images header to edit Product images
- From portrait mode, rotate the device to landscape and then back to portrait --> there should not be warnings like below:

```
2020-02-28 17:57:26.695250+0800 WooCommerce[1641:11271964] The behavior of the UICollectionViewFlowLayout is not defined because:
2020-02-28 17:57:26.695362+0800 WooCommerce[1641:11271964] the item width must be less than the width of the UICollectionView minus the section insets left and right values, minus the content insets left and right values.
2020-02-28 17:57:26.695686+0800 WooCommerce[1641:11271964] The relevant UICollectionViewFlowLayout instance is <WooCommerce.ColumnFlowLayout: 0x7f868545f650>, and it is attached to <UICollectionView: 0x7f86811e3600; frame = (0 0; 287 670); clipsToBounds = YES; autoresize = W+H; gestureRecognizers = <NSArray: 0x600000da6d60>; animations = { position=<CABasicAnimation: 0x6000000ed080>; bounds.origin=<CABasicAnimation: 0x6000000ed620>; bounds.size=<CABasicAnimation: 0x6000000ed1c0>; }; layer = <CALayer: 0x6000001f7ca0>; contentOffset: {0, 0}; contentSize: {724, 724}; adjustedContentInset: {0, 0, 0, 0}; layout: <WooCommerce.ColumnFlowLayout: 0x7f868545f650>; dataSource: <WooCommerce.ProductImagesCollectionViewController: 0x7f8685450b70>>.
```

Note: instead of the warnings, you might see new log messages like:

```
2020-02-28 17:59:06.736629+0800 WooCommerce[2248:11277911] [Snapshotting] Snapshotting a view (0x7fb3f2075240, WooCommerce.ProductImageCollectionViewCell) that has not been rendered at least once requires afterScreenUpdates:YES.
2020-02-28 17:59:06.737339+0800 WooCommerce[2248:11277911] [Snapshotting] Snapshotting a view (0x7fb3f20763b0, WooCommerce.ProductImageCollectionViewCell) that has not been rendered at least once requires afterScreenUpdates:YES.
```

after some research, I haven't been able to find much information about these log messages and how to make them disappear. lemme know if you have any insights!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
