### PR TITLE
Allow Customization of Keyboard Height Frame

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameAdjustmentProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameAdjustmentProvider.swift
@@ -1,0 +1,39 @@
+
+import UIKit
+
+/// A ViewController that provides additional adjustment for when the keyboard is shown.
+///
+/// This is used by container ViewControllers to customize how their children should adjust
+/// their frame, content insets, or scroll indicator insets in relation to the keyboard.
+///
+/// An example scenario is when a ViewController has a UITableViewController child. That child
+/// will have a zero `safeAreaInsets` value by default. If the keyboard is shown and the child
+/// handles it by using `KeyboardScrollable`, there will be an extra space shown above the keyboard.
+/// The table will only scroll up to that space, not up to the keyboard's top edge. To fix this,
+/// the container ViewController can pass its `safeAreaInsets` like this:
+///
+/// ```
+/// override func viewSafeAreaInsetsDidChange() {
+///     super.viewSafeAreaInsetsDidChange()
+///
+///     children.compactMap {
+///         $0 as? KeyboardFrameAdjustmentProvider
+///     }.forEach {
+///         $0.additionalKeyboardFrameHeight = 0 - view.safeAreaInsets.bottom
+///     }
+/// }
+/// ```
+///
+/// The child UITableViewController can then simply use `KeyboardScrollable` to automatically
+/// adjust the scrollable height when the keyboard is shown. The `additionalKeyboardFrameHeight`
+/// will be automatically applied by `KeyboardScrollable`.
+///
+/// - SeeAlso: KeyboardScrollable
+///
+protocol KeyboardFrameAdjustmentProvider: UIViewController {
+    /// The height that should be added to inset calculations.
+    ///
+    /// This is read-write because this will typically be adjusted by container ViewControllers.
+    ///
+    var additionalKeyboardFrameHeight: CGFloat { get set }
+}

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
@@ -11,11 +11,19 @@ extension KeyboardScrollable where Self: UIViewController {
     func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
         let keyboardHeight = keyboardFrame.height
 
-        // iPhone X+ adds a bottom inset for the Home Indicator. This inset is made irrelevant
-        // if the keyboard is present. That's why we should deduct it from the final `bottomInset`
-        // value. If we don't, the `scrollable` (i.e. TableView) will be shown with a space above
-        // the keyboard.
-        let bottomInset = keyboardHeight - view.safeAreaInsets.bottom
+        let bottomInset: CGFloat = {
+            // iPhone X+ adds a bottom inset for the Home Indicator. This inset is made irrelevant
+            // if the keyboard is present. That's why we should deduct it from the final `bottomInset`
+            // value. If we don't, the `scrollable` (i.e. TableView) will be shown with a space above
+            // the keyboard.
+            var inset = keyboardHeight - view.safeAreaInsets.bottom
+
+            if let provider = self as? KeyboardFrameAdjustmentProvider {
+                inset += provider.additionalKeyboardFrameHeight
+            }
+
+            return inset
+        }()
 
         scrollable.contentInset.bottom = bottomInset
         scrollable.scrollIndicatorInsets.bottom = bottomInset

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
@@ -7,10 +7,17 @@ protocol KeyboardScrollable {
     func handleKeyboardFrameUpdate(keyboardFrame: CGRect)
 }
 
-extension KeyboardScrollable {
+extension KeyboardScrollable where Self: UIViewController {
     func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
         let keyboardHeight = keyboardFrame.height
-        scrollable.contentInset.bottom = keyboardHeight
-        scrollable.scrollIndicatorInsets.bottom = keyboardHeight
+
+        // iPhone X+ adds a bottom inset for the Home Indicator. This inset is made irrelevant
+        // if the keyboard is present. That's why we should deduct it from the final `bottomInset`
+        // value. If we don't, the `scrollable` (i.e. TableView) will be shown with a space above
+        // the keyboard.
+        let bottomInset = keyboardHeight - view.safeAreaInsets.bottom
+
+        scrollable.contentInset.bottom = bottomInset
+        scrollable.scrollIndicatorInsets.bottom = bottomInset
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -7,7 +7,7 @@ import struct Yosemite.OrderStatus
 ///
 /// This shows a list of `OrderStatus` that the user can pick to filter Orders by status.
 ///
-final class OrderSearchStarterViewController: UIViewController {
+final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdjustmentProvider {
     private lazy var analytics = ServiceLocator.analytics
 
     @IBOutlet private var tableView: UITableView!
@@ -17,6 +17,9 @@ final class OrderSearchStarterViewController: UIViewController {
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
         KeyboardFrameObserver(onKeyboardFrameUpdate: handleKeyboardFrameUpdate(keyboardFrame:))
     }()
+
+    /// Required implementation for `KeyboardFrameAdjustmentProvider`.
+    var additionalKeyboardFrameHeight: CGFloat = 0
 
     init() {
         super.init(nibName: type(of: self).nibName, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -199,11 +199,29 @@ where Cell.SearchModel == Command.CellViewModel {
         view.endEditing(true)
         dismiss(animated: true, completion: nil)
     }
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+
+        applyAdditionalKeyboardFrameHeightTo(children)
+    }
 }
+
+// MARK: - Keyboard Handling
 
 extension SearchViewController: KeyboardScrollable {
     var scrollable: UIScrollView {
         return tableView
+    }
+}
+
+private extension SearchViewController {
+    func applyAdditionalKeyboardFrameHeightTo(_ viewControllers: [UIViewController]) {
+        children.compactMap {
+            $0 as? KeyboardFrameAdjustmentProvider
+        }.forEach {
+            $0.additionalKeyboardFrameHeight = 0 - view.safeAreaInsets.bottom
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
 		57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */; };
+		6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -1039,6 +1040,7 @@
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
 		57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModelTests.swift; sourceTree = "<group>"; };
+		6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameAdjustmentProvider.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -1769,6 +1771,7 @@
 			children = (
 				0269576923726304001BA0BF /* KeyboardFrameObserver.swift */,
 				024DF3042372ADCD006658FE /* KeyboardScrollable.swift */,
+				6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */,
 			);
 			path = Keyboard;
 			sourceTree = "<group>";
@@ -4386,6 +4389,7 @@
 				D817586422BDD81600289CFE /* OrderDetailsDataSource.swift in Sources */,
 				CE1F512920697F0100C6C810 /* UIFont+Helpers.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
+				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I'm almost done with #1974 but I was currently blocked by this today. 

## Problems

I was trying to vertically align the text and image shown in #1974 but found out that there's an inherited `safeAreaInsets` from `SearchViewController` that causes the vertical alignment to be skewed. 

If you'll look at the image below, the bottom area is slightly bigger. It's not because the keyboard height calculation is wrong. It's because the view is placed slightly higher because of the parent's (`SearchViewController`) `safeAreaInsets` already including the iOS Home Indicator's height.

![image](https://user-images.githubusercontent.com/198826/77965717-da3c3700-729e-11ea-8e01-bf65b9f4546f.png)

I also found that the `safeAreaInsets` is the cause of the extra space at the bottom of the Products and Orders search results.

<img src="https://user-images.githubusercontent.com/198826/77966043-8bdb6800-729f-11ea-957d-5fe676b0c5e9.png" width="320">

## Solutions

### Search Results Table

To remove the extra space in the search results, I included the `view.safeAreaInsets.bottom` as part of the keyboard height calculation in `KeyboardScrollable` (64a71ebfb52e4b0d653ba93a2f58753429c8a4ed). 

https://github.com/woocommerce/woocommerce-ios/blob/b604a93cfd312c30444ebb8b6dbbb161ebd09373/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift#L14-L19

Before | After 
--------|-------
  ![image](https://user-images.githubusercontent.com/198826/77967771-0e195b80-72a3-11ea-9c8d-d1febb6ba021.png)      |       ![image](https://user-images.githubusercontent.com/198826/77967838-32753800-72a3-11ea-8ba0-8a7a98c3f09b.png)
![image](https://user-images.githubusercontent.com/198826/77967642-c0045800-72a2-11ea-86af-a5f88c9c856d.png) | ![image](https://user-images.githubusercontent.com/198826/77967900-4faa0680-72a3-11ea-832c-604552cc6b77.png)


### SearchViewController Children

The above change isn't enough to fix any child ViewController that has a table because `safeAreaInsets` from the parent are not propagated to the children. Which makes sense. 

I contemplated using something like this to calculate the keyboard height in `KeyboardScrollable`:

```swift
// safeAreaInsetsOfParent finds the topmost parent viewcontroller and returns the safeAreaInsets
var inset = keyboardHeight - view.safeAreaInsetsOfParent.bottom
```

But having a `safeAreaInsetsOfParent` means that the child **knows** how the parent works. This seems incorrect. 

I ended up going the other way and allowed _configuration_ of the children's keyboard height adjustment through a protocol:

https://github.com/woocommerce/woocommerce-ios/blob/b604a93cfd312c30444ebb8b6dbbb161ebd09373/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameAdjustmentProvider.swift#L33-L39

And the parent **passes the adjustment** to the children instead:

https://github.com/woocommerce/woocommerce-ios/blob/b604a93cfd312c30444ebb8b6dbbb161ebd09373/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift#L219-L225

The `additionalKeyboardFrameHeight` is then read by `KeyboardScrollable` when it calculates the height:

https://github.com/woocommerce/woocommerce-ios/blob/b604a93cfd312c30444ebb8b6dbbb161ebd09373/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift#L19-L23

This is enough to fix the height calculation for children (e.g. `OrderSearchStarterViewController`):



Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/77967709-e629f800-72a2-11ea-861b-d2a1ae9059f0.png)      |       ![image](https://user-images.githubusercontent.com/198826/77967189-dbbb2e80-72a1-11ea-8c03-f9b0922a6651.png)

This should also be enough to unblock me from finishing #1974.  

## Testing

1. Navigate to Orders → Search.
2. Enter a search string that will return many results.
3. Scroll to the bottom. 
4. Confirm that there is no extra space between the keyboard and the table's scroll indicator. 
5. Clear the search string. 
6. Scroll to the bottom. 
7. Confirm that there is no extra space between the keyboard and the table's scroll indicator. 

Please do similar steps for the Products search. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


