### PR TITLE
[Categories] Display product categories on Product Edit screen

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -47,6 +47,12 @@ extension UIImage {
             .applyTintColor(.placeholderImage)!
     }
 
+    /// Product categories Icon
+    ///
+    static var categoriesIcon: UIImage {
+        return UIImage.gridicon(.folder).imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// Add Image icon
     ///
     static var addImage: UIImage {

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -36,7 +36,7 @@ extension UIImage {
     /// Brief Description Icon
     ///
     static var briefDescriptionImage: UIImage {
-        return UIImage.gridicon(.alignLeft, size: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.alignLeft, size: CGSize(width: 24, height: 24)).imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Camera Icon
@@ -304,7 +304,7 @@ extension UIImage {
     /// Shipping Icon
     ///
     static var shippingImage: UIImage {
-        return UIImage.gridicon(.shipping, size: CGSize(width: 24, height: 24))
+        return UIImage.gridicon(.shipping, size: CGSize(width: 24, height: 24)).imageFlippedForRightToLeftLayoutDirection()
     }
 
     /// Shipping class list selector empty icon

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -13,6 +13,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
     var siteTimezone: TimeZone = TimeZone.siteTimezone
 
     private let isEditProductsRelease2Enabled: Bool
+    private let isEditProductsRelease3Enabled: Bool
 
     init(product: Product,
          currency: String,
@@ -21,6 +22,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
         self.currency = currency
         self.currencyFormatter = currencyFormatter
         self.isEditProductsRelease2Enabled = featureFlagService.isFeatureFlagEnabled(.editProductsRelease2)
+        self.isEditProductsRelease3Enabled = featureFlagService.isFeatureFlagEnabled(.editProductsRelease3)
         configureSections(product: product)
     }
 }
@@ -49,11 +51,13 @@ private extension DefaultProductFormTableViewModel {
     func settingsRows(product: Product) -> [ProductFormSection.SettingsRow] {
         let shouldShowShippingSettingsRow = product.downloadable == false && product.virtual == false
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
+        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
 
         let rows: [ProductFormSection.SettingsRow?] = [
             .price(viewModel: priceSettingsRow(product: product)),
             shouldShowShippingSettingsRow ? .shipping(viewModel: shippingSettingsRow(product: product)): nil,
             .inventory(viewModel: inventorySettingsRow(product: product)),
+            shouldShowCategoriesRow ? .categories(viewModel: categoriesRow(product: product)): nil,
             shouldShowBriefDescriptionRow ? .briefDescription(viewModel: briefDescriptionRow(product: product)): nil
         ]
 
@@ -177,6 +181,13 @@ private extension DefaultProductFormTableViewModel {
                                                         details: details)
     }
 
+    private func categoriesRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.categoriesIcon
+        let title = Constants.categoriesTitle
+        let details = product.categoriesDescription
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details)
+    }
+
     func briefDescriptionRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.briefDescriptionImage
         let title = Constants.briefDescriptionTitle
@@ -196,6 +207,8 @@ private extension DefaultProductFormTableViewModel {
                                                               comment: "Title of the Inventory Settings row on Product main screen")
         static let shippingSettingsTitle = NSLocalizedString("Shipping",
                                                              comment: "Title of the Shipping Settings row on Product main screen")
+        static let categoriesTitle = NSLocalizedString("Categories",
+                                                       comment: "Title of the Categories row on Product main screen")
         static let briefDescriptionTitle = NSLocalizedString("Short description",
                                                              comment: "Title of the Short Description row on Product main screen")
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -181,10 +181,10 @@ private extension DefaultProductFormTableViewModel {
                                                         details: details)
     }
 
-    private func categoriesRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+    func categoriesRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.categoriesIcon
         let title = Constants.categoriesTitle
-        let details = product.categoriesDescription
+        let details = product.categoriesDescription.isNotEmpty ? product.categoriesDescription: Constants.categoriesPlaceholder
         return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details)
     }
 
