### PR TITLE
shouldPop: delegate method is not called on simulators with iOS 13.4

### DIFF
--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -33,7 +33,7 @@ extension UINavigationController {
 
 // MARK: - Handle UINavigationBar's 'Back' button action
 //
-protocol  UINavigationBarBackButtonHandler {
+protocol UINavigationBarBackButtonHandler {
 
     /// Should block the 'Back' button action
     ///
@@ -49,6 +49,9 @@ extension UIViewController: UINavigationBarBackButtonHandler {
 }
 
 extension UINavigationController: UINavigationBarDelegate {
+
+    // This delegate method is not called on the simulator running iOS 13.4.
+    // Test in on a real device.
     public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
         guard let items = navigationBar.items else {
             return false

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -51,7 +51,7 @@ extension UIViewController: UINavigationBarBackButtonHandler {
 extension UINavigationController: UINavigationBarDelegate {
 
     // This delegate method is not called on the simulator running iOS 13.4.
-    // Test in on a real device.
+    // Test it on a real device.
     public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
         guard let items = navigationBar.items else {
             return false

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -50,8 +50,8 @@ extension UIViewController: UINavigationBarBackButtonHandler {
 
 extension UINavigationController: UINavigationBarDelegate {
 
-    // This delegate method is not called on the simulator running iOS 13.4.
-    // Test it on a real device.
+    // This delegate method is not called on the simulator or device running iOS 13.4 from Xcode.
+    // You need to use a release build.
     public func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
         guard let items = navigationBar.items else {
             return false


### PR DESCRIPTION
Resolve #2089 

Sometimes, working on the bugs that Apple creates is really frustrating.
This time, I lost a lot of time investigating on why the `shouldPop:` delegate method is no more called on iOS 13.4. The curious thing, after [investigating it](https://a8c.slack.com/archives/C6H8C3G23/p1585927493166300), is that the similar delegate `didPop:` continue to be called without any issue. This created a lot of issues on our side because we use a method called `shouldPopOnBackButton:` to present the Discard Changes Action Sheet in Products.

After a lot of tests, I discovered that it seems an issue that is present only on the iOS simulator using iOS 13.4. In fact, testing it with the help of @rachelmcr on a real device with iOS 13.4 seems that everything works properly. I also tested the issue on my device with iOS 13.4.1, and everything continues to work as expected.

## Changes
In this PR, just to remind us that maybe something may not work as it should, I added a comment.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
