### PR TITLE
Turned on edit products editing feature behind switch

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - Dashboard stats: any negative revenue (from refunds for example) for a time period are shown now.
 - Redesigned Orders List: Processing and All Orders are now shown in front. Filtering was moved to the Search view.
 - Fix Reviews sometimes failing to load on some WooCommerce configurations
+- Experimental: a Products feature switch is visible in Settings > Experimental Features that shows/hides the Products tab, and allow to edit a product.
  
 3.7
 -----

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -4,7 +4,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         case .productList:
             return true
         case .editProducts:
-            return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
+            return true
         case .editProductsRelease2:
             return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
         case .readonlyProductVariants:


### PR DESCRIPTION
Fixes #1887 

## Description
This PR enables the edit product functionality, which is behind the switch in Settings > Experimental Features that shows/hides the Products tab.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
