### PR TITLE
Record the stats v4 start/end date parsing error instead of crashing the app

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -628,11 +628,12 @@ private extension StoreStatsV4PeriodViewController {
         }
 
         guard firstStatsInterval.dateStart() != nil, firstStatsInterval.dateEnd() != nil else {
-            let errorInfo = "Failed to parse stats interval start date: \(firstStatsInterval.dateStart); end date: \(firstStatsInterval.dateEnd)"
+            let errorInfo = "Failed to parse stats v4 interval date(s)"
             let error = NSError(domain: "WooCommerceStatsV4ErrorDomain",
                                 code: 100,
                                 userInfo: [NSLocalizedDescriptionKey: errorInfo])
-            CrashLogging.logError(error, userInfo: ["Message": errorInfo], level: .error)
+            let errorMessage = "Failed to parse stats interval start date: \(firstStatsInterval.dateStart); end date: \(firstStatsInterval.dateEnd)"
+            CrashLogging.logError(error, userInfo: ["Message": errorMessage], level: .error)
             return
         }
 

--- a/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
+++ b/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
@@ -7,18 +7,12 @@ extension OrderStatsV4Interval {
     }
 
     /// Returns the interval start date by parsing the `dateStart` string.
-    public func dateStart() -> Date {
-        guard let date = dateFormatter.date(from: dateStart) else {
-            fatalError("Failed to parse date: \(dateStart)")
-        }
-        return date
+    public func dateStart() -> Date? {
+        return dateFormatter.date(from: dateStart)
     }
 
     /// Returns the interval end date by parsing the `dateEnd` string.
-    public func dateEnd() -> Date {
-        guard let date = dateFormatter.date(from: dateEnd) else {
-            fatalError("Failed to parse date: \(dateEnd)")
-        }
-        return date
+    public func dateEnd() -> Date? {
+        return dateFormatter.date(from: dateEnd)
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -11,7 +11,7 @@ class OrderStatsV4Interval_DateTests: XCTestCase {
                                             dateStart: dateStringInSiteTimeZone,
                                             dateEnd: dateStringInSiteTimeZone,
                                             subtotals: mockIntervalSubtotals)
-        [interval.dateStart(), interval.dateEnd()].forEach { date in
+        [interval.dateStart(), interval.dateEnd()].compactMap { $0 }.forEach { date in
             let dateComponents = Calendar.current.dateComponents(in: .current, from: date)
             XCTAssertEqual(dateComponents.year, 2019)
             XCTAssertEqual(dateComponents.month, 8)


### PR DESCRIPTION
Fixes #2061 

## Context

We've had [this `fatalError` when a stats v4 interval's start date cannot be parsed](https://github.com/woocommerce/woocommerce-ios/blame/develop/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval%2BDate.swift#L12) for 6 months and the frequency just spiked recently on March 29 UTC with 3.9k events. Since the message in the `fatalError` didn't seem to be recorded to the crash log, we don't know what the date strings are in the crash events to investigate further yet. This PR replaces the `fatalError` with `nil` return value and recording the error via `CrashLogging` (non-fatal) in the app layer instead.

```
     public func dateStart() -> Date {
        guard let date = dateFormatter.date(from: dateStart) else {
            fatalError("Failed to parse date: \(dateStart)")
        }
        return date
    }
```

## Changes

- In `OrderStatsV4Interval`'s `dateStart()` and `dateEnd()`, replaced the `fatalError` with nil return value
- In `StoreStatsV4PeriodViewController`, handled the optional `OrderStatsV4Interval` `dateStart()` and `dateEnd()` with early returns. In `updateOrderDataIfNeeded` (called on stats data change), records the error with the first interval's start/end date via `CrashLogging.logError`

## Testing

- Launch the app
- Opt in to new stats if the app hasn't --> make sure each tab in the new stats looks as before and consistent with the dashboard in WC Admin

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
