### PR TITLE
Remove "NSLocalizedString" in comment

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -83,8 +83,7 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
             total: 0
         )
         // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
-        // text in here. Having an explicit `NSLocalizedString` makes sure that we'll have this
-        // word translated.
+        // text in here. We want the string to be translated.
         let processingOrdersVC = OrdersViewController(
             title: NSLocalizedString("Processing", comment: "Title for the first page in the Orders tab."),
             statusFilter: processingOrderStatus


### PR DESCRIPTION
Turns out that mentioning `NSLocalizedString` **inside a comment** triggers `genstrings` to validate it. Since the comment has obviously incorrect syntax, this error is generated by `genstrings`:

```
genstrings: error: bad entry in file
WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift (line =
86): Argument is not a literal string.
```

Ref: p1585064201352500-slack-C6H8C3G23

## Testing

1. Go to the project folder in the terminal
2. Run `./Scripts/localize.py`
3. Confirm that no errors are generated 

Note that the `Localizable.strings` may be changed after running `localize.py` so please revert it when you're done.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




