### PR TITLE
Added placeholder when the shipping provider is empty in Add Tracking

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -230,7 +230,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
     private func configureShippingProvider(cell: TitleAndEditableValueTableViewCell) {
         cell.title.text = NSLocalizedString("Shipping provider", comment: "Add / Edit shipping provider. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
-
+        cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
+        
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -230,7 +230,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
     private func configureShippingProvider(cell: TitleAndEditableValueTableViewCell) {
         cell.title.text = NSLocalizedString("Shipping provider", comment: "Add / Edit shipping provider. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
-        cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
+        cell.value.placeholder = NSLocalizedString("Select carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
 
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -231,7 +231,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.title.text = NSLocalizedString("Shipping provider", comment: "Add / Edit shipping provider. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
         cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
-        
+
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType
     }


### PR DESCRIPTION
Fixes #1937 

## Description
You can see in the "Add Tracking" screen that the "Shipping Provider" field is empty. This PR adds a placeholder text.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/76540013-d8dad400-6481-11ea-86f5-e7e87b448391.png" width="300">


## Testing
1) install WooCommerce shipment tracking extension
2) Go to order details screen
3) select "Add tracking"
4) Make sure when the tracking is empty, that you can see the new placeholder text.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
