### PR TITLE
Edit Products: show discard changes action sheet if the product has outstanding changes when navigating away

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -6,7 +6,10 @@ final class ProductFormViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
 
+    /// The product model before any potential edits; reset after a remote update.
     private var originalProduct: Product
+
+    /// The product model with potential edits; reset after a remote update.
     private var product: Product {
         didSet {
             viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -6,6 +6,7 @@ final class ProductFormViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
 
+    private var originalProduct: Product
     private var product: Product {
         didSet {
             viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
@@ -34,6 +35,7 @@ final class ProductFormViewController: UIViewController {
 
     init(product: Product, currency: String) {
         self.currency = currency
+        self.originalProduct = product
         self.product = product
         self.viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
         self.productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
@@ -160,6 +162,7 @@ private extension ProductFormViewController {
                 }
                 return
             }
+            self?.originalProduct = product
             self?.product = product
 
             ServiceLocator.analytics.track(.productDetailUpdateSuccess)
@@ -329,8 +332,24 @@ extension ProductFormViewController: TextViewViewControllerDelegate {
         return NSLocalizedString("Please add a title",
                                  comment: "Product title error notice message, when the title is empty")
     }
+}
 
+// MARK: - Navigation actions handling
+//
+extension ProductFormViewController {
+    override func shouldPopOnBackButton() -> Bool {
+        if product != originalProduct {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
 
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
+    }
 }
 
 // MARK: Action - Edit Product Parameters


### PR DESCRIPTION
Fixes #1953

## Changes

- On the Edit Product main screen, added a check to compare the latest product against the original product to detect any outstanding changes. If so, the same "discard changes" alert is presented like in other Edit Product settings

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap "< Products" in the navigation bar --> it should navigate back to the Products tab since there are no changes
- Tap on a simple Product again
- Edit the product in any way you like - name, description, price, inventory, shipping
- Tap "< Products" in the navigation bar --> it should prompt an action sheet asking if you'd like to discard changes to the product like in the screenshot below
- Tap "Cancel" --> it should stay on the Edit Product screen without the action sheet
- Tap "Update" and wait for the product to be updated remotely
- Tap "< Products" in the navigation bar --> it should navigate back to the Products tab since there are no changes to the recently updated Product

## Example screenshots

<img src="https://user-images.githubusercontent.com/1945542/76737526-e787fa80-67a3-11ea-9788-95bf0060baf2.png" width="320" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
