### PR TITLE
Products Search: show the editable version of a product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -56,10 +56,18 @@ final class ProductSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController) {
+        let isEditProductsEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts)
         let currencyCode = CurrencySettings.shared.currencyCode
         let currency = CurrencySettings.shared.symbol(from: currencyCode)
-        let viewModel = ProductDetailsViewModel(product: model, currency: currency)
-        let productViewController = ProductDetailsViewController(viewModel: viewModel)
-        viewController.navigationController?.pushViewController(productViewController, animated: true)
+        let vc: UIViewController
+        if model.productType == .simple && isEditProductsEnabled {
+            vc = ProductFormViewController(product: model, currency: currency)
+            // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
+            vc.hidesBottomBarWhenPushed = true
+        } else {
+            let viewModel = ProductDetailsViewModel(product: model, currency: currency)
+            vc = ProductDetailsViewController(viewModel: viewModel)
+        }
+        viewController.navigationController?.pushViewController(vc, animated: true)
     }
 }


### PR DESCRIPTION
Fixes #1965 

## Description
When you try to search for a product, you get the read-only view of the product, with no way to edit it.
This PR enables the presentation of the edit product screen.

## Testing
1. Go to the Products tab.
2. Select the search icon.
3. Enter a search query.
4. Select a product from the search results.
5. You should see the editable version (if it's a simple product).

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
