### PR TITLE
Adds ManageProductCategories feature flag #2000

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,6 +9,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
         case .readonlyProductVariants:
             return true
+        case .manageProductCategories:
+            return BuildConfiguration.current == .localDeveloper
         case .stats:
             return true
         case .refunds:

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,10 +7,10 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .editProductsRelease2:
             return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
+        case .editProductsRelease3:
+            return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
         case .readonlyProductVariants:
             return true
-        case .manageProductCategories:
-            return BuildConfiguration.current == .localDeveloper
         case .stats:
             return true
         case .refunds:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -22,6 +22,10 @@ enum FeatureFlag: Int {
     ///
     case readonlyProductVariants
 
+    /// Manage product categories
+    ///
+    case manageProductCategories
+
     /// Store stats
     ///
     case stats

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -18,13 +18,13 @@ enum FeatureFlag: Int {
     ///
     case editProductsRelease2
 
+    /// Edit products - release 3
+    ///
+    case editProductsRelease3
+
     /// Readonly Product variants
     ///
     case readonlyProductVariants
-
-    /// Manage product categories
-    ///
-    case manageProductCategories
 
     /// Store stats
     ///


### PR DESCRIPTION
# Why

This tiny PR aims to start the development of the [Manage Categories feature](https://github.com/woocommerce/woocommerce-ios/issues/2000) 

I've submitted only the feature flag code in case someone considers working with a feature branch is better for this case, however I think that working under a feature flag is easier to manage and maintain.

# How
- Adds `.editProductsRelease3` case
- Enable it when `BuildConfiguration.current == .localDeveloper` and `BuildConfiguration.current == .alpha`