### PR TITLE
Edit Products: fix unexpected discard changes prompt

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -174,8 +174,12 @@ extension ProductPriceSettingsViewController {
         let newTaxClass = taxClass?.slug == standardTaxClass.slug ? "" : taxClass?.slug
         let originalTaxClass = product.taxClass == standardTaxClass.slug ? "": product.taxClass
 
-        if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart ||
-            dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != originalTaxClass {
+        if getDecimalPrice(regularPrice) != getDecimalPrice(product.regularPrice) ||
+            getDecimalPrice(newSalePrice) != getDecimalPrice(product.salePrice) ||
+            dateOnSaleStart != product.dateOnSaleStart ||
+            dateOnSaleEnd != product.dateOnSaleEnd ||
+            taxStatus.rawValue != product.taxStatusKey ||
+            newTaxClass != originalTaxClass {
             presentBackNavigationActionSheet()
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -173,7 +173,7 @@ extension ProductPriceSettingsViewController {
         // tax classes are converted to empty string whenever the value matches the standard tax class's slug.
         let newTaxClass = taxClass?.slug == standardTaxClass.slug ? "" : taxClass?.slug
         let originalTaxClass = product.taxClass == standardTaxClass.slug ? "": product.taxClass
-        
+
         if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart ||
             dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != originalTaxClass {
             presentBackNavigationActionSheet()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -168,9 +168,14 @@ extension ProductPriceSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
         let newSalePrice = salePrice == "0" ? nil : salePrice
+
+        // Since an empty string and the standard tax class's slug both represent the standard tax class, the original and new
+        // tax classes are converted to empty string whenever the value matches the standard tax class's slug.
         let newTaxClass = taxClass?.slug == standardTaxClass.slug ? "" : taxClass?.slug
+        let originalTaxClass = product.taxClass == standardTaxClass.slug ? "": product.taxClass
+        
         if regularPrice != product.regularPrice || newSalePrice != product.salePrice || dateOnSaleStart != product.dateOnSaleStart ||
-            dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != product.taxClass {
+            dateOnSaleEnd != product.dateOnSaleEnd || taxStatus.rawValue != product.taxStatusKey || newTaxClass != originalTaxClass {
             presentBackNavigationActionSheet()
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -168,8 +168,23 @@ extension ProductInventorySettingsViewController {
             return true
         }
 
-        if sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually ||
-            stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting || stockStatus != product.productStockStatus {
+        // Checks general settings regardless of whether stock management is enabled.
+        let hasChangesInGeneralSettings = sku != product.sku || manageStockEnabled != product.manageStock || soldIndividually != product.soldIndividually
+
+        if hasChangesInGeneralSettings {
+            presentBackNavigationActionSheet()
+            return false
+        }
+
+        // Checks stock settings depending on whether stock management is enabled.
+        let hasChangesInStockSettings: Bool
+        if manageStockEnabled {
+            hasChangesInStockSettings = stockQuantity != product.stockQuantity || backordersSetting != product.backordersSetting
+        } else {
+            hasChangesInStockSettings = stockStatus != product.productStockStatus
+        }
+
+        if hasChangesInStockSettings {
             presentBackNavigationActionSheet()
             return false
         }


### PR DESCRIPTION
Fixes #1959 

## Changes

## Testing

### Reproduce on `release/3.8` first

Please make sure you can reproduce the issues on `release/3.8` following the steps below!

Prerequisite: the simple product has a standard tax class (`product.taxClass` is empty), and its stock management is disabled (`product.manageStock` is false)

#### Price settings

- Go to the Products tab
- Tap on the simple Product in the prerequisite
- Tap Price
- Update the regular price to a different value
- Tap "Done"
- Tap Price again
- Tap "<" in the navigation bar -->
  - on `release/3.8`, the discard changes action sheet comes up without any overall changes
  - now it should just navigate back to the Edit Product main screen

#### Inventory settings

- Go to the Products tab
- Tap on the simple Product in the prerequisite
- Tap Inventory
- Turn on the "Manage stock" toggle
- Change the "Quantity" field to a different value from 0
- Change the "Quantity" field back to 0
- Turn off the "Manage stock" toggle
- Tap "<" in the navigation bar -->
  - on `release/3.8`, the discard changes action sheet comes up without any overall changes
  - now it should just navigate back to the Edit Product main screen

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
