### PR TITLE
Add NSMutableAttributedString.replaceFirstOccurrence

### DIFF
--- a/WooCommerce/Classes/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/NSMutableAttributedString+Helpers.swift
@@ -14,6 +14,17 @@ extension NSMutableAttributedString {
         }
     }
 
+    /// Replaces the first found occurrence of `target` with the `replacement`.
+    ///
+    /// Example usage:
+    ///
+    /// ```
+    /// let attributedString = NSMutableAttributedString(string: Hello, #{person}")
+    /// let replacement = NSAttributedString(string: "Slim Shady",
+    ///                                      attributes: [.font: UIFont.boldSystemFont(ofSize: 32)])
+    /// attributedString.replaceFirstOccurrence(of: "#{person}", with: replacement)
+    /// ```
+    ///
     func replaceFirstOccurrence(of target: String, with replacement: NSAttributedString) {
         guard let range = string.range(of: target) else {
             return

--- a/WooCommerce/Classes/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/NSMutableAttributedString+Helpers.swift
@@ -13,4 +13,13 @@ extension NSMutableAttributedString {
             addAttributes(attributes, range: range)
         }
     }
+
+    func replaceFirstOccurrence(of target: String, with replacement: NSAttributedString) {
+        guard let range = string.range(of: target) else {
+            return
+        }
+        let nsRange = NSRange(range, in: string)
+
+        replaceCharacters(in: nsRange, with: replacement)
+    }
 }

--- a/WooCommerce/Classes/Extensions/NSMutableAttributedString+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/NSMutableAttributedString+Helpers.swift
@@ -19,7 +19,7 @@ extension NSMutableAttributedString {
     /// Example usage:
     ///
     /// ```
-    /// let attributedString = NSMutableAttributedString(string: Hello, #{person}")
+    /// let attributedString = NSMutableAttributedString(string: "Hello, #{person}")
     /// let replacement = NSAttributedString(string: "Slim Shady",
     ///                                      attributes: [.font: UIFont.boldSystemFont(ofSize: 32)])
     /// attributedString.replaceFirstOccurrence(of: "#{person}", with: replacement)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */; };
 		6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */; };
 		6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */; };
+		6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */; };
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74036CBF211B882100E462C2 /* PeriodDataViewController.swift */; };
 		740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */; };
@@ -1048,6 +1049,7 @@
 		57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModelTests.swift; sourceTree = "<group>"; };
 		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
 		6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameAdjustmentProvider.swift; sourceTree = "<group>"; };
+		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74036CBF211B882100E462C2 /* PeriodDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodDataViewController.swift; sourceTree = "<group>"; };
@@ -2560,6 +2562,7 @@
 				021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */,
 				F997174623DC070C00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift */,
 				0215320C2423309B003F2BBD /* UIStackView+SubviewsTests.swift */,
