### PR TITLE
Order List: fixed clipped order status

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+3.9
+-----
+- bugfix: now in the Order List the order status label is no more clipped
+
 3.8
 -----
 - Dashboard stats: any negative revenue (from refunds for example) for a time period are shown now.

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,7 +20,7 @@
                         <rect key="frame" x="15" y="19" width="326" height="69"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wZx-1J-JYV">
-                                <rect key="frame" x="0.0" y="0.0" width="106" height="69"/>
+                                <rect key="frame" x="0.0" y="0.0" width="229" height="69"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="Date Created" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ylK-xx-FWE" userLabel="Date Label">
                                         <rect key="frame" x="0.0" y="0.0" width="75" height="14.5"/>
@@ -29,17 +29,28 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="260" text="#00 First Last" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nzo-QV-IP1">
-                                        <rect key="frame" x="0.0" y="21.5" width="106" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="20.5" width="106" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" verticalCompressionResistancePriority="749" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="48.5" width="97.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ps-WY-D2t">
+                                        <rect key="frame" x="0.0" y="47" width="229" height="22"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="260" verticalHuggingPriority="240" verticalCompressionResistancePriority="749" text="Order Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6EE-dX-ERE" customClass="PaddedLabel" customModule="WooCommerce" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="0.0" width="97.5" height="22"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="6EE-dX-ERE" secondAttribute="bottom" id="Fge-dY-VaV"/>
+                                            <constraint firstItem="6EE-dX-ERE" firstAttribute="top" secondItem="0Ps-WY-D2t" secondAttribute="top" id="pGC-oV-PJo"/>
+                                            <constraint firstItem="6EE-dX-ERE" firstAttribute="leading" secondItem="0Ps-WY-D2t" secondAttribute="leading" id="vHJ-wa-36Z"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" text="$75,894.63" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9oo-9a-Tey">

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -212,6 +212,8 @@ private extension OrdersViewController {
         tableView.estimatedSectionHeaderHeight = Settings.estimatedHeaderHeight
         tableView.sectionHeaderHeight = UITableView.automaticDimension
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = UITableView.automaticDimension
     }
 
     /// Setup: Ghostable TableView
@@ -480,7 +482,7 @@ extension OrdersViewController: UITableViewDataSource {
         let viewModel = detailsViewModel(at: indexPath)
         let orderStatus = lookUpOrderStatus(for: viewModel.order)
         cell.configureCell(viewModel: viewModel, orderStatus: orderStatus)
-
+        cell.layoutIfNeeded()
         return cell
     }
 
@@ -504,13 +506,6 @@ extension OrdersViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate Conformance
 //
 extension OrdersViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return estimatedRowHeights[indexPath] ?? Settings.estimatedRowHeight
-    }
-
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -76,10 +76,6 @@ class OrdersViewController: UIViewController {
         return statusResultsController.fetchedObjects
     }
 
-    /// Keep track of the (Autosizing Cell's) Height. This helps us prevent UI flickers, due to sizing recalculations.
-    ///
-    private var estimatedRowHeights = [IndexPath: CGFloat]()
-
     /// Indicates if there are no results onscreen.
     ///
     private var isEmpty: Bool {
@@ -526,13 +522,6 @@ extension OrdersViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         let orderIndex = resultsController.objectIndex(from: indexPath)
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
-
-        // Preserve the Cell Height
-        // Why: Because Autosizing Cells, upon reload, will need to be laid yout yet again. This might cause
-        // UI glitches / unwanted animations. By preserving it, *then* the estimated will be extremely close to
-        // the actual value. AKA no flicker!
-        //
-        estimatedRowHeights[indexPath] = cell.frame.height
     }
 }
 


### PR DESCRIPTION
Fixes #1801 

## Description
Previously, order status label gets clipped on the first load of an order list, and isn't fully visible on certain orders. It happened only if there are 2 or more lines for the Order # + Name.
This PR fixes the problem, and remove the `estimatedRowHeights` array, which is no more useful.


## Testing
1) Run the app (you need to run the app for every test you will do because the problem happens only on the first load of the table view).
2) Make sure to have also some order titles with 2+ lines.
3) Navigate to the order list (Processing tab). Make sure that every status is visible and is not clipped.
4) Navigate to the "All Orders" tab, make sure that every status is no more clipped.
5) Try also to refresh the content and to scroll across the list.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-03-10 at 11 43 27](https://user-images.githubusercontent.com/495617/76346448-54fbdd00-6305-11ea-9b88-acae4cbe813b.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-03-10 at 19 21 51](https://user-images.githubusercontent.com/495617/76346460-588f6400-6305-11ea-9f3d-e71cdc0879d8.png)

| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-03-10 at 11 41 39](https://user-images.githubusercontent.com/495617/76346502-6a710700-6305-11ea-88eb-a6c0d055d499.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-03-10 at 19 22 04](https://user-images.githubusercontent.com/495617/76346508-6e048e00-6305-11ea-9d20-ca1e819b25fe.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
