### PR TITLE
Tax and Shipping Classes: Show existing data instead of ghost view when synchronizing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,8 @@
 4.0
 -----
-- [internal] the signup and login Magic Link flows have code changes. See https://git.io/JvyB3 for testing details.
-
- 
 - Fix pulling to refresh on the Processing tab sometimes will not show the up-to-date orders.
+- [internal] the signup and login Magic Link flows have code changes. See https://git.io/JvyB3 for testing details.
+- [internal] Changed the Shipping and Tax classes list loading so that any cached data is shown right away
 
 3.9
 -----

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -257,7 +257,10 @@ private extension PaginatedListSelectorViewController {
             displayNoResultsOverlay()
         case .syncing(let pageNumber):
             if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
-                displayPlaceholderProducts()
+                // Show any existing (cached) data if we already have some
+                if isEmpty {
+                    displayPlaceholderProducts()
+                }
             } else {
                 ensureFooterSpinnerIsStarted()
             }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -256,11 +256,8 @@ private extension PaginatedListSelectorViewController {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
         case .syncing(let pageNumber):
-            if pageNumber == SyncingCoordinator.Defaults.pageFirstIndex {
-                // Show any existing (cached) data if we already have some
-                if isEmpty {
-                    displayPlaceholderProducts()
-                }
+            if isEmpty {
+                displayPlaceholderProducts()
             } else {
                 ensureFooterSpinnerIsStarted()
             }


### PR DESCRIPTION
Fixes #1954

## Findings

It looks like we are already caching tax classes in `retrieveTaxClasses`:

https://github.com/woocommerce/woocommerce-ios/blob/b13f081de28c08b807e219ef41bc1a3714d309db/Yosemite/Yosemite/Stores/TaxClassStore.swift#L45-L56

The concern was because we're always showing the placeholders (ghost) if we are synchronizing the first page. 

https://github.com/woocommerce/woocommerce-ios/blob/b13f081de28c08b807e219ef41bc1a3714d309db/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift#L258-L261

It looks like this was done during https://github.com/woocommerce/woocommerce-ios/pull/1659 (0c8c6fab3b346487680677f78050c198663a1eb7). 

## Solution

This reverts the change in 0c8c6fab3b346487680677f78050c198663a1eb7 so that the placeholders are only shown if there is no existing data. 

This change should only affect both the Tax Classes and Shipping Classes lists.

## Testing

1. Navigate to a Product → Price → Tax class
2. Confirm that the existing Tax classes are immediately shown
3. Confirm that if there are no existing Tax classes, the placeholders will be shown.
4. Repeat steps 2 and 3 for the Product → Shipping → Shipping class

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