+				6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4544,6 +4547,7 @@
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
 				45FBDF34238D33F100127F77 /* MockProduct.swift in Sources */,
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
+				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerceTests/Extensions/NSMutableAttributedStringHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/NSMutableAttributedStringHelperTests.swift
@@ -11,7 +11,8 @@ final class NSMutableAttributedStringHelperTests: XCTestCase {
     func testReplaceFirstOccurrenceReplacesTheFirstMatch() {
         // Arrange
         let attributedString = NSMutableAttributedString(string: "Will the real #{person} please stand up?")
-        let replacement = NSAttributedString(string: "Slim Shady", attributes: [.font: UIFont.boldSystemFont(ofSize: 32)])
+        let replacement = NSAttributedString(string: "Slim Shady",
+                                             attributes: [.font: UIFont.boldSystemFont(ofSize: 32)])
 
         // Act
         attributedString.replaceFirstOccurrence(of: "#{person}", with: replacement)
@@ -28,6 +29,43 @@ final class NSMutableAttributedStringHelperTests: XCTestCase {
         let font = attributes[.font] as! UIFont
         XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
         XCTAssertEqual(font.pointSize, 32)
+    }
+
+    func testWhenReplacementExistsInTheStringReplaceFirstOccurrenceCorrectlyReplacesTheTarget() {
+        // Arrange
+        let repeatedWord = "_echo_"
+        // The attributedString also contains the repeatedWord
+        let format = "_echo__echo_%@_echo__echo_"
+
+        let rangeUpToPlaceholder = NSRange(format.startIndex..<format.range(of: "%@")!.lowerBound, in: format)
+
+        let attributedString = NSMutableAttributedString(string: format)
+        let replacement = NSAttributedString(string: repeatedWord,
+                                             attributes: [.font: UIFont.italicSystemFont(ofSize: 64)])
+
+        // Act
+        attributedString.replaceFirstOccurrence(of: "%@", with: replacement)
+
+        // Assert
+        // The placeholder %@ is still replaced with the defined "_echo_" replacement
+        XCTAssertEqual(attributedString.string, "_echo__echo__echo__echo__echo_")
+
+        // Assert that there are no attributes (e.g. bold) from the first character to the
+        // beginning of the replaced placeholder ("%@").
+        var effectiveRange = NSRange()
+        let attributesBeforePlaceholder = attributedString.attributes(at: 0, effectiveRange: &effectiveRange)
+        XCTAssertTrue(attributesBeforePlaceholder.isEmpty)
+        XCTAssertEqual(effectiveRange, rangeUpToPlaceholder)
+
+        // Assert that the italic font attribute is applied to the inserted "_echo_"
+        let attributesAtPlaceholder = attributedString.attributes(at: rangeUpToPlaceholder.upperBound,
+                                                                  effectiveRange: &effectiveRange)
+        XCTAssertFalse(attributesAtPlaceholder.isEmpty)
+        XCTAssertEqual(effectiveRange, NSMakeRange(rangeUpToPlaceholder.upperBound, repeatedWord.characterCount))
+        // Assert that it's the italic font that we defined earlier
+        let font = attributesAtPlaceholder[.font] as! UIFont
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitItalic))
+        XCTAssertEqual(font.pointSize, 64)
     }
 
     func testReplaceFirstOccurrenceOnlyReplacesTheFirstMatch() {

--- a/WooCommerce/WooCommerceTests/Extensions/NSMutableAttributedStringHelperTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/NSMutableAttributedStringHelperTests.swift
@@ -1,0 +1,57 @@
+
+import XCTest
+import UIKit
+
+@testable import WooCommerce
+
+/// Tests for methods in NSMutableAttributedString+Helpers
+///
+final class NSMutableAttributedStringHelperTests: XCTestCase {
+
+    func testReplaceFirstOccurrenceReplacesTheFirstMatch() {
+        // Arrange
+        let attributedString = NSMutableAttributedString(string: "Will the real #{person} please stand up?")
+        let replacement = NSAttributedString(string: "Slim Shady", attributes: [.font: UIFont.boldSystemFont(ofSize: 32)])
+
+        // Act
+        attributedString.replaceFirstOccurrence(of: "#{person}", with: replacement)
+
+        // Assert
+        XCTAssertEqual(attributedString.string, "Will the real Slim Shady please stand up?")
+        // There are no attributes at the first character
+        XCTAssertTrue(attributedString.attributes(at: 0, effectiveRange: nil).isEmpty)
+
+        // There is an attribute at 14 (the position of "#{person}") which was replaced.
+        let attributes = attributedString.attributes(at: 14, effectiveRange: nil)
+        XCTAssertFalse(attributes.isEmpty)
+
+        let font = attributes[.font] as! UIFont
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold))
+        XCTAssertEqual(font.pointSize, 32)
+    }
+
+    func testReplaceFirstOccurrenceOnlyReplacesTheFirstMatch() {
+        // Arrange
+        let attributedString = NSMutableAttributedString(string: "Hi {name}. How are you, {name}?")
+        let replacement = NSAttributedString(string: "Wilmer")
+
+        // Act
+        attributedString.replaceFirstOccurrence(of: "{name}", with: replacement)
+
+        // Assert
+        XCTAssertEqual(attributedString.string, "Hi Wilmer. How are you, {name}?")
+    }
+
+    func testReplaceFirstOccurrenceFinishesSafelyIfTheTargetIsNotFound() {
+        // Arrange
+        let attributedString = NSMutableAttributedString(string: "These are the days of our lives")
+        let replacement = NSAttributedString(string: "Wilmer")
+
+        // Act
+        attributedString.replaceFirstOccurrence(of: "{name}", with: replacement)
+
+        // Assert
+        // Nothing changed
+        XCTAssertEqual(attributedString.string, "These are the days of our lives")
+    }
+}


### PR DESCRIPTION
Refs #1974.

This adds a new `NSMutableAttributedString.replaceFirstOccurrence()` method. It is used to generate the _empty results_ messages in #1974. The unique case here is the search text entered by the user should be **bold**.

<img src="https://user-images.githubusercontent.com/198826/78158482-86e0fa80-73fe-11ea-815c-2ef103474743.png" width="320">

Here is an example of how it will be used: 

https://github.com/woocommerce/woocommerce-ios/blob/b820192bdf81d3e4b4a258593356762233ea55e6/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift#L35-L40

We'd usually use [`String.localizedStringWithFormat()`](https://developer.apple.com/documentation/swift/string/1414192-localizedstringwithformat) for cases like this but there doesn't seem to be something like that in `NSAttributedString`. 

## Testing

The method isn't used anywhere yet. Please review the unit tests instead. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

