### PR TITLE
Remove extra logic in `CurrencySettings`'s init

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencySettings.swift
@@ -6,7 +6,11 @@ import Yosemite
 public class CurrencySettings {
     /// Shared Instance
     ///
-    static let shared = CurrencySettings()
+    static let shared: CurrencySettings = {
+        let currencySettings = CurrencySettings()
+        currencySettings.configureResultsController()
+        return currencySettings
+    }()
 
 
     // MARK: - Enums
@@ -130,7 +134,6 @@ public class CurrencySettings {
                   thousandSeparator: CurrencySettings.Default.thousandSeparator,
                   decimalSeparator: CurrencySettings.Default.decimalSeparator,
                   numberOfDecimals: CurrencySettings.Default.decimalPosition)
-        configureResultsController()
     }
 
     /// Convenience Initializer:


### PR DESCRIPTION
Related to #1956, a refactoring task from this conversation with @shiki  https://github.com/woocommerce/woocommerce-ios/pull/2008#discussion_r395638889

## Changes

- Removed `configureResultsController` from  `CurrencySettings`'s `init()` so that the initialization is just setting up its properties. Called `configureResultsController` in the singleton's init

## Testing

There should be no UX changes. To sanity check, please check the steps below:

Prerequisite: having 2 sites with different currency settings

- Launch the app
- Check the UI that displays prices in the app (e.g. Orders, Products) --> the price format should follow the currency settings in core under `wp-admin > WooCommerce > Settings > General`
- Go to the "My store" tab, and switch to another store
- Check the UI that displays prices in the app (e.g. Orders, Products) --> the price format should follow the currency settings of the second site
- In wp-admin, change the currency settings of the second site under `WooCommerce > Settings > General`
- Relaunch the app (since we only sync the site settings per app launch or switching site)
- Check the UI that displays prices in the app (e.g. Orders, Products) --> the price format should follow the updated currency settings of the second site

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
