### PR TITLE
Add Tracking: changed all the occurences of "Shipping Provider" to "Shipping Carrier"

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - bugfix: now in the Order List the order status label is no more clipped
 - bugfix: now the launch screen is no more stretched
+- The Shipping Provider flow, will be called now Shipping Carrier.
 
 3.8
 -----

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -162,7 +162,7 @@ private extension AddTrackingViewModel {
                 return
             }
 
-            DDLogError("⛔️ Save selected Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
+            DDLogError("⛔️ Save selected Tracking Carrier Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
         ServiceLocator.stores.dispatch(action)
@@ -178,7 +178,7 @@ private extension AddTrackingViewModel {
                 return
             }
 
-            DDLogError("⛔️ Read selected Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
+            DDLogError("⛔️ Read selected Tracking Carrier Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
         ServiceLocator.stores.dispatch(action)
@@ -228,7 +228,7 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
     var shipmentProviderGroupName: String?
 
     var providerCellName: String {
-        return NSLocalizedString("Custom Provider", comment: "Add custom shipping provider. Content of cell titled Shipping Provider")
+        return NSLocalizedString("Custom Carrier", comment: "Add custom shipping carrier. Content of cell titled Shipping Carrier")
     }
 
     let providerCellAccessoryType = UITableViewCell.AccessoryType.none
@@ -275,7 +275,7 @@ private extension AddCustomTrackingViewModel {
                 return
             }
 
-            DDLogError("⛔️ Save selected Custom Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
+            DDLogError("⛔️ Save selected Custom Tracking Carrier Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
         ServiceLocator.stores.dispatch(action)
@@ -291,7 +291,7 @@ private extension AddCustomTrackingViewModel {
                 return
             }
 
-            DDLogError("⛔️ Read selected Custom Tracking Provider Failure: [siteID = \(siteID)]. Error: \(error)")
+            DDLogError("⛔️ Read selected Custom Tracking Carrier Failure: [siteID = \(siteID)]. Error: \(error)")
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -343,7 +343,7 @@ private enum Constants {
     static let customSectionIndex = 1
     static let specialSectionsCount = 2
     static let customGroup = NSLocalizedString("Custom",
-                                               comment: "Name of the section for custom shipment tracking providers")
-    static let customProvider = NSLocalizedString("Custom Provider",
-                                                  comment: "Placeholder name of a custom shipment tracking provider")
+                                               comment: "Name of the section for custom shipment tracking carriers")
+    static let customProvider = NSLocalizedString("Custom Carrier",
+                                                  comment: "Placeholder name of a custom shipment tracking carrier")
 }

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -10,8 +10,8 @@ final class ShippingProvidersViewModel {
     let order: Order
 
     /// Title of view displaying all available Shipment Tracking Providers
-    let title = NSLocalizedString("Shipping Providers",
-                                  comment: "Title of view displaying all available Shipment Tracking Providers")
+    let title = NSLocalizedString("Shipping Carriers",
+                                  comment: "Title of view displaying all available Shipment Tracking Carriers")
 
     /// The currently selected tracking provider.
     private let selectedProvider: ShipmentTrackingProvider?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -230,7 +230,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
     private func configureShippingProvider(cell: TitleAndEditableValueTableViewCell) {
         cell.title.text = NSLocalizedString("Shipping provider", comment: "Add / Edit shipping provider. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
-
+        cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
+        
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -230,7 +230,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
     private func configureShippingProvider(cell: TitleAndEditableValueTableViewCell) {
         cell.title.text = NSLocalizedString("Shipping carrier", comment: "Add / Edit shipping carrier. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
-        cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping carrier. Placeholder of cell presenting carrier name")
+        cell.value.placeholder = NSLocalizedString("Select carrier", comment: "Add the shipping carrier. Placeholder of cell presenting carrier name")
 
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -228,17 +228,17 @@ extension ManualTrackingViewController: UITableViewDataSource {
     }
 
     private func configureShippingProvider(cell: TitleAndEditableValueTableViewCell) {
-        cell.title.text = NSLocalizedString("Shipping provider", comment: "Add / Edit shipping provider. Title of cell presenting name")
+        cell.title.text = NSLocalizedString("Shipping carrier", comment: "Add / Edit shipping carrier. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
-        cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
+        cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping carrier. Placeholder of cell presenting carrier name")
 
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType
     }
 
     private func configureProviderName(cell: TitleAndEditableValueTableViewCell) {
-        cell.title.text = NSLocalizedString("Provider name", comment: "Add Custom shipping provider. Title of cell presenting the provider name")
-        cell.value.placeholder = NSLocalizedString("Enter provider name", comment: "Add custom shipping provider. Placeholder of cell presenting provider name")
+        cell.title.text = NSLocalizedString("Carrier name", comment: "Add Custom shipping carrier. Title of cell presenting the carrier name")
+        cell.value.placeholder = NSLocalizedString("Enter carrier name", comment: "Add custom shipping carrier. Placeholder of cell presenting carrier name")
 
         cell.value.text = viewModel.providerName
         cell.value.isEnabled = true
@@ -248,10 +248,10 @@ extension ManualTrackingViewController: UITableViewDataSource {
     }
 
     private func configureTrackingNumber(cell: TitleAndEditableValueTableViewCell) {
-        cell.title.text = NSLocalizedString("Tracking number", comment: "Add / Edit shipping provider. Title of cell presenting tracking number")
+        cell.title.text = NSLocalizedString("Tracking number", comment: "Add / Edit shipping carrier. Title of cell presenting tracking number")
 
         cell.value.placeholder = NSLocalizedString("Enter tracking number",
-                                                   comment: "Add custom shipping provider. Placeholder of cell presenting tracking number")
+                                                   comment: "Add custom shipping carrier. Placeholder of cell presenting tracking number")
         cell.value.text = viewModel.trackingNumber
         cell.value.isEnabled = true
 
@@ -260,9 +260,9 @@ extension ManualTrackingViewController: UITableViewDataSource {
     }
 
     private func configureTrackingLink(cell: TitleAndEditableValueTableViewCell) {
-        cell.title.text = NSLocalizedString("Tracking link (optional)", comment: "Add custom shipping provider. Title of cell presenting tracking link")
+        cell.title.text = NSLocalizedString("Tracking link (optional)", comment: "Add custom shipping carrier. Title of cell presenting carrier link")
 
-        cell.value.placeholder = NSLocalizedString("Enter tracking link", comment: "Add custom shipping provider. Placeholder of cell presenting tracking link")
+        cell.value.placeholder = NSLocalizedString("Enter tracking link", comment: "Add custom shipping carrier. Placeholder of cell presenting carrier link")
 
         cell.value.text = viewModel.trackingLink
 
@@ -273,7 +273,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
     }
 
     private func configureDateShipped(cell: TitleAndEditableValueTableViewCell) {
-        cell.title.text = NSLocalizedString("Date shipped", comment: "Add / Edit shipping provider. Title of cell date shipped")
+        cell.title.text = NSLocalizedString("Date shipped", comment: "Add / Edit shipping carrier. Title of cell date shipped")
 
         cell.value.text = viewModel.shipmentDate.toString(dateStyle: .medium, timeStyle: .none)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -231,7 +231,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.title.text = NSLocalizedString("Shipping provider", comment: "Add / Edit shipping provider. Title of cell presenting name")
         cell.value.text = viewModel.providerCellName
         cell.value.placeholder = NSLocalizedString("Select Carrier", comment: "Add the shipping provider. Placeholder of cell presenting provider name")
-        
+
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -255,8 +255,8 @@ extension ShipmentProvidersViewController: UISearchControllerDelegate {
 private extension ShipmentProvidersViewController {
     func presentNotice(_ error: Error) {
         let title = NSLocalizedString(
-            "Unable to load Shipment Providers",
-            comment: "Content of error presented when loading the list of shipment providers failed. It reads: Unable to load Shipment Providers"
+            "Unable to load Shipment Carriers",
+            comment: "Content of error presented when loading the list of shipment carriers failed. It reads: Unable to load Shipment Carriers"
         )
         let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
         let notice = Notice(title: title,
@@ -294,10 +294,10 @@ private extension ShipmentProvidersViewController {
         }
 
         let emptyState: EmptyListMessageWithActionView = EmptyListMessageWithActionView.instantiateFromNib()
-        emptyState.messageText = NSLocalizedString("No results found for \(term)\nAdd a custom provider",
-            comment: "Empty state for the list of shipment providers. It reads: 'No results for DHL. Add a custom provider'")
-        emptyState.actionText = NSLocalizedString("Custom Provider",
-                                                  comment: "Title of button to add a custom tracking provider if filtering the list yields no results."
+        emptyState.messageText = NSLocalizedString("No results found for \(term)\nAdd a custom carrier",
+            comment: "Empty state for the list of shipment carriers. It reads: 'No results for DHL. Add a custom carrier'")
+        emptyState.actionText = NSLocalizedString("Custom Carrier",
+                                                  comment: "Title of button to add a custom tracking carrier if filtering the list yields no results."
         )
 
         emptyState.onAction = { [weak self] in


### PR DESCRIPTION
Fixes #1936 

## Description
This PR update all the strings that mention the **Shipping Provider** to the new **Shipping Carrier**.
Since we use in a massive way a lot of code called shipping provider, this PR doesn't handle these changes. We can continue to call it `Shipping Provider` inside the code, but all the strings in the UI will become `Shipping Carrier`.

## Testing
- Look at the code
- Run the app, and make sure there are no more strings with the word `Provider`

## Screenshots

| Add Tracking             |  Shipping Carriers |  Custom Carrier |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-03-12 at 17 30 52](https://user-images.githubusercontent.com/495617/76544610-a2ed1e00-6488-11ea-8fe3-b7e96aac588d.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-03-12 at 17 30 55](https://user-images.githubusercontent.com/495617/76544666-b7c9b180-6488-11ea-8bdd-a2cea0ce16d1.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-03-12 at 17 30 59](https://user-images.githubusercontent.com/495617/76544641-ada7b300-6488-11ea-9bb7-b83f6d21672c.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
