### PR TITLE
Add .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ default.profraw
 
 # WireMock (UI Tests)
 WooCommerce/WooCommerceScreenshots/Mocks/vendor/
+
+# AppCode
+.idea


### PR DESCRIPTION
I'm playing with AppCode again for 30 days. It _seems_ faster in WC than WP. 

I _think_ ignoring the `.idea` folder is the best practice. Please let me know if it isn't. 😄 

## Testing

CircleCI should not choke.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

