### PR TITLE
Fixed decimal type in price comparison to check if product data has changed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -396,8 +396,8 @@ private extension ProductFormViewController {
         }
 
         let hasChangedData: Bool = {
-            regularPrice != product.regularPrice ||
-                salePrice != product.salePrice ||
+                getDecimalPrice(regularPrice) != getDecimalPrice(product.regularPrice) ||
+                getDecimalPrice(salePrice) != getDecimalPrice(product.salePrice) ||
                 dateOnSaleStart != product.dateOnSaleStart ||
                 dateOnSaleEnd != product.dateOnSaleEnd ||
                 taxStatus != product.productTaxStatus ||
@@ -497,6 +497,18 @@ private extension ProductFormViewController {
             return
         }
         self.product = productUpdater.briefDescriptionUpdated(briefDescription: newBriefDescription)
+    }
+}
+
+// MARK: Convenience Methods
+//
+private extension ProductFormViewController {
+    func getDecimalPrice(_ price: String?) -> NSDecimalNumber? {
+        guard let price = price else {
+            return nil
+        }
+        let currencyFormatter = CurrencyFormatter()
+        return currencyFormatter.convertToDecimal(from: price)
     }
 }
 


### PR DESCRIPTION
Fixes #1993

## Description
Now we use the decimal type in the price comparison. Before this, the comparison creates the same problem that occurred here #1979. 

## Testing
- Look at the code
- CI


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
