### PR TITLE
Update colors for Aztec HTML text view and blockquote text

### DIFF
--- a/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
+++ b/WooCommerce/Classes/Styles/UIColor+SemanticColors.swift
@@ -451,3 +451,35 @@ extension UIColor {
         }
     }
 }
+
+// MARK: - Woo Purples
+extension UIColor {
+    class func wooCommercePurple(_ shade: ColorStudioShade) -> UIColor {
+        switch shade {
+        case .shade0:
+            return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade0), dark: .withColorStudio(.wooCommercePurple, shade: .shade100))
+            case .shade5:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade5), dark: .withColorStudio(.wooCommercePurple, shade: .shade90))
+            case .shade10:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade10), dark: .withColorStudio(.wooCommercePurple, shade: .shade80))
+            case .shade20:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade20), dark: .withColorStudio(.wooCommercePurple, shade: .shade70))
+            case .shade30:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade30), dark: .withColorStudio(.wooCommercePurple, shade: .shade60))
+            case .shade40:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade40), dark: .withColorStudio(.wooCommercePurple, shade: .shade50))
+            case .shade50:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50), dark: .withColorStudio(.wooCommercePurple, shade: .shade40))
+            case .shade60:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade60), dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
+            case .shade70:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade70), dark: .withColorStudio(.wooCommercePurple, shade: .shade20))
+            case .shade80:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade80), dark: .withColorStudio(.wooCommercePurple, shade: .shade10))
+            case .shade90:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade90), dark: .withColorStudio(.wooCommercePurple, shade: .shade5))
+            case .shade100:
+                return UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade100), dark: .withColorStudio(.wooCommercePurple, shade: .shade0))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
@@ -78,9 +78,9 @@ private extension AztecUIConfigurator {
         textView.textAttachmentDelegate = textViewAttachmentDelegate
         textView.backgroundColor = .basicBackground
         textView.textColor = .systemColor(.label)
-        textView.blockquoteBackgroundColor = .neutral(.shade5)
-        textView.blockquoteBorderColor = .listIcon
-        textView.preBackgroundColor = .neutral(.shade5)
+        textView.blockquoteBackgroundColor = .wooCommercePurple(.shade5)
+        textView.blockquoteBorderColor = .wooCommercePurple(.shade50)
+        textView.preBackgroundColor = .wooCommercePurple(.shade5)
         textView.linkTextAttributes = linkAttributes
 
         // We need this false to be able to set negative `scrollInset` values.

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
@@ -8,6 +8,7 @@ struct AztecUIConfigurator {
                              textViewDelegate: UITextViewDelegate,
                              textViewAttachmentDelegate: TextViewAttachmentDelegate) {
         editorView.clipsToBounds = false
+        editorView.htmlStorage.textColor = .text
         configureHTMLTextView(editorView.htmlTextView, textViewDelegate: textViewDelegate)
         configureRichTextView(editorView.richTextView,
                               textViewDelegate: textViewDelegate,
@@ -77,6 +78,9 @@ private extension AztecUIConfigurator {
         textView.textAttachmentDelegate = textViewAttachmentDelegate
         textView.backgroundColor = .basicBackground
         textView.textColor = .systemColor(.label)
+        textView.blockquoteBackgroundColor = .neutral(.shade5)
+        textView.blockquoteBorderColor = .listIcon
+        textView.preBackgroundColor = .neutral(.shade5)
         textView.linkTextAttributes = linkAttributes
 
         // We need this false to be able to set negative `scrollInset` values.


### PR DESCRIPTION
Fixes #1963 

## Changes

- Updated the text color of the HTML text view via `editorView.htmlStorage.textColor = .text`
- Updated the colors of blockquote text

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap the Description row to edit product description
- Format some text with blockquote (`"` icon) --> make sure the blockquote text looks good in both Dark and Light modes
- Tap the HTML icon in the keyboard toolbar (`</>` icon) --> make sure the content is visible in both Dark and Light modes

## Example screenshots

mode | before | after
-- | -- | --
blockquote - dark | ![Simulator Screen Shot - iPhone 11 - 2020-03-17 at 10 38 51](https://user-images.githubusercontent.com/1945542/76816771-1782dc80-683c-11ea-865b-e5b56a1ea680.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-18 at 09 47 42](https://user-images.githubusercontent.com/1945542/76917503-904a6d00-68fe-11ea-810c-e44fd4b61408.png)
HTML - dark | ![Simulator Screen Shot - iPhone 11 - 2020-03-17 at 10 38 54](https://user-images.githubusercontent.com/1945542/76816816-33867e00-683c-11ea-9be0-f6edd9632977.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-17 at 10 40 31](https://user-images.githubusercontent.com/1945542/76816895-6466b300-683c-11ea-8812-4b0708d6d30e.png)
blockquote - light | ![Simulator Screen Shot - iPhone 11 - 2020-03-17 at 10 39 11](https://user-images.githubusercontent.com/1945542/76816823-35e8d800-683c-11ea-8c36-1fe928063fd5.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-18 at 09 47 49](https://user-images.githubusercontent.com/1945542/76917789-73626980-68ff-11ea-9c25-ce6e3534fade.png)
HTML - light | ![Simulator Screen Shot - iPhone 11 - 2020-03-17 at 10 39 15](https://user-images.githubusercontent.com/1945542/76816826-36816e80-683c-11ea-8695-83881956c89d.png) | ![Simulator Screen Shot - iPhone 11 - 2020-03-17 at 10 40 19](https://user-images.githubusercontent.com/1945542/76816893-62045900-683c-11ea-84aa-9891beaef0b9.png)








Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
