### PR TITLE
Updated Wormholy to v.1.5.2 which is fully compatible with Swift 5.2 and Xcode 11.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ target 'WooCommerce' do
   pod 'Charts', '~> 3.3.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
   pod 'Kingfisher', '~> 5.11.0'
-  pod 'Wormholy', '~> 1.5.1', :configurations => ['Debug']
+  pod 'Wormholy', '~> 1.5.2', :configurations => ['Debug']
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.2)
-  - Wormholy (1.5.1)
+  - Wormholy (1.5.2)
   - WPMediaPicker (1.6.0)
   - wpxmlrpc (0.8.5)
   - XLPagerTabStrip (9.0.0)
@@ -104,7 +104,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.12.0-beta.5)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.5.2)
-  - Wormholy (~> 1.5.1)
+  - Wormholy (~> 1.5.2)
   - WPMediaPicker (~> 1.6.0)
   - XLPagerTabStrip (~> 9.0)
   - ZendeskSupportSDK (~> 5.0)
@@ -176,7 +176,7 @@ SPEC CHECKSUMS:
   WordPressKit: bd4cd5b4e7616c388082db83e7cd2031b6b3404e
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
-  Wormholy: f01b096b449a9fcab864a10f7e5b5693b1225c88
+  Wormholy: 3344d3591d78488d957402d51dccfbfafd6f9641
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
@@ -188,6 +188,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 382b505b76ea2653f6d6c1e80d8b56e66afada84
+PODFILE CHECKSUM: 1875ae94fbd15468590412a5f8c5dc8d1f949f23
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
I see that updating to Xcode 11.4, witch use Swift 5.2, [Wormholy is no more presented](https://github.com/pmusolino/Wormholy/pull/80).

This PR update [Wormholy](https://github.com/pmusolino/Wormholy) to the latest version which is fully compatible with the latest version of Swift.

## Testing
- Run the app on Xcode 11.4
- Navigate to Settings
- Tap Wormholy
- Make sure that Wormholy is presented correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
