### PR TITLE
Attempt to fix crash after visiting the tax class list selector screen a few times

### DIFF
--- a/Yosemite/Yosemite/Actions/TaxClassAction.swift
+++ b/Yosemite/Yosemite/Actions/TaxClassAction.swift
@@ -10,10 +10,6 @@ public enum TaxClassAction: Action {
     ///
     case retrieveTaxClasses(siteID: Int64, onCompletion: ([TaxClass]?, Error?) -> Void)
 
-    /// Deletes all of the cached tax classes.
-    ///
-    case resetStoredTaxClasses(onCompletion: () -> Void)
-
     /// Request the Tax Class found in a specified Product.
     ///
     case requestMissingTaxClasses(for: Product, onCompletion: (TaxClass?, Error?) -> Void)

--- a/Yosemite/Yosemite/Stores/TaxClassStore.swift
+++ b/Yosemite/Yosemite/Stores/TaxClassStore.swift
@@ -28,8 +28,6 @@ public class TaxClassStore: Store {
         switch action {
         case .retrieveTaxClasses(let siteID, let onCompletion):
             retrieveTaxClasses(siteID: siteID, onCompletion: onCompletion)
-        case .resetStoredTaxClasses(let onCompletion):
-            resetStoredTaxClasses(onCompletion: onCompletion)
         case .requestMissingTaxClasses(let product, let onCompletion):
             requestMissingTaxClasses(for: product, onCompletion: onCompletion)
         }
@@ -57,17 +55,6 @@ private extension TaxClassStore {
                 onCompletion(taxClasses, nil)
             }
         }
-    }
-
-    /// Deletes all of the Stored TaxClasses.
-    ///
-    func resetStoredTaxClasses(onCompletion: () -> Void) {
-        let storage = storageManager.viewStorage
-        storage.deleteAllObjects(ofType: Storage.TaxClass.self)
-        storage.saveIfNeeded()
-        DDLogDebug("Tax Classes deleted")
-
-        onCompletion()
     }
 
     /// Synchronizes the Tax Class found in a specified Product.
@@ -127,12 +114,10 @@ private extension TaxClassStore {
     ///     - storage: Where we should save all the things!
     ///
     func upsertStoredTaxClasses(readOnlyTaxClasses: [Networking.TaxClass], in storage: StorageType) {
-        resetStoredTaxClasses {
-            for readOnlyTaxClass in readOnlyTaxClasses {
-                let storageTaxClass = storage.loadTaxClass(slug: readOnlyTaxClass.slug) ?? storage.insertNewObject(ofType: Storage.TaxClass.self)
-
-                storageTaxClass.update(with: readOnlyTaxClass)
-            }
+        storage.deleteAllObjects(ofType: Storage.TaxClass.self)
+        for readOnlyTaxClass in readOnlyTaxClasses {
+            let storageTaxClass = storage.insertNewObject(ofType: Storage.TaxClass.self)
+            storageTaxClass.update(with: readOnlyTaxClass)
         }
     }
 

--- a/Yosemite/YosemiteTests/Stores/TaxClassStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/TaxClassStoreTests.swift
@@ -153,23 +153,6 @@ final class TaxClassStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
-    // MARK: - TaxClassAction.resetStoredTaxClasses
-
-    /// Verifies that `TaxClassAction.resetStoredTaxClasses` deletes the Tax Classes from Storage
-    ///
-    func testResetStoredTaxClassesEffectivelyNukesTheTaxClassesCache() {
-        let expectation = self.expectation(description: "Stored Tax Classes Reset")
-
-        let action = TaxClassAction.resetStoredTaxClasses {
-            self.store.upsertStoredTaxClass(readOnlyTaxClass: self.sampleTaxClass(), in: self.viewStorage)
-            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.TaxClass.self), 1)
-            expectation.fulfill()
-        }
-
-        store.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-    }
-
     // MARK: - TaxClassAction.requestMissingTaxClasses
 
     /// Verifies that `TaxClassAction.requestMissingTaxClasses` request the Tax Class found in a specified Product.


### PR DESCRIPTION
Attempt for #1978 

## Changes

- More background in https://github.com/woocommerce/woocommerce-ios/issues/1978#issuecomment-599977771
- When upserting tax classes from API response inside a Core Data child context's async `perform` block, updated the call to `resetStoredTaxClasses(onCompletion:)` (which saves the parent context) to directly delete the existing storage models
- Removed unused `resetStoredTaxClasses(onCompletion:)`

## Testing

The difficulty to reproduce the crash depends on the device and maybe other factors. I haven't been able to repro in a simulator yet, while @pmusolino has! I found that removing the `DDLogDebug("Tax Classes deleted")` line helped a little bit. I'd recommend trying to reproduce on a device/simulator on `release/3.8` first.

Generally, I was able to reproduce by:

- Go to the Products tab
- Tap on a simple Product
- Tap on the price settings
- Tap on the tax class row to see a list of tax classes
- Navigate back
- Repeat the above 2-3 steps a few times

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
