### PR TITLE
Make reviewer_avatar_urls optional

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */; };
 		45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ED4F11239E8C57004F1BE3 /* taxes-classes.json */; };
 		45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */; };
+		57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */ = {isa = PBXBuildFile; fileRef = 57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */; };
 		6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */; };
 		74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */; };
 		74002D6C2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */; };
@@ -357,6 +358,7 @@
 		45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapperTest.swift; sourceTree = "<group>"; };
 		45ED4F11239E8C57004F1BE3 /* taxes-classes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "taxes-classes.json"; sourceTree = "<group>"; };
 		45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemoteTests.swift; sourceTree = "<group>"; };
+		57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-missing-avatar-urls.json"; sourceTree = "<group>"; };
 		69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NetworkingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsMapperTests.swift; sourceTree = "<group>"; };
 		74002D6B2118B88200A63C19 /* SiteVisitStatsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsRemoteTests.swift; sourceTree = "<group>"; };
@@ -985,6 +987,7 @@
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
 				7412A8EF21B6E415005D182A /* report-orders.json */,
 				D88D5A40230BC5DA007B6E01 /* reviews-all.json */,
+				57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */,
 				D88D5A42230BC668007B6E01 /* reviews-single.json */,
 				74046E20217A73D0007DD7BF /* settings-general.json */,
 				7492FAE2217FBDBC00ED2C69 /* settings-general-alt.json */,
@@ -1309,6 +1312,7 @@
 				B505F6D520BEE4E700BB1B69 /* me.json in Resources */,
 				02BA23C922EEF62C009539E7 /* order-stats-v4-wcadmin-deactivated.json in Resources */,
 				743E84F422172D0A00FAC9D7 /* shipment_tracking_multiple.json in Resources */,
+				57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */,
 				74AB5B4F21AF3F0E00859C12 /* site-api-no-woo.json in Resources */,
 				D8FBFF2422D52815006E3336 /* order-stats-v4-daily.json in Resources */,
 				CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */,

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -65,16 +65,7 @@ public struct ProductReview: Decodable {
         let statusKey = try container.decode(String.self, forKey: .status)
         let reviewer = try container.decode(String.self, forKey: .reviewer)
         let reviewerEmail = try container.decode(String.self, forKey: .reviewerEmail)
-
-        let reviewerAvatarURL: String? = try {
-            guard container.contains(.avatarURLs) else {
-                return nil
-            }
-
-            let avatarURLs = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .avatarURLs)
-            return try avatarURLs.decode(String.self, forKey: .avatar96)
-        }()
-
+        let avatarURLs = try container.decodeIfPresent(ReviewerAvatarURLs.self, forKey: .avatarURLs)
         let review = try container.decode(String.self, forKey: .review)
         let rating = try container.decode(Int.self, forKey: .rating)
         let verified = try container.decode(Bool.self, forKey: .verified)
@@ -86,7 +77,7 @@ public struct ProductReview: Decodable {
                   statusKey: statusKey,
                   reviewer: reviewer,
                   reviewerEmail: reviewerEmail,
-                  reviewerAvatarURL: reviewerAvatarURL,
+                  reviewerAvatarURL: avatarURLs?.url96,
                   review: review,
                   rating: rating,
                   verified: verified)
@@ -106,12 +97,21 @@ private extension ProductReview {
         case reviewer       = "reviewer"
         case reviewerEmail  = "reviewer_email"
         case avatarURLs     = "reviewer_avatar_urls"
-        /// We are ignoring all avatars except the one marked as 96
-        /// to avoid adding an unecessary intermediate object
-        case avatar96       = "96"
         case review         = "review"
         case rating         = "rating"
         case verified       = "verified"
+    }
+
+    struct ReviewerAvatarURLs: Decodable {
+        /// The URL of the "96" key in the JSON.
+        ///
+        /// We are ignoring all avatars except the one marked as 96
+        /// to avoid adding an unecessary intermediate object
+        let url96: String?
+
+        enum CodingKeys: String, CodingKey {
+            case url96 = "96"
+        }
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -65,8 +65,16 @@ public struct ProductReview: Decodable {
         let statusKey = try container.decode(String.self, forKey: .status)
         let reviewer = try container.decode(String.self, forKey: .reviewer)
         let reviewerEmail = try container.decode(String.self, forKey: .reviewerEmail)
-        let avatarURLs = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .avatarURLs)
-        let reviewerAvatarURL = try avatarURLs.decode(String.self, forKey: .avatar96)
+
+        let reviewerAvatarURL: String? = try {
+            guard container.contains(.avatarURLs) else {
+                return nil
+            }
+
+            let avatarURLs = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .avatarURLs)
+            return try avatarURLs.decode(String.self, forKey: .avatar96)
+        }()
+
         let review = try container.decode(String.self, forKey: .review)
         let rating = try container.decode(Int.self, forKey: .rating)
         let verified = try container.decode(Bool.self, forKey: .verified)

