### PR TITLE
Allow sending of initial events in KeyboardFrameObserver

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -56,6 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupPushNotificationsManagerIfPossible()
         setupAppRatingManager()
         setupWormholy()
+        setupKeyboardStateProvider()
         handleLaunchArguments()
 
         // Display the Authentication UI
@@ -291,6 +292,10 @@ private extension AppDelegate {
         /// We want to activate it programmatically, not using the shake.
         Wormholy.shakeEnabled = false
         #endif
+    }
+
+    func setupKeyboardStateProvider() {
+        _ = ServiceLocator.keyboardStateProvider
     }
 
     func handleLaunchArguments() {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -294,7 +294,11 @@ private extension AppDelegate {
         #endif
     }
 
+    /// Set up `KeyboardStateProvider`
+    ///
     func setupKeyboardStateProvider() {
+        // Simply _accessing_ it is enough. We only want the object to be initialized right away
+        // so it can start observing keyboard changes.
         _ = ServiceLocator.keyboardStateProvider
     }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -3,7 +3,7 @@ import CocoaLumberjack
 import Storage
 import Yosemite
 
-/// Provides global depedencies.
+/// Provides global dependencies.
 ///
 final class ServiceLocator {
 
@@ -48,7 +48,6 @@ final class ServiceLocator {
     /// Cocoalumberjack DDLog
     ///
     private static var _fileLogger: Logs = DDFileLogger()
-
 
     // MARK: - Getters
 
@@ -120,6 +119,8 @@ final class ServiceLocator {
     static var fileLogger: Logs {
         return _fileLogger
     }
+
+    static var keyboardStateProvider: KeyboardStateProviding = KeyboardStateProvider()
 }
 
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -120,7 +120,12 @@ final class ServiceLocator {
         return _fileLogger
     }
 
-    static var keyboardStateProvider: KeyboardStateProviding = KeyboardStateProvider()
+    /// Provides the last known `KeyboardState`.
+    ///
+    /// Because `static let` is lazy, this should be accessed when the app is started
+    /// (i.e. AppDelegate) for it to accurately provide the last known state.
+    ///
+    static let keyboardStateProvider: KeyboardStateProviding = KeyboardStateProvider()
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -4,6 +4,8 @@ import UIKit
 struct KeyboardFrameObserver {
     private let onKeyboardFrameUpdate: OnKeyboardFrameUpdate
 
+    private let keyboardStateProvider: KeyboardStateProviding
+
     /// Notifies the closure owner about any keyboard frame change.
     /// Note that the frame is based on the keyboard window coordinate.
     typealias OnKeyboardFrameUpdate = (_ keyboardFrame: CGRect) -> Void
@@ -19,8 +21,10 @@ struct KeyboardFrameObserver {
     }
 
     init(notificationCenter: NotificationCenter = NotificationCenter.default,
+         keyboardStateProvider: KeyboardStateProviding = ServiceLocator.keyboardStateProvider,
          onKeyboardFrameUpdate: @escaping OnKeyboardFrameUpdate) {
         self.notificationCenter = notificationCenter
+        self.keyboardStateProvider = keyboardStateProvider
         self.onKeyboardFrameUpdate = onKeyboardFrameUpdate
     }
 

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -4,6 +4,10 @@ import UIKit
 struct KeyboardFrameObserver {
     private let onKeyboardFrameUpdate: OnKeyboardFrameUpdate
 
+    /// Provides the last known keyboard state.
+    ///
+    /// This will only be used for sending an initial event.
+    ///
     private let keyboardStateProvider: KeyboardStateProviding
 
     /// Notifies the closure owner about any keyboard frame change.

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -28,7 +28,7 @@ struct KeyboardFrameObserver {
         self.onKeyboardFrameUpdate = onKeyboardFrameUpdate
     }
 
-    mutating func startObservingKeyboardFrame() {
+    mutating func startObservingKeyboardFrame(sendInitialEvent: Bool = false) {
         var observer = self
         notificationCenter.addObserver(forName: UIResponder.keyboardWillShowNotification,
                                        object: nil,
@@ -40,6 +40,10 @@ struct KeyboardFrameObserver {
                                        object: nil,
                                        queue: nil) { notification in
                                         observer.keyboardWillHide(notification)
+        }
+
+        if sendInitialEvent {
+            keyboardFrame = keyboardStateProvider.state.frameEnd
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -28,6 +28,10 @@ struct KeyboardFrameObserver {
         self.onKeyboardFrameUpdate = onKeyboardFrameUpdate
     }
 
+    /// Start observing for keyboard notifications and notify subscribers when they arrive.
+    ///
+    /// - Parameter sendInitialEvent: If true, the subscriber will be immediately notified
+    ///                               using the last known keyboard frame.
     mutating func startObservingKeyboardFrame(sendInitialEvent: Bool = false) {
         var observer = self
         notificationCenter.addObserver(forName: UIResponder.keyboardWillShowNotification,

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -1,0 +1,37 @@
+
+import UIKit
+
+enum KeyboardState {
+    case hidden
+    case shown
+}
+
+protocol KeyboardStateProviding {
+    var state: KeyboardState { get }
+}
+
+final class KeyboardStateProvider: KeyboardStateProviding {
+    private(set) var state: KeyboardState = .hidden
+
+    private var observations = [Any]()
+
+    init() {
+        let nc = NotificationCenter.default
+
+        observations.append(
+            nc.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { [weak self] _ in
+                self?.state = .shown
+            }
+        )
+        observations.append(
+            nc.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { [weak self] _ in
+                self?.state = .hidden
+            }
+        )
+    }
+
+    deinit {
+        observations.forEach(NotificationCenter.default.removeObserver)
+    }
+}
+

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// Keyboard information usually received from `Notifications`.
 ///
-struct KeyboardState {
+struct KeyboardState: Equatable {
     /// True if the keyboard is visible.
     let isVisible: Bool
     /// The frame of the keyboard when it is fully shown or hidden.

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -1,18 +1,40 @@
 
 import UIKit
 
+/// Keyboard information usually received from `Notifications`.
+///
 struct KeyboardState {
+    /// True if the keyboard is visible.
     let isVisible: Bool
+    /// The frame of the keyboard when it is fully shown or hidden.
+    ///
+    /// The value is usually from `UIResponder.keyboardFrameEndUserInfoKey`.
     let frameEnd: CGRect
 }
 
+/// Provides the last known state of the keyboard.
+///
 protocol KeyboardStateProviding {
+    /// The last known state of the keyboard.
     var state: KeyboardState { get }
 }
 
+/// Provides and tracks the last known state of the keyboard.
+///
+/// This does not work very well as a one-off instance. It has to be instantiated and **kept**
+/// when the app is started (i.e. `UIApplicationDelegate`) so it can _track_ the keyboard changes.
+/// Only then will this be able to accurately provide the last known state of the keyboard.
+///
+/// Initially, this assumes that the keyboard is not visible.
+///
 final class KeyboardStateProvider: KeyboardStateProviding {
+    /// The last known state.
+    ///
+    /// This is kept up to date whenever we receive keyboard notifications.
+    ///
     private(set) var state: KeyboardState = KeyboardState(isVisible: false, frameEnd: .zero)
 
+    /// NSNotification observers that will be removed on deinit
     private var observations = [Any]()
 
     init() {
@@ -40,6 +62,8 @@ final class KeyboardStateProvider: KeyboardStateProviding {
 }
 
 private extension Notification {
+    /// The `CGRect` value of `UIResponder.keyboardFrameEndUserInfoKey` from self.
+    ///
     var keyboardFrameEnd: CGRect? {
         guard let rectAsValue = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
             return nil

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -1,9 +1,9 @@
 
 import UIKit
 
-enum KeyboardState {
-    case hidden
-    case shown
+struct KeyboardState {
+    let isVisible: Bool
+    let frameEnd: CGRect
 }
 
 protocol KeyboardStateProviding {
@@ -11,7 +11,7 @@ protocol KeyboardStateProviding {
 }
 
 final class KeyboardStateProvider: KeyboardStateProviding {
-    private(set) var state: KeyboardState = .hidden
+    private(set) var state: KeyboardState = KeyboardState(isVisible: false, frameEnd: .zero)
 
     private var observations = [Any]()
 
@@ -19,19 +19,36 @@ final class KeyboardStateProvider: KeyboardStateProviding {
         let nc = NotificationCenter.default
 
         observations.append(
-            nc.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { [weak self] _ in
-                self?.state = .shown
+            nc.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { [weak self] notification in
+                self?.updateState(from: notification)
             }
         )
         observations.append(
-            nc.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { [weak self] _ in
-                self?.state = .hidden
+            nc.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { [weak self] notification in
+                self?.updateState(from: notification)
             }
+        )
+    }
+
+    private func updateState(from notification: Notification) {
+        state = KeyboardState(
+            isVisible: notification.name == UIResponder.keyboardDidShowNotification,
+            frameEnd: notification.keyboardFrameEnd ?? .zero
         )
     }
 
     deinit {
         observations.forEach(NotificationCenter.default.removeObserver)
+    }
+}
+
+private extension Notification {
+    var keyboardFrameEnd: CGRect? {
+        guard let rectAsValue = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+            return nil
+        }
+
+        return rectAsValue.cgRectValue
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -75,4 +75,3 @@ private extension Notification {
         return rectAsValue.cgRectValue
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -28,6 +28,9 @@ protocol KeyboardStateProviding {
 /// Initially, this assumes that the keyboard is not visible.
 ///
 final class KeyboardStateProvider: KeyboardStateProviding {
+    /// The NotificationCenter to observe
+    private let notificationCenter: NotificationCenter
+
     /// The last known state.
     ///
     /// This is kept up to date whenever we receive keyboard notifications.
@@ -37,13 +40,13 @@ final class KeyboardStateProvider: KeyboardStateProviding {
     /// NSNotification observers that will be removed on deinit
     private var observations = [Any]()
 
-    init() {
-        let nc = NotificationCenter.default
+    init(notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.notificationCenter = notificationCenter
 
         let notificationNames = [UIResponder.keyboardDidShowNotification, UIResponder.keyboardDidHideNotification]
 
         observations.append(contentsOf: notificationNames.map { notificationName in
-            nc.addObserver(forName: notificationName, object: nil, queue: nil) { [weak self] notification in
+            notificationCenter.addObserver(forName: notificationName, object: nil, queue: nil) { [weak self] notification in
                 self?.updateState(from: notification)
             }
         })
@@ -57,7 +60,7 @@ final class KeyboardStateProvider: KeyboardStateProviding {
     }
 
     deinit {
-        observations.forEach(NotificationCenter.default.removeObserver)
+        observations.forEach(notificationCenter.removeObserver)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift
@@ -18,16 +18,13 @@ final class KeyboardStateProvider: KeyboardStateProviding {
     init() {
         let nc = NotificationCenter.default
 
-        observations.append(
-            nc.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: nil) { [weak self] notification in
+        let notificationNames = [UIResponder.keyboardDidShowNotification, UIResponder.keyboardDidHideNotification]
+
+        observations.append(contentsOf: notificationNames.map { notificationName in
+            nc.addObserver(forName: notificationName, object: nil, queue: nil) { [weak self] notification in
                 self?.updateState(from: notification)
             }
-        )
-        observations.append(
-            nc.addObserver(forName: UIResponder.keyboardDidHideNotification, object: nil, queue: nil) { [weak self] notification in
-                self?.updateState(from: notification)
-            }
-        )
+        })
     }
 
     private func updateState(from notification: Notification) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
 		57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */; };
 		6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */; };
+		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
 		740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 740382DA2267D94100A627F4 /* LargeImageTableViewCell.xib */; };
@@ -1044,6 +1045,7 @@
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
 		57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModelTests.swift; sourceTree = "<group>"; };
+		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
 		6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameAdjustmentProvider.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -1776,6 +1778,7 @@
 				0269576923726304001BA0BF /* KeyboardFrameObserver.swift */,
 				024DF3042372ADCD006658FE /* KeyboardScrollable.swift */,
 				6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */,
+				6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */,
 			);
 			path = Keyboard;
 			sourceTree = "<group>";
@@ -4406,6 +4409,7 @@
 				CE1F512920697F0100C6C810 /* UIFont+Helpers.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,
+				6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
 		57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */; };
+		6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */; };
 		6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */; };
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
@@ -1047,6 +1048,7 @@
 		57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModelTests.swift; sourceTree = "<group>"; };
 		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
 		6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameAdjustmentProvider.swift; sourceTree = "<group>"; };
+		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -1787,6 +1789,7 @@
 			isa = PBXGroup;
 			children = (
 				0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */,
+				6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */,
 			);
 			path = Keyboard;
 			sourceTree = "<group>";
@@ -4540,6 +4543,7 @@
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
 				45FBDF34238D33F100127F77 /* MockProduct.swift in Sources */,
+				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ServiceLocatorTests.swift
@@ -66,6 +66,11 @@ final class ServiceLocatorTests: XCTestCase {
         XCTAssertNotNil(ServiceLocator.fileLogger)
     }
 
+    func testServiceLocatorProvidesKeyboardStateProvider() {
+        XCTAssertNotNil(ServiceLocator.keyboardStateProvider)
+        XCTAssertTrue(ServiceLocator.keyboardStateProvider is KeyboardStateProvider)
+    }
+
     func testFileLoggerDefaultsToDDFileLogger() {
         let fileLogger = ServiceLocator.fileLogger
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -100,6 +100,26 @@ final class KeyboardFrameObserverTests: XCTestCase {
         expectationForKeyboardFrame.isInverted = true
         waitForExpectations(timeout: 0.1)
     }
+    
+    func testItCanSendInitialEvents() {
+        // Arrange
+        let expectedKeyboardState = KeyboardState(
+            isVisible: true,
+            frameEnd: CGRect(x: 2_100, y: 3_123, width: 9_981_123, height: 1_514)
+        )
+        let keyboardStateProvider = MockKeyboardStateProvider(state: expectedKeyboardState)
+
+        var actualKeyboardFrame: CGRect = .zero
+        var keyboardFrameObserver = KeyboardFrameObserver(keyboardStateProvider: keyboardStateProvider) { frame in
+            actualKeyboardFrame = frame
+        }
+
+        // Act
+        keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
+
+        // Assert
+        XCTAssertEqual(actualKeyboardFrame, expectedKeyboardState.frameEnd)
+    }
 }
 
 private extension NotificationCenter {
@@ -126,4 +146,8 @@ private extension NotificationCenter {
              object: nil,
              userInfo: [UIResponder.keyboardFrameEndUserInfoKey: CGRect.zero])
     }
+}
+
+private struct MockKeyboardStateProvider: KeyboardStateProviding {
+    let state: KeyboardState
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -100,7 +100,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         expectationForKeyboardFrame.isInverted = true
         waitForExpectations(timeout: 0.1)
     }
-    
+
     func testItCanSendInitialEvents() {
         // Arrange
         let expectedKeyboardState = KeyboardState(

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -1,0 +1,93 @@
+
+import XCTest
+import UIKit
+@testable import WooCommerce
+
+/// Tests for the concrete `KeyboardStateProvider`
+///
+final class KeyboardStateProviderTests: XCTestCase {
+    func testItDefaultsToNotVisibleAndNoFrame() {
+        let provider = KeyboardStateProvider()
+
+        XCTAssertEqual(provider.state, KeyboardState(isVisible: false, frameEnd: .zero))
+    }
+
+    func testItUpdatesTheStateWhenTheKeyboardIsShown() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
+
+        let expectedFrameEnd = CGRect(x: 1_981, y: 9_312, width: 311, height: 981)
+
+        // Act
+        notificationCenter.postKeyboardDidShowNotification(frameEnd: expectedFrameEnd)
+
+        // Assert
+        XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedFrameEnd))
+    }
+
+    func testItUpdatesTheStateWhenTheKeyboardIsHidden() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
+
+        // Still using a dummy CGRect and not zero to test that KeyboardStateProvider uses the
+        // frame given by the Notification
+        let expectedFrameEnd = CGRect(x: 981, y: 5_135, width: 146, height: 561)
+
+        // Act
+        notificationCenter.postKeyboardDidHideNotification(frameEnd: expectedFrameEnd)
+
+        // Assert
+        XCTAssertEqual(provider.state, KeyboardState(isVisible: false, frameEnd: expectedFrameEnd))
+    }
+
+    /// Test receiving multiple Notifications
+    func testItContinuouslyUpdatesTheStateWhenMultipleEventsHappen() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
+
+        let expectedLastFrameEnd = CGRect(x: 888, y: 555, width: 121_411, height: 971_471)
+
+        // Act
+        notificationCenter.postKeyboardDidHideNotification(frameEnd: .zero)
+        notificationCenter.postKeyboardDidShowNotification(frameEnd: CGRect(x: 1, y: 2, width: 3, height: 4))
+        notificationCenter.postKeyboardDidHideNotification(frameEnd: .zero)
+        notificationCenter.postKeyboardDidShowNotification(frameEnd: expectedLastFrameEnd)
+
+        // Assert
+        XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: expectedLastFrameEnd))
+    }
+
+    func testItUpdatesTheStateToZeroFrameEndWhenTheNotificationHasNoFrameEnd() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+        let provider = KeyboardStateProvider(notificationCenter: notificationCenter)
+
+        // Act
+        notificationCenter.postKeyboardDidShowNotification(frameEnd: nil)
+
+        // Assert
+        XCTAssertEqual(provider.state, KeyboardState(isVisible: true, frameEnd: .zero))
+    }
+}
+
+private extension NotificationCenter {
+    func postKeyboardDidShowNotification(frameEnd: CGRect? = nil) {
+        let userInfo: [AnyHashable: Any?]? = {
+            if let frameEnd = frameEnd {
+                return [UIResponder.keyboardFrameEndUserInfoKey: frameEnd]
+            } else {
+                return nil
+            }
+        }()
+
+        post(name: UIResponder.keyboardDidShowNotification, object: nil, userInfo: userInfo)
+    }
+
+    func postKeyboardDidHideNotification(frameEnd: CGRect) {
+        let userInfo = [UIResponder.keyboardFrameEndUserInfoKey: frameEnd]
+        post(name: UIResponder.keyboardDidHideNotification, object: nil, userInfo: userInfo)
+    }
+}


### PR DESCRIPTION
Refs #1974. 

In my WIP for #1974, the empty state view is created when the keyboard is **already present**. This makes it challenging to _adjust_ constraints to fit the viewable space. Or vertically align the image and text. 

This is how it currently looks right now. 😭 

<img src="https://user-images.githubusercontent.com/198826/78060502-d8c74900-7348-11ea-89db-fbdcea8b3478.gif" width="320">

I'm using the `KeyboardFrameObserver` for the constraint adjustments. However, `KeyboardFrameObserver` doesn't inform the consumer _right way_ if the keyboard is already present. It has to _wait_ for events to happen. 

This PR adds that feature:

https://github.com/woocommerce/woocommerce-ios/blob/b2498fd3f0dc4069760dd89161433573f17fccfd/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift#L37-L40

## Solution

There doesn't seem to be a way to _detect_ if the keyboard is currently present. To support this, I created a similar class called `KeyboardStateProvider` which is kept forever in `ServiceLocator`.

https://github.com/woocommerce/woocommerce-ios/blob/b2498fd3f0dc4069760dd89161433573f17fccfd/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift#L123-L129

The `KeyboardStateProvider` observes for keyboard notifications and **saves** the values of the last notification in a `KeyboardState`:

https://github.com/woocommerce/woocommerce-ios/blob/b2498fd3f0dc4069760dd89161433573f17fccfd/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardStateProvider.swift#L6-L13

This **last saved `KeyboardState`** is used by any instance of `KeyboardFrameObserver` to send the _last known keyboard frame_:

https://github.com/woocommerce/woocommerce-ios/blob/b2498fd3f0dc4069760dd89161433573f17fccfd/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift#L53-L55

Using the `sendInitialEvent` argument in my #1974 WIP fixes the issue:

<img src="https://user-images.githubusercontent.com/198826/78061420-75d6b180-734a-11ea-9ded-04ea606785b5.gif" width="320">

### Duplication? 

There are some overlaps for `KeyboardFrameObserver` and `KeyboardStateProvider`. They both observe keyboard notifications. However, I think the separation is acceptable because they have different purposes:

- `KeyboardFrameObserver`: for updating the view whenever the keyboard changes. Emits keyboard events.
- `KeyboardStateProvider`: acquire the last known keyboard state (visibility and frame). It does not emit any events. And it's essentially a singleton (`ServiceLocator`). 

We should still use `KeyboardFrameObserver` most of the time. 

## Testing

The new `sendInitialEvent` is not currently used. It is only used in my WIP for #1974. I did add a [test in `KeyboardFrameObserverTests` ](https://github.com/woocommerce/woocommerce-ios/blob/b2498fd3f0dc4069760dd89161433573f17fccfd/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift#L104-L122) to prove that it works. Please scrutinize that instead. 🙂 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



