### PR TITLE
Removed load product visibility check

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -158,15 +158,7 @@ private extension ProductLoaderViewController {
     ///
     func presentProductDetails(for product: Product) {
         let isEditProductsFeatureFlagOn = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts)
-        guard isEditProductsFeatureFlagOn else {
-            presentProductDetails(for: product, isEditProductsEnabled: false)
-            return
-        }
-
-        let action = AppSettingsAction.loadProductsVisibility { [weak self] isEditProductsEnabled in
-            self?.presentProductDetails(for: product, isEditProductsEnabled: isEditProductsEnabled)
-        }
-        ServiceLocator.stores.dispatch(action)
+        self.presentProductDetails(for: product, isEditProductsEnabled: isEditProductsFeatureFlagOn)
     }
 
     func presentProductDetails(for product: Product, isEditProductsEnabled: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -158,7 +158,7 @@ private extension ProductLoaderViewController {
     ///
     func presentProductDetails(for product: Product) {
         let isEditProductsFeatureFlagOn = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts)
-        self.presentProductDetails(for: product, isEditProductsEnabled: isEditProductsFeatureFlagOn)
+        presentProductDetails(for: product, isEditProductsEnabled: isEditProductsFeatureFlagOn)
     }
 
     func presentProductDetails(for product: Product, isEditProductsEnabled: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -390,15 +390,7 @@ extension ProductsViewController: UITableViewDelegate {
         let product = resultsController.object(at: indexPath)
 
         let isEditProductsFeatureFlagOn = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProducts)
-        guard isEditProductsFeatureFlagOn else {
-            didSelectProduct(product: product, isEditProductsEnabled: false)
-            return
-        }
-
-        let action = AppSettingsAction.loadProductsVisibility { [weak self] isEditProductsEnabled in
-            self?.didSelectProduct(product: product, isEditProductsEnabled: isEditProductsEnabled)
-        }
-        ServiceLocator.stores.dispatch(action)
+        didSelectProduct(product: product, isEditProductsEnabled: isEditProductsFeatureFlagOn)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {


### PR DESCRIPTION
While I was testing the app on Xcode 11.4, on a clean simulator, I found that we were checking in some points of the app if the edit product needs to be presented based on load "product visibility flag" in Settings, that we don't use anymore from this PR #2040 (because we enabled product release 1 for all our users).
So, I removed the code in the app where we did this check.

Why didn't we find out about this problem when testing #2040?
I believe we all had the product flag enabled, and we didn't try on a clean install.

## Testing
- Erase all contents and settings from your iOS simulator (you can test it also on Xcode 11.3)
- Run the app
- Go to products
- Open a simple product
- Make sure you are able to see the new edit product screen


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
