### PR TITLE
Fix build error on `develop`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -89,7 +89,8 @@ final class ProductImageActionHandler {
 
     func addSiteMediaLibraryImagesToProduct(mediaItems: [Media]) {
         let newProductImageStatuses = mediaItems.map { ProductImageStatus.remote(image: $0.toProductImage) }
-        productImageStatuses = newProductImageStatuses + productImageStatuses
+        let imageStatuses = newProductImageStatuses + productImageStatuses
+        allStatuses = (productImageStatuses: imageStatuses, error: nil)
     }
 
     func uploadMediaAssetToSiteMediaLibrary(asset: PHAsset) {


### PR DESCRIPTION
This PR fixes the build error on `develop` in https://circleci.com/gh/woocommerce/woocommerce-ios/7352?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```
▸ Compiling ProductImageActionHandler.swift

❌  /Users/distiller/project/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift:92:9: cannot assign to property: 'productImageStatuses' is a get-only property

        productImageStatuses = newProductImageStatuses + productImageStatuses
        ^~~~~~~~~~~~~~~~~~~~
```

## Cause

The internal state variable type was changed from just the statuses array to a tuple of the statuses array and the optional error in https://github.com/woocommerce/woocommerce-ios/pull/2075, but this change was missed in the new action for media from WP media library in https://github.com/woocommerce/woocommerce-ios/pull/2060. My bad not catching the conflict earlier!

## Testing

Just CI! there is a test case on `addSiteMediaLibraryImagesToProduct`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
