### PR TITLE
Edit Product > Shipping Settings: retrieve shipping class and block tap action before completion

### DIFF
--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -82,7 +82,7 @@ class ProductMapperTests: XCTestCase {
         XCTAssertFalse(product.shippingRequired)
         XCTAssertFalse(product.shippingTaxable)
         XCTAssertEqual(product.shippingClass, "")
-        XCTAssertEqual(product.shippingClassID, 0)
+        XCTAssertEqual(product.shippingClassID, 134)
 
         XCTAssertTrue(product.reviewsAllowed)
         XCTAssertEqual(product.averageRating, "4.30")

--- a/Networking/NetworkingTests/Responses/product.json
+++ b/Networking/NetworkingTests/Responses/product.json
@@ -51,7 +51,7 @@
             "shipping_required": false,
             "shipping_taxable": false,
             "shipping_class": "",
-            "shipping_class_id": 0,
+            "shipping_class_id": 134,
             "reviews_allowed": true,
             "average_rating": "4.30",
             "rating_count": 23,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -21,6 +21,10 @@ final class ProductShippingSettingsViewController: UIViewController {
     //
     private var shippingClass: ProductShippingClass?
 
+    /// Tracks whether the original shipping class has been retrieved, if the product has a shipping class.
+    /// The shipping class picker action is blocked until the original shipping class has been retrieved.
+    private var hasRetrievedShippingClassIfNeeded: Bool = false
+
     /// Table Sections to be rendered
     ///
     private let sections: [Section] = [
@@ -96,15 +100,18 @@ private extension ProductShippingSettingsViewController {
     }
 
     func retrieveProductShippingClass() {
-        guard let shippingClass = shippingClass else {
+        let productHasShippingClass = product.shippingClass?.isEmpty == false
+        guard productHasShippingClass else {
+            hasRetrievedShippingClassIfNeeded = true
             return
         }
 
         let action = ProductShippingClassAction
             .retrieveProductShippingClass(siteID: product.siteID,
-                                          remoteID: shippingClass.shippingClassID) { [weak self] (shippingClass, error) in
-            self?.shippingClass = shippingClass
-            self?.tableView.reloadData()
+                                          remoteID: product.shippingClassID) { [weak self] (shippingClass, error) in
+                                            self?.shippingClass = shippingClass
+                                            self?.hasRetrievedShippingClassIfNeeded = true
+                                            self?.tableView.reloadData()
         }
         ServiceLocator.stores.dispatch(action)
     }
@@ -187,6 +194,9 @@ extension ProductShippingSettingsViewController: UITableViewDelegate {
         let row = rowAtIndexPath(indexPath)
         switch row {
         case .shippingClass:
+            guard hasRetrievedShippingClassIfNeeded else {
+                return
+            }
             let dataSource = PaginatedProductShippingClassListSelectorDataSource(product: product, selected: shippingClass)
             let navigationBarTitle = NSLocalizedString("Shipping classes", comment: "Navigation bar title of the Product shipping class selector screen")
             let noResultsPlaceholderText = NSLocalizedString("No shipping classes yet",

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -170,8 +170,9 @@ private extension ProductStore {
                 return
             }
 
-            self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) {
-                onCompletion(product, nil)
+            self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
+                let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: siteID, productID: productID)
+                onCompletion(storageProduct?.toReadOnly(), nil)
             }
         }
     }
@@ -187,8 +188,9 @@ private extension ProductStore {
                 return
             }
 
-            self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) {
-                onCompletion(product, nil)
+            self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
+                let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: product.siteID, productID: product.productID)
+                onCompletion(storageProduct?.toReadOnly(), nil)
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -268,11 +268,15 @@ class ProductStoreTests: XCTestCase {
     /// Verifies that `ProductAction.retrieveProduct` returns the expected `Product`.
     ///
     func testRetrieveSingleProductReturnsExpectedFields() {
+        // The shipping class ID should match the `shipping_class_id` field in `product.json`.
+        let expectedShippingClass = sampleProductShippingClass(remoteID: 134, siteID: sampleSiteID)
+        storageManager.insertSampleProductShippingClass(readOnlyProductShippingClass: expectedShippingClass)
+
         let expectation = self.expectation(description: "Retrieve single product")
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let remoteProduct = sampleProduct()
+        let remoteProduct = sampleProduct(productShippingClass: expectedShippingClass)
 
-        network.simulateResponse(requestUrlSuffix: "products/282", filename: "product")
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product")
         let action = ProductAction.retrieveProduct(siteID: sampleSiteID, productID: sampleProductID) { (product, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(product)
@@ -311,7 +315,12 @@ class ProductStoreTests: XCTestCase {
     func testRetrieveSingleProductEffectivelyPersistsProductFieldsAndRelatedObjects() {
         let expectation = self.expectation(description: "Persist single product")
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        let remoteProduct = sampleProduct()
+
+        // The shipping class ID should match the `shipping_class_id` field in `product.json`.
+        let expectedShippingClass = sampleProductShippingClass(remoteID: 134, siteID: sampleSiteID)
+        storageManager.insertSampleProductShippingClass(readOnlyProductShippingClass: expectedShippingClass)
+
+        let remoteProduct = sampleProduct(productShippingClass: expectedShippingClass)
 
         network.simulateResponse(requestUrlSuffix: "products/282", filename: "product")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 0)
@@ -748,6 +757,7 @@ class ProductStoreTests: XCTestCase {
         let expectedProductDescription = "Learn something!"
         let expectedProductShippingClassID: Int64 = 96987515
         let expectedProductShippingClassSlug = "two-days"
+        let expectedProductShippingClass = sampleProductShippingClass(remoteID: expectedProductShippingClassID, siteID: sampleSiteID)
         let expectedProductSKU = "94115"
         let expectedProductManageStock = true
         let expectedProductSoldIndividually = false
@@ -764,6 +774,11 @@ class ProductStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/\(expectedProductID)", filename: "product-update")
         let product = sampleProduct(productID: expectedProductID)
 
+        // Saves an existing shipping class into storage, so that it can be linked to the updated product.
+        // The shipping class ID should match the `shipping_class_id` field in `product.json`.
+        storageManager.insertSampleProductShippingClass(readOnlyProductShippingClass: expectedProductShippingClass)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductShippingClass.self), 1)
+
         // Saves an existing Product into storage.
         // Note: the fields to be tested should be different in the sample model and network response.
         storageManager.insertSampleProduct(readOnlyProduct: product)
@@ -778,6 +793,7 @@ class ProductStoreTests: XCTestCase {
             // Shipping settings.
             XCTAssertEqual(product?.shippingClassID, expectedProductShippingClassID)
             XCTAssertEqual(product?.shippingClass, expectedProductShippingClassSlug)
+            XCTAssertEqual(product?.productShippingClass, expectedProductShippingClass)
             // Inventory settings.
             XCTAssertEqual(product?.sku, expectedProductSKU)
             XCTAssertEqual(product?.manageStock, expectedProductManageStock)
@@ -920,7 +936,7 @@ class ProductStoreTests: XCTestCase {
 //
 private extension ProductStoreTests {
 
-    func sampleProduct(_ siteID: Int64? = nil, productID: Int64? = nil) -> Networking.Product {
+    func sampleProduct(_ siteID: Int64? = nil, productID: Int64? = nil, productShippingClass: Networking.ProductShippingClass? = nil) -> Networking.Product {
         let testSiteID = siteID ?? sampleSiteID
         let testProductID = productID ?? sampleProductID
         return Product(siteID: testSiteID,
@@ -969,9 +985,9 @@ private extension ProductStoreTests {
                        dimensions: sampleDimensions(),
                        shippingRequired: false,
                        shippingTaxable: false,
-                       shippingClass: "",
-                       shippingClassID: 0,
-                       productShippingClass: nil,
+                       shippingClass: productShippingClass?.slug ?? "",
+                       shippingClassID: productShippingClass?.shippingClassID ?? 0,
+                       productShippingClass: productShippingClass,
                        reviewsAllowed: true,
                        averageRating: "4.30",
                        ratingCount: 23,
@@ -1182,6 +1198,15 @@ private extension ProductStoreTests {
         let defaultAttribute1 = ProductDefaultAttribute(attributeID: 0, name: "Color", option: "Purple")
 
         return [defaultAttribute1]
+    }
+
+    func sampleProductShippingClass(remoteID: Int64, siteID: Int64) -> Yosemite.ProductShippingClass {
+        return ProductShippingClass(count: 3,
+                                    descriptionHTML: "Limited offer!",
+                                    name: "Free Shipping",
+                                    shippingClassID: remoteID,
+                                    siteID: siteID,
+                                    slug: "")
     }
 
     func sampleVariationTypeProduct(_ siteID: Int64? = nil) -> Networking.Product {


### PR DESCRIPTION
Fixes #2064 

Note: I'm targeting release 4.0 branch for M1, lemme know if you think it's better to target `develop`!

## Changes

There 2 issues to this shipping class UX problem:

### Issue 1: when to retrieve shipping class remotely

We retrieve the product's shipping class with the shipping class ID so that we can display the name on the shipping class row. Before this PR, we only retrieve the product's shipping class if the product's `shippingClass: ProductShippingClass?` relationship object is non-nil. However, a product could have a shipping class (which we can tell from its `shippingClass` the slug and `shippingClassID` the remote ID) while its `productShippingClass` relationship object hasn't been retrieved and linked yet (for example, before we never load the shipping class list when the user navigates to the shipping class selector UI).

This PR changed the condition where we determine whether to retrieve the product's shipping class remotely, and blocked the tap action until the shipping class retrieval completes.

### Issue 2: the relationships are missing after updating the product remotely

There is another issue, where the `ProductAction.updateProduct` doesn't return the relationships (like `productShippingClass`) in the `product` on completion. We handle the relationships when upserting product(s) to storage from the API response in [`upsertStoredProductsInBackground(readOnlyProducts:)`](https://github.com/woocommerce/woocommerce-ios/blob/65f2a3f4f1020a850a9cb39cc857c8d86d0de971/Yosemite/Yosemite/Stores/ProductStore.swift#L245-L276), but we pass the readonly `product` from Networking layer to the completion block on L191, which doesn't include the relationships.

https://github.com/woocommerce/woocommerce-ios/blob/65f2a3f4f1020a850a9cb39cc857c8d86d0de971/Yosemite/Yosemite/Stores/ProductStore.swift#L181-L194

The UX impact is after the user saves the product shipping class remotely and then navigates to the shipping settings again, the shipping class isn't initially loaded because the relationship was `nil` from the original API response and only linked in `upsertStoredProductsInBackground(readOnlyProducts:)` in the storage layer.

This PR updated the result product passed to the completion block in both `ProductAction.retrieveProduct` and `Product.updateProduct`, and updated the unit tests with a valid shipping class ID in `product.json` to test the changes.

## Testing

Prerequisites: the site has two products: one with a shipping class and the other without a shipping class

### Product with a shipping class

- Log out and in so that no previous data are stored
- Go to the Products tab
- Tap on a simple Product with a shipping class
- Tap the shipping row --> the shipping class should be displayed and tappable after a little bit (API request)
- Tap the shipping class row and change to another shipping class, then tap "Done"
- Tap "Update" to save the product remotely and wait for completion
- Tap the shipping row --> the new shipping class should be displayed

### Product without a shipping class

- Go to the Products tab
- Tap on a simple Product without a shipping class
- Tap the shipping row --> the shipping class should be empty and tappable immediately
- Tap the shipping class row and select shipping class, then tap "Done"
- Tap "Update" to save the product remotely and wait for completion
- Tap the shipping row --> the selected shipping class should be displayed

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
