### PR TITLE
Update Product cell style

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -91,6 +91,6 @@ private extension ProductTableViewCell {
         static let cornerRadius = CGFloat(2.0)
         static let borderWidth = CGFloat(0.5)
         static let borderColor = UIColor.border
-        static let backgroundColor = UIColor.systemColor(.systemGray6)
+        static let backgroundColor = UIColor.listForeground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -11,6 +11,7 @@ class ProductTableViewCell: UITableViewCell {
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var detailLabel: UILabel!
     @IBOutlet private var priceLabel: UILabel!
+    @IBOutlet private var bottomBorderView: UIView!
 
     var nameText: String? {
         get {
@@ -46,6 +47,7 @@ class ProductTableViewCell: UITableViewCell {
         detailLabel.applyFootnoteStyle()
         applyProductImageStyle()
         contentView.backgroundColor = .listForeground
+        bottomBorderView.backgroundColor = .systemColor(.separator)
     }
 
     private func applyProductImageStyle() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -11,6 +11,8 @@ class ProductTableViewCell: UITableViewCell {
     @IBOutlet private var nameLabel: UILabel!
     @IBOutlet private var detailLabel: UILabel!
     @IBOutlet private var priceLabel: UILabel!
+
+    /// We use a custom view isntead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
     @IBOutlet private var bottomBorderView: UIView!
 
     var nameText: String? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -21,22 +21,22 @@
                         <rect key="frame" x="16" y="16" width="256" height="72"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-X3-NSJ">
-                                <rect key="frame" x="0.0" y="0.0" width="29" height="29"/>
+                                <rect key="frame" x="0.0" y="0.0" width="37" height="37"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="52Z-Kf-0Bw"/>
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="45" y="0.0" width="145" height="58.5"/>
+                                <rect key="frame" x="53" y="0.0" width="137" height="58.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                        <rect key="frame" x="0.0" y="0.0" width="145" height="42.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="137" height="42.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="42.5" width="145" height="16"/>
+                                        <rect key="frame" x="0.0" y="42.5" width="137" height="16"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -66,7 +66,7 @@
                     <constraint firstAttribute="trailing" secondItem="VJh-YT-pnW" secondAttribute="trailing" constant="16" id="EuK-Sc-fLf"/>
                     <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="ZfX-mu-zvg"/>
                     <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="16" id="hC4-B8-Gtj"/>
-                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.1" id="p6g-et-9ff"/>
+                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.128" id="p6g-et-9ff"/>
                     <constraint firstItem="VJh-YT-pnW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ymu-ST-LOb"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -61,18 +61,30 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Tw8-4v-wTe"/>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lOL-Ke-vhW">
+                        <rect key="frame" x="69" y="103.5" width="219" height="0.5"/>
+                        <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="XW4-X6-mV7"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="dER-lG-WQT"/>
+                    </view>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailing" secondItem="lOL-Ke-vhW" secondAttribute="trailing" id="5MW-g7-JV0"/>
                     <constraint firstAttribute="trailing" secondItem="VJh-YT-pnW" secondAttribute="trailing" constant="16" id="EuK-Sc-fLf"/>
                     <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="ZfX-mu-zvg"/>
+                    <constraint firstAttribute="bottom" secondItem="lOL-Ke-vhW" secondAttribute="bottom" id="fUE-8a-FFo"/>
                     <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="16" id="hC4-B8-Gtj"/>
                     <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.128" id="p6g-et-9ff"/>
+                    <constraint firstItem="lOL-Ke-vhW" firstAttribute="leading" secondItem="wbD-Qx-IG5" secondAttribute="leading" id="s1Q-au-hSG"/>
                     <constraint firstItem="VJh-YT-pnW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ymu-ST-LOb"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <inset key="separatorInset" minX="82" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
+                <outlet property="bottomBorderView" destination="lOL-Ke-vhW" id="k0w-aD-sTk"/>
                 <outlet property="detailLabel" destination="hrx-8V-5Ga" id="tzf-vx-Bs7"/>
                 <outlet property="nameLabel" destination="B98-58-fIv" id="Hh5-mS-u6w"/>
                 <outlet property="priceLabel" destination="2yh-4i-vuE" id="Pe0-nm-XVK"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -18,31 +18,30 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VJh-YT-pnW">
-                        <rect key="frame" x="16" y="6" width="256" height="92"/>
+                        <rect key="frame" x="16" y="16" width="256" height="72"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-X3-NSJ">
-                                <rect key="frame" x="0.0" y="0.0" width="37" height="37"/>
+                                <rect key="frame" x="0.0" y="0.0" width="29" height="29"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="52Z-Kf-0Bw"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="53" y="0.0" width="137" height="66.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
+                                <rect key="frame" x="45" y="0.0" width="145" height="61.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                        <rect key="frame" x="0.0" y="3" width="137" height="42.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="145" height="42.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="47.5" width="137" height="16"/>
+                                        <rect key="frame" x="0.0" y="45.5" width="145" height="16"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <edgeInsets key="layoutMargins" top="3" left="0.0" bottom="3" right="0.0"/>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yc7-gf-KCU">
                                 <rect key="frame" x="206" y="0.0" width="50" height="70.5"/>
@@ -63,7 +62,7 @@
                         <viewLayoutGuide key="safeArea" id="Tw8-4v-wTe"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lOL-Ke-vhW">
-                        <rect key="frame" x="69" y="103.5" width="219" height="0.5"/>
+                        <rect key="frame" x="61" y="103.5" width="227" height="0.5"/>
                         <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="XW4-X6-mV7"/>
@@ -74,10 +73,10 @@
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="lOL-Ke-vhW" secondAttribute="trailing" id="5MW-g7-JV0"/>
                     <constraint firstAttribute="trailing" secondItem="VJh-YT-pnW" secondAttribute="trailing" constant="16" id="EuK-Sc-fLf"/>
-                    <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="6" id="ZfX-mu-zvg"/>
+                    <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="ZfX-mu-zvg"/>
                     <constraint firstAttribute="bottom" secondItem="lOL-Ke-vhW" secondAttribute="bottom" id="fUE-8a-FFo"/>
-                    <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="6" id="hC4-B8-Gtj"/>
-                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.128" id="p6g-et-9ff"/>
+                    <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="16" id="hC4-B8-Gtj"/>
+                    <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.1" id="p6g-et-9ff"/>
                     <constraint firstItem="lOL-Ke-vhW" firstAttribute="leading" secondItem="wbD-Qx-IG5" secondAttribute="leading" id="s1Q-au-hSG"/>
                     <constraint firstItem="VJh-YT-pnW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ymu-ST-LOb"/>
                 </constraints>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -18,7 +18,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VJh-YT-pnW">
-                        <rect key="frame" x="16" y="16" width="256" height="72"/>
+                        <rect key="frame" x="16" y="6" width="256" height="92"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="yk6-X3-NSJ">
                                 <rect key="frame" x="0.0" y="0.0" width="37" height="37"/>
@@ -26,22 +26,23 @@
                                     <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="52Z-Kf-0Bw"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="53" y="0.0" width="137" height="58.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
+                                <rect key="frame" x="53" y="0.0" width="137" height="66.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
-                                        <rect key="frame" x="0.0" y="0.0" width="137" height="42.5"/>
+                                        <rect key="frame" x="0.0" y="3" width="137" height="42.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="42.5" width="137" height="16"/>
+                                        <rect key="frame" x="0.0" y="47.5" width="137" height="16"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
+                                <edgeInsets key="layoutMargins" top="3" left="0.0" bottom="3" right="0.0"/>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yc7-gf-KCU">
                                 <rect key="frame" x="206" y="0.0" width="50" height="70.5"/>
@@ -73,9 +74,9 @@
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="lOL-Ke-vhW" secondAttribute="trailing" id="5MW-g7-JV0"/>
                     <constraint firstAttribute="trailing" secondItem="VJh-YT-pnW" secondAttribute="trailing" constant="16" id="EuK-Sc-fLf"/>
-                    <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="ZfX-mu-zvg"/>
+                    <constraint firstItem="VJh-YT-pnW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="6" id="ZfX-mu-zvg"/>
                     <constraint firstAttribute="bottom" secondItem="lOL-Ke-vhW" secondAttribute="bottom" id="fUE-8a-FFo"/>
-                    <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="16" id="hC4-B8-Gtj"/>
+                    <constraint firstAttribute="bottom" secondItem="VJh-YT-pnW" secondAttribute="bottom" constant="6" id="hC4-B8-Gtj"/>
                     <constraint firstItem="yk6-X3-NSJ" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.128" id="p6g-et-9ff"/>
                     <constraint firstItem="lOL-Ke-vhW" firstAttribute="leading" secondItem="wbD-Qx-IG5" secondAttribute="leading" id="s1Q-au-hSG"/>
                     <constraint firstItem="VJh-YT-pnW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ymu-ST-LOb"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -26,8 +26,8 @@
                                     <constraint firstAttribute="width" secondItem="yk6-X3-NSJ" secondAttribute="height" multiplier="1:1" id="52Z-Kf-0Bw"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
-                                <rect key="frame" x="45" y="0.0" width="145" height="61.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wbD-Qx-IG5">
+                                <rect key="frame" x="45" y="0.0" width="145" height="62.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B98-58-fIv">
                                         <rect key="frame" x="0.0" y="0.0" width="145" height="42.5"/>
@@ -36,7 +36,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="     " textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hrx-8V-5Ga">
-                                        <rect key="frame" x="0.0" y="45.5" width="145" height="16"/>
+                                        <rect key="frame" x="0.0" y="46.5" width="145" height="16"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +19,7 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="quh-Rf-B3R" customClass="IntrinsicTableView" customModule="WooCommerce" customModuleProvider="target">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="quh-Rf-B3R" customClass="IntrinsicTableView" customModule="WooCommerce" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -17,6 +17,10 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         return label
     }()
 
+    private let bottomBorderView: UIView = {
+        return UIView(frame: .zero)
+    }()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         configureBackground()
@@ -24,7 +28,7 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         configureNameLabel()
         configureDetailsLabel()
         configureProductImageView()
-        configureAccessoryType()
+        configureBottomBorderView()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -81,8 +85,17 @@ private extension ProductsTabProductTableViewCell {
         stackView.alignment = .leading
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        bottomBorderView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(stackView)
+        contentView.addSubview(bottomBorderView)
         contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
+
+        NSLayoutConstraint.activate([
+            bottomBorderView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            bottomBorderView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            bottomBorderView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
+            bottomBorderView.heightAnchor.constraint(equalToConstant: 0.5)
+        ])
     }
 
     func createContentStackView() -> UIView {
@@ -119,14 +132,14 @@ private extension ProductsTabProductTableViewCell {
         productImageView.clipsToBounds = true
 
         NSLayoutConstraint.activate([
-            // This multiplier matches the required size(48pt) for a 375pt(349pt contentView) screen
-            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.137),
+            // This multiplier matches the required size(48pt) for a 375pt(as per designs) content view width
+            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.128),
             productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor)
             ])
     }
 
-    func configureAccessoryType() {
-        accessoryType = .disclosureIndicator
+    func configureBottomBorderView() {
+        bottomBorderView.backgroundColor = .systemColor(.separator)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -88,7 +88,7 @@ private extension ProductsTabProductTableViewCell {
         bottomBorderView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(stackView)
         contentView.addSubview(bottomBorderView)
-        contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
+        contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16))
 
         NSLayoutConstraint.activate([
             bottomBorderView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
@@ -102,6 +102,9 @@ private extension ProductsTabProductTableViewCell {
         let contentStackView = UIStackView(arrangedSubviews: [nameLabel, detailsLabel])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
+        contentStackView.spacing = 2
+        contentStackView.layoutMargins = .init(top: 3, left: 0, bottom: 3, right: 0)
+        contentStackView.isLayoutMarginsRelativeArrangement = true
         return contentStackView
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -88,7 +88,7 @@ private extension ProductsTabProductTableViewCell {
         bottomBorderView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(stackView)
         contentView.addSubview(bottomBorderView)
-        contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16))
+        contentView.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
 
         NSLayoutConstraint.activate([
             bottomBorderView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
@@ -102,9 +102,7 @@ private extension ProductsTabProductTableViewCell {
         let contentStackView = UIStackView(arrangedSubviews: [nameLabel, detailsLabel])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
-        contentStackView.spacing = 2
-        contentStackView.layoutMargins = .init(top: 3, left: 0, bottom: 3, right: 0)
-        contentStackView.isLayoutMarginsRelativeArrangement = true
+        contentStackView.spacing = 3
         return contentStackView
     }
 
@@ -135,8 +133,8 @@ private extension ProductsTabProductTableViewCell {
         productImageView.clipsToBounds = true
 
         NSLayoutConstraint.activate([
-            // This multiplier matches the required size(48pt) for a 375pt(as per designs) content view width
-            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.128),
+            // This multiplier matches the required size(37.5pt) for a 375pt(as per designs) content view width
+            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1),
             productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor)
             ])
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -119,7 +119,8 @@ private extension ProductsTabProductTableViewCell {
         productImageView.clipsToBounds = true
 
         NSLayoutConstraint.activate([
-            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1),
+            // This multiplier matches the required size(48pt) for a 375pt(349pt contentView) screen
+            productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.137),
             productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor)
             ])
     }
@@ -140,6 +141,6 @@ private extension ProductsTabProductTableViewCell {
     enum Colors {
         static let imageBorderColor = UIColor.border
         static let imagePlaceholderTintColor = UIColor.systemColor(.systemGray2)
-        static let imageBackgroundColor = UIColor.systemColor(.systemGray6)
+        static let imageBackgroundColor = UIColor.listForeground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -102,7 +102,7 @@ private extension ProductsTabProductTableViewCell {
         let contentStackView = UIStackView(arrangedSubviews: [nameLabel, detailsLabel])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .vertical
-        contentStackView.spacing = 3
+        contentStackView.spacing = 4
         return contentStackView
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -17,6 +17,7 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         return label
     }()
 
+    /// We use a custom view isntead of the default separator as it's width varies depending on the image size, which varies depending on the screen size.
     private let bottomBorderView: UIView = {
         return UIView(frame: .zero)
     }()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -215,6 +215,7 @@ private extension ProductsViewController {
         tableView.backgroundColor = .listBackground
         tableView.refreshControl = refreshControl
         tableView.tableFooterView = footerSpinnerView
+        tableView.separatorStyle = .none
 
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: Int(Constants.headerDefaultHeight)))
         headerContainer.addSubview(topBannerView)


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/woocommerce-ios/issues/1934

# Why

It has been required to update the Product Cell and the TopPerformers Cell as per the latests design.

![design](https://user-images.githubusercontent.com/562080/77239950-569f8d80-6bae-11ea-8ada-bc2fbe3210e3.png)


# How
- Updates cell image background color
- Increase spacing between text components
- Updates cell separator width by replacing the standard table view separator for a custom view, as it varies depending on the image size, which varies depending on the screen size.
- Removes cell `accessoryType` on Product Tab

# Screenshots

### Before
Top Performer|Product
---|---
<img src="https://user-images.githubusercontent.com/562080/77240012-15f44400-6baf-11ea-8122-ddfd1b97f1e8.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/76927149-3e78f700-68ac-11ea-8c78-a213960d61db.png" width="300" />


### After
Top Performer|Product
---|---
<img src="https://user-images.githubusercontent.com/562080/77330199-fc591680-6cec-11ea-907f-f862d82f515a.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/77330191-fb27e980-6cec-11ea-89b8-6456117e743d.png" width="300" />

