### PR TITLE
Remove `stats` feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -11,8 +11,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
         case .readonlyProductVariants:
             return true
-        case .stats:
-            return true
         case .refunds:
             return true
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -26,10 +26,6 @@ enum FeatureFlag: Int {
     ///
     case readonlyProductVariants
 
-    /// Store stats
-    ///
-    case stats
-
     /// Product Reviews
     ///
     case reviews

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -123,9 +123,8 @@ private extension DashboardViewController {
             self.siteID = siteID
         }
 
-        dashboardUIFactory?.reloadDashboardUI(isFeatureFlagOn: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.stats),
-                                              onUIUpdate: { [weak self] dashboardUI in
-                                                self?.onDashboardUIUpdate(updatedDashboardUI: dashboardUI)
+        dashboardUIFactory?.reloadDashboardUI(onUIUpdate: { [weak self] dashboardUI in
+            self?.onDashboardUIUpdate(updatedDashboardUI: dashboardUI)
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -32,18 +32,13 @@ final class DashboardUIFactory {
         self.stateCoordinator = StatsVersionStateCoordinator(siteID: siteID)
     }
 
-    func reloadDashboardUI(isFeatureFlagOn: Bool,
-                           onUIUpdate: @escaping (_ dashboardUI: DashboardUI) -> Void) {
-        if isFeatureFlagOn {
-            stateCoordinator.onStateChange = { [weak self] (previousState, currentState) in
-                self?.onStatsVersionStateChange(previousState: previousState,
-                                                currentState: currentState,
-                                                onUIUpdate: onUIUpdate)
-            }
-            stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
-        } else {
-            onUIUpdate(statsV3DashboardUI())
+    func reloadDashboardUI(onUIUpdate: @escaping (_ dashboardUI: DashboardUI) -> Void) {
+        stateCoordinator.onStateChange = { [weak self] (previousState, currentState) in
+            self?.onStatsVersionStateChange(previousState: previousState,
+                                            currentState: currentState,
+                                            onUIUpdate: onUIUpdate)
         }
+        stateCoordinator.loadLastShownVersionAndCheckV4Eligibility()
     }
 
     private func statsV3DashboardUI() -> DashboardUI & TopBannerPresenter {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -304,8 +304,7 @@ private extension SettingsViewController {
     }
 
     func couldShowBetaFeaturesRow() -> Bool {
-        let featureFlagService = ServiceLocator.featureFlagService
-        return featureFlagService.isFeatureFlagEnabled(.stats) || featureFlagService.isFeatureFlagEnabled(.productList)
+        return true
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -15,20 +15,6 @@ final class DashboardUIFactoryTests: XCTestCase {
         super.tearDown()
     }
 
-    func testStatsVersionWhenFeatureFlagIsOff() {
-        mockStoresManager = MockupStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
-        ServiceLocator.setStores(mockStoresManager)
-        dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
-
-        let expectation = self.expectation(description: "Wait for the initial stats version")
-
-        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: false) { dashboardUI in
-            XCTAssertTrue(dashboardUI is DashboardStatsV3ViewController)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.1, handler: nil)
-    }
-
     func testWhenV4IsAvailableWhileNoStatsVersionIsSaved() {
         mockStoresManager = MockupStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = true
@@ -43,7 +29,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
 
-        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { dashboardUI in
+        dashboardUIFactory.reloadDashboardUI { dashboardUI in
             dashboardUITypes.append(type(of: dashboardUI))
             if dashboardUITypes.count >= expectedDashboardUITypes.count {
                 for i in 0..<dashboardUITypes.count {
@@ -66,7 +52,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
 
-        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { dashboardUI in
+        dashboardUIFactory.reloadDashboardUI { dashboardUI in
             dashboardUIArray.append(dashboardUI)
             // 2 view controllers are expected to be the same v3 UI.
             if dashboardUIArray.count >= 2 {
@@ -91,7 +77,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
 
-        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { dashboardUI in
+        dashboardUIFactory.reloadDashboardUI { dashboardUI in
             dashboardUIArray.append(dashboardUI)
             // 2 view controllers are expected to be the same v3 UI.
             if dashboardUIArray.count >= 2 {
@@ -116,7 +102,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
 
-        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { dashboardUI in
+        dashboardUIFactory.reloadDashboardUI { dashboardUI in
             dashboardUIArray.append(dashboardUI)
             // 2 view controllers are expected to be the same v4 UI.
             if dashboardUIArray.count >= 2 {
@@ -141,7 +127,7 @@ final class DashboardUIFactoryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for the stats v4")
         expectation.expectedFulfillmentCount = 1
 
-        dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { [weak self] dashboardUI in
+        dashboardUIFactory.reloadDashboardUI { [weak self] dashboardUI in
             dashboardUIArray.append(dashboardUI)
             // The first updated view controller is v4, and the second view controller is reverted back to v3.
             if dashboardUIArray.count >= 2 {
@@ -156,7 +142,7 @@ final class DashboardUIFactoryTests: XCTestCase {
                 self.mockStoresManager.isStatsV4Available = true
                 dashboardUIArray = []
 
-                self.dashboardUIFactory.reloadDashboardUI(isFeatureFlagOn: true) { dashboardUI in
+                self.dashboardUIFactory.reloadDashboardUI { dashboardUI in
                     dashboardUIArray.append(dashboardUI)
 
                     // The first view controller is v4 -> v3 UI, and the second view controller is v3 -> v4 UI.


### PR DESCRIPTION
Fixes #2052 

## Changes

- Removed the feature flag that was used to determine whether stats v4 UI can be shown when it's available:
  - Dashboard ("My store" tab) uses the flag to determine whether it could show stats v4 UI (stats v3 UI only if the flag is off)
  - In Settings > Experimental Features, the "Beta Features" is partially determined by the flag (if the `productList` flag is off, the row is hidden if the `stats` flag is off)

 ## Testing

- Launch the app --> if the site is WC 4.0+ or has WC Admin plugin, stats v4 should be available, and you can switch between 2 versions in Settings > Experimental Features

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
