### PR TITLE
Fix function name in `DefaultProductFormTableViewModel+EditProductsM2Tests`

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM2Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel+EditProductsM2Tests.swift
@@ -10,7 +10,7 @@ final class DefaultProductFormTableViewModel_EditProductsM2Tests: XCTestCase {
 
     private let mockFeatureFlagService = MockFeatureFlagService(isEditProductsRelease2On: true)
 
-    func testViewModelForSimplePhysicalProductWithoutImagesWhenM2FeatureFlagIsOff() {
+    func testViewModelForPhysicalSimpleProductWithoutImages() {
         let product = MockProduct().product(downloadable: false,
                                             name: "woo",
                                             productType: .simple,
@@ -47,7 +47,7 @@ final class DefaultProductFormTableViewModel_EditProductsM2Tests: XCTestCase {
         }
     }
 
-    func testViewModelForPhysicalSimpleProductWithImages() {
+    func testViewModelForVirtualSimpleProductWithImages() {
         let product = MockProduct().product(downloadable: false,
                                             name: "woo",
                                             productType: .simple,


### PR DESCRIPTION
Fixes #2045 

## Changes

- Updated the name of 2 test cases to avoid future confusion (more context in #2045)

## Testing

no user facing changes, just CI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
