### PR TITLE
Add Dark Mode support to the open-source licenses

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -54,6 +54,8 @@ private extension LicensesViewController {
     ///
     func configureWebView() {
         webView.navigationDelegate = self
+        webView.backgroundColor = .clear
+        webView.isOpaque = false
         webView.loadFileURL(licenseURL, allowingReadAccessTo: licenseURL)
     }
 }

--- a/WooCommerce/Resources/HTML/licenses.html
+++ b/WooCommerce/Resources/HTML/licenses.html
@@ -11,6 +11,16 @@
             a {
                 color: #96588a;
             }
+
+            @media (prefers-color-scheme: dark) {
+                body {
+                    color: #f7f7f7;
+                    background-color: transparent;
+                }
+                a {
+                    color: #B07DD1;
+                }
+            }
         </style>
     </head>
     <body>


### PR DESCRIPTION
Adds dark mode support to the Settings > Open Source Licenses screen.

Uses colours pulled from other areas of the app, but could probably use a quick design review.

**To Test:**
- On the simulator, go to the licenses screen in dark or light mode – swap modes twice to see that it properly changes as the mode setting changes.

<img src="https://user-images.githubusercontent.com/1123407/78096742-a98bf880-7397-11ea-90cf-9ea55c648d67.png" width="350" />

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
