### PR TITLE
Migrating to WKWebView, after that Apple stop accepting apps that use UIWebView

### DIFF
--- a/WooCommerce/Classes/Tools/UserAgent.swift
+++ b/WooCommerce/Classes/Tools/UserAgent.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import WebKit
 
 
 /// WooCommerce User Agent!
@@ -20,7 +21,11 @@ class UserAgent {
     /// Returns the WebKit User Agent
     ///
     static var webkitUserAgent: String {
-        return UIWebView().stringByEvaluatingJavaScript(from: Constants.loadUserAgentScript) ?? String()
+        guard let userAgent = WKWebView().value(forKey: Constants.userAgentKey) as? String,
+            userAgent.count > 0 else {
+                return ""
+        }
+        return userAgent
     }
 
     /// Returns the Bundle Version ID
@@ -44,7 +49,7 @@ private extension UserAgent {
 
         /// Load User Agent JS Script
         ///
-        static let loadUserAgentScript = "navigator.userAgent"
+        static let userAgentKey = "_userAgent"
 
         /// Short Version Key
         ///

--- a/WooCommerce/Classes/Tools/UserAgent.swift
+++ b/WooCommerce/Classes/Tools/UserAgent.swift
@@ -47,7 +47,7 @@ private extension UserAgent {
         ///
         static let woocommerceIdentifier = "wc-ios"
 
-        /// Load User Agent JS Script
+        /// User Agent Key
         ///
         static let userAgentKey = "_userAgent"
 

--- a/WooCommerce/Classes/Tools/UserAgent.swift
+++ b/WooCommerce/Classes/Tools/UserAgent.swift
@@ -22,7 +22,7 @@ class UserAgent {
     ///
     static var webkitUserAgent: String {
         guard let userAgent = WKWebView().value(forKey: Constants.userAgentKey) as? String,
-            userAgent.count > 0 else {
+            userAgent.isNotEmpty else {
                 return ""
         }
         return userAgent

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		4580BA7523F192D400B5F764 /* ProductSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */; };
 		4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */; };
 		459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */; };
+		45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
 		45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */; };
@@ -969,6 +970,7 @@
 		4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSettingsViewController.xib; sourceTree = "<group>"; };
 		4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewModel.swift; sourceTree = "<group>"; };
 		459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Helpers.swift"; sourceTree = "<group>"; };
+		45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewController.swift; sourceTree = "<group>"; };
@@ -2208,6 +2210,7 @@
 				B517EA19218B2D2600730EC4 /* StringFormatterTests.swift */,
 				B56BBD15214820A70053A32D /* SyncCoordinatorTests.swift */,
 				D83A6A7923792B2400419D48 /* UIColor+Muriel-Tests.swift */,
+				45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */,
 				CE50345621B1F26C007573C6 /* ZendeskManagerTests.swift */,
 			);
 			path = Tools;
@@ -4333,6 +4336,7 @@
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
 				020B2F9923BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift in Sources */,
+				45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */,
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/UserAgentTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/UserAgentTests.swift
@@ -15,6 +15,7 @@ final class UserAgentTests: XCTestCase {
     }
 
     func testUserAgentIsNeverEmpty() {
-        XCTAssertFalse(UserAgent.webkitUserAgent.isEmpty, "This method for retrieveing the user agent seems to be no longer working. We need to figure out an alternative.")
+        let message = "This method for retrieveing the user agent seems to be no longer working. We need to figure out an alternative."
+        XCTAssertFalse(UserAgent.webkitUserAgent.isEmpty, message)
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/UserAgentTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/UserAgentTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import WooCommerce
+
+/// UserAgent Unit Tests
+///
+final class UserAgentTests: XCTestCase {
+
+    func testDefaultUserAgent() {
+        let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? String()
+
+        let defaultUserAgent = UserAgent.defaultUserAgent
+        let expectedUserAgent = UserAgent.webkitUserAgent + " " + "wc-ios" + "/" + appVersion
+
+        XCTAssertEqual(defaultUserAgent, expectedUserAgent)
+    }
+
+    func testUserAgentIsNeverEmpty() {
+        XCTAssertFalse(UserAgent.webkitUserAgent.isEmpty, "This method for retrieveing the user agent seems to be no longer working. We need to figure out an alternative.")
+    }
+}


### PR DESCRIPTION
Ref. p77Llu-cAF

## Description
Apple will stop accepting submissions of apps that use `UIWebView` APIs. We used using  `UIWebView` to take the user agent.
On this PR, I substituted all the occurrences of `UIWebView` with `WKWebView` and I wrote some unit tests for it.

This PR fixes only our code. Related issue: https://github.com/woocommerce/woocommerce-ios/issues/1929

## Testing
- Look at the code
- CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
