### PR TITLE
Fix build warnings on `develop`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -255,7 +255,7 @@ private extension PaginatedListSelectorViewController {
         switch state {
         case .noResultsPlaceholder:
             displayNoResultsOverlay()
-        case .syncing(let pageNumber):
+        case .syncing:
             if isEmpty {
                 displayPlaceholderProducts()
             } else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -75,7 +75,7 @@ final class KeyboardStateProviderTests: XCTestCase {
 
 private extension NotificationCenter {
     func postKeyboardDidShowNotification(frameEnd: CGRect? = nil) {
-        let userInfo: [AnyHashable: Any?]? = {
+        let userInfo: [AnyHashable: Any]? = {
             if let frameEnd = frameEnd {
                 return [UIResponder.keyboardFrameEndUserInfoKey: frameEnd]
             } else {


### PR DESCRIPTION
## Changes

This PR fixed 2 straightforward build warnings 😄 

- WooCommerce target

```
/woocommerce-ios/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift:258:27: warning: immutable value 'pageNumber' was never used; consider replacing with '_' or removing it
        case .syncing(let pageNumber):
                          ^~~~~~~~~~
```

- WooCommerceTests target

```
/woocommerce-ios/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift:86:84: Expression implicitly coerced from '[AnyHashable : Any?]' to '[AnyHashable : Any]'
```

## Testing

Just CI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