@@ -245,5 +245,9 @@ private extension DefaultProductFormTableViewModel {
         // Short description
         static let briefDescriptionPlaceholder = NSLocalizedString("A brief excerpt about the product",
                                                                    comment: "Placeholder of the Product Short Description row on Product main screen")
+
+        // Categories
+        static let categoriesPlaceholder = NSLocalizedString("Uncategorized",
+                                                                   comment: "Placeholder of the Product Categories row on Product main screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -184,7 +184,7 @@ private extension DefaultProductFormTableViewModel {
     func categoriesRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.categoriesIcon
         let title = Constants.categoriesTitle
-        let details = product.categoriesDescription.isNotEmpty ? product.categoriesDescription: Constants.categoriesPlaceholder
+        let details = product.categoriesDescription() ?? Constants.categoriesPlaceholder
         return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -24,7 +24,7 @@ extension Product {
         if #available(iOS 13.0, *) {
             return ListFormatter.localizedString(byJoining: categoriesNames)
         } else {
-            return categoriesNames.joined(separator: ",")
+            return categoriesNames.joined(separator: ", ")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -18,11 +18,18 @@ extension Product {
     }
 
     /// Returns a comma separated string with each category names.
-    /// Uses `ListFormatter` if available
-    var categoriesDescription: String {
+    /// Returns `nil` if the product doesn't have any associated category
+    /// iOS 13+ set a specific locale on to properly format the list with the `ListFormatter` class
+    func categoriesDescription(using locale: Locale = .autoupdatingCurrent) -> String? {
+        guard categories.isNotEmpty else {
+            return nil
+        }
+
         let categoriesNames = categories.map { $0.name }
         if #available(iOS 13.0, *) {
-            return ListFormatter.localizedString(byJoining: categoriesNames)
+            let formatter = ListFormatter()
+            formatter.locale = locale
+            return formatter.string(from: categoriesNames)
         } else {
             return categoriesNames.joined(separator: ", ")
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -16,4 +16,15 @@ extension Product {
         }
         return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    /// Returns a coma separated string with each category names.
+    /// Uses `ListFormatter` if available
+    var categoriesDescription: String {
+        let categoriesNames = categories.map { $0.name }
+        if #available(iOS 13.0, *) {
+            return ListFormatter.localizedString(byJoining: categoriesNames)
+        } else {
+            return categoriesNames.joined(separator: ",")
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -17,7 +17,7 @@ extension Product {
         return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Returns a coma separated string with each category names.
+    /// Returns a comma separated string with each category names.
     /// Uses `ListFormatter` if available
     var categoriesDescription: String {
         let categoriesNames = categories.map { $0.name }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -52,7 +52,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
 extension ProductFormSection.SettingsRow: ReusableTableRow {
     var cellTypes: [UITableViewCell.Type] {
         switch self {
-        case .price, .inventory, .shipping, .briefDescription:
+        case .price, .inventory, .shipping, .categories, .briefDescription:
             return [ImageAndTitleAndTextTableViewCell.self]
         }
     }
@@ -63,7 +63,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
 
     private var cellType: UITableViewCell.Type {
         switch self {
-        case .price, .inventory, .shipping, .briefDescription:
+        case .price, .inventory, .shipping, .categories, .briefDescription:
             return ImageAndTitleAndTextTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -162,7 +162,8 @@ private extension ProductFormTableViewDataSource {
             fatalError()
         }
         switch row {
-        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel), .briefDescription(let viewModel):
+        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel), .categories(let viewModel),
+             .briefDescription(let viewModel):
             configureSettings(cell: cell, viewModel: viewModel)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -15,6 +15,7 @@ enum ProductFormSection {
         case price(viewModel: ViewModel)
         case shipping(viewModel: ViewModel)
         case inventory(viewModel: ViewModel)
+        case categories(viewModel: ViewModel)
         case briefDescription(viewModel: ViewModel)
 
         struct ViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -278,6 +278,9 @@ extension ProductFormViewController: UITableViewDelegate {
             case .inventory:
                 ServiceLocator.analytics.track(.productDetailViewInventorySettingsTapped)
                 editInventorySettings()
+            case .categories:
+                // TODO-2000
+                break
             case .briefDescription:
                 // TODO-1879: Edit Products M2 analytics
                 editBriefDescription()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests+ProductListFeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests+ProductListFeatureFlag.swift */; };
 		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
+		263EB409242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */; };
 		451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */; };
 		451A04E72386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */; };
 		451A04EA2386D28300E368C9 /* ProductImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */; };
@@ -972,6 +973,7 @@
 		02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagService.swift; sourceTree = "<group>"; };
 		02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultProductFormTableViewModel+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesHeaderTableViewCell.swift; sourceTree = "<group>"; };
@@ -1560,6 +1562,7 @@
 			children = (
 				020B2F9823BDF2E000BD79AD /* DefaultProductFormTableViewModelTests.swift */,
 				02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */,
+				263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */,
 				02153210242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift */,
 			);
 			path = "Edit Product";
@@ -4378,6 +4381,7 @@
 				D8C11A6022E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift in Sources */,
 				D83F593D225B4B5000626E75 /* ManualTrackingViewControllerTests.swift in Sources */,
 				CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */,
+				263EB409242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift in Sources */,
 				02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */,
 				B555531121B57E6F00449E71 /* MockupApplicationAdapter.swift in Sources */,
 				021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorDataSourceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -225,4 +225,13 @@ final class IconsTests: XCTestCase {
     func testWaitingForCustomersImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.waitingForCustomersImage)
     }
+
+    func testCategoriesIconIsNotNil() {
+        XCTAssertNotNil(UIImage.categoriesIcon)
+    }
+
+    func testCategoriesIconHasDefaultSize() {
+        let categoriesIcon = UIImage.categoriesIcon
+        XCTAssertEqual(categoriesIcon.size, Gridicon.defaultSize)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
@@ -3,11 +3,14 @@
 struct MockFeatureFlagService: FeatureFlagService {
     private let isProductListFeatureOn: Bool
     private let isEditProductsRelease2On: Bool
+    private let isEditProductsRelease3On: Bool
 
     init(isProductListFeatureOn: Bool = true,
-         isEditProductsRelease2On: Bool = false) {
+         isEditProductsRelease2On: Bool = false,
+         isEditProductsRelease3On: Bool = false) {
         self.isProductListFeatureOn = isProductListFeatureOn
         self.isEditProductsRelease2On = isEditProductsRelease2On
+        self.isEditProductsRelease3On = isEditProductsRelease3On
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -16,6 +19,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isProductListFeatureOn
         case .editProductsRelease2:
             return isEditProductsRelease2On
+        case .editProductsRelease3:
+            return isEditProductsRelease3On
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM3Tests.swift
@@ -1,0 +1,173 @@
+import XCTest
+
+@testable import WooCommerce
+@testable import Yosemite
+
+/// The same tests as `DefaultProductFormTableViewModel_EditProductsM2Tests`, but with Edit Products M2 and M3 feature flag on.
+/// When we fully launch Edit Products M2 and M3, we can replace `DefaultProductFormTableViewModel_EditProductsM2Tests` with the test cases here.
+///
+final class DefaultProductFormTableViewModel_EditProductsM3Tests: XCTestCase {
+
+    private let mockFeatureFlagService = MockFeatureFlagService(isEditProductsRelease2On: true, isEditProductsRelease3On: true)
+
+    func testViewModelForSimplePhysicalProductWithoutImagesWhenM3FeatureFlagIsOff() {
+        let product = MockProduct().product(downloadable: false,
+                                            name: "woo",
+                                            productType: .simple,
+                                            virtual: false)
+        let viewModel = DefaultProductFormTableViewModel(product: product,
+                                                         currency: "$",
+                                                         featureFlagService: mockFeatureFlagService)
+        let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
+            .name(name: product.name),
+            .description(description: product.trimmedFullDescription)
+        ])
+        XCTAssertEqual(viewModel.sections[0], primaryFieldsSection)
+
+        let settingFieldsSection = viewModel.sections[1]
+        switch settingFieldsSection {
+        case .settings(let rows):
+            XCTAssertEqual(rows.count, 5)
+
+            if case .price(_) = rows[0] {} else {
+                XCTFail("Unexpected setting section: \(rows[0])")
+            }
+            if case .shipping(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .inventory(_) = rows[2] {} else {
+                XCTFail("Unexpected setting section: \(rows[2])")
+            }
+            if case .categories(_) = rows[3] {} else {
+                XCTFail("Unexpected setting section: \(rows[3])")
+            }
+            if case .briefDescription(_) = rows[4] {} else {
+                XCTFail("Unexpected setting section: \(rows[4])")
+            }
+        default:
+            XCTFail("Unexpected section: \(settingFieldsSection)")
+        }
+    }
+
+    func testViewModelForPhysicalSimpleProductWithImages() {
+        let product = MockProduct().product(downloadable: false,
+                                            name: "woo",
+                                            productType: .simple,
+                                            virtual: true,
+                                            images: sampleImages())
+        let viewModel = DefaultProductFormTableViewModel(product: product,
+                                                         currency: "$",
+                                                         featureFlagService: mockFeatureFlagService)
+        let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
+            .name(name: product.name),
+            .description(description: product.trimmedFullDescription)
+        ])
+        XCTAssertEqual(viewModel.sections[0], primaryFieldsSection)
+
+        let settingFieldsSection = viewModel.sections[1]
+        switch settingFieldsSection {
+        case .settings(let rows):
+            XCTAssertEqual(rows.count, 4)
+
+            if case .price(_) = rows[0] {} else {
+                XCTFail("Unexpected setting section: \(rows[0])")
+            }
+            if case .inventory(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .categories(_) = rows[2] {} else {
+                XCTFail("Unexpected setting section: \(rows[2])")
+            }
+            if case .briefDescription(_) = rows[3] {} else {
+                XCTFail("Unexpected setting section: \(rows[3])")
+            }
+        default:
+            XCTFail("Unexpected section: \(settingFieldsSection)")
+        }
+    }
+
+    func testViewModelForDownloadableSimpleProduct() {
+        let product = MockProduct().product(downloadable: true,
+                                            name: "woo",
+                                            productType: .simple)
+        let viewModel = DefaultProductFormTableViewModel(product: product,
+                                                         currency: "$",
+                                                         featureFlagService: mockFeatureFlagService)
+        let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
+            .name(name: product.name),
+            .description(description: product.trimmedFullDescription)
+        ])
+        XCTAssertEqual(viewModel.sections[0], primaryFieldsSection)
+
+        let settingFieldsSection = viewModel.sections[1]
+        switch settingFieldsSection {
+        case .settings(let rows):
+            XCTAssertEqual(rows.count, 4)
+            if case .price(_) = rows[0] {} else {
+                XCTFail("Unexpected setting section: \(rows[0])")
+            }
+            if case .inventory(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .categories(_) = rows[2] {} else {
+                XCTFail("Unexpected setting section: \(rows[2])")
+            }
+            if case .briefDescription(_) = rows[3] {} else {
+                XCTFail("Unexpected setting section: \(rows[3])")
+            }
+        default:
+            XCTFail("Unexpected section: \(settingFieldsSection)")
+        }
+    }
+
+    func testViewModelForVirtualSimpleProduct() {
+        let product = MockProduct().product(downloadable: false,
+                                            name: "woo",
+                                            productType: .simple,
+                                            virtual: true)
+        let viewModel = DefaultProductFormTableViewModel(product: product,
+                                                         currency: "$",
+                                                         featureFlagService: mockFeatureFlagService)
+        let primaryFieldsSection = ProductFormSection.primaryFields(rows: [
+            .images(product: product),
+            .name(name: product.name),
+            .description(description: product.trimmedFullDescription)
+        ])
+        XCTAssertEqual(viewModel.sections[0], primaryFieldsSection)
+
+        let settingFieldsSection = viewModel.sections[1]
+        switch settingFieldsSection {
+        case .settings(let rows):
+            XCTAssertEqual(rows.count, 4)
+            if case .price(_) = rows[0] {} else {
+                XCTFail("Unexpected setting section: \(rows[0])")
+            }
+            if case .inventory(_) = rows[1] {} else {
+                XCTFail("Unexpected setting section: \(rows[1])")
+            }
+            if case .categories(_) = rows[2] {} else {
+                XCTFail("Unexpected setting section: \(rows[2])")
+            }
+            if case .briefDescription(_) = rows[3] {} else {
+                XCTFail("Unexpected setting section: \(rows[3])")
+            }
+        default:
+            XCTFail("Unexpected section: \(settingFieldsSection)")
+        }
+    }
+}
+
+private extension DefaultProductFormTableViewModel_EditProductsM3Tests {
+    func sampleImages() -> [ProductImage] {
+        let image1 = ProductImage(imageID: 19,
+                                  dateCreated: Date(),
+                                  dateModified: Date(),
+                                  src: "https://photo.jpg",
+                                  name: "Tshirt",
+                                  alt: "")
+        return [image1]
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM3Tests.swift
@@ -10,7 +10,7 @@ final class DefaultProductFormTableViewModel_EditProductsM3Tests: XCTestCase {
 
     private let mockFeatureFlagService = MockFeatureFlagService(isEditProductsRelease2On: true, isEditProductsRelease3On: true)
 
-    func testViewModelForSimplePhysicalProductWithoutImagesWhenM3FeatureFlagIsOff() {
+    func testViewModelForSimplePhysicalProductWithoutImages() {
         let product = MockProduct().product(downloadable: false,
                                             name: "woo",
                                             productType: .simple,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -19,11 +19,16 @@ class Product_ProductFormTests: XCTestCase {
         XCTAssertEqual(product.trimmedBriefDescription, expectedDescription)
     }
 
+    func testNoCategoryDescriptionOutputsNilDescription() {
+        let product = sampleProduct(categories: [])
+        XCTAssertNil(product.categoriesDescription())
+    }
+
     func testSingleCategoryDescriptionOutputsSingleCategory() {
         let category = sampleCategory(name: "Pants")
         let product = sampleProduct(categories: [category])
         let expectedDescription = "Pants"
-        XCTAssertEqual(product.categoriesDescription, expectedDescription)
+        XCTAssertEqual(product.categoriesDescription(), expectedDescription)
     }
 
     func testMutipleCategoriesDescriptionOutputsFormattedList() {
@@ -31,12 +36,13 @@ class Product_ProductFormTests: XCTestCase {
         let product = sampleProduct(categories: categories)
         let expectedDescription: String = {
             if #available(iOS 13.0, *) {
-                return ListFormatter.localizedString(byJoining: ["Pants", "Dress", "Shoes"])
+                return "Pants, Dress, and Shoes"
             } else {
                 return "Pants, Dress, Shoes"
             }
         }()
-        XCTAssertEqual(product.categoriesDescription, expectedDescription)
+        let usLocale = Locale(identifier: "en_US")
+        XCTAssertEqual(product.categoriesDescription(using: usLocale), expectedDescription)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -18,11 +18,37 @@ class Product_ProductFormTests: XCTestCase {
         let expectedDescription = "This is the party room!"
         XCTAssertEqual(product.trimmedBriefDescription, expectedDescription)
     }
+
+    func testSingleCategoryDescriptionOutputsSingleCategory() {
+        let category = sampleCategory(name: "Pants")
+        let product = sampleProduct(categories: [category])
+        let expectedDescription = "Pants"
+        XCTAssertEqual(product.categoriesDescription, expectedDescription)
+    }
+
+    func testMutipleCategoriesDescriptionOutputsFormattedList() {
+        let categories = ["Pants", "Dress", "Shoes"].map { sampleCategory(name: $0) }
+        let product = sampleProduct(categories: categories)
+        let expectedDescription: String = {
+            if #available(iOS 13.0, *) {
+                return ListFormatter.localizedString(byJoining: ["Pants", "Dress", "Shoes"])
+            } else {
+                return "Pants, Dress, Shoes"
+            }
+        }()
+        XCTAssertEqual(product.categoriesDescription, expectedDescription)
+    }
 }
 
 private extension Product_ProductFormTests {
 
-    func sampleProduct(description: String? = "", briefDescription: String? = "") -> Product {
+    func sampleCategory(name: String = "") -> ProductCategory {
+        return ProductCategory(categoryID: Int64.random(in: 0 ..< Int64.max),
+                               name: name,
+                               slug: "")
+    }
+
+    func sampleProduct(description: String? = "", briefDescription: String? = "", categories: [ProductCategory] = []) -> Product {
         return Product(siteID: 109,
                        productID: 177,
                        name: "Book the Green Room",
@@ -75,7 +101,7 @@ private extension Product_ProductFormTests {
                        crossSellIDs: [1234, 234234, 3],
                        parentID: 0,
                        purchaseNote: "Thank you!",
-                       categories: [],
+                       categories: categories,
                        tags: [],
                        images: [],
                        attributes: [],


### PR DESCRIPTION
Relates to: #2000 

# Why

- This PR displays(under the `editProductsRelease3`)  the product categories in the product edit screen.
- This PR also fixes some icon orientation issues on RTL languages.

# How

- Adds a `.categories` case in the `ProductFormSection.SettingsRow` enum.
- Adds a `categoriesDescription` helper method on `Product` to display a comma separated list of category names.
- Added the necessary code to include the new categories section on `DefaultProductFormTableViewModel`
- Added tests

# Test steps
- Go to the Products tab
- Tap on a simple Product with no categories
   - See categories row with "Uncategorized" description label
- Tap con a simple Product with one category
   - See categories row with the single category in the description label
- Tap con a simple Product with multiple categories
   - See categories row with the formatted list of categories names in the description label

# Notes
 - ~I have not added a categories list placeholder because the web app doesn't let you have a 0 category product. It always have at least the `uncategorized` category. Let me know if this is wrong~ 
I have added a categories list placeholder("Uncategorized") for when a product doesn't have any category.

- I have copied the approach with `DefaultProductFormTableViewModel_EditProductsM2Tests`. This seems a bit hard to maintain but I hope that `EditProductsM2Tests` should be shipped soon?

# Screenshots

Single Category|Mutiple Categories|RTL
---|---|---
<img src="https://user-images.githubusercontent.com/562080/77609229-6dffb300-6eed-11ea-8670-5e93451c8459.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/77609234-6fc97680-6eed-11ea-9fc1-5d2020e6b59d.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/77609232-6f30e000-6eed-11ea-9684-0aca60259378.png" width="300" />
