### PR TITLE
Edit Product: allow empty title

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -126,7 +126,7 @@ private extension ProductFormTableViewDataSource {
             guard let cell = cell as? BasicTableViewCell else {
                 fatalError()
             }
-            let placeholder = NSLocalizedString("Title (required)", comment: "Placeholder in the Product Title row on Product form screen.")
+            let placeholder = NSLocalizedString("Title", comment: "Placeholder in the Product Title row on Product form screen.")
             cell.textLabel?.text = placeholder
             cell.textLabel?.applyBodyStyle()
             cell.textLabel?.textColor = .textSubtle

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -300,7 +300,6 @@ private extension ProductFormViewController {
         ) { [weak self] (newProductName) in
             self?.onEditProductNameCompletion(newName: newProductName ?? "")
         }
-        textViewController.delegate = self
 
         navigationController?.pushViewController(textViewController, animated: true)
     }
@@ -318,19 +317,6 @@ private extension ProductFormViewController {
         }
         self.product = productUpdater.nameUpdated(name: newName)
     }
-}
-
-extension ProductFormViewController: TextViewViewControllerDelegate {
-    func validate(text: String) -> Bool {
-        return !text.isEmpty
-    }
-
-    func validationErrorMessage() -> String {
-        return NSLocalizedString("Please add a title",
-                                 comment: "Product title error notice message, when the title is empty")
-    }
-
-
 }
 
 // MARK: Action - Edit Product Parameters


### PR DESCRIPTION
Fixes #1981 

## Description
Following the Android and Core behavior, now we allow users to insert an empty title while editing a product.

## Testing
- Navigate to a product
- Try to insert an empty title
- Try to save the product

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
