### PR TITLE
Add Coding Style Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,10 @@
-# WooCommerce for iOS Docs
+# WooCommerce for iOS 
+
+## Getting Started
+
+- [Coding Style Guide](coding-style-guide.md)
+
+## Architecture
 
 - [Architecture](ARCHITECTURE.md)
 - [Networking](NETWORKING.md)

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -3,3 +3,29 @@
 We use the [Swift.org API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) as the base. We refer to the [raywenderlich.com Swift Style Guide](https://github.com/raywenderlich/swift-style-guide/) for guides that are not described here.
 
 We also use [SwiftLint](https://github.com/realm/SwiftLint) to enforce as many of our rules as we can. 
+
+## Braces
+
+Closing braces should always be placed on a new line regardless of the number of enclosed statements.
+
+#### Preferred
+
+```swift
+guard condition else {
+   return
+}
+
+if condition {
+
+} else  {
+
+}
+```
+
+#### Not Preferred
+
+```swift
+guard condition else { return }
+
+if condition { } else { }
+```

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -17,7 +17,7 @@ guard condition else {
 
 if condition {
 
-} else  {
+} else {
 
 }
 ```

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -8,7 +8,7 @@ We also use [SwiftLint](https://github.com/realm/SwiftLint) to enforce as many o
 
 Closing braces should always be placed on a new line regardless of the number of enclosed statements.
 
-#### Preferred
+**Preferred:**
 
 ```swift
 guard condition else {
@@ -22,10 +22,30 @@ if condition {
 }
 ```
 
-#### Not Preferred
+**Not Preferred:**
 
 ```swift
 guard condition else { return }
 
 if condition { } else { }
+```
+
+## Parentheses
+
+Parentheses around conditionals are not required and should be omitted.
+
+**Preferred:**
+
+```swift
+if name == "Hello" {
+  print("World")
+}
+```
+
+**Not Preferred:**
+
+```swift
+if (name == "Hello") {
+  print("World")
+}
 ```

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -49,3 +49,27 @@ if (name == "Hello") {
   print("World")
 }
 ```
+
+## Forced Downcasts and Unwrapping
+
+Avoid using `as!` to force a downcast, or `!` to force unwrap. Prefer using `as?` to attempt the cast, then deal with the failure case explicitly.
+
+**Preferred:**
+
+```swift
+func process(someObject: Any) {
+    guard let element = someObject as? Element else {
+        // Optional error handling goes here
+        return
+    }
+    process(element)
+}
+```
+
+**Not Preferred:**
+
+```swift
+func process(someObject: Any) {
+    process(someObject as! Element)
+}
+```

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -1,3 +1,5 @@
 # Coding Style Guide
 
 We use the [Swift.org API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) as the base. We refer to the [raywenderlich.com Swift Style Guide](https://github.com/raywenderlich/swift-style-guide/) for guides that are not described here.
+
+We also use [SwiftLint](https://github.com/realm/SwiftLint) to enforce as many of our rules as we can. 

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -12,7 +12,7 @@ Closing braces should always be placed on a new line regardless of the number of
 
 ```swift
 guard condition else {
-   return
+    return
 }
 
 if condition {
@@ -38,7 +38,7 @@ Parentheses around conditionals are not required and should be omitted.
 
 ```swift
 if name == "Hello" {
-  print("World")
+    print("World")
 }
 ```
 
@@ -46,7 +46,7 @@ if name == "Hello" {
 
 ```swift
 if (name == "Hello") {
-  print("World")
+    print("World")
 }
 ```
 

--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -1,0 +1,3 @@
+# Coding Style Guide
+
+We use the [Swift.org API Design Guidelines](https://swift.org/documentation/api-design-guidelines/) as the base. We refer to the [raywenderlich.com Swift Style Guide](https://github.com/raywenderlich/swift-style-guide/) for guides that are not described here.


### PR DESCRIPTION
This adds an initial Coding Style Guide doc. It is based on the [WordPress Swift Style Guide](https://github.com/wordpress-mobile/swift-style-guide) which we currently use. 

I mainly copied the contents and fixed some typos. I did not copy everything as some of the rules described in the WP Style Guide are already well enforced by SwiftLint. We should only document those that we cannot automate. 

I also changed the “Correct” and “Wrong”  wording to “Preferred” and “Not Preferred”. There are always exceptions to rules. 

## Why 

<img src="https://user-images.githubusercontent.com/198826/77366434-9d5fc580-6d1d-11ea-95d3-2df82b8085f5.gif" width="320">

We've been discussing about styling during pull request reviews and I believe it's better if we start documenting our team's agreements. Having our own explicitly defined style guide, though still heavily dependent on WP, should make us **move faster**. 

## Testing

- Please view the guide [here](https://github.com/woocommerce/woocommerce-ios/blob/docs/add-codestyle/docs/coding-style-guide.md). 
- Please make sure the links work.
- Please feel free to comment on anything. 