### PR TITLE
Update main project to use Gridicons 1.0-beta.1 pod

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,11 +22,11 @@ target 'WooCommerce' do
   #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.4-beta.1'
   pod 'Automattic-Tracks-iOS', '~> 0.4.4-beta'
 
-  pod 'Gridicons', '~> 0.20-beta'
+  pod 'Gridicons', '~> 1.0-beta'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/wc-support-site-url-login'
-  pod 'WordPressAuthenticator', '~> 1.11.0-beta.13'
+  pod 'WordPressAuthenticator', '~> 1.11.0-beta.14'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'  
   pod 'WordPressShared', '~> 1.8.16-beta'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,7 +29,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - Gridicons (0.20-beta.1)
+  - Gridicons (1.0-beta.1)
   - GTMSessionFetcher/Core (1.3.1)
   - KeychainAccess (3.2.1)
   - Kingfisher (5.11.0):
@@ -47,12 +47,12 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.11.0-beta.13):
+  - WordPressAuthenticator (1.11.0-beta.14):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 4.4)
-    - Gridicons (~> 0.20-beta)
+    - Gridicons (~> 1.0-beta.1)
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
@@ -95,11 +95,11 @@ DEPENDENCIES:
   - Charts (~> 3.3.0)
   - CocoaLumberjack (~> 3.5)
   - CocoaLumberjack/Swift (~> 3.5)
-  - Gridicons (~> 0.20-beta)
+  - Gridicons (~> 1.0-beta)
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.11.0-beta.13)
+  - WordPressAuthenticator (~> 1.11.0-beta.14)
   - WordPressShared (~> 1.8.16-beta)
   - WordPressUI (~> 1.5.2-beta)
   - Wormholy (~> 1.5.1)
@@ -155,7 +155,7 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  Gridicons: a89c04840b560895223a2c5c1e1299b518e0fc6f
+  Gridicons: 48ccbe284c39db15cc796af0c523e749683ae061
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   KeychainAccess: d5470352939ced6d6f7fb51cb2e67aae51fc294f
   Kingfisher: 4569606189149e19c7d9439f47e885d0679b7a90
@@ -168,7 +168,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: a932d9db6a439f7e47372c8f64de629724c63462
+  WordPressAuthenticator: 76bd1c9042add8ff5cb960aa8216f2e7519c9ea0
   WordPressKit: eb884caeba0fab58ea1e99ceee2403559c4e99a4
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
   WordPressUI: 77907b59f39530af1003a30e6148a3ad0d2b179f
@@ -184,6 +184,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 5f8b5efd8c9f59d56087322d020716ce49507dc9
+PODFILE CHECKSUM: d2422c4bf06ea2d88892275206dba6d4e7ed2cdf
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -10,39 +10,39 @@ extension UIImage {
     /// Add Icon
     ///
     static var addOutlineImage: UIImage {
-        return Gridicon.iconOfType(.addOutline)
+        return UIImage.gridicon(.addOutline)
     }
 
     /// Notice Icon
     ///
     static var noticeImage: UIImage {
         let tintColor = UIColor.listIcon
-        return Gridicon.iconOfType(.notice).imageWithTintColor(tintColor)!
+        return UIImage.gridicon(.notice).imageWithTintColor(tintColor)!
     }
 
     /// Aside Image
     ///
     static var asideImage: UIImage {
-        return Gridicon.iconOfType(.aside)
+        return UIImage.gridicon(.aside)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Bell Icon
     ///
     static var bellImage: UIImage {
-        return Gridicon.iconOfType(.bell)
+        return UIImage.gridicon(.bell)
     }
 
     /// Brief Description Icon
     ///
     static var briefDescriptionImage: UIImage {
-        return Gridicon.iconOfType(.alignLeft, withSize: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.alignLeft, size: CGSize(width: 24, height: 24))
     }
 
     /// Camera Icon
     ///
     static var cameraImage: UIImage {
-        return Gridicon.iconOfType(.camera)
+        return UIImage.gridicon(.camera)
             .imageFlippedForRightToLeftLayoutDirection()
             .applyTintColor(.placeholderImage)!
     }
@@ -51,13 +51,13 @@ extension UIImage {
     ///
     static var addImage: UIImage {
         let tintColor = UIColor.neutral(.shade40)
-        return Gridicon.iconOfType(.addImage).imageWithTintColor(tintColor)!
+        return UIImage.gridicon(.addImage).imageWithTintColor(tintColor)!
     }
 
     /// Checkmark image, no style applied
     ///
     static var checkmarkImage: UIImage {
-        return Gridicon.iconOfType(.checkmark)
+        return UIImage.gridicon(.checkmark)
     }
 
     /// WooCommerce Styled Checkmark
@@ -71,44 +71,44 @@ extension UIImage {
     ///
     static var chevronImage: UIImage {
         let tintColor = UIColor.neutral(.shade40)
-        return Gridicon.iconOfType(.chevronRight).imageWithTintColor(tintColor)!
+        return UIImage.gridicon(.chevronRight).imageWithTintColor(tintColor)!
     }
 
     /// Chevron Pointing Down
     ///
     static var chevronDownImage: UIImage {
-        return Gridicon.iconOfType(.chevronDown)
+        return UIImage.gridicon(.chevronDown)
     }
 
     /// Chevron Pointing Up
     ///
     static var chevronUpImage: UIImage {
-        return Gridicon.iconOfType(.chevronUp)
+        return UIImage.gridicon(.chevronUp)
     }
 
     /// Close bar button item
     ///
     static var closeButton: UIImage {
-        return Gridicon.iconOfType(.cross)
+        return UIImage.gridicon(.cross)
     }
 
     /// Cog Icon
     ///
     static var cogImage: UIImage {
-        return Gridicon.iconOfType(.cog)
+        return UIImage.gridicon(.cog)
     }
 
     /// Comment Icon
     ///
     static var commentImage: UIImage {
-        return Gridicon.iconOfType(.comment)
+        return UIImage.gridicon(.comment)
     }
 
     /// Delete Icon
     ///
     static var deleteImage: UIImage {
         let tintColor = UIColor.primary
-        return Gridicon.iconOfType(.crossCircle)
+        return UIImage.gridicon(.crossCircle)
             .imageWithTintColor(tintColor)!
             .imageFlippedForRightToLeftLayoutDirection()
     }
@@ -116,7 +116,7 @@ extension UIImage {
     /// Ellipsis Icon
     ///
     static var ellipsisImage: UIImage {
-        return Gridicon.iconOfType(.ellipsis)
+        return UIImage.gridicon(.ellipsis)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
@@ -141,20 +141,20 @@ extension UIImage {
     /// External Link Icon
     ///
     static var externalImage: UIImage {
-        return Gridicon.iconOfType(.external)
+        return UIImage.gridicon(.external)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Filter Icon
     ///
     static var filterImage: UIImage {
-        return Gridicon.iconOfType(.filter)
+        return UIImage.gridicon(.filter)
     }
 
     /// Gift Icon (with a red dot at the top right corner)
     ///
     static var giftWithTopRightRedDotImage: UIImage {
-        guard let image = Gridicon.iconOfType(.gift, withSize: CGSize(width: 24, height: 24))
+        guard let image = UIImage.gridicon(.gift, size: CGSize(width: 24, height: 24))
             // Applies a constant gray color that looks fine in both Light/Dark modes, since we are generating an image with multiple colors.
             .applyTintColor(.gray(.shade30))?
             .imageWithTopRightDot(imageOrigin: CGPoint(x: 0, y: 2),
@@ -173,7 +173,7 @@ extension UIImage {
     /// Heart Outline
     ///
     static var heartOutlineImage: UIImage {
-        return Gridicon.iconOfType(.heartOutline)
+        return UIImage.gridicon(.heartOutline)
     }
 
     /// Login prologue slanted rectangle
@@ -185,7 +185,7 @@ extension UIImage {
     /// Inventory Icon
     ///
     static var inventoryImage: UIImage {
-        return Gridicon.iconOfType(.listCheckmark, withSize: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.listCheckmark, size: CGSize(width: 24, height: 24))
     }
 
     /// Jetpack Logo Image
@@ -197,13 +197,13 @@ extension UIImage {
     /// Info Icon
     ///
     static var infoImage: UIImage {
-        return Gridicon.iconOfType(.info, withSize: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.info, size: CGSize(width: 24, height: 24))
     }
 
     /// Invisible Image
     ///
     static var invisibleImage: UIImage {
-        return Gridicon.iconOfType(.image)
+        return UIImage.gridicon(.image)
     }
 
     /// Login magic link
@@ -221,7 +221,7 @@ extension UIImage {
     /// Mail Icon
     ///
     static var mailImage: UIImage {
-        return Gridicon.iconOfType(.mail)
+        return UIImage.gridicon(.mail)
     }
 
     /// More Icon
@@ -234,22 +234,21 @@ extension UIImage {
     /// Price Icon
     ///
     static var priceImage: UIImage {
-        return Gridicon.iconOfType(.money, withSize: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.money, size: CGSize(width: 24, height: 24))
     }
 
     /// Product Placeholder Image
     ///
     static var productPlaceholderImage: UIImage {
         let tintColor = UIColor.listIcon
-        return Gridicon.iconOfType(.product).imageWithTintColor(tintColor)!
+        return UIImage.gridicon(.product).imageWithTintColor(tintColor)!
     }
 
     /// Product Placeholder Image on Products Tab Cell
     ///
     static var productsTabProductCellPlaceholderImage: UIImage {
         let tintColor = UIColor.listSmallIcon
-        return Gridicon
-            .iconOfType(.product, withSize: CGSize(width: 20, height: 20))
+        return UIImage.gridicon(.product, size: CGSize(width: 20, height: 20))
             .imageWithTintColor(tintColor)!
     }
 
@@ -264,14 +263,14 @@ extension UIImage {
     /// Product Image
     ///
     static var productImage: UIImage {
-        return Gridicon.iconOfType(.product)
+        return UIImage.gridicon(.product)
     }
 
     /// Pencil Icon
     ///
     static var pencilImage: UIImage {
         let tintColor = UIColor.primary
-        return Gridicon.iconOfType(.pencil)
+        return UIImage.gridicon(.pencil)
             .imageWithTintColor(tintColor)!
             .imageFlippedForRightToLeftLayoutDirection()
     }
@@ -279,39 +278,39 @@ extension UIImage {
     /// Quote Image
     ///
     static var quoteImage: UIImage {
-        return Gridicon.iconOfType(.quote)
+        return UIImage.gridicon(.quote)
     }
 
     /// Pages Icon
     ///
     static var pagesImage: UIImage {
-        return Gridicon.iconOfType(.pages)
+        return UIImage.gridicon(.pages)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Search Icon
     ///
     static var searchImage: UIImage {
-        return Gridicon.iconOfType(.search)
+        return UIImage.gridicon(.search)
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Shipping Icon
     ///
     static var shippingImage: UIImage {
-        return Gridicon.iconOfType(.shipping, withSize: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.shipping, size: CGSize(width: 24, height: 24))
     }
 
     /// Shipping class list selector empty icon
     ///
     static var shippingClassListSelectorEmptyImage: UIImage {
-        return Gridicon.iconOfType(.shipping, withSize: CGSize(width: 80, height: 80))
+        return UIImage.gridicon(.shipping, size: CGSize(width: 80, height: 80))
     }
 
     /// Spam Icon
     ///
     static var spamImage: UIImage {
-        return Gridicon.iconOfType(.spam)
+        return UIImage.gridicon(.spam)
     }
 
     /// Returns a star icon with the given size
@@ -322,8 +321,7 @@ extension UIImage {
     ///
     static func starImage(size: Double) -> UIImage {
         let starSize = CGSize(width: size, height: size)
-        return Gridicon.iconOfType(.star,
-                                   withSize: starSize)
+        return UIImage.gridicon(.star, size: starSize)
     }
 
     /// Returns a star outline icon with the given size
@@ -334,28 +332,27 @@ extension UIImage {
     ///
     static func starOutlineImage(size: Double = Double(Gridicon.defaultSize.height)) -> UIImage {
         let starSize = CGSize(width: size, height: size)
-        return Gridicon.iconOfType(.starOutline,
-                                   withSize: starSize)
+        return UIImage.gridicon(.starOutline, size: starSize)
     }
 
     /// Stats Icon
     ///
     static var statsImage: UIImage {
-        return Gridicon.iconOfType(.stats)
+        return UIImage.gridicon(.stats)
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Stats Alt Icon
     ///
     static var statsAltImage: UIImage {
-        return Gridicon.iconOfType(.statsAlt)
+        return UIImage.gridicon(.statsAlt)
         .imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Trash Can Icon
     ///
     static var trashImage: UIImage {
-        return Gridicon.iconOfType(.trash)
+        return UIImage.gridicon(.trash)
     }
 
     /// Creates a bitmap image of the Woo "bubble" logo based on a vector image in our asset catalog.

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/AztecFormatBarFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/AztecFormatBarFactory.swift
@@ -12,7 +12,7 @@ struct AztecFormatBarFactory {
         toolbar.selectedTintColor = .primary
         toolbar.disabledTintColor = .textTertiary
         toolbar.dividerTintColor = .divider
-        toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
+        toolbar.overflowToggleIcon = UIImage.gridicon(.ellipsis)
         toolbar.backgroundColor = .systemColor(.secondarySystemBackground)
 
         updateToolbar(toolbar)

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/FormatBarItemViewProperties.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/FormatBarItemViewProperties.swift
@@ -14,49 +14,49 @@ extension FormattingIdentifier: FormatBarItemViewProperties {
     var iconImage: UIImage {
         switch self {
         case .media:
-            return Gridicon.iconOfType(.addOutline)
+            return UIImage.gridicon(.addOutline)
         case .p:
-            return Gridicon.iconOfType(.heading)
+            return UIImage.gridicon(.heading)
         case .bold:
-            return Gridicon.iconOfType(.bold)
+            return UIImage.gridicon(.bold)
         case .italic:
-            return Gridicon.iconOfType(.italic)
+            return UIImage.gridicon(.italic)
         case .underline:
-            return Gridicon.iconOfType(.underline)
+            return UIImage.gridicon(.underline)
         case .strikethrough:
-            return Gridicon.iconOfType(.strikethrough)
+            return UIImage.gridicon(.strikethrough)
         case .blockquote:
-            return Gridicon.iconOfType(.quote)
+            return UIImage.gridicon(.quote)
         case .orderedlist:
             if layoutDirection == .leftToRight {
-                return Gridicon.iconOfType(.listOrdered)
+                return UIImage.gridicon(.listOrdered)
             } else {
-                return Gridicon.iconOfType(.listOrderedRTL)
+                return UIImage.gridicon(.listOrderedRtl)
             }
         case .unorderedlist:
-            return Gridicon.iconOfType(.listUnordered).imageFlippedForRightToLeftLayoutDirection()
+            return UIImage.gridicon(.listUnordered).imageFlippedForRightToLeftLayoutDirection()
         case .link:
-            return Gridicon.iconOfType(.link)
+            return UIImage.gridicon(.link)
         case .horizontalruler:
-            return Gridicon.iconOfType(.minusSmall)
+            return UIImage.gridicon(.minusSmall)
         case .sourcecode:
-            return Gridicon.iconOfType(.code)
+            return UIImage.gridicon(.code)
         case .more:
-            return Gridicon.iconOfType(.readMore)
+            return UIImage.gridicon(.readMore)
         case .header1:
-            return Gridicon.iconOfType(.headingH1)
+            return UIImage.gridicon(.headingH1)
         case .header2:
-            return Gridicon.iconOfType(.headingH2)
+            return UIImage.gridicon(.headingH2)
         case .header3:
-            return Gridicon.iconOfType(.headingH3)
+            return UIImage.gridicon(.headingH3)
         case .header4:
-            return Gridicon.iconOfType(.headingH4)
+            return UIImage.gridicon(.headingH4)
         case .header5:
-            return Gridicon.iconOfType(.headingH5)
+            return UIImage.gridicon(.headingH5)
         case .header6:
-            return Gridicon.iconOfType(.headingH6)
+            return UIImage.gridicon(.headingH6)
         default:
-            return Gridicon.iconOfType(.help)
+            return UIImage.gridicon(.help)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -86,7 +86,7 @@ private extension TopBannerView {
         infoLabel.numberOfLines = 0
 
         if isActionEnabled {
-            dismissButton.setImage(Gridicon.iconOfType(.cross, withSize: CGSize(width: 24, height: 24)), for: .normal)
+            dismissButton.setImage(UIImage.gridicon(.cross, size: CGSize(width: 24, height: 24)), for: .normal)
             dismissButton.tintColor = .textSubtle
             dismissButton.addTarget(self, action: #selector(onDismissButtonTapped), for: .touchUpInside)
 


### PR DESCRIPTION
### Issue
I went to merge https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/207 and https://github.com/woocommerce/woocommerce-ios/pull/2007. Unfortunately, the Authenticator recently had a Gridicons pod update to 1.0-beta.1. Since the Gridicon pods can't be out of sync for version numbers in Authenticator podfile and in the main project's podfile, this PR must be approved before I can merge in https://github.com/woocommerce/woocommerce-ios/pull/2007.

### In this PR
- updates the Authenticator to point to the latest pod changes, which upgraded Gridicons from `0.20` -> `1.0`
- updates the main podfile to Gridicons `1.0`
- find / replace deprecated Gridicons method calls

### To Test
1. `rake dependencies`
2. Build and run
3. Choose an icon at random from the code to smoke-test

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
