### PR TITLE
Added "View product in store" option in Products "More" Action Sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -596,7 +596,7 @@ private extension ProductFormViewController {
     }
 
     enum ActionSheetStrings {
-        static let viewProduct = NSLocalizedString("View product in store",
+        static let viewProduct = NSLocalizedString("View Product in Store",
                                                    comment: "Button title View product in store in Edit Product More Options Action Sheet")
         static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Options Action Sheet")
         static let productSettings = NSLocalizedString("Product Settings", comment: "Button title Product Settings in Edit Product More Options Action Sheet")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -206,14 +206,14 @@ private extension ProductFormViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    func viewProductInStore() {
+    func displayWebViewForProductInStore() {
         guard let url = URL(string: product.permalink) else {
             return
         }
         WebviewHelper.launch(url, with: self)
     }
 
-    func shareProduct() {
+    func displayShareProduct() {
         guard let url = URL(string: product.permalink) else {
             return
         }
@@ -574,11 +574,11 @@ private extension ProductFormViewController {
         actionSheet.view.tintColor = .text
 
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.viewProduct) { [weak self] _ in
-            self?.viewProductInStore()
+            self?.displayWebViewForProductInStore()
         }
 
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { [weak self] _ in
-            self?.shareProduct()
+            self?.displayShareProduct()
         }
 
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.productSettings) { [weak self] _ in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -206,6 +206,13 @@ private extension ProductFormViewController {
         present(alert, animated: true, completion: nil)
     }
 
+    func viewProductInStore() {
+        guard let url = URL(string: product.permalink) else {
+            return
+        }
+        WebviewHelper.launch(url, with: self)
+    }
+
     func shareProduct() {
         guard let url = URL(string: product.permalink) else {
             return
@@ -566,6 +573,10 @@ private extension ProductFormViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
+        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.viewProduct) { [weak self] _ in
+            self?.viewProductInStore()
+        }
+
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { [weak self] _ in
             self?.shareProduct()
         }
@@ -585,6 +596,7 @@ private extension ProductFormViewController {
     }
 
     enum ActionSheetStrings {
+        static let viewProduct = NSLocalizedString("View product in store", comment: "Button title View product in store in Edit Product More Options Action Sheet")
         static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Options Action Sheet")
         static let productSettings = NSLocalizedString("Product Settings", comment: "Button title Product Settings in Edit Product More Options Action Sheet")
         static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Options Action Sheet")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -596,7 +596,8 @@ private extension ProductFormViewController {
     }
 
     enum ActionSheetStrings {
-        static let viewProduct = NSLocalizedString("View product in store", comment: "Button title View product in store in Edit Product More Options Action Sheet")
+        static let viewProduct = NSLocalizedString("View product in store",
+                                                   comment: "Button title View product in store in Edit Product More Options Action Sheet")
         static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Options Action Sheet")
         static let productSettings = NSLocalizedString("Product Settings", comment: "Button title Product Settings in Edit Product More Options Action Sheet")
         static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Options Action Sheet")


### PR DESCRIPTION
Resolve #1824 

## Description
This PR adds the **View product in store** option inside the "**More**" action sheet in Add/Edit Products. This is part of Products Milestone 2.

| Action Sheet             |  Product in store opened |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-04-07 at 06 47 13](https://user-images.githubusercontent.com/495617/78661208-58e73480-789c-11ea-858b-3ae65616a109.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-04-07 at 06 47 23](https://user-images.githubusercontent.com/495617/78661224-5be22500-789c-11ea-87df-4bba9b0b9c0a.png)

## Testing
- Run the app, and navigate to a simple product detail
- Tap the "More" nav bar button
- Make sure to see the "View product in store"
- Tap the button, make sure that a Safari VC is opened and loads the product in store

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
