### PR TITLE
[Auth] Remove the `.showLoginEmail` segue and navigate programmatically

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,10 +22,10 @@ target 'WooCommerce' do
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
   pod 'Automattic-Tracks-iOS', '~> 0.4.4-beta'
 
-  pod 'Gridicons', '~> 0.20-beta'
+  pod 'Gridicons', '~> 1.0-beta'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/204-remove-showLoginEmail'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '6a5018eb50fdc6a627c0ed7691798e07bb8a517d' #:branch => 'issue/204-remove-showLoginEmail'
   #pod 'WordPressAuthenticator', '~> 1.11.0-beta.14'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  

--- a/Podfile
+++ b/Podfile
@@ -20,18 +20,18 @@ target 'WooCommerce' do
 
   # Use the latest bugfix for coretelephony
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
-  pod 'Automattic-Tracks-iOS', '~> 0.4.4-beta'
+  pod 'Automattic-Tracks-iOS', '~> 0.4.4-beta.2'
 
-  pod 'Gridicons', '~> 0.20-beta'
+  pod 'Gridicons', '~> 0.20-beta.1'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
-  pod 'WordPressAuthenticator', '~> 1.11.0-beta'
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/204-remove-showLoginEmail'
+  #pod 'WordPressAuthenticator', '~> 1.11.0-beta.14'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
-  pod 'WordPressShared', '~> 1.8.16-beta'
+  pod 'WordPressShared', '~> 1.8.16-beta.1'
   
-  pod 'WordPressUI', '~> 1.5.2-beta'
+  pod 'WordPressUI', '~> 1.5.2-beta.1'
 
   pod 'WordPress-Editor-iOS', '~> 1.11.0'
 

--- a/Podfile
+++ b/Podfile
@@ -20,18 +20,18 @@ target 'WooCommerce' do
 
   # Use the latest bugfix for coretelephony
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
-  pod 'Automattic-Tracks-iOS', '~> 0.4.4-beta.2'
+  pod 'Automattic-Tracks-iOS', '~> 0.4.4-beta'
 
-  pod 'Gridicons', '~> 0.20-beta.1'
+  pod 'Gridicons', '~> 0.20-beta'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/204-remove-showLoginEmail'
   #pod 'WordPressAuthenticator', '~> 1.11.0-beta.14'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
-  pod 'WordPressShared', '~> 1.8.16-beta.1'
+  pod 'WordPressShared', '~> 1.8.16-beta'
   
-  pod 'WordPressUI', '~> 1.5.2-beta.1'
+  pod 'WordPressUI', '~> 1.5.2-beta'
 
   pod 'WordPress-Editor-iOS', '~> 1.11.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -91,17 +91,17 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 0.4.4-beta.2)
