### PR TITLE
Edit Product: "update" CTA should only be displayed when a change is made

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -21,6 +21,8 @@ final class ProductFormViewController: UIViewController {
             })
             tableView.dataSource = tableViewDataSource
             tableView.reloadData()
+
+            updateNavigationBar(isUpdateEnabled: product != originalProduct)
         }
     }
 
@@ -82,23 +84,8 @@ final class ProductFormViewController: UIViewController {
 
 private extension ProductFormViewController {
     func configureNavigationBar() {
-        let updateTitle = NSLocalizedString("Update", comment: "Action for updating a Product remotely")
-        navigationItem.rightBarButtonItems = [UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))]
-
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2) {
-            navigationItem.rightBarButtonItems?.insert(createMoreOptionsBarButtonItem(), at: 0)
-        }
+        updateNavigationBar(isUpdateEnabled: originalProduct != product)
         removeNavigationBackBarButtonText()
-    }
-
-    func createMoreOptionsBarButtonItem() -> UIBarButtonItem {
-        let moreButton = UIBarButtonItem(image: .moreImage,
-                                     style: .plain,
-                                     target: self,
-                                     action: #selector(presentMoreOptionsActionSheet))
-        moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
-        moreButton.accessibilityIdentifier = "edit-product-more-options-button"
-        return moreButton
     }
 
     func configureMainView() {
@@ -207,6 +194,37 @@ private extension ProductFormViewController {
     func displayProductSettings() {
         let viewController = ProductSettingsViewController(product: product)
         navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+private extension ProductFormViewController {
+    func updateNavigationBar(isUpdateEnabled: Bool) {
+        var rightBarButtonItems = [UIBarButtonItem]()
+
+        if isUpdateEnabled {
+            rightBarButtonItems.append(createUpdateBarButtonItem())
+        }
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2) {
+            rightBarButtonItems.insert(createMoreOptionsBarButtonItem(), at: 0)
+        }
+
+        navigationItem.rightBarButtonItems = rightBarButtonItems
+    }
+
+    func createUpdateBarButtonItem() -> UIBarButtonItem {
+        let updateTitle = NSLocalizedString("Update", comment: "Action for updating a Product remotely")
+        return UIBarButtonItem(title: updateTitle, style: .done, target: self, action: #selector(updateProduct))
+    }
+
+    func createMoreOptionsBarButtonItem() -> UIBarButtonItem {
+        let moreButton = UIBarButtonItem(image: .moreImage,
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(presentMoreOptionsActionSheet))
+        moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
+        moreButton.accessibilityIdentifier = "edit-product-more-options-button"
+        return moreButton
     }
 }
 


### PR DESCRIPTION
Fixes #1968 

## Changes

Moved navigation right bar button items logic from `configureNavigationBar()` to `updateNavigationBar(isUpdateEnabled: Bool)`, which is called in the original `configureNavigationBar()` and when view controller's `product` is set (e.g. when some properties are updated or when the product has been updated remotely)

## Testing

- Go to the Products tab
- Tap on a simple Product --> Update button should not appear in the navigation bar
- Update the product in any way you like (e.g. name, description) --> Update button should appear in the navigation bar after a change is made
- Tap "Update" button and wait for the product to be updated remotely --> Update button should not appear in the navigation bar afterward

## Example screencast

![simulator](https://user-images.githubusercontent.com/1945542/76832456-4ca32500-6864-11ea-89d9-2e18affcee26.gif)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
