### PR TITLE
Update hotfix tooling

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,7 +132,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane creates the release branch for a new hotix release. 
+  # This lane creates the release branch for a new hotfix release. 
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -132,7 +132,7 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane updates the release branch for a new hotix release. 
+  # This lane creates the release branch for a new hotix release. 
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
@@ -145,6 +145,22 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
   lane :new_hotfix_release do | options |
     prev_ver = ios_hotfix_prechecks(options)
     ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
+  end
+
+  #####################################################################################
+  # finalize_hotfix_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalizes the hotfix branch. 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_hotfix_release [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane finalize_hotfix_release skip_confirm:true  
+  #####################################################################################
+  desc "Creates a new hotfix branch from the given tag"
+  lane :finalize_hotfix_release do | options |
+    ios_finalize_prechecks(options)
     ios_tag_build()
   end
 


### PR DESCRIPTION
This PR fixes the hotfix branch creation tooling.
The current implementation tags the branch as soon as it's created, which means that the tag has to be manually deleted and re-added after the changes are merged.
This PR removes the tagging step from the creation lane and adds a short lane only for tagging.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
