### PR TITLE
Edit Products: fixed inconsistent case in error message title

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -170,7 +170,7 @@ private extension ProductFormViewController {
     }
 
     func displayError(error: ProductUpdateError?) {
-        let title = NSLocalizedString("Cannot update Product", comment: "The title of the alert when there is an error updating the product")
+        let title = NSLocalizedString("Cannot update product", comment: "The title of the alert when there is an error updating the product")
 
         let message = error?.alertMessage
 


### PR DESCRIPTION
Fixes #1955 

## Description
This PR fixes an inconsistent case in error message title.

## Testing
- Just CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
