### PR TITLE
Parse the stats v4 dates with the site time zone instead of device time zone

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - Products is now available with limited editing for simple products!
 - Fix pulling to refresh on the Processing tab sometimes will not show the up-to-date orders.
 - Edit Product > Price Settings: schedule sale is now available even when either the start or end date is not set, and the sale end date can be removed now.
+- Improved stats: fixed a crash when loading improved stats on a day when daily saving time changes.
 - [internal] Changed the Shipping and Tax classes list loading so that any cached data is shown right away
 - [internal] Edit Products M2: added an image upload source for product images - WordPress Media Library.
 - [internal] Slightly changed the dependency graph of the database fetching component. Please watch out for data loading regressions.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -117,20 +117,22 @@ private extension StoreStatsAndTopPerformersViewController {
             }
         }
 
-        // When the site time zone can be correctly fetched, and also supports the Stats v4 API, consider using the site time zone
-        // for stats UI (#1375).
-        let timezoneForStatsDates = TimeZone.current
+        // Since the stats charts are based on site time zone, we set the time zone for the stats UI to be the site time zone.
+        // On the other hand, when syncing the stats data with the API, we want to use the device time zone to find the time range since the API date parameters
+        // have no time zone information and are relative to the site time zone (e.g. 12:00am-11:59pm for "Today" tab).
+        let timezoneForStatsDates = TimeZone.siteTimezone
+        let timezoneForSync = TimeZone.current
 
         periodVCs.forEach { (vc) in
             vc.siteTimezone = timezoneForStatsDates
 
             let currentDate = Date()
             vc.currentDate = currentDate
-            let latestDateToInclude = vc.timeRange.latestDate(currentDate: currentDate, siteTimezone: timezoneForStatsDates)
+            let latestDateToInclude = vc.timeRange.latestDate(currentDate: currentDate, siteTimezone: timezoneForSync)
 
             group.enter()
             self.syncStats(for: siteID,
-                           siteTimezone: timezoneForStatsDates,
+                           siteTimezone: timezoneForSync,
                            timeRange: vc.timeRange,
                            latestDateToInclude: latestDateToInclude) { [weak self] error in
                 if let error = error {
@@ -144,7 +146,7 @@ private extension StoreStatsAndTopPerformersViewController {
 
             group.enter()
             self.syncSiteVisitStats(for: siteID,
-                                    siteTimezone: timezoneForStatsDates,
+                                    siteTimezone: timezoneForSync,
                                     timeRange: vc.timeRange,
                                     latestDateToInclude: latestDateToInclude) { error in
                 if let error = error {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -34,7 +34,7 @@ class StoreStatsV4PeriodViewController: UIViewController {
     private var orderStatsIntervals: [OrderStatsV4Interval] = [] {
         didSet {
             let helper = StoreStatsV4ChartAxisHelper()
-            let intervalDates = orderStatsIntervals.map({ $0.dateStart() })
+            let intervalDates = orderStatsIntervals.map({ $0.dateStart(timeZone: siteTimezone) })
             orderStatsIntervalLabels = helper.generateLabelText(for: intervalDates,
                                                                 timeRange: timeRange,
                                                                 siteTimezone: siteTimezone)
@@ -492,8 +492,8 @@ private extension StoreStatsV4PeriodViewController {
     ///
     /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
     func updateTimeRangeBar(selectedIndex: Int?) {
-        guard let startDate = orderStatsIntervals.first?.dateStart(),
-            let endDate = orderStatsIntervals.last?.dateStart() else {
+        guard let startDate = orderStatsIntervals.first?.dateStart(timeZone: siteTimezone),
+            let endDate = orderStatsIntervals.last?.dateStart(timeZone: siteTimezone) else {
                 return
         }
         guard let selectedIndex = selectedIndex else {
@@ -504,7 +504,7 @@ private extension StoreStatsV4PeriodViewController {
             timeRangeBarView.updateUI(viewModel: timeRangeBarViewModel)
             return
         }
-        let date = orderStatsIntervals[selectedIndex].dateStart()
+        let date = orderStatsIntervals[selectedIndex].dateStart(timeZone: siteTimezone)
         let timeRangeBarViewModel = StatsTimeRangeBarViewModel(startDate: startDate,
                                                                endDate: endDate,
                                                                selectedDate: date,
@@ -614,10 +614,10 @@ private extension StoreStatsV4PeriodViewController {
 
     func updateOrderDataIfNeeded() {
         orderStatsIntervals = orderStats?.intervals.sorted(by: { (lhs, rhs) -> Bool in
-            return lhs.dateStart() < rhs.dateStart()
+            return lhs.dateStart(timeZone: siteTimezone) < rhs.dateStart(timeZone: siteTimezone)
         }) ?? []
-        if let startDate = orderStatsIntervals.first?.dateStart(),
-            let endDate = orderStatsIntervals.last?.dateStart() {
+        if let startDate = orderStatsIntervals.first?.dateStart(timeZone: siteTimezone),
+            let endDate = orderStatsIntervals.last?.dateStart(timeZone: siteTimezone) {
             let timeRangeBarViewModel = StatsTimeRangeBarViewModel(startDate: startDate,
                                                                    endDate: endDate,
                                                                    timeRange: timeRange,
@@ -747,12 +747,12 @@ private extension StoreStatsV4PeriodViewController {
 
     func formattedAxisPeriodString(for item: OrderStatsV4Interval) -> String {
         let chartDateFormatter = timeRange.chartDateFormatter(siteTimezone: siteTimezone)
-        return chartDateFormatter.string(from: item.dateStart())
+        return chartDateFormatter.string(from: item.dateStart(timeZone: siteTimezone))
     }
 
     func formattedChartMarkerPeriodString(for item: OrderStatsV4Interval) -> String {
         let chartDateFormatter = timeRange.chartDateFormatter(siteTimezone: siteTimezone)
-        return chartDateFormatter.string(from: item.dateStart())
+        return chartDateFormatter.string(from: item.dateStart(timeZone: siteTimezone))
     }
 }
 

--- a/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
+++ b/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
@@ -1,24 +1,27 @@
 import Foundation
 
 extension OrderStatsV4Interval {
-    private var dateFormatter: DateFormatter {
-        let dateFormatter = DateFormatter.Stats.dateTimeFormatter
-        return dateFormatter
-    }
-
     /// Returns the interval start date by parsing the `dateStart` string.
-    public func dateStart() -> Date {
-        guard let date = dateFormatter.date(from: dateStart) else {
+    public func dateStart(timeZone: TimeZone) -> Date {
+        guard let date = createDateFormatter(timeZone: timeZone).date(from: dateStart) else {
             fatalError("Failed to parse date: \(dateStart)")
         }
         return date
     }
 
     /// Returns the interval end date by parsing the `dateEnd` string.
-    public func dateEnd() -> Date {
-        guard let date = dateFormatter.date(from: dateEnd) else {
+    public func dateEnd(timeZone: TimeZone) -> Date {
+        guard let date = createDateFormatter(timeZone: timeZone).date(from: dateEnd) else {
             fatalError("Failed to parse date: \(dateEnd)")
         }
         return date
+    }
+}
+
+private extension OrderStatsV4Interval {
+    func createDateFormatter(timeZone: TimeZone) -> DateFormatter {
+        let dateFormatter = DateFormatter.Stats.dateTimeFormatter
+        dateFormatter.timeZone = timeZone
+        return dateFormatter
     }
 }

--- a/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
+++ b/Yosemite/YosemiteTests/Model/Extensions/OrderStatsV4Interval+DateTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Yosemite
 
-class OrderStatsV4Interval_DateTests: XCTestCase {
+final class OrderStatsV4Interval_DateTests: XCTestCase {
     private let mockIntervalSubtotals = OrderStatsV4Totals(totalOrders: 0, totalItemsSold: 0, grossRevenue: 0, couponDiscount: 0, totalCoupons: 0,
                                                            refunds: 0, taxes: 0, shipping: 0, netRevenue: 0, totalProducts: nil)
 
@@ -11,8 +11,10 @@ class OrderStatsV4Interval_DateTests: XCTestCase {
                                             dateStart: dateStringInSiteTimeZone,
                                             dateEnd: dateStringInSiteTimeZone,
                                             subtotals: mockIntervalSubtotals)
-        [interval.dateStart(), interval.dateEnd()].forEach { date in
-            let dateComponents = Calendar.current.dateComponents(in: .current, from: date)
+        // As long as the dates are parsed and formatted in the same time zone, they should be consistent.
+        let timeZone = TimeZone(secondsFromGMT: 29302)!
+        [interval.dateStart(timeZone: timeZone), interval.dateEnd(timeZone: timeZone)].forEach { date in
+            let dateComponents = Calendar.current.dateComponents(in: timeZone, from: date)
             XCTAssertEqual(dateComponents.year, 2019)
             XCTAssertEqual(dateComponents.month, 8)
             XCTAssertEqual(dateComponents.day, 8)


### PR DESCRIPTION
Fixes #2061 
More details in p91TBi-2Ba-p2

## Changes

- When converting a date string to a `Date` object for `OrderStatsV4Interval`'s start/end dates, a time zone is now used to parse the date
- Used the site time zone `TimeZone.siteTimezone` to convert the stats v4 date strings to `Date` for UI display, instead of the device time zone (the crash was from not being able to parse a non-existent date time). Since the site time zone is from the site's `gmt_offset`, it doesn't have daily saving time and thus can parse any time.

## Testing

Prerequisites:
1. set the device date time to anytime on March 29, 2020 in Rome, Italy (or any other city that has daily saving time change on the same day) under Settings > "Date & Time".
2. the site has WC 4.0+ or WC Admin plugin activated

* Notes:
1. try relaunching the app once if the time range doesn't look correct, since the site time zone is refreshed on switching store or app launch.
2. there's an existing issue https://github.com/woocommerce/woocommerce-ios/issues/2051 with the "This week" tab that I can reproduce with the same steps - it'd be fixed separately

### Case 1: Site with time zone in UTC offset

- In wp-admin, set the site time zone to **a UTC offset** (try a non-integer one) under Settings
- Launch the app with stats v4 enabled (Settings > Experimental Features > Stats) --> the time range on each tab (today, this week *, this month, this year) should look correct

### Case 2: Site with time zone in a region with daily saving time change on the same day

- In wp-admin, set the site time zone to a **Rome** under Settings
- Launch the app with stats v4 enabled (Settings > Experimental Features > Stats) --> the time range on each tab (today, this week *, this month, this year) should look correct

### Case 3: Site with time zone in a region without daily saving time change on this day

- In wp-admin, set the site time zone to **New York** under Settings
- Launch the app with stats v4 enabled (Settings > Experimental Features > Stats) --> the time range on each tab (today, this week *, this month, this year) should look correct

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