--- a/Networking/Networking/Model/Product/ProductReview.swift
+++ b/Networking/Networking/Model/Product/ProductReview.swift
@@ -13,7 +13,7 @@ public struct ProductReview: Decodable {
 
     public let reviewer: String
     public let reviewerEmail: String
-    public let reviewerAvatarURL: String
+    public let reviewerAvatarURL: String?
 
     public let review: String
     public let rating: Int
@@ -33,7 +33,7 @@ public struct ProductReview: Decodable {
                 statusKey: String,
                 reviewer: String,
                 reviewerEmail: String,
-                reviewerAvatarURL: String,
+                reviewerAvatarURL: String?,
                 review: String,
                 rating: Int,
                 verified: Bool) {

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -59,6 +59,23 @@ final class ProductReviewsRemoteTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    /// Tests that loadAllProductReviews can handle responses with missing `reviewer_avatar_urls`.
+    ///
+    func testLoadAllCanHandleMissingReviewerAvatarURLs() {
+        let remote = ProductReviewsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Product Reviews")
+
+        network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-missing-avatar-urls")
+
+        remote.loadAllProductReviews(for: sampleSiteID) { reviews, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(reviews)
+            XCTAssertEqual(reviews?.count, 2)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
 
     // MARK: - Load single product review tests
 

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -62,19 +62,25 @@ final class ProductReviewsRemoteTests: XCTestCase {
     /// Tests that loadAllProductReviews can handle responses with missing `reviewer_avatar_urls`.
     ///
     func testLoadAllCanHandleMissingReviewerAvatarURLs() {
+        // Given
         let remote = ProductReviewsRemote(network: network)
         let expectation = self.expectation(description: "Load All Product Reviews")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-missing-avatar-urls")
 
+        // When
+        var result: (reviews: [ProductReview]?, error: Error?)
         remote.loadAllProductReviews(for: sampleSiteID) { reviews, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(reviews)
-            XCTAssertEqual(reviews?.count, 2)
+            result = (reviews, error)
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.reviews)
+        XCTAssertEqual(result.reviews?.count, 2)
     }
 
     // MARK: - Load single product review tests

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -48,6 +48,11 @@ final class ProductReviewsRemoteTests: XCTestCase {
         XCTAssertNil(result.error)
         XCTAssertNotNil(result.reviews)
         XCTAssertEqual(result.reviews?.count, 2)
+
+        // Assert proper parsing of reviewer_avatar_urls
+        result.reviews?.forEach {
+            XCTAssertNotNil($0.reviewerAvatarURL)
+        }
     }
 
     /// Verifies that loadAllProductReviews properly relays Networking Layer errors.

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -29,19 +29,25 @@ final class ProductReviewsRemoteTests: XCTestCase {
     /// Verifies that loadAllProductReviews properly parses the `reviews-all` sample response.
     ///
     func testLoadAllProductReviewsProperlyReturnsParsedProductReviews() {
+        // Given
         let remote = ProductReviewsRemote(network: network)
         let expectation = self.expectation(description: "Load All Product Reviews")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews", filename: "reviews-all")
 
+        // When
+        var result: (reviews: [ProductReview]?, error: Error?)
         remote.loadAllProductReviews(for: sampleSiteID) { reviews, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(reviews)
-            XCTAssertEqual(reviews?.count, 2)
+            result = (reviews, error)
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.reviews)
+        XCTAssertEqual(result.reviews?.count, 2)
     }
 
     /// Verifies that loadAllProductReviews properly relays Networking Layer errors.

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -8,20 +8,26 @@ final class ProductReviewsRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
-    let network = MockupNetwork()
+    private var network: MockupNetwork!
 
     /// Dummy Site ID
     ///
-    let sampleSiteID: Int64 = 1234
+    private let sampleSiteID: Int64 = 1234
 
     /// Dummy Product ID
     ///
-    let sampleReviewID: Int64 = 173
+    private let sampleReviewID: Int64 = 173
 
     /// Repeat always!
     ///
     override func setUp() {
-        network.removeAllSimulatedResponses()
+        super.setUp()
+        network = MockupNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
     }
 
     // MARK: - Load all product reviews tests

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -81,6 +81,8 @@ final class ProductReviewsRemoteTests: XCTestCase {
         XCTAssertNil(result.error)
         XCTAssertNotNil(result.reviews)
         XCTAssertEqual(result.reviews?.count, 2)
+
+        XCTAssertNil(result.reviews?.first?.reviewerAvatarURL)
     }
 
     // MARK: - Load single product review tests

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -105,7 +105,9 @@ final class ProductReviewsRemoteTests: XCTestCase {
         XCTAssertNotNil(result.reviews)
         XCTAssertEqual(result.reviews?.count, 2)
 
-        XCTAssertNil(result.reviews?.first?.reviewerAvatarURL)
+        result.reviews?.forEach {
+            XCTAssertNil($0.reviewerAvatarURL)
+        }
     }
 
     // MARK: - Load single product review tests

--- a/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift
@@ -47,16 +47,22 @@ final class ProductReviewsRemoteTests: XCTestCase {
     /// Verifies that loadAllProductReviews properly relays Networking Layer errors.
     ///
     func testLoadAllProductReviewsProperlyRelaysNetwokingErrors() {
+        // Given
         let remote = ProductReviewsRemote(network: network)
         let expectation = self.expectation(description: "Load All Product Reviews returns error")
 
+        // When
+        var result: (reviews: [ProductReview]?, error: Error?)
         remote.loadAllProductReviews(for: sampleSiteID) { reviews, error in
-            XCTAssertNil(reviews)
-            XCTAssertNotNil(error)
+            result = (reviews, error)
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.reviews)
+        XCTAssertNotNil(result.error)
     }
 
     /// Tests that loadAllProductReviews can handle responses with missing `reviewer_avatar_urls`.

--- a/Networking/NetworkingTests/Responses/reviews-missing-avatar-urls.json
+++ b/Networking/NetworkingTests/Responses/reviews-missing-avatar-urls.json
@@ -11,11 +11,6 @@
             "review": "<p>The fancy chair gets only three stars</p>\n",
             "rating": 3,
             "verified": false,
-            "reviewer_avatar_urls": {
-                "24": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=24&d=mm&r=g",
-                "48": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=48&d=mm&r=g",
-                "96": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=96&d=mm&r=g"
-            },
             "_links": {
                 "self": [
                     {

--- a/Networking/NetworkingTests/Responses/reviews-missing-avatar-urls.json
+++ b/Networking/NetworkingTests/Responses/reviews-missing-avatar-urls.json
@@ -46,11 +46,7 @@
             "review": "<p>A glowing review with a five star rating for the Colourful dress</p>\n",
             "rating": 5,
             "verified": false,
-            "reviewer_avatar_urls": {
-                "24": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=24&d=mm&r=g",
-                "48": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=48&d=mm&r=g",
-                "96": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=96&d=mm&r=g"
-            },
+            "reviewer_avatar_urls": null,
             "_links": {
                 "self": [
                     {

--- a/Networking/NetworkingTests/Responses/reviews-missing-avatar-urls.json
+++ b/Networking/NetworkingTests/Responses/reviews-missing-avatar-urls.json
@@ -1,0 +1,78 @@
+{
+    "data": [
+        {
+            "id": 173,
+            "date_created": "2019-08-20T06:06:29",
+            "date_created_gmt": "2019-08-20T06:06:29",
+            "product_id": 32,
+            "status": "approved",
+            "reviewer": "somereviewer",
+            "reviewer_email": "somewhere@intheinternet.com",
+            "review": "<p>The fancy chair gets only three stars</p>\n",
+            "rating": 3,
+            "verified": false,
+            "reviewer_avatar_urls": {
+                "24": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=24&d=mm&r=g",
+                "48": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=48&d=mm&r=g",
+                "96": "http://2.gravatar.com/avatar/b371b7de1e58a5dcc3fc3aa236784081?s=96&d=mm&r=g"
+            },
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/173"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/32"
+                    }
+                ],
+                "reviewer": [
+                    {
+                        "embeddable": true,
+                        "href": "http://store.ctarda.com/wp-json/wp/v2/users/1"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 169,
+            "date_created": "2019-08-20T06:02:21",
+            "date_created_gmt": "2019-08-20T06:02:21",
+            "product_id": 11,
+            "status": "approved",
+            "reviewer": "Software Engineer",
+            "reviewer_email": "somewhereelse@theinternet.com",
+            "review": "<p>A glowing review with a five star rating for the Colourful dress</p>\n",
+            "rating": 5,
+            "verified": false,
+            "reviewer_avatar_urls": {
+                "24": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=24&d=mm&r=g",
+                "48": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=48&d=mm&r=g",
+                "96": "http://0.gravatar.com/avatar/ca0e84fbb6e1cf1584c8b8f3ad5e2965?s=96&d=mm&r=g"
+            },
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews/169"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/reviews"
+                    }
+                ],
+                "up": [
+                    {
+                        "href": "http://store.ctarda.com/wp-json/wc/v3/products/11"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Dashboard stats: any negative revenue (from refunds for example) for a time period are shown now.
 - Redesigned Orders List: Processing and All Orders are now shown in front. Filtering was moved to the Search view.
+- Fix Reviews sometimes failing to load on some WooCommerce configurations
  
 3.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift
@@ -345,8 +345,12 @@ private extension ReviewDetailsViewController {
 
         commentCell.starRating = productReview.rating
 
-        let gravatar = productReview.reviewerAvatarURL
-        let gravatarURL = URL(string: gravatar)
+        let gravatarURL: URL? = {
+            guard let gravatar = productReview.reviewerAvatarURL else {
+                return nil
+            }
+            return URL(string: gravatar)
+        }()
         commentCell.downloadGravatar(with: gravatarURL)
 
         commentCell.isApproveEnabled  = true

--- a/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/ProductReview+ReadOnlyConvertible.swift
@@ -32,7 +32,7 @@ extension Storage.ProductReview: ReadOnlyConvertible {
                              statusKey: statusKey ?? "",
                              reviewer: reviewer ?? "" ,
                              reviewerEmail: reviewerEmail ?? "",
-                             reviewerAvatarURL: reviewerAvatarURL ?? "",
+                             reviewerAvatarURL: reviewerAvatarURL,
                              review: review ?? "",
                              rating: Int(rating),
                              verified: verified)


### PR DESCRIPTION
Fixes #1917

## Findings

### How

As described in #1917, we could not find the cause of why `reviewer_avatar_urls` is `null` in the JSON response. We will fix it by making `Networking.ProductReview.reviewerAvatarURLs` for now. 

### Storage <> Networking

Luckily, the Core Data `ProductReviews.reviewerAvatarURL` is **Optional** so we don't need to do any migration. This was odd too, because Networking's `reviewerAvatarURL` **is not** optional while Storage's `reviewerAvatarURL` **is** optional. ¯\\\_(ツ)\_/¯

## Solution

The main change is utilizing `decodeIfPresent` so that the avatar URLs object will not be parsed if the key is not there or if it's `null`. 

https://github.com/woocommerce/woocommerce-ios/blob/b30443f70eca4dcc1e310b46e25506063ea63f65/Networking/Networking/Model/Product/ProductReview.swift#L68

### Fetching

I then added a test that proves that if the response has no `reviewer_avatar_urls` or its value is `null`, the app will still parse the object. 

https://github.com/woocommerce/woocommerce-ios/blob/b30443f70eca4dcc1e310b46e25506063ea63f65/Networking/NetworkingTests/Remote/ProductReviewsRemoteTests.swift#L85-L111

If you follow the commits, this test was failing before I fixed it. TDD FTW! 

### Saving in Core Data

I then added a test that this `ProductReview` can be saved in Core Data:

https://github.com/woocommerce/woocommerce-ios/blob/b30443f70eca4dcc1e310b46e25506063ea63f65/Yosemite/YosemiteTests/Stores/ProductReviewStoreTests.swift#L125-L153

## Testing

This is tricky to test so I propose the following.

### Test for Regression

1. Navigate to Reviews
2. Tap on any review. 
3. Confirm that the Gravatar URL is still shown.

### Test Dummy Scenario

Edit this part so that `gravatarURL` is always `nil`:

https://github.com/woocommerce/woocommerce-ios/blob/b30443f70eca4dcc1e310b46e25506063ea63f65/WooCommerce/Classes/ViewRelated/Notifications/ReviewDetailsViewController.swift#L348-L353

1. Navigate to Reviews
2. Tap on any review. 
3. Confirm that a placeholder image is shown.

### Unit Test

Scrutinize the unit test. Am I testing the correct scenarios? 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

