### PR TITLE
Edit Product Sale Price: revised the date pickers behavior

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -438,12 +438,12 @@ private extension ProductPriceSettingsViewController {
             guard let self = self else {
                 return
             }
-            if date > dateOnSaleEnd {
-                cell.getPicker().setDate(dateOnSaleStart, animated: true)
+            self.dateOnSaleStart = date.startOfDay(timezone: self.timezoneForScheduleSaleDates)
+
+            if dateOnSaleEnd < date {
+                self.dateOnSaleEnd = date.endOfDay(timezone: self.timezoneForScheduleSaleDates)
             }
-            else {
-                self.dateOnSaleStart = date.startOfDay(timezone: self.timezoneForScheduleSaleDates)
-            }
+
             self.refreshViewContent()
         }
     }


### PR DESCRIPTION
Close #1952 

## Description
Previously, scheduling a sale for a product was hard to do, due to the way the date picker behaves. The reason was well explained by @rachelmcr here #1952. 
To solve the problem and make everything more intuitive for the end-user, now when you choose a start date which is after the end date, the end date picker will be moved on the same date as the start picker. You will therefore not be stuck as before in entering an initial date in the picker that is after the end date.

## Gif
![2020-03-17 18-09-48 2020-03-17 18_15_16](https://user-images.githubusercontent.com/495617/76882659-44a2af80-687b-11ea-988b-378576e0adaa.gif)

## Testing
1. Select the product and open the Price settings.
2. Enable the "Schedule sale" toggle.
3. Notice the preset start and end dates.
4. Try to schedule a future start date for the sale, past the preset end date.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
