### PR TITLE
Update ReviewsViewController tabbar-item icon

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -329,10 +329,10 @@ extension UIImage {
     /// Returns a star outline icon with the given size
     ///
     /// - Parameters:
-    ///   - size: desired size of the resulting star icon
+    ///   - size: desired size of the resulting star icon, defaults to `Gridicon.defaultSize.height`
     /// - Returns: a bitmap image
     ///
-    static func starOutlineImage(size: Double) -> UIImage {
+    static func starOutlineImage(size: Double = Double(Gridicon.defaultSize.height)) -> UIImage {
         let starSize = CGSize(width: size, height: size)
         return Gridicon.iconOfType(.starOutline,
                                    withSize: starSize)

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
@@ -156,7 +156,7 @@ private extension ReviewsViewController {
     ///
     func configureTabBarItem() {
         tabBarItem.title = NSLocalizedString("Reviews", comment: "Title of the Reviews tab — plural form of Review")
-        tabBarItem.image = .commentImage
+        tabBarItem.image = .starOutlineImage()
         tabBarItem.accessibilityIdentifier = "tab-bar-reviews-item"
     }
 

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Gridicons
 @testable import WooCommerce
 
 final class IconsTests: XCTestCase {
@@ -192,6 +193,11 @@ final class IconsTests: XCTestCase {
         let size = Double(1)
         let starOutlineImage = UIImage.starOutlineImage(size: size)
         XCTAssertEqual(starOutlineImage.size, CGSize(width: size, height: size))
+    }
+
+    func testStarOutlineImageDefaultSize() {
+        let starOutlineImage = UIImage.starOutlineImage()
+        XCTAssertEqual(starOutlineImage.size, Gridicon.defaultSize)
     }
 
     func testStatsImageIconIsNotNil() {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-ios/issues/1935

# Why
As part of the [Woo app UX audit](https://hogsmeadep2.wordpress.com/2019/11/27/woo-app-ux-audit-ios/) the design team has requested to update the `ReviewsViewController` comment icon in favor of the start outlined icon. 

# How
- Update the method that generates a `startOutlined` icon to have a default icon value in order to not expose `Gridicon.defaultSize` and make them behave like the rest of icons defined on `UIImage+Woo.swift`
- Update `ReviewsViewController` to use `starOutlineImage()` instead of `commentImage`

# Screenshots

## Before
![before](https://user-images.githubusercontent.com/562080/76822633-add4e500-67df-11ea-95bc-28b418d90514.png)

## After

Light|Dark
---|---
<img src="https://user-images.githubusercontent.com/562080/76822549-6ea69400-67df-11ea-8dc5-3db5918e8a1d.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/76823025-d4475000-67e0-11ea-81c8-01d42bd2bc54.png" width="300" />


