### PR TITLE
Simplify the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -15,7 +15,13 @@ assignees: ""
 ### Steps to reproduce the behavior
 
 
-##### Tested on [device], iOS [version], WooCommerce app [version]
+#### Mobile Environment
+
+Please include:
+
+- Device: 
+- iOS version: 
+- WooCommerce app version:
 
 
 ##### If you have tried any of the following troubleshooting steps already, please mark completed items with an [x]):**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,39 +1,31 @@
 ---
 name: "\U0001F41E Bug report"
 about: Report a bug if something isn't working as expected in the WooCommerce iOS app.
-
+title: ""
+labels: "[Type] Bug"
+assignees: ""
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is. Please be as descriptive as possible; issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+### Expected behavior
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Actual behavior
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
 
-**Isolating the problem (mark completed items with an [x]):**
+### Steps to reproduce the behavior
+
+
+##### Tested on [device], iOS [version], WooCommerce app [version]
+
+
+##### If you have tried any of the following troubleshooting steps already, please mark completed items with an [x]):**
 - [ ] I have deactivated other plugins and confirmed this bug occurs when only WooCommerce plugin is active.
 - [ ] This bug happens with a default WordPress theme active, or [Storefront](https://woocommerce.com/storefront/).
 - [ ] I can reproduce this bug consistently using the steps above.
 
-**Mobile Environment**
-Please include:
-- Device: 
-- iOS version: 
-- WooCommerce iOS version: 
-
-**WordPress Environment**
+##### Optional WordPress Environment Details
 <details>
 ```
-Copy and paste the system status report from **WooCommerce > System Status** in WordPress admin.
+If you are able to find helpful information in WP Admin > WooCommerce > System Status, please copy and paste the system status report here. Otherwise, please delete this section.
 ```
 </details>


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/1943

Taking inspiration from https://github.com/wordpress-mobile/WordPress-iOS/issues/new let's make our bug report template easier to fill out. 

Reviewers, has the troubleshooting section been helpful to you? Could it be improved? What would you add or remove from that list?

Regarding the WordPress Environment section, I reviewed the latest 25 open issues and found that it was only filled out 3 of 25 times. Most often, people leave the default template language or write something like "N/A" or "irrelevant" in that space. I could be easily swayed to get rid of it but feel fine about keeping it if it's helpful _sometimes_. Is it helpful sometimes? Is it worth keeping?


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
