### PR TITLE
Product Settings: edit the product slug (product's URL)

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -459,6 +459,7 @@ public struct Product: Codable {
         try container.encode(statusKey, forKey: .statusKey)
         try container.encode(featured, forKey: .featured)
         try container.encode(catalogVisibilityKey, forKey: .catalogVisibilityKey)
+        try container.encode(slug, forKey: .slug)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -103,12 +103,12 @@ enum ProductSettingsRows {
         }
 
         func configure(cell: UITableViewCell) {
-            guard let cell = cell as? BasicTableViewCell else {
+            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
                 return
             }
 
-            cell.textLabel?.text = NSLocalizedString("Slug", comment: "Slug label in Product Settings")
-            cell.detailTextLabel?.text = "TO BE IMPLEMENTED"
+            let titleView = NSLocalizedString("Slug", comment: "Slug label in Product Settings")
+            cell.updateUI(title: titleView, value: settings.slug)
             cell.accessoryType = .disclosureIndicator
         }
 
@@ -116,8 +116,8 @@ enum ProductSettingsRows {
             // TODO: Show a VC
         }
 
-        let reuseIdentifier: String = BasicTableViewCell.reuseIdentifier
+        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
 
-        let cellTypes: [UITableViewCell.Type] = [BasicTableViewCell.self]
+        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -113,7 +113,11 @@ enum ProductSettingsRows {
         }
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
-            // TODO: Show a VC
+            let viewController = ProductSlugViewController(settings: settings) { (productSettings) in
+                self.settings.slug = productSettings.slug
+                onCompletion(self.settings)
+            }
+            sourceViewController.navigationController?.pushViewController(viewController, animated: true)
         }
 
         let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -24,9 +24,7 @@ final class ProductSettingsViewModel {
 
     init(product: Product) {
         self.product = product
-        productSettings = ProductSettings(status: product.productStatus,
-                                          featured: product.featured,
-                                          catalogVisibility: product.productCatalogVisibility)
+        productSettings = ProductSettings(from: product)
         sections = Self.configureSections(productSettings)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class ProductSlugViewController: UIViewController {
+
+    @IBOutlet weak private var tableView: UITableView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -29,7 +29,9 @@ final class ProductSlugViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        configureNavigationBar()
+        configureMainView()
+        configureTableView()
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -12,10 +12,13 @@ final class ProductSlugViewController: UIViewController {
 
     private let productSettings: ProductSettings
     
+    private let sections: [Section]
+    
     /// Init
     ///
     init(settings: ProductSettings, completion: @escaping Completion) {
         productSettings = settings
+        sections = [Section(rows: [.slug])]
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
     }
@@ -57,5 +60,40 @@ private extension ProductSlugViewController {
 
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
+    }
+}
+
+// MARK: - Constants
+//
+extension ProductSlugViewController {
+
+    /// Table Rows
+    ///
+    enum Row {
+        /// Listed in the order they appear on screen
+        case slug
+
+        var reuseIdentifier: String {
+            switch self {
+            case .slug:
+                return TextFieldTableViewCell.reuseIdentifier
+            }
+        }
+    }
+
+    /// Table Sections
+    ///
+    struct Section {
+        let footer: String?
+        let rows: [Row]
+
+        init(footer: String? = nil, rows: [Row]) {
+            self.footer = footer
+            self.rows = rows
+        }
+
+        init(footer: String? = nil, row: Row) {
+            self.init(footer: footer, rows: [row])
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -58,6 +58,7 @@ private extension ProductSlugViewController {
     }
 
     func configureTableView() {
+        tableView.register(TextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TextFieldTableViewCell.reuseIdentifier)
         tableView.dataSource = self
         tableView.delegate = self
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -59,7 +59,7 @@ private extension ProductSlugViewController {
 
     func configureTableView() {
         tableView.register(TextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TextFieldTableViewCell.reuseIdentifier)
-        
+
         tableView.dataSource = self
         tableView.delegate = self
 
@@ -129,8 +129,10 @@ private extension ProductSlugViewController {
 
         let placeholder = NSLocalizedString("Slug", comment: "Placeholder in the Product Slug row on Edit Product Slug screen.")
 
-        let viewModel = TextFieldTableViewCell.ViewModel(text: productSettings.slug, placeholder: placeholder, onTextChange: { [weak self] newSlug in
-            self?.productSettings.slug = newSlug
+        let viewModel = TextFieldTableViewCell.ViewModel(text: productSettings.slug, placeholder: placeholder, onTextChange: { [weak self] newName in
+            if let newName = newName {
+                self?.productSettings.slug = newName
+            }
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
         })

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -18,7 +18,9 @@ final class ProductSlugViewController: UIViewController {
     ///
     init(settings: ProductSettings, completion: @escaping Completion) {
         productSettings = settings
-        sections = [Section(rows: [.slug])]
+        let footerText = NSLocalizedString("This is the URL-friendly version of the product title",
+        comment: "Footer text in Product Slug screen")
+        sections = [Section(footer: footerText, rows: [.slug])]
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
     }
@@ -56,12 +58,81 @@ private extension ProductSlugViewController {
     }
 
     func configureTableView() {
-
-        //tableView.dataSource = self
-        //tableView.delegate = self
+        tableView.dataSource = self
+        tableView.delegate = self
 
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductSlugViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductSlugViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+}
+
+// MARK: - Support for UITableViewDataSource
+//
+private extension ProductSlugViewController {
+    /// Configure cellForRowAtIndexPath:
+    ///
+   func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TextFieldTableViewCell:
+            configureSlug(cell: cell)
+        default:
+            fatalError("Unidentified product catalog visibility row type")
+        }
+    }
+
+    func configureSlug(cell: TextFieldTableViewCell) {
+        cell.accessoryType = .none
+
+        let placeholder = NSLocalizedString("Slug", comment: "Placeholder in the Product Slug row on Edit Product Slug screen.")
+
+        let viewModel = TextFieldTableViewCell.ViewModel(text: productSettings.slug, placeholder: placeholder, onTextChange: { [weak self] newName in
+            //self?.onNameChange?(newName)
+            }, onTextDidBeginEditing: {
+                //TODO: Add analytics track
+        })
+        cell.configure(viewModel: viewModel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -169,9 +169,5 @@ private extension ProductSlugViewController {
             self.footer = footer
             self.rows = rows
         }
-
-        init(footer: String? = nil, row: Row) {
-            self.init(footer: footer, rows: [row])
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -59,6 +59,7 @@ private extension ProductSlugViewController {
 
     func configureTableView() {
         tableView.register(TextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TextFieldTableViewCell.reuseIdentifier)
+        
         tableView.dataSource = self
         tableView.delegate = self
 
@@ -128,12 +129,13 @@ private extension ProductSlugViewController {
 
         let placeholder = NSLocalizedString("Slug", comment: "Placeholder in the Product Slug row on Edit Product Slug screen.")
 
-        let viewModel = TextFieldTableViewCell.ViewModel(text: productSettings.slug, placeholder: placeholder, onTextChange: { [weak self] newName in
-            //self?.onNameChange?(newName)
+        let viewModel = TextFieldTableViewCell.ViewModel(text: productSettings.slug, placeholder: placeholder, onTextChange: { [weak self] newSlug in
+            self?.productSettings.slug = newSlug
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
         })
         cell.configure(viewModel: viewModel)
+        cell.textField.applyBodyStyle()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -4,16 +4,16 @@ import Yosemite
 final class ProductSlugViewController: UIViewController {
 
     @IBOutlet weak private var tableView: UITableView!
-    
+
     // Completion callback
     //
     typealias Completion = (_ productSettings: ProductSettings) -> Void
     private let onCompletion: Completion
 
     private let productSettings: ProductSettings
-    
+
     private let sections: [Section]
-    
+
     /// Init
     ///
     init(settings: ProductSettings, completion: @escaping Completion) {
@@ -24,18 +24,18 @@ final class ProductSlugViewController: UIViewController {
         onCompletion = completion
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar()
         configureMainView()
         configureTableView()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         onCompletion(productSettings)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -1,12 +1,61 @@
 import UIKit
+import Yosemite
 
-class ProductSlugViewController: UIViewController {
+final class ProductSlugViewController: UIViewController {
 
     @IBOutlet weak private var tableView: UITableView!
+    
+    // Completion callback
+    //
+    typealias Completion = (_ productSettings: ProductSettings) -> Void
+    private let onCompletion: Completion
+
+    private let productSettings: ProductSettings
+    
+    /// Init
+    ///
+    init(settings: ProductSettings, completion: @escaping Completion) {
+        productSettings = settings
+        onCompletion = completion
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        onCompletion(productSettings)
+    }
 
+}
+
+// MARK: - View Configuration
+//
+private extension ProductSlugViewController {
+
+    func configureNavigationBar() {
+        title = NSLocalizedString("Slug", comment: "Product Slug navigation title")
+
+        removeNavigationBackBarButtonText()
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+
+        //tableView.dataSource = self
+        //tableView.delegate = self
+
+        tableView.backgroundColor = .listBackground
+        tableView.removeLastCellSeparator()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -143,7 +143,7 @@ private extension ProductSlugViewController {
 
 // MARK: - Constants
 //
-extension ProductSlugViewController {
+private extension ProductSlugViewController {
 
     /// Table Rows
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductSlugViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="0v4-5D-Sre" id="PVk-NY-eif"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="0v4-5D-Sre">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="0v4-5D-Sre" secondAttribute="trailing" id="EeD-Eo-raO"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="0v4-5D-Sre" secondAttribute="bottom" id="jze-fq-S6F"/>
+                <constraint firstItem="0v4-5D-Sre" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="tVd-Fy-99I"/>
+                <constraint firstItem="0v4-5D-Sre" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="zEJ-al-tSl"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="132" y="105"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -10,7 +10,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         let onTextDidBeginEditing: (() -> Void)?
     }
 
-    @IBOutlet private weak var textField: UITextField!
+    @IBOutlet weak var textField: UITextField!
 
     private var onTextChange: ((_ text: String?) -> Void)?
     private var onTextDidBeginEditing: (() -> Void)?

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -239,6 +239,8 @@
 		453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */; };
 		453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
+		457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */; };
+		457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */; };
 		4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7223F192D400B5F764 /* ProductSettingsViewController.swift */; };
 		4580BA7523F192D400B5F764 /* ProductSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */; };
 		4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */; };
@@ -1018,6 +1020,8 @@
 		453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Helpers.swift"; sourceTree = "<group>"; };
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
+		457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSlugViewController.swift; sourceTree = "<group>"; };
+		457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSlugViewController.xib; sourceTree = "<group>"; };
 		4580BA7223F192D400B5F764 /* ProductSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewController.swift; sourceTree = "<group>"; };
 		4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSettingsViewController.xib; sourceTree = "<group>"; };
 		4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -2077,6 +2081,15 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		457151A8243B6E6200EB2DFA /* Slug */ = {
+			isa = PBXGroup;
+			children = (
+				457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */,
+				457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */,
+			);
+			path = Slug;
+			sourceTree = "<group>";
+		};
 		45739F2E2436302600480C95 /* Catalog Visibility */ = {
 			isa = PBXGroup;
 			children = (
@@ -2095,6 +2108,7 @@
 				451C77722404534000413F73 /* ProductSettingsSections.swift */,
 				451C77702404518600413F73 /* ProductSettingsRows.swift */,
 				45739F2E2436302600480C95 /* Catalog Visibility */,
+				457151A8243B6E6200EB2DFA /* Slug */,
 				4524CD9F242D023300B2F20A /* List Selector Data Source */,
 			);
 			path = "Product Settings";
@@ -3754,6 +3768,7 @@
 				5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */,
 				45B9C63F23A8E50D007FC4C5 /* ProductPriceSettingsViewController.xib in Resources */,
 				B5F571A621BEC92A0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.xib in Resources */,
+				457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */,
 				B5F355F121CD504400A7077A /* SearchViewController.xib in Resources */,
 				CE1EC8F020B8A408009762BF /* OrderNoteTableViewCell.xib in Resources */,
 				B55D4BFD20B5CDE700D7A50F /* replace_secrets.rb in Resources */,
@@ -4378,6 +4393,7 @@
 				B57C744E20F56E3800EEFC87 /* UITableViewCell+Helpers.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				CEEC9B5C21E79B3E0055EEF0 /* FeatureFlag.swift in Sources */,
+				457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */,
 				02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */,
 				74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */,
 				740382DB2267D94100A627F4 /* LargeImageTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -25,12 +25,13 @@ final class MockProduct {
                  status: ProductStatus = .publish,
                  featured: Bool = false,
                  catalogVisibility: ProductCatalogVisibility = .visible,
+                 slug: String = "book-the-green-room",
                  images: [ProductImage] = []) -> Product {
 
     return Product(siteID: testSiteID,
                    productID: testProductID,
                    name: name,
-                   slug: "book-the-green-room",
+                   slug: slug,
                    permalink: "https://example.com/product/book-the-green-room/",
                    dateCreated: Date(),
                    dateModified: Date(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -6,7 +6,7 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
     func testOnReloadClosure() {
 
-        let product = MockProduct().product(status: .publish, featured: true, catalogVisibility: .search)
+        let product = MockProduct().product(status: .publish, featured: true, catalogVisibility: .search, slug: "this-is-a-slug")
         let viewModel = ProductSettingsViewModel(product: product)
 
         // Act
@@ -17,7 +17,7 @@ final class ProductSettingsViewModelTests: XCTestCase {
         }
 
         // Update settings. Section data changed. This will update the view model, and will fire the `onReload` closure.
-        viewModel.productSettings = ProductSettings(status: product.productStatus, featured: true, catalogVisibility: .search)
+        viewModel.productSettings = ProductSettings(status: product.productStatus, featured: true, catalogVisibility: .search, slug: "this-is-a-slug")
 
         waitForExpectations(timeout: 1.5, handler: nil)
     }

--- a/Yosemite/Yosemite/Model/Products/ProductSettings.swift
+++ b/Yosemite/Yosemite/Model/Products/ProductSettings.swift
@@ -7,15 +7,17 @@ public final class ProductSettings {
     public var status: ProductStatus
     public var featured: Bool
     public var catalogVisibility: ProductCatalogVisibility
+    public var slug: String
 
-    public init(status: ProductStatus, featured: Bool, catalogVisibility: ProductCatalogVisibility) {
+    public init(status: ProductStatus, featured: Bool, catalogVisibility: ProductCatalogVisibility, slug: String) {
         self.status = status
         self.featured = featured
         self.catalogVisibility = catalogVisibility
+        self.slug = slug
     }
 
     public convenience init(from product: Product) {
-        self.init(status: product.productStatus, featured: product.featured, catalogVisibility: product.productCatalogVisibility)
+        self.init(status: product.productStatus, featured: product.featured, catalogVisibility: product.productCatalogVisibility, slug: product.slug)
     }
 }
 
@@ -25,6 +27,7 @@ extension ProductSettings: Equatable {
     public static func == (lhs: ProductSettings, rhs: ProductSettings) -> Bool {
         return lhs.status.rawValue == rhs.status.rawValue &&
             lhs.featured == rhs.featured &&
-            lhs.catalogVisibility.rawValue == rhs.catalogVisibility.rawValue
+            lhs.catalogVisibility.rawValue == rhs.catalogVisibility.rawValue &&
+            lhs.slug == rhs.slug
     }
 }

--- a/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
+++ b/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
@@ -476,7 +476,7 @@ extension Product: ProductUpdater {
         return Product(siteID: siteID,
                        productID: productID,
                        name: name,
-                       slug: slug,
+                       slug: settings.slug,
                        permalink: permalink,
                        dateCreated: dateCreated,
                        dateModified: dateModified,

--- a/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
+++ b/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
@@ -122,9 +122,9 @@ final class Product_UpdaterTestCases: XCTestCase {
         let catalogVisibility = "search"
         let slug = "this-is-a-test"
         let productSettings = ProductSettings(status: .pending,
-                                                                featured: true,
+                                                                featured: featured,
                                                                 catalogVisibility: .search,
-                                                                slug: "this-is-a-test")
+                                                                slug: slug)
         let updatedProduct = product.productSettingsUpdated(settings: productSettings)
         XCTAssertEqual(updatedProduct.statusKey, newStatus)
         XCTAssertEqual(updatedProduct.featured, featured)

--- a/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
+++ b/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
@@ -120,13 +120,16 @@ final class Product_UpdaterTestCases: XCTestCase {
         let newStatus = "pending"
         let featured = true
         let catalogVisibility = "search"
+        let slug = "this-is-a-test"
         let productSettings = ProductSettings(status: .pending,
                                                                 featured: true,
-                                                                catalogVisibility: .search)
+                                                                catalogVisibility: .search,
+                                                                slug: "this-is-a-test")
         let updatedProduct = product.productSettingsUpdated(settings: productSettings)
         XCTAssertEqual(updatedProduct.statusKey, newStatus)
         XCTAssertEqual(updatedProduct.featured, featured)
         XCTAssertEqual(updatedProduct.catalogVisibilityKey, catalogVisibility)
+        XCTAssertEqual(updatedProduct.slug, slug)
     }
 }
 


### PR DESCRIPTION
Resolve #1826 

This PR implement the edit product slug under Product Settings, part of milestone 2.

## Changes
- Encoded the `slug` field in Product model
- `ProductSettingsRows` now  manage the Slug cell
- Improved init of product settings in `ProductSettingsViewModel`
- New `ProductSlugViewController` that handle all the changes to the slug field
- Fixed tests to match the introduction of `slug`
- Updated `ProductSettings` and `ProductUpdated` to handle the `slug`
- The `textField` variable is no more private because we need to change the style of the text.

## Testing

### Case 1
1. Navigate to a product detail
2. Press the "more" button in the navigation bar
3. Press "Product Settings" -> You are able to see the cell "Slug" with the current slug.
4. Press the "Slug" cell, you will be able to see the current slug
5. Try to change the slug. Press back.
6. Press "done", and update the product. -> Reopening the Slug view, you will be able to see the new `slug` updated.

### Case 2
Retry the procedure using an existing slug. -> When you reopen the screen after saving the product, you will see that the slug will be in this format `*-2`

### Case 3
Retry the procedure, adding on it also special characters like`!£+]+`. -> When you reopen the screen after saving the product, you will see that the slug will be cleaned.

## Screenshots
| Product Settings             |  Product Slug screen |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-04-06 at 16 58 59](https://user-images.githubusercontent.com/495617/78573527-1f291600-7829-11ea-8f87-1c04dd742cf9.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-04-06 at 16 59 18](https://user-images.githubusercontent.com/495617/78573573-2819e780-7829-11ea-9fb8-e55cf954d1de.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
