### PR TITLE
Update Octokit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
     netrc (0.11.0)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.10.5)


### PR DESCRIPTION
This PR updates the Octokit Gem to version `4.18` as `4.17` has been removed from RubyGems (https://rubygems.org/gems/octokit/versions/4.3.0) because it had this issue: https://github.com/octokit/octokit.rb/releases/tag/v4.17.0.

Thanks @shiki for the heads up!

### To Test:
- Verify that the CI is green.
- On your system: delete the `vendor` folder, run `bundle install` and verify that there are no errors.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