+  - Automattic-Tracks-iOS (~> 0.4.4-beta)
   - Charts (~> 3.3.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
-  - Gridicons (~> 0.20-beta.1)
+  - Gridicons (~> 0.20-beta)
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/204-remove-showLoginEmail`)
-  - WordPressShared (~> 1.8.16-beta.1)
-  - WordPressUI (~> 1.5.2-beta.1)
+  - WordPressShared (~> 1.8.16-beta)
+  - WordPressUI (~> 1.5.2-beta)
   - Wormholy (~> 1.5.1)
   - WPMediaPicker (~> 1.6.0)
   - XLPagerTabStrip (~> 9.0)
@@ -193,6 +193,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: a66f14dca777595e757464026fb4091fcb7a3af8
+PODFILE CHECKSUM: 5ebbb13c96d05d99a8541d94dad7d9eefee1c18c
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,7 +47,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.11.0-beta.16):
+  - WordPressAuthenticator (1.11.0-beta.15):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -99,7 +99,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `6a5018eb50fdc6a627c0ed7691798e07bb8a517d`)
+  - WordPressAuthenticator (~> 1.11.0-beta.15)
   - WordPressShared (~> 1.8.16-beta)
   - WordPressUI (~> 1.5.2-beta)
   - Wormholy (~> 1.5.1)
@@ -130,6 +130,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -144,16 +145,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: 6a5018eb50fdc6a627c0ed7691798e07bb8a517d
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 6a5018eb50fdc6a627c0ed7691798e07bb8a517d
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -177,7 +168,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 8c26b5ee4938a76d64587574aa2b5793d4923c6b
+  WordPressAuthenticator: 0a4bd049afda4ab782543de9c0e12ecd90af8e9e
   WordPressKit: eb884caeba0fab58ea1e99ceee2403559c4e99a4
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
@@ -193,6 +184,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 5debf0e53adf8ec7907f34d234c2d16ff7a736f8
+PODFILE CHECKSUM: 5682daf331331a169c11245f667765b7de8b69ec
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - 1PasswordExtension (1.8.5)
+  - 1PasswordExtension (1.8.6)
   - Alamofire (4.8.0)
   - Automattic-Tracks-iOS (0.4.4-beta.2):
     - CocoaLumberjack (~> 3.5.2)
@@ -35,9 +35,9 @@ PODS:
   - Kingfisher (5.11.0):
     - Kingfisher/Core (= 5.11.0)
   - Kingfisher/Core (5.11.0)
-  - lottie-ios (2.5.2)
+  - lottie-ios (3.1.6)
   - NSObject-SafeExpectations (0.0.4)
-  - "NSURL+IDN (0.3)"
+  - "NSURL+IDN (0.4)"
   - Reachability (3.2)
   - Sentry (4.5.0):
     - Sentry/Core (= 4.5.0)
@@ -47,19 +47,19 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.11.0-beta.1):
-    - 1PasswordExtension (= 1.8.5)
+  - WordPressAuthenticator (1.11.0-beta.14):
+    - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 4.4)
-    - Gridicons (~> 0.15)
-    - lottie-ios (= 2.5.2)
-    - "NSURL+IDN (= 0.3)"
+    - Gridicons (~> 0.20-beta)
+    - lottie-ios (= 3.1.6)
+    - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.6.0-beta.1)
-    - WordPressShared (~> 1.8.13-beta)
-    - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.6.0-beta.7):
+    - WordPressKit (~> 4.6.0-beta.8)
+    - WordPressShared (~> 1.8.16-beta)
+    - WordPressUI (~> 1.5-beta)
+  - WordPressKit (4.6.0-beta.8):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -91,17 +91,17 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 4.8)
-  - Automattic-Tracks-iOS (~> 0.4.4-beta)
+  - Automattic-Tracks-iOS (~> 0.4.4-beta.2)
   - Charts (~> 3.3.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
-  - Gridicons (~> 0.20-beta)
+  - Gridicons (~> 0.20-beta.1)
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.11.0-beta)
-  - WordPressShared (~> 1.8.16-beta)
-  - WordPressUI (~> 1.5.2-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/204-remove-showLoginEmail`)
+  - WordPressShared (~> 1.8.16-beta.1)
+  - WordPressUI (~> 1.5.2-beta.1)
   - Wormholy (~> 1.5.1)
   - WPMediaPicker (~> 1.6.0)
   - XLPagerTabStrip (~> 9.0)
@@ -130,7 +130,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -146,8 +145,18 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: issue/204-remove-showLoginEmail
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 6fe1522eb5e64610a794307c242476a2231d8681
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
-  1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
+  1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   Automattic-Tracks-iOS: 6d382b8a75dd107c6d73f8f539e734ff5064ec69
   Charts: e0dd4cd8f257bccf98407b58183ddca8e8d5b578
@@ -159,17 +168,17 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
   Kingfisher: 4569606189149e19c7d9439f47e885d0679b7a90
