### PR TITLE
Edit Product: fixed the discard changes prompt on iPad

### DIFF
--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -28,6 +28,13 @@ extension UIAlertController {
 
         viewController.present(actionSheet, animated: true)
     }
+
+    open override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        if let window = UIApplication.shared.keyWindow {
+            popoverPresentationController?.sourceRect = CGRect(x: window.bounds.midX, y: window.bounds.midY, width: 0, height: 0)
+        }
+    }
 }
 
 private enum ActionSheetStrings {

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -20,9 +20,11 @@ extension UIAlertController {
             onCancel?()
         }
 
-        let popoverController = actionSheet.popoverPresentationController
-        popoverController?.sourceView = viewController.view
-        popoverController?.sourceRect = viewController.view.bounds
+        if let popoverController = actionSheet.popoverPresentationController {
+            popoverController.sourceView = viewController.view
+            popoverController.sourceRect = viewController.view.bounds
+            popoverController.permittedArrowDirections = []
+        }
 
         viewController.present(actionSheet, animated: true)
     }


### PR DESCRIPTION
Fixed #1960 

## Description
Previously, when you make a change to a product setting and don't save it, an action sheet popover appears on iPad but the discard changes prompt isn't visible.
This PR fix this bug, which doesn't allow the user to proceed.

## Screenshots
<img src="https://user-images.githubusercontent.com/495617/76646148-c5e80280-655a-11ea-8d27-2d74db7460e7.png" width="400">

## Testing
1. Go to the Products tab on an iPad.
2. Select a product.
3. Make a change to the product (e.g. edit the title).
4. Tap the back button, and notice that you are not anymore blocked from going back. An action sheet popover appears at the center of the screen.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
