### PR TITLE
[Dark Mode] Fixes tab-bar invisible border in iOS 13.1

### DIFF
--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -11,7 +11,7 @@ extension UITabBar {
         appearance.barTintColor = .appTabBar
         appearance.tintColor = .text
 
-        /// iOS 13.1 don't render the tabbar shadow color correcly while in dark mode.
+        /// iOS 13.0 and 13.1 doesn't render the tabbar shadow color correcly while in dark mode.
         /// To fix it, we have to specifically set it in the `standardAppearance` object.
         ///
         if #available(iOS 13.0, *) {

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -11,7 +11,7 @@ extension UITabBar {
         appearance.barTintColor = .appTabBar
         appearance.tintColor = .text
 
-        /// Some iOS 13.x versions don't render the tabbar shadow color correcly while in dark mode.
+        /// iOS 13.1 don't render the tabbar shadow color correcly while in dark mode.
         /// To fix it, we have to specifically set it in the `standardAppearance` object.
         /// Which forces us to set other properties like `badgeBackgroundColor` and `badgeTextAttributes` in the `UITabBarItemAppearance` layouts.
         ///

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -10,5 +10,29 @@ extension UITabBar {
         let appearance = Self.appearance()
         appearance.barTintColor = .appTabBar
         appearance.tintColor = .text
+
+        /// Some iOS 13.x versions don't render the tabbar shadow color correcly while in dark mode.
+        /// To fix it, we have to specifically set it in the `standardAppearance` object.
+        /// Which forces us to set other properties like `badgeBackgroundColor` and `badgeTextAttributes` in the `UITabBarItemAppearance` layouts.
+        ///
+        if #available(iOS 13.0, *) {
+            let standardAppearance = UITabBarAppearance()
+            standardAppearance.backgroundColor = .appTabBar
+            standardAppearance.shadowColor = .systemColor(.separator)
+            applyItemWooAppearance(to: standardAppearance.inlineLayoutAppearance)
+            applyItemWooAppearance(to: standardAppearance.stackedLayoutAppearance)
+            applyItemWooAppearance(to: standardAppearance.compactInlineLayoutAppearance)
+            appearance.standardAppearance = standardAppearance
+        }
+    }
+
+    @available(iOS 13.0, *)
+    private class func applyItemWooAppearance(to layoutAppearance: UITabBarItemAppearance) {
+        layoutAppearance.normal.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
+        layoutAppearance.selected.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
+        layoutAppearance.disabled.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
+        layoutAppearance.normal.badgeBackgroundColor = .primary
+        layoutAppearance.selected.badgeBackgroundColor = .primary
+        layoutAppearance.disabled.badgeBackgroundColor = .primary
     }
 }

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -19,20 +19,20 @@ extension UITabBar {
             let standardAppearance = UITabBarAppearance()
             standardAppearance.backgroundColor = .appTabBar
             standardAppearance.shadowColor = .systemColor(.separator)
-            applyItemWooAppearance(to: standardAppearance.inlineLayoutAppearance)
-            applyItemWooAppearance(to: standardAppearance.stackedLayoutAppearance)
-            applyItemWooAppearance(to: standardAppearance.compactInlineLayoutAppearance)
+            applyWooAppearance(to: standardAppearance.inlineLayoutAppearance)
+            applyWooAppearance(to: standardAppearance.stackedLayoutAppearance)
+            applyWooAppearance(to: standardAppearance.compactInlineLayoutAppearance)
             appearance.standardAppearance = standardAppearance
         }
     }
 
     @available(iOS 13.0, *)
