### PR TITLE
Allow editing a link on tap in Aztec

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -120,6 +120,7 @@ final class AztecEditorViewController: UIViewController, Editor {
         aztecUIConfigurator.configureConstraints(editorView: editorView,
                                                  editorContainerView: view,
                                                  placeholderView: placeholderLabel)
+        disableLinkTapRecognizer(from: editorView.richTextView)
 
         setHTML(content)
 
@@ -164,6 +165,19 @@ private extension AztecEditorViewController {
         for provider in providers {
             richTextView.registerAttachmentImageProvider(provider)
         }
+    }
+
+    /**
+    This handles a bug introduced by iOS 13.0 (tested up to 13.2) where link interactions don't respect what the documentation says.
+    The documenatation for textView(_:shouldInteractWith:in:interaction:) says:
+    > Links in text views are interactive only if the text view is selectable but noneditable.
+    Our Aztec Text views are selectable and editable, and yet iOS was opening links on Safari when tapped.
+    */
+    func disableLinkTapRecognizer(from textView: UITextView) {
+        guard let recognizer = textView.gestureRecognizers?.first(where: { $0.name == "UITextInteractionNameLinkTap" }) else {
+            return
+        }
+        recognizer.isEnabled = false
     }
 }
 


### PR DESCRIPTION
Fixes #1964 

## Changes

This PR resolved the issue the same way as in WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/12898

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the product description row
- Create a link for some text, if there are no links in the text already
- Tap into the link --> the link should be tappable without navigating to the web view and the link settings can be updated from the toolbar above the keyboard

## Example screenshot

<img src="https://user-images.githubusercontent.com/1945542/76927877-00ff8280-691b-11ea-801f-55b3990c983a.png" width="320" />


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
