### PR TITLE
Update Top-Performers cell to match the Product-Tab design

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -46,8 +46,16 @@ class ProductTableViewCell: UITableViewCell {
         nameLabel.applyBodyStyle()
         priceLabel.applyBodyStyle()
         detailLabel.applyFootnoteStyle()
-        productImage.contentMode = .scaleAspectFit
+        applyProductImageStyle()
         contentView.backgroundColor = .listForeground
+    }
+
+    private func applyProductImageStyle() {
+        productImage.layer.cornerRadius = Constants.cornerRadius
+        productImage.layer.borderWidth = Constants.borderWidth
+        productImage.layer.borderColor = Colors.imageBorderColor.cgColor
+        productImage.clipsToBounds = true
+        productImage.contentMode = .scaleAspectFill
     }
 }
 
@@ -68,5 +76,18 @@ extension ProductTableViewCell {
                                                        placeholder: .productPlaceholderImage,
                                                        progressBlock: nil,
                                                        completion: nil)
+    }
+}
+
+/// Constants
+///
+private extension ProductTableViewCell {
+    enum Constants {
+        static let cornerRadius = CGFloat(2.0)
+        static let borderWidth = CGFloat(0.5)
+    }
+
+    enum Colors {
+        static let imageBorderColor = UIColor.border
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -51,6 +51,7 @@ class ProductTableViewCell: UITableViewCell {
     }
 
     private func applyProductImageStyle() {
+        productImage.backgroundColor = Colors.imageBackgroundColor
         productImage.layer.cornerRadius = Constants.cornerRadius
         productImage.layer.borderWidth = Constants.borderWidth
         productImage.layer.borderColor = Colors.imageBorderColor.cgColor
@@ -93,5 +94,6 @@ private extension ProductTableViewCell {
 
     enum Colors {
         static let imageBorderColor = UIColor.border
+        static let imageBackgroundColor = UIColor.systemColor(.systemGray6)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -75,8 +75,10 @@ extension ProductTableViewCell {
         imageService.downloadAndCacheImageForImageView(productImage,
                                                        with: statsItem?.imageUrl,
                                                        placeholder: .productPlaceholderImage,
-                                                       progressBlock: nil) { [productImage] (image, error) in
-                                                        guard image != nil, error == nil else { return }
+                                                       progressBlock: nil) { [productImage] (image, _) in
+                                                        guard image != nil else {
+                                                            return
+                                                        }
                                                         productImage?.contentMode = .scaleAspectFill
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -11,7 +11,6 @@ class ProductTableViewCell: UITableViewCell {
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var detailLabel: UILabel!
     @IBOutlet private var priceLabel: UILabel!
-    @IBOutlet private var stackView: UIStackView!
 
     var nameText: String? {
         get {
@@ -42,7 +41,6 @@ class ProductTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        stackView.alignment = .leading
         nameLabel.applyBodyStyle()
         priceLabel.applyBodyStyle()
         detailLabel.applyFootnoteStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -55,7 +55,6 @@ class ProductTableViewCell: UITableViewCell {
         productImage.layer.borderWidth = Constants.borderWidth
         productImage.layer.borderColor = Colors.imageBorderColor.cgColor
         productImage.clipsToBounds = true
-        productImage.contentMode = .scaleAspectFill
     }
 }
 
@@ -71,11 +70,16 @@ extension ProductTableViewCell {
         )
         priceText = statsItem?.formattedTotalString
 
+        /// Set `center` contentMode to not distort the placeholder aspect ratio.
+        /// After a sucessfull image download set the contentMode to `scaleAspectFill`
+        productImage.contentMode = .center
         imageService.downloadAndCacheImageForImageView(productImage,
                                                        with: statsItem?.imageUrl,
                                                        placeholder: .productPlaceholderImage,
-                                                       progressBlock: nil,
-                                                       completion: nil)
+                                                       progressBlock: nil) { [productImage] (image, error) in
+                                                        guard image != nil, error == nil else { return }
+                                                        productImage?.contentMode = .scaleAspectFill
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -75,7 +75,7 @@ extension ProductTableViewCell {
         imageService.downloadAndCacheImageForImageView(productImage,
                                                        with: statsItem?.imageUrl,
                                                        placeholder: .productPlaceholderImage,
-                                                       progressBlock: nil) { [productImage] (image, _) in
+                                                       progressBlock: nil) { [weak productImage] (image, _) in
                                                         guard image != nil else {
                                                             return
                                                         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -11,6 +11,7 @@ class ProductTableViewCell: UITableViewCell {
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var detailLabel: UILabel!
     @IBOutlet private var priceLabel: UILabel!
+    @IBOutlet private var stackView: UIStackView!
 
     var nameText: String? {
         get {
@@ -41,6 +42,7 @@ class ProductTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        stackView.alignment = .leading
         nameLabel.applyBodyStyle()
         priceLabel.applyBodyStyle()
         detailLabel.applyFootnoteStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -49,10 +49,10 @@ class ProductTableViewCell: UITableViewCell {
     }
 
     private func applyProductImageStyle() {
-        productImage.backgroundColor = Colors.imageBackgroundColor
-        productImage.layer.cornerRadius = Constants.cornerRadius
-        productImage.layer.borderWidth = Constants.borderWidth
-        productImage.layer.borderColor = Colors.imageBorderColor.cgColor
+        productImage.backgroundColor = ProductImage.backgroundColor
+        productImage.layer.cornerRadius = ProductImage.cornerRadius
+        productImage.layer.borderWidth = ProductImage.borderWidth
+        productImage.layer.borderColor = ProductImage.borderColor.cgColor
         productImage.clipsToBounds = true
     }
 }
@@ -84,16 +84,13 @@ extension ProductTableViewCell {
     }
 }
 
-/// Constants
+/// Style Constants
 ///
 private extension ProductTableViewCell {
-    enum Constants {
+    enum ProductImage {
         static let cornerRadius = CGFloat(2.0)
         static let borderWidth = CGFloat(0.5)
-    }
-
-    enum Colors {
-        static let imageBorderColor = UIColor.border
-        static let imageBackgroundColor = UIColor.systemColor(.systemGray6)
+        static let borderColor = UIColor.border
+        static let backgroundColor = UIColor.systemColor(.systemGray6)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -77,6 +77,7 @@
                 <outlet property="nameLabel" destination="B98-58-fIv" id="Hh5-mS-u6w"/>
                 <outlet property="priceLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>
                 <outlet property="productImage" destination="yk6-X3-NSJ" id="Kva-Sx-kub"/>
+                <outlet property="stackView" destination="VJh-YT-pnW" id="BOT-fW-0lU"/>
             </connections>
             <point key="canvasLocation" x="-609.60000000000002" y="-173.61319340329837"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -1,68 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="80" id="KGk-i7-Jjw" customClass="ProductTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="104" id="KGk-i7-Jjw" customClass="ProductTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="340" height="104"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
+                <rect key="frame" x="0.0" y="0.0" width="340" height="104"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-X3-NSJ">
-                        <rect key="frame" x="14" y="10" width="60" height="60"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="60" id="IWM-Cq-psD"/>
-                            <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="j1r-Wj-e83"/>
-                        </constraints>
-                    </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                        <rect key="frame" x="82" y="11" width="141" height="58"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VJh-YT-pnW">
+                        <rect key="frame" x="16" y="16" width="308" height="70.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                <rect key="frame" x="0.0" y="0.0" width="141" height="42.5"/>
-                                <string key="text" base64-UTF8="YES">
-ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAg
-ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAg
-ICAgICAgICAgICAgICA
-</string>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="                                       " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                <rect key="frame" x="0.0" y="42.5" width="141" height="15.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-X3-NSJ">
+                                <rect key="frame" x="0.0" y="0.0" width="70.5" height="70.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="52Z-Kf-0Bw"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
+                                <rect key="frame" x="86.5" y="0.0" width="155.5" height="70.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
+                                        <rect key="frame" x="0.0" y="0.0" width="155.5" height="54.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
+                                        <rect key="frame" x="0.0" y="54.5" width="155.5" height="16"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yc7-gf-KCU">
+                                <rect key="frame" x="258" y="0.0" width="50" height="70.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="    " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2yh-4i-vuE">
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YoE-TO-fIp">
+                                        <rect key="frame" x="0.0" y="20.5" width="50" height="50"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    </view>
+                                </subviews>
+                            </stackView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Tw8-4v-wTe"/>
                     </stackView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="                 " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2yh-4i-vuE">
-                        <rect key="frame" x="231" y="11" width="75" height="20.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="wbD-Qx-IG5" secondAttribute="bottom" constant="11" id="8XX-uY-dZd"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="yk6-X3-NSJ" secondAttribute="bottom" constant="9.5" id="D8e-kn-yDo"/>
-                    <constraint firstItem="wbD-Qx-IG5" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="11" id="GvQ-XM-I5x"/>
-                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="14" id="Sjd-SJ-4DE"/>
-                    <constraint firstAttribute="trailing" secondItem="2yh-4i-vuE" secondAttribute="trailing" constant="14" id="Soi-l0-NlP"/>
-                    <constraint firstItem="wbD-Qx-IG5" firstAttribute="leading" secondItem="yk6-X3-NSJ" secondAttribute="trailing" constant="8" id="hAX-8Q-22o"/>
-                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="hAv-Hz-eNa"/>
-                    <constraint firstItem="2yh-4i-vuE" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="11" id="non-2F-i9i"/>
-                    <constraint firstItem="2yh-4i-vuE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="B98-58-fIv" secondAttribute="trailing" constant="8" id="zZ4-zQ-QsH"/>
+                    <constraint firstAttribute="trailing" secondItem="VJh-YT-pnW" secondAttribute="trailing" constant="16" id="EuK-Sc-fLf"/>
+                    <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="ZfX-mu-zvg"/>
+                    <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="16" id="hC4-B8-Gtj"/>
+                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.1" id="p6g-et-9ff"/>
+                    <constraint firstItem="VJh-YT-pnW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ymu-ST-LOb"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -73,7 +78,7 @@ ICAgICAgICAgICAgICA
                 <outlet property="priceLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>
                 <outlet property="productImage" destination="yk6-X3-NSJ" id="Kva-Sx-kub"/>
             </connections>
-            <point key="canvasLocation" x="-5" y="-124"/>
+            <point key="canvasLocation" x="-609.60000000000002" y="-173.61319340329837"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -11,32 +11,32 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="104" id="KGk-i7-Jjw" customClass="ProductTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="340" height="104"/>
+            <rect key="frame" x="0.0" y="0.0" width="288" height="104"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="340" height="104"/>
+                <rect key="frame" x="0.0" y="0.0" width="288" height="104"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VJh-YT-pnW">
-                        <rect key="frame" x="16" y="16" width="308" height="70.5"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VJh-YT-pnW">
+                        <rect key="frame" x="16" y="16" width="256" height="72"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-X3-NSJ">
-                                <rect key="frame" x="0.0" y="0.0" width="70.5" height="70.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="29" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="52Z-Kf-0Bw"/>
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="86.5" y="0.0" width="155.5" height="70.5"/>
+                                <rect key="frame" x="45" y="0.0" width="145" height="58.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                        <rect key="frame" x="0.0" y="0.0" width="155.5" height="54.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="145" height="42.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="54.5" width="155.5" height="16"/>
+                                        <rect key="frame" x="0.0" y="42.5" width="145" height="16"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -44,7 +44,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yc7-gf-KCU">
-                                <rect key="frame" x="258" y="0.0" width="50" height="70.5"/>
+                                <rect key="frame" x="206" y="0.0" width="50" height="70.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="    " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2yh-4i-vuE">
                                         <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
@@ -77,9 +77,8 @@
                 <outlet property="nameLabel" destination="B98-58-fIv" id="Hh5-mS-u6w"/>
                 <outlet property="priceLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>
                 <outlet property="productImage" destination="yk6-X3-NSJ" id="Kva-Sx-kub"/>
-                <outlet property="stackView" destination="VJh-YT-pnW" id="BOT-fW-0lU"/>
             </connections>
-            <point key="canvasLocation" x="-609.60000000000002" y="-173.61319340329837"/>
+            <point key="canvasLocation" x="-651.20000000000005" y="-173.61319340329837"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
Refs: https://github.com/woocommerce/woocommerce-ios/issues/1934 

Fixes https://github.com/woocommerce/woocommerce-ios/issues/1857

# Why
It was requested by the design team for the Top-Performers cell to match the design of the Product cell.

# How
- Refactor `ProductTableViewCell.xib` to use stack views for it's layout and match the `ProductsTabProductTableViewCell` style
- Fix issue where the product image placeholder was distorted by changing the content mode when required.

# Screenshots

### Before
Top Performer|Product
---|---
<img src="https://user-images.githubusercontent.com/562080/76927148-3caf3380-68ac-11ea-92bf-36e9901d6eb8.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/76927149-3e78f700-68ac-11ea-8c78-a213960d61db.png" width="300" />


### After
Top Performer|Product
---|---
<img src="https://user-images.githubusercontent.com/562080/76927181-4df84000-68ac-11ea-8b77-0e26c8050c81.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/76927173-4cc71300-68ac-11ea-9186-0d7d5e40f540.png" width="300" />

### Placeholder correct aspect ratio
![placeholder](https://user-images.githubusercontent.com/562080/76927921-2609dc00-68ae-11ea-9558-c7fe15288cb9.png)

