### PR TITLE
Pass `CurrencySettings` to `CurrencyFormatter` and `PriceInputFormatter` for unit tests

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -5,6 +5,12 @@ import Yosemite
 // MARK: - Manual currency formatting
 //
 public class CurrencyFormatter {
+    private let currencySettings: CurrencySettings
+
+    init(currencySettings: CurrencySettings = CurrencySettings.shared) {
+        self.currencySettings = currencySettings
+    }
+
     /// Returns a decimal value from a given string.
     /// - Parameters:
     ///   - stringValue: the string received from the API
@@ -13,13 +19,13 @@ public class CurrencyFormatter {
 
         // NSDecimalNumber use by default the local decimal separator to evaluate a decimal amount.
         // We substitute the current decimal separator with the locale decimal separator.
-        let localeDecimalSeparator = Locale.current.decimalSeparator ?? CurrencySettings.shared.decimalSeparator
+        let localeDecimalSeparator = Locale.current.decimalSeparator ?? currencySettings.decimalSeparator
         var newStringValue = stringValue.replacingOccurrences(of: ",", with: localeDecimalSeparator)
         newStringValue = newStringValue.replacingOccurrences(of: ".", with: localeDecimalSeparator)
 
         // Removes the currency symbol, if any.
-        let currencyCode = CurrencySettings.shared.currencyCode
-        let unit = CurrencySettings.shared.symbol(from: currencyCode)
+        let currencyCode = currencySettings.currencyCode
+        let unit = currencySettings.symbol(from: currencyCode)
         newStringValue = newStringValue.replacingOccurrences(of: unit, with: "")
 
         let decimalValue = NSDecimalNumber(string: newStringValue, locale: Locale.current)
@@ -176,9 +182,9 @@ public class CurrencyFormatter {
 
         // If we are here, the human readable version of the amount param is a "large" number *OR* a small number but rounding has been requested,
         // so let's just put the currency symbol on the correct side of the string with proper spacing (based on the site settings).
-        let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? CurrencySettings.shared.currencyCode
-        let symbol = CurrencySettings.shared.symbol(from: code)
-        let position = CurrencySettings.shared.currencyPosition
+        let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
+        let symbol = currencySettings.symbol(from: code)
+        let position = currencySettings.currencyPosition
         let isNegative = amount.isNegative()
 
         return formatCurrency(using: humanReadableAmount,
@@ -194,13 +200,13 @@ public class CurrencyFormatter {
     ///
     func formatAmount(_ decimalAmount: NSDecimalNumber, with currency: String = CurrencySettings.shared.currencyCode.rawValue) -> String? {
         // Get the currency code
-        let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? CurrencySettings.shared.currencyCode
+        let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
         // Grab the read-only currency options. These are set by the user in Site > Settings.
-        let symbol = CurrencySettings.shared.symbol(from: code)
-        let separator = CurrencySettings.shared.decimalSeparator
-        let numberOfDecimals = CurrencySettings.shared.numberOfDecimals
-        let position = CurrencySettings.shared.currencyPosition
-        let thousandSeparator = CurrencySettings.shared.thousandSeparator
+        let symbol = currencySettings.symbol(from: code)
+        let separator = currencySettings.decimalSeparator
+        let numberOfDecimals = currencySettings.numberOfDecimals
+        let position = currencySettings.currencyPosition
+        let thousandSeparator = currencySettings.thousandSeparator
 
         // Put all the pieces of user preferences on currency formatting together
         // and spit out a string that has the formatted amount.

--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -118,8 +118,6 @@ public class CurrencySettings {
         self.thousandSeparator = thousandSeparator
         self.decimalSeparator = decimalSeparator
         self.numberOfDecimals = numberOfDecimals
-
-        configureResultsController()
     }
 
 
@@ -132,6 +130,7 @@ public class CurrencySettings {
                   thousandSeparator: CurrencySettings.Default.thousandSeparator,
                   decimalSeparator: CurrencySettings.Default.decimalSeparator,
                   numberOfDecimals: CurrencySettings.Default.decimalPosition)
+        configureResultsController()
     }
 
     /// Convenience Initializer:

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -6,7 +6,7 @@ struct PriceInputFormatter: UnitInputFormatter {
 
     /// Currency Formatter.
     ///
-    private var currencyFormatter = CurrencyFormatter()
+    private let currencySettings: CurrencySettings
 
     /// Number formatter with comma
     ///
@@ -26,6 +26,10 @@ struct PriceInputFormatter: UnitInputFormatter {
         return numberFormatter
     }()
 
+    init(currencySettings: CurrencySettings = CurrencySettings.shared) {
+        self.currencySettings = currencySettings
+    }
+
     func isValid(input: String) -> Bool {
         guard input.isEmpty == false else {
             // Allows empty input to be replaced by 0.
@@ -42,7 +46,7 @@ struct PriceInputFormatter: UnitInputFormatter {
 
         let formattedText = text
             // Replace any characters not in the set of 0-9 with the current decimal separator configured on website
-            .replacingOccurrences(of: "[^0-9]", with: CurrencySettings.shared.decimalSeparator, options: .regularExpression)
+            .replacingOccurrences(of: "[^0-9]", with: currencySettings.decimalSeparator, options: .regularExpression)
             // Remove any initial zero number in the string. Es. 00224.30 will be 2224.30
             .replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
             // Replace all the occurrences of regex plus all the points or comma (but not the last `.` or `,`) like thousand separators

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -60,18 +60,27 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingInputWithLeadingZeros() {
+        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let formatter = PriceInputFormatter(currencySettings: currencySettings)
+
         let input = "00123.91"
-        XCTAssertEqual(formatter.format(input: input), "123.91".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
+        XCTAssertEqual(formatter.format(input: input), "123.91")
     }
 
     func testFormattingDecimalInputWithPoint() {
+        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let formatter = PriceInputFormatter(currencySettings: currencySettings)
+
         let input = "0.314"
-        XCTAssertEqual(formatter.format(input: input), "0.314".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
+        XCTAssertEqual(formatter.format(input: input), "0.314")
     }
 
     func testFormattingDecimalInputWithComma() {
+        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let formatter = PriceInputFormatter(currencySettings: currencySettings)
+
         let input = "0,314"
-        XCTAssertEqual(formatter.format(input: input), "0.314".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
+        XCTAssertEqual(formatter.format(input: input), "0.314")
     }
 
     func testFormattingIntegerInput() {
@@ -80,12 +89,18 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingBigPriceInput() {
+        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let formatter = PriceInputFormatter(currencySettings: currencySettings)
+
         let input = "189293891203.20"
-        XCTAssertEqual(formatter.format(input: input), "189293891203.20".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
+        XCTAssertEqual(formatter.format(input: input), "189293891203.20")
     }
 
     func testFormattingBigPriceInputWithThousandSeparators() {
+        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: ",", decimalSeparator: ".", numberOfDecimals: 3)
+        let formatter = PriceInputFormatter(currencySettings: currencySettings)
+
         let input = "189,293,891,203.20"
-        XCTAssertEqual(formatter.format(input: input), "189293891203.20".replacingOccurrences(of: ".", with: CurrencySettings.shared.decimalSeparator))
+        XCTAssertEqual(formatter.format(input: input), "189293891203.20")
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -60,7 +60,11 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingInputWithLeadingZeros() {
-        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let formatter = PriceInputFormatter(currencySettings: currencySettings)
 
         let input = "00123.91"
@@ -68,7 +72,11 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingDecimalInputWithPoint() {
-        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let formatter = PriceInputFormatter(currencySettings: currencySettings)
 
         let input = "0.314"
@@ -76,7 +84,11 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingDecimalInputWithComma() {
-        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let formatter = PriceInputFormatter(currencySettings: currencySettings)
 
         let input = "0,314"
@@ -89,7 +101,11 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingBigPriceInput() {
-        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 3)
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let formatter = PriceInputFormatter(currencySettings: currencySettings)
 
         let input = "189293891203.20"
@@ -97,7 +113,11 @@ final class PriceInputFormatterTests: XCTestCase {
     }
 
     func testFormattingBigPriceInputWithThousandSeparators() {
-        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .leftSpace, thousandSeparator: ",", decimalSeparator: ".", numberOfDecimals: 3)
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
         let formatter = PriceInputFormatter(currencySettings: currencySettings)
 
         let input = "189,293,891,203.20"


### PR DESCRIPTION
Part of #1956 

## Changes

This PR is just a small refactoring to make `CurrencyFormatter` and `PriceInputFormatter` more testable without having to modify the app `CurrencySettings` shared instance. No user-facing changes are intended.

- DI'ed `CurrencySettings` to `CurrencyFormatter`
- DI'ed `CurrencySettings` to `PriceInputFormatter`
- In `CurrencySettings` init with parameters for all the properties, removed the side effect of `configureResultsController()` and called `configureResultsController()` in the convenient `init()` that is only used in the app shared instance
- Updated unit tests to specify the currency settings for test cases that depend on certain settings (e.g. decimal separator, thousand separator)

## Testing

- Launch the app
- Go to the Orders tab --> make sure the price is formatted as in the store settings (e.g. currency symbol and its position, thousand separator)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