-  lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
+  lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
-  "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
+  "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: c69b217614533d91e449fb54c3a813e544464922
-  WordPressKit: af813ac74d5248bbc2b89e274dc023b6e960e000
+  WordPressAuthenticator: 4c8b556d2daad85b054e32d08ba605a83315f80e
+  WordPressKit: eb884caeba0fab58ea1e99ceee2403559c4e99a4
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
   Wormholy: f01b096b449a9fcab864a10f7e5b5693b1225c88
@@ -184,6 +193,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 16e2eb969da87f3c034f687957dc2d753409b8d1
+PODFILE CHECKSUM: a66f14dca777595e757464026fb4091fcb7a3af8
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,7 +29,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - Gridicons (0.20-beta.1)
+  - Gridicons (1.0-beta.1)
   - GTMSessionFetcher/Core (1.3.1)
   - KeychainAccess (3.2.1)
   - Kingfisher (5.11.0):
@@ -47,12 +47,12 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.11.0-beta.14):
+  - WordPressAuthenticator (1.11.0-beta.16):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 4.4)
-    - Gridicons (~> 0.20-beta)
+    - Gridicons (~> 1.0-beta.1)
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
@@ -95,11 +95,11 @@ DEPENDENCIES:
   - Charts (~> 3.3.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
-  - Gridicons (~> 0.20-beta)
+  - Gridicons (~> 1.0-beta)
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/204-remove-showLoginEmail`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `6a5018eb50fdc6a627c0ed7691798e07bb8a517d`)
   - WordPressShared (~> 1.8.16-beta)
   - WordPressUI (~> 1.5.2-beta)
   - Wormholy (~> 1.5.1)
@@ -147,12 +147,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: issue/204-remove-showLoginEmail
+    :commit: 6a5018eb50fdc6a627c0ed7691798e07bb8a517d
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 6fe1522eb5e64610a794307c242476a2231d8681
+    :commit: 6a5018eb50fdc6a627c0ed7691798e07bb8a517d
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -164,7 +164,7 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  Gridicons: a89c04840b560895223a2c5c1e1299b518e0fc6f
+  Gridicons: 48ccbe284c39db15cc796af0c523e749683ae061
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
   Kingfisher: 4569606189149e19c7d9439f47e885d0679b7a90
@@ -177,7 +177,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 4c8b556d2daad85b054e32d08ba605a83315f80e
+  WordPressAuthenticator: 8c26b5ee4938a76d64587574aa2b5793d4923c6b
   WordPressKit: eb884caeba0fab58ea1e99ceee2403559c4e99a4
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
@@ -193,6 +193,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 5ebbb13c96d05d99a8541d94dad7d9eefee1c18c
+PODFILE CHECKSUM: 5debf0e53adf8ec7907f34d234c2d16ff7a736f8
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/FormatBarItemViewProperties.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/FormatBarItemViewProperties.swift
@@ -31,7 +31,7 @@ extension FormattingIdentifier: FormatBarItemViewProperties {
             if layoutDirection == .leftToRight {
                 return Gridicon.iconOfType(.listOrdered)
             } else {
-                return Gridicon.iconOfType(.listOrderedRTL)
+                return Gridicon.iconOfType(.listOrderedRtl)
             }
         case .unorderedlist:
             return Gridicon.iconOfType(.listUnordered).imageFlippedForRightToLeftLayoutDirection()


### PR DESCRIPTION
Ref. #2003.

### In this PR
- TIL that Cocoapods does not like our beta versions and will ignore newer beta versions, so I made the beta versions explicit in the podfile.
- Authenticator has been updated to remove the storyboard segue `.showLoginEmail`
- See also https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/207

### To Test
1. Check out this branch
2. `rake dependencies`
3. Run unit tests
4. Build and run
5. Log out
6. Select the "Log in with Jetpack" button. 

### Do not merge until
1. The Authenticator PR has been merged: wordpress-mobile/WordPressAuthenticator-iOS#207 ✔️
2. A new Authenticator release has been created ✔️
3. The release is published on Cocoapods trunk ✔️
4. This PR points to the new release ✔️

**Expected result:** it should show the expected LoginEmailViewController

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