-    private class func applyItemWooAppearance(to layoutAppearance: UITabBarItemAppearance) {
-        layoutAppearance.normal.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
-        layoutAppearance.selected.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
-        layoutAppearance.disabled.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
-        layoutAppearance.normal.badgeBackgroundColor = .primary
-        layoutAppearance.selected.badgeBackgroundColor = .primary
-        layoutAppearance.disabled.badgeBackgroundColor = .primary
+    private static func applyWooAppearance(to tabBarItemAppearance: UITabBarItemAppearance) {
+        tabBarItemAppearance.normal.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
+        tabBarItemAppearance.selected.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
+        tabBarItemAppearance.disabled.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]
+        tabBarItemAppearance.normal.badgeBackgroundColor = .primary
+        tabBarItemAppearance.selected.badgeBackgroundColor = .primary
+        tabBarItemAppearance.disabled.badgeBackgroundColor = .primary
     }
 }

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -13,19 +13,27 @@ extension UITabBar {
 
         /// iOS 13.1 don't render the tabbar shadow color correcly while in dark mode.
         /// To fix it, we have to specifically set it in the `standardAppearance` object.
-        /// Which forces us to set other properties like `badgeBackgroundColor` and `badgeTextAttributes` in the `UITabBarItemAppearance` layouts.
         ///
         if #available(iOS 13.0, *) {
-            let standardAppearance = UITabBarAppearance()
-            standardAppearance.backgroundColor = .appTabBar
-            standardAppearance.shadowColor = .systemColor(.separator)
-            applyWooAppearance(to: standardAppearance.inlineLayoutAppearance)
-            applyWooAppearance(to: standardAppearance.stackedLayoutAppearance)
-            applyWooAppearance(to: standardAppearance.compactInlineLayoutAppearance)
-            appearance.standardAppearance = standardAppearance
+            appearance.standardAppearance = createWooTabBarAppearance()
         }
     }
 
+    /// Creates an iOS 13+ appearance object for a tabbar with the default WC style.
+    ///
+    @available(iOS 13.0, *)
+    private static func createWooTabBarAppearance() -> UITabBarAppearance {
+        let standardAppearance = UITabBarAppearance()
+        standardAppearance.backgroundColor = .appTabBar
+        standardAppearance.shadowColor = .systemColor(.separator)
+        applyWooAppearance(to: standardAppearance.inlineLayoutAppearance)
+        applyWooAppearance(to: standardAppearance.stackedLayoutAppearance)
+        applyWooAppearance(to: standardAppearance.compactInlineLayoutAppearance)
+        return standardAppearance
+    }
+
+    /// Configures the appearance object for a tabbar's items with the default WC style.
+    ///
     @available(iOS 13.0, *)
     private static func applyWooAppearance(to tabBarItemAppearance: UITabBarItemAppearance) {
         tabBarItemAppearance.normal.badgeTextAttributes = [.foregroundColor: UIColor.textInverted]


### PR DESCRIPTION
Refs https://github.com/woocommerce/woocommerce-ios/issues/1938

# Why
It was reported that the tab-bar separator was not visible while using the app in dark mode.
After some investigation we realized that there is a bug on `iOS 13.1` that doesn't render the tab-bar shadow color correctly. iOS 13.3 seems to have the issue fixed.

While testing this, I also noticed that the badge text color in dark mode [should be black](https://www.figma.com/file/S62xbAwtgoMgax4GcuFjKS/System---Dark%2FLight-modes?node-id=307%3A609), so I've proceed to adjust that too.

# How

In order to fix it, we have to specifically set it in the `standardAppearance` object to the `UITabbar.Appearance()` That also forces forces us to set other properties like `badgeBackgroundColor` and `badgeTextAttributes` to the `UITabBarItemAppearance` properties.

# Screenshots

### Before
![ios13 1-dark-before](https://user-images.githubusercontent.com/562080/76674493-1e7cc700-657e-11ea-8700-ba4db8a32ec5.png)

### After
iOS 13.1 Dark|iOS 13.1 Light
---|---
<img src="https://user-images.githubusercontent.com/562080/76674516-4f5cfc00-657e-11ea-9003-b415798d2381.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/76674517-4ff59280-657e-11ea-9b96-00e6f7e5f701.png" width="300" />


iOS 13.3 Dark|iOS 13.3 Light
---|---
<img src="https://user-images.githubusercontent.com/562080/76674540-9d71ff80-657e-11ea-94c6-7b2b6ebd8ef7.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/76674541-9e0a9600-657e-11ea-9d3e-db52b5c757ea.png" width="300" />
