### PR TITLE
Update media POST endpoint to v1.1 with error handling

### DIFF
--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -36,6 +36,7 @@ public class MediaRemote: Remote {
     }
 
     /// Uploads an array of media in the local file system.
+    /// API reference: https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/new/
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll upload the media to.
@@ -53,7 +54,7 @@ public class MediaRemote: Remote {
         ]
 
         let path = "sites/\(siteID)/media/new"
-        let request = DotcomRequest(wordpressApiVersion: .mark1_2,
+        let request = DotcomRequest(wordpressApiVersion: .mark1_1,
                                     method: .post,
                                     path: path,
                                     parameters: parameters)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -4,15 +4,20 @@ import Yosemite
 /// Encapsulates the implementation of Product images actions from the UI.
 ///
 final class ProductImageActionHandler {
-    typealias OnAllStatusesUpdate = ([ProductImageStatus], Error?) -> Void
+    typealias AllStatuses = (productImageStatuses: [ProductImageStatus], error: Error?)
+    typealias OnAllStatusesUpdate = (AllStatuses) -> Void
     typealias OnAssetUpload = (PHAsset, ProductImage) -> Void
 
     private let siteID: Int64
 
-    private(set) var productImageStatuses: [ProductImageStatus] {
+    var productImageStatuses: [ProductImageStatus] {
+        return allStatuses.productImageStatuses
+    }
+
+    private var allStatuses: AllStatuses {
         didSet {
             observations.allStatusesUpdated.values.forEach { closure in
-                closure(productImageStatuses, nil)
+                closure(allStatuses)
             }
         }
     }
@@ -24,7 +29,7 @@ final class ProductImageActionHandler {
 
     init(siteID: Int64, product: Product) {
         self.siteID = siteID
-        self.productImageStatuses = product.imageStatuses
+        self.allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
     }
 
     /// Observes when the image statuses have been updated.
@@ -37,7 +42,7 @@ final class ProductImageActionHandler {
                                          onUpdate: @escaping OnAllStatusesUpdate) -> ObservationToken {
         let id = UUID()
 
-        observations.allStatusesUpdated[id] = { [weak self, weak observer] statuses, error in
+        observations.allStatusesUpdated[id] = { [weak self, weak observer] allStatuses in
             // If the observer has been deallocated, we can
             // automatically remove the observation closure.
             guard observer != nil else {
@@ -45,11 +50,11 @@ final class ProductImageActionHandler {
                 return
             }
 
-            onUpdate(statuses, error)
+            onUpdate(allStatuses)
         }
 
         // Sends the initial value.
-        onUpdate(productImageStatuses, nil)
+        onUpdate(allStatuses)
 
         return ObservationToken { [weak self] in
             self?.observations.allStatusesUpdated.removeValue(forKey: id)
@@ -83,7 +88,8 @@ final class ProductImageActionHandler {
     }
 
     func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset) {
-        productImageStatuses = [.uploading(asset: asset)] + productImageStatuses
+        let imageStatuses = [.uploading(asset: asset)] + allStatuses.productImageStatuses
+        allStatuses = (productImageStatuses: imageStatuses, error: nil)
 
         let action = MediaAction.uploadMedia(siteID: siteID,
                                              mediaAsset: asset) { [weak self] (media, error) in
@@ -115,18 +121,20 @@ final class ProductImageActionHandler {
     }
 
     func deleteProductImage(_ productImage: ProductImage) {
-        productImageStatuses.removeAll { status -> Bool in
+        var imageStatuses = allStatuses.productImageStatuses
+        imageStatuses.removeAll { status -> Bool in
             guard case .remote(let image) = status else {
                 return false
             }
             return image.imageID == productImage.imageID
         }
+        allStatuses = (productImageStatuses: imageStatuses, error: nil)
     }
 }
 
 private extension ProductImageActionHandler {
     func index(of asset: PHAsset) -> Int? {
-        return productImageStatuses.firstIndex(where: { status -> Bool in
+        return allStatuses.productImageStatuses.firstIndex(where: { status -> Bool in
             switch status {
             case .uploading(let uploadingAsset):
                 return uploadingAsset == asset
@@ -137,16 +145,20 @@ private extension ProductImageActionHandler {
     }
 
     func updateProductImageStatus(at index: Int, productImage: ProductImage) {
-        if case .uploading(let asset) = productImageStatuses[safe: index] {
+        if case .uploading(let asset) = allStatuses.productImageStatuses[safe: index] {
             observations.assetUploaded.values.forEach { closure in
                 closure(asset, productImage)
             }
         }
 
-        productImageStatuses[index] = .remote(image: productImage)
+        var imageStatuses = allStatuses.productImageStatuses
+        imageStatuses[index] = .remote(image: productImage)
+        allStatuses = (productImageStatuses: imageStatuses, error: nil)
     }
 
     func updateProductImageStatus(at index: Int, error: Error?) {
-        productImageStatuses.remove(at: index)
+        var imageStatuses = allStatuses.productImageStatuses
+        imageStatuses.remove(at: index)
+        allStatuses = (productImageStatuses: imageStatuses, error: error)
     }
 }


### PR DESCRIPTION
"Update the media POST endpoint to 1.1" part of #1713 

## Changes

- During testing, I realized site media POST endpoint isn't available in WP.com API v1.2 (https://developer.wordpress.com/docs/api/1.2/post/sites/%24site/media/new/ isn't available and the API response is 404) as for the [media GET endpoint](https://developer.wordpress.com/docs/api/1.2/get/sites/%24site/media/). This PR updated the endpoint from 1.2 to 1.1.
- I also noticed that no error was thrown on `develop` before this PR when receiving 404 from the media POST request. It was because `func updateProductImageStatus(at index: Int, error: Error?)` wasn't propagating the error to the all statuses callbacks. This PR updated the all statuses state to include the optional error for each update event

## Testing

### Success case
- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera --> the photo should be uploaded remotely successfully; on `develop`, it fails silently

### Error handling
- Change the WP.com API version in `MediaRemote` for upload request to `mark1_2` as in the old diff (so that the server returns 404)
- Launch the app
- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera --> there should be an error alert like the screenshot below

<img src="https://user-images.githubusercontent.com/1945542/78225127-45cf1000-74fc-11ea-9253-ddd98e365b50.png" width="320" />

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
