### PR TITLE
[Manage Categories] Shows simple/basic Category Selector screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.swift
@@ -10,6 +10,7 @@ final class ProductCategoryTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        applyDefaultBackgroundStyle()
         styleLabels()
         styleCheckmark()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.swift
@@ -16,6 +16,7 @@ final class ProductCategoryTableViewCell: UITableViewCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
         nameLabel.text = nil
         accessoryType = .none
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+/// Displays a Product Category Row
+///
+final class ProductCategoryTableViewCell: UITableViewCell {
+
+    /// Label to display the category name
+    ///
+    @IBOutlet private var nameLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        styleLabels()
+        styleCheckmark()
+    }
+
+    override func prepareForReuse() {
+        nameLabel.text = nil
+        accessoryType = .none
+    }
+
+    private func styleLabels() {
+        nameLabel.applyBodyStyle()
+    }
+
+    private func styleCheckmark() {
+        tintColor = .primary
+    }
+
+    /// Configure the cell with the given content
+    /// - Parameters:
+    ///   - name: Product Category name
+    ///   - selected: `true` renders  a chekmark, `false` renders nothing.
+    func configure(name: String, selected: Bool) {
+        nameLabel.text = name
+        accessoryType = selected ? .checkmark : .none
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/Cell/ProductCategoryTableViewCell.xib
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="53" id="gmH-tL-xnI" customClass="ProductCategoryTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="462" height="53"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gmH-tL-xnI" id="E1P-Ug-NXk">
+                <rect key="frame" x="0.0" y="0.0" width="462" height="53"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iPu-uq-Yz5">
+                        <rect key="frame" x="16" y="13" width="42" height="27"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="iPu-uq-Yz5" secondAttribute="bottom" constant="13" id="1L2-Sh-zd7"/>
+                    <constraint firstItem="iPu-uq-Yz5" firstAttribute="leading" secondItem="E1P-Ug-NXk" secondAttribute="leading" constant="16" id="3hZ-f9-3Hj"/>
+                    <constraint firstItem="iPu-uq-Yz5" firstAttribute="top" secondItem="E1P-Ug-NXk" secondAttribute="top" constant="13" id="ZhA-IB-Dha"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iPu-uq-Yz5" secondAttribute="trailing" constant="16" id="dPm-ca-vbT"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="nameLabel" destination="iPu-uq-Yz5" id="D22-2I-Vyu"/>
+            </connections>
+            <point key="canvasLocation" x="-5.7971014492753632" y="-122.87946428571428"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 import Yosemite
 
+/// ProductCategoryListViewController: Displays the list of ProductCategories associated to the active Account.
+///
 final class ProductCategoryListViewController: UIViewController {
 
     @IBOutlet private var tableView: UITableView!

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
@@ -37,6 +37,7 @@ private extension ProductCategoryListViewController {
         tableView.backgroundColor = .listBackground
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.removeLastCellSeparator()
     }
 
     func configureNavigationBar() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
@@ -83,6 +83,11 @@ private extension ProductCategoryListViewController {
 // MARK: - UITableViewConformace conformance
 //
 extension ProductCategoryListViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.numberOfSections()
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.numberOfRowsInSection(section: section)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
@@ -1,0 +1,104 @@
+import UIKit
+import Yosemite
+
+final class ProductCategoryListViewController: UIViewController {
+
+    @IBOutlet private var tableView: UITableView!
+
+    private let viewModel: ProductCategoryListViewModel
+
+    init(product: Product) {
+        self.viewModel = ProductCategoryListViewModel(product: product)
+        super.init(nibName: type(of: self).nibName, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        registerTableViewCells()
+        configureTableView()
+        configureNavigationBar()
+        observeCategories()
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ProductCategoryListViewController {
+    func registerTableViewCells() {
+        tableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
+    }
+
+    func configureTableView() {
+        view.backgroundColor = .listBackground
+        tableView.backgroundColor = .listBackground
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func configureNavigationBar() {
+        configureTitle()
+        configureRightButton()
+    }
+
+    func configureTitle() {
+        title = NSLocalizedString("Categories", comment: "Edit product categories screen - Screen title")
+    }
+
+    func configureRightButton() {
+        let applyButtonTitle = NSLocalizedString("Done",
+                                               comment: "Edit product categories screen - button title to apply categories selection")
+        let rightBarButton = UIBarButtonItem(title: applyButtonTitle,
+                                             style: .done,
+                                             target: self,
+                                             action: #selector(doneButtonTapped))
+        navigationItem.setRightBarButton(rightBarButton, animated: false)
+    }
+}
+
+// MARK: - Synchronize Categories
+//
+private extension ProductCategoryListViewController {
+    /// Listen to category list changes and reload the table view when needed.
+    ///
+    func observeCategories() {
+        viewModel.observeCategoryListChanges { [weak self] in
+            self?.tableView.reloadData()
+        }
+    }
+}
+
+// MARK: - Actions
+//
+private extension ProductCategoryListViewController {
+    @objc private func doneButtonTapped() {
+        // TODO-2020: Submit category changes
+    }
+}
+
+// MARK: - UITableViewConformace conformance
+//
+extension ProductCategoryListViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.numberOfRowsInSection(section: section)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductCategoryTableViewCell.reuseIdentifier,
+                                                       for: indexPath) as? ProductCategoryTableViewCell else {
+            fatalError()
+        }
+
+        let category = viewModel.item(at: indexPath)
+        let isSelected = viewModel.isCategorySelected(category)
+        cell.configure(name: category.name, selected: isSelected)
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // TODO-2020: Select category and update state
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.swift
@@ -23,7 +23,7 @@ final class ProductCategoryListViewController: UIViewController {
         registerTableViewCells()
         configureTableView()
         configureNavigationBar()
-        observeCategories()
+        configureViewModel()
     }
 }
 
@@ -65,9 +65,8 @@ private extension ProductCategoryListViewController {
 // MARK: - Synchronize Categories
 //
 private extension ProductCategoryListViewController {
-    /// Listen to category list changes and reload the table view when needed.
-    ///
-    func observeCategories() {
+    func configureViewModel() {
+        viewModel.performInitialFetch()
         viewModel.observeCategoryListChanges { [weak self] in
             self?.tableView.reloadData()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewController.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductCategoryListViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="4pa-Cw-LKR" id="uF3-aL-9kf"/>
+                <outlet property="view" destination="iN0-l3-epB" id="t1s-Mw-tT3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="4pa-Cw-LKR">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="4pa-Cw-LKR" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="0d8-Xy-4Fp"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="top" secondItem="4pa-Cw-LKR" secondAttribute="top" id="NIw-KU-oxA"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="4pa-Cw-LKR" secondAttribute="trailing" id="j6T-xA-y2b"/>
+                <constraint firstItem="4pa-Cw-LKR" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="ttj-uA-s0c"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="137.68115942028987" y="128.57142857142856"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
@@ -14,7 +14,6 @@ final class ProductCategoryListViewModel {
 
     init(product: Product) {
         self.product = product
-        performInitialFetch()
     }
 
     /// Returns the number sections.
@@ -35,6 +34,13 @@ final class ProductCategoryListViewModel {
         return resultController.object(at: indexPath)
     }
 
+    /// Load existing categories from storage and fire the synchronize product categories action
+    ///
+    func performInitialFetch() {
+        syncronizeCategories()
+        try? resultController.performFetch()
+    }
+
     /// Observes and notifies of changes made to product categories
     ///
     func observeCategoryListChanges(onReload: @escaping () -> (Void)) {
@@ -42,21 +48,16 @@ final class ProductCategoryListViewModel {
     }
 
     /// Returns `true` if the receiver's product contains the given category. Otherwise returns `false`
+    ///
     func isCategorySelected(_ category: ProductCategory) -> Bool {
         return product.categories.contains(category)
-    }
-
-    /// Load existing categories from storage and fire the synchronize product categories action
-    private func performInitialFetch() {
-        syncronizeCategories()
-        try? resultController.performFetch()
     }
 }
 
 // MARK: - Synchronize Categories
 //
 private extension ProductCategoryListViewModel {
-    private func syncronizeCategories() {
+    func syncronizeCategories() {
         /// TODO-2020: Page Number and PageSized to be updated when `SyncingCoordinator` is implemented.
         let action = ProductCategoryAction.synchronizeProductCategories(siteID: product.siteID, pageNumber: 1, pageSize: 30) { error in
             if let error = error {
@@ -66,7 +67,7 @@ private extension ProductCategoryListViewModel {
         ServiceLocator.stores.dispatch(action)
     }
 
-    private func observeResultControllerChanges(onReload: @escaping () -> (Void)) {
+    func observeResultControllerChanges(onReload: @escaping () -> (Void)) {
         resultController.onDidChangeContent = {
             onReload()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
@@ -14,6 +14,7 @@ final class ProductCategoryListViewModel {
 
     init(product: Product) {
         self.product = product
+        performInitialFetch()
     }
 
     /// Returns the number sections.
@@ -38,13 +39,17 @@ final class ProductCategoryListViewModel {
     ///
     func observeCategoryListChanges(onReload: @escaping () -> (Void)) {
         observeResultControllerChanges(onReload: onReload)
-        syncronizeCategories()
-        try? categoriesResultController.performFetch()
     }
 
     /// Returns `true` if the receiver's product contains the given category. Otherwise returns `false`
     func isCategorySelected(_ category: ProductCategory) -> Bool {
         return product.categories.contains(category)
+    }
+
+    /// Load existing categories from storage and fire the synchronize product categories action
+    private func performInitialFetch() {
+        syncronizeCategories()
+        try? categoriesResultController.performFetch()
     }
 }
 
@@ -52,7 +57,7 @@ final class ProductCategoryListViewModel {
 //
 private extension ProductCategoryListViewModel {
     private func syncronizeCategories() {
-        /// TODO-2020: Page Number and PageSized to be updated when `SyncingCoordinator` is supported.
+        /// TODO-2020: Page Number and PageSized to be updated when `SyncingCoordinator` is implemented.
         let action = ProductCategoryAction.synchronizeProductCategories(siteID: product.siteID, pageNumber: 1, pageSize: 30) { error in
             if let error = error {
                 DDLogError("⛔️ Error fetching product categories: \(error.localizedDescription)")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
@@ -16,6 +16,12 @@ final class ProductCategoryListViewModel {
         self.product = product
     }
 
+    /// Returns the number sections.
+    ///
+    func numberOfSections() -> Int {
+        return categoriesResultController.sections.count
+    }
+
     /// Returns the number of items for a given `section` that should be displayed
     ///
     func numberOfRowsInSection(section: Int) -> Int {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
@@ -5,7 +5,7 @@ final class ProductCategoryListViewModel {
 
     private let product: Product
 
-    private lazy var categoriesResultController: ResultsController<StorageProductCategory> = {
+    private lazy var resultController: ResultsController<StorageProductCategory> = {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID = %ld", self.product.siteID)
         let descriptor = NSSortDescriptor(keyPath: \StorageProductCategory.name, ascending: true)
@@ -20,19 +20,19 @@ final class ProductCategoryListViewModel {
     /// Returns the number sections.
     ///
     func numberOfSections() -> Int {
-        return categoriesResultController.sections.count
+        return resultController.sections.count
     }
 
     /// Returns the number of items for a given `section` that should be displayed
     ///
     func numberOfRowsInSection(section: Int) -> Int {
-        return categoriesResultController.sections[section].numberOfObjects
+        return resultController.sections[section].numberOfObjects
     }
 
     /// Returns a product category for a given `indexPath`
     ///
     func item(at indexPath: IndexPath) -> ProductCategory {
-        return categoriesResultController.object(at: indexPath)
+        return resultController.object(at: indexPath)
     }
 
     /// Observes and notifies of changes made to product categories
@@ -49,7 +49,7 @@ final class ProductCategoryListViewModel {
     /// Load existing categories from storage and fire the synchronize product categories action
     private func performInitialFetch() {
         syncronizeCategories()
-        try? categoriesResultController.performFetch()
+        try? resultController.performFetch()
     }
 }
 
@@ -67,7 +67,7 @@ private extension ProductCategoryListViewModel {
     }
 
     private func observeResultControllerChanges(onReload: @escaping () -> (Void)) {
-        categoriesResultController.onDidChangeContent = {
+        resultController.onDidChangeContent = {
             onReload()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditCategories/ProductCategoryListViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Yosemite
+
+final class ProductCategoryListViewModel {
+
+    private let product: Product
+
+    private lazy var categoriesResultController: ResultsController<StorageProductCategory> = {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID = %ld", self.product.siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageProductCategory.name, ascending: true)
+        return ResultsController<StorageProductCategory>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
+    init(product: Product) {
+        self.product = product
+    }
+
+    /// Returns the number of items for a given `section` that should be displayed
+    ///
+    func numberOfRowsInSection(section: Int) -> Int {
+        return categoriesResultController.sections[section].numberOfObjects
+    }
+
+    /// Returns a product category for a given `indexPath`
+    ///
+    func item(at indexPath: IndexPath) -> ProductCategory {
+        return categoriesResultController.object(at: indexPath)
+    }
+
+    /// Observes and notifies of changes made to product categories
+    ///
+    func observeCategoryListChanges(onReload: @escaping () -> (Void)) {
+        observeResultControllerChanges(onReload: onReload)
+        syncronizeCategories()
+        try? categoriesResultController.performFetch()
+    }
+
+    /// Returns `true` if the receiver's product contains the given category. Otherwise returns `false`
+    func isCategorySelected(_ category: ProductCategory) -> Bool {
+        return product.categories.contains(category)
+    }
+}
+
+// MARK: - Synchronize Categories
+//
+private extension ProductCategoryListViewModel {
+    private func syncronizeCategories() {
+        /// TODO-2020: Page Number and PageSized to be updated when `SyncingCoordinator` is supported.
+        let action = ProductCategoryAction.synchronizeProductCategories(siteID: product.siteID, pageNumber: 1, pageSize: 30) { error in
+            if let error = error {
+                DDLogError("⛔️ Error fetching product categories: \(error.localizedDescription)")
+            }
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    private func observeResultControllerChanges(onReload: @escaping () -> (Void)) {
+        categoriesResultController.onDidChangeContent = {
+            onReload()
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -291,12 +291,11 @@ extension ProductFormViewController: UITableViewDelegate {
                 ServiceLocator.analytics.track(.productDetailViewInventorySettingsTapped)
                 editInventorySettings()
             case .categories:
-                // TODO-2000
-                break
+                // TODO-2000 Edit Product M3 analytics
+                editCategories()
             case .briefDescription:
                 // TODO-1879: Edit Products M2 analytics
                 editBriefDescription()
-                break
             }
         }
     }
@@ -548,6 +547,16 @@ private extension ProductFormViewController {
             return
         }
         self.product = productUpdater.briefDescriptionUpdated(briefDescription: newBriefDescription)
+    }
+}
+
+// MARK: Action - Edit Product Categories
+//
+
+private extension ProductFormViewController {
+    func editCategories() {
+        let categoryListViewController = ProductCategoryListViewController(product: product)
+        show(categoryListViewController, sender: self)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests+ProductListFeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests+ProductListFeatureFlag.swift */; };
 		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
+		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		263EB409242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */; };
 		265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */; };
 		265BCA072430E62E004E53EE /* ProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */; };
@@ -1005,6 +1006,7 @@
 		02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagService.swift; sourceTree = "<group>"; };
 		02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultProductFormTableViewModel+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
 		265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
 		265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryListViewController.xib; sourceTree = "<group>"; };
@@ -1614,6 +1616,7 @@
 				02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */,
 				263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */,
 				02153210242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift */,
+				2611EE57243A46C500A74490 /* Categories */,
 				453770CF2431FEC400AC718D /* Settings */,
 			);
 			path = "Edit Product";
@@ -2050,6 +2053,14 @@
 				02F4F50E237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		2611EE57243A46C500A74490 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */,
+			);
+			path = Categories;
 			sourceTree = "<group>";
 		};
 		265BCA032430E5EA004E53EE /* EditCategories */ = {
@@ -4567,6 +4578,7 @@
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
+				2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */,
 				0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */,
 				B509FED521C052D1000076A9 /* MockupSupportManager.swift in Sources */,
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -220,6 +220,11 @@
 		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
 		263EB409242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */; };
+		265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */; };
+		265BCA072430E62E004E53EE /* ProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */; };
+		265BCA092430E6E0004E53EE /* ProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */; };
+		265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA0B2430E741004E53EE /* ProductCategoryTableViewCell.swift */; };
+		265BCA0E2430E771004E53EE /* ProductCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */; };
 		451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */; };
 		451A04E72386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */; };
 		451A04EA2386D28300E368C9 /* ProductImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */; };
@@ -1001,6 +1006,11 @@
 		02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* DefaultProductFormTableViewModel+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultProductFormTableViewModel+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
+		265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
+		265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryListViewController.xib; sourceTree = "<group>"; };
+		265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModel.swift; sourceTree = "<group>"; };
+		265BCA0B2430E741004E53EE /* ProductCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryTableViewCell.swift; sourceTree = "<group>"; };
+		265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
 		451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesHeaderTableViewCell.swift; sourceTree = "<group>"; };
@@ -1626,6 +1636,7 @@
 				02E262CA238D0D0500B79588 /* List Selector Data Source */,
 				0262DA5523A23AA40029AF30 /* Shipping Settings */,
 				45B9C63B23A8E4DB007FC4C5 /* Edit Price */,
+				265BCA032430E5EA004E53EE /* EditCategories */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
 				02162725237963AF000208D2 /* ProductFormViewController.xib */,
 				02162728237965E8000208D2 /* ProductFormTableViewModel.swift */,
@@ -2039,6 +2050,26 @@
 				02F4F50E237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		265BCA032430E5EA004E53EE /* EditCategories */ = {
+			isa = PBXGroup;
+			children = (
+				265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */,
+				265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */,
+				265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */,
+				265BCA0A2430E719004E53EE /* Cell */,
+			);
+			path = EditCategories;
+			sourceTree = "<group>";
+		};
+		265BCA0A2430E719004E53EE /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				265BCA0B2430E741004E53EE /* ProductCategoryTableViewCell.swift */,
+				265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 		451A04E82386D04900E368C9 /* Product Images */ = {
@@ -3741,6 +3772,7 @@
 				CE0F17D022A8105800964A63 /* ReadMoreTableViewCell.xib in Resources */,
 				CE1D5A5A228A1C2C00DF3715 /* ProductReviewsTableViewCell.xib in Resources */,
 				B5A8F8AF20B88DCC00D211DE /* LoginPrologueViewController.xib in Resources */,
+				265BCA072430E62E004E53EE /* ProductCategoryListViewController.xib in Resources */,
 				0262DA5923A23AC80029AF30 /* ProductShippingSettingsViewController.xib in Resources */,
 				74E0F441211C9AE600A79CCE /* PeriodDataViewController.xib in Resources */,
 				B5F571B021BF149D0010D1B8 /* o.caf in Resources */,
@@ -3785,6 +3817,7 @@
 				457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */,
 				B5F355F121CD504400A7077A /* SearchViewController.xib in Resources */,
 				CE1EC8F020B8A408009762BF /* OrderNoteTableViewCell.xib in Resources */,
+				265BCA0E2430E771004E53EE /* ProductCategoryTableViewCell.xib in Resources */,
 				B55D4BFD20B5CDE700D7A50F /* replace_secrets.rb in Resources */,
 				020BE74E23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.xib in Resources */,
 				4580BA7523F192D400B5F764 /* ProductSettingsViewController.xib in Resources */,
@@ -4110,6 +4143,7 @@
 				02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */,
 				02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */,
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
+				265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
@@ -4231,6 +4265,7 @@
 				0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */,
 				D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */,
 				CE4DA5C621DD755E00074607 /* CurrencyFormatter.swift in Sources */,
+				265BCA092430E6E0004E53EE /* ProductCategoryListViewModel.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,
 				D85136C1231E09C300DD0539 /* ReviewsDataSource.swift in Sources */,
@@ -4437,6 +4472,7 @@
 				B59D1EE5219080B4009D1978 /* Note+Woo.swift in Sources */,
 				02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */,
 				02F49ADC23BF3A0100FA0BFA /* ErrorSectionHeaderView.swift in Sources */,
+				265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */,
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -26,6 +26,7 @@ final class MockProduct {
                  featured: Bool = false,
                  catalogVisibility: ProductCatalogVisibility = .visible,
                  slug: String = "book-the-green-room",
+                 categories: [ProductCategory] = [],
                  images: [ProductImage] = []) -> Product {
 
     return Product(siteID: testSiteID,
@@ -85,7 +86,7 @@ final class MockProduct {
                    crossSellIDs: [1234, 234234, 3],
                    parentID: 0,
                    purchaseNote: "Thank you!",
-                   categories: [],
+                   categories: categories,
                    tags: [],
                    images: images,
                    attributes: [],

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import WooCommerce
+@testable import Yosemite
+
+/// Tests for `ProductCategoryListViewModel`.
+///
+final class ProductCategoryListViewModelTests: XCTestCase {
+
+    func testsCategoriesAreSelectedIfTheyArePartOfMainProduct() {
+        // Given
+        let categories = (1...3).map { sampleCategory(categoryID: $0, name: String($0)) }
+        let product = MockProduct().product(categories: categories)
+        let viewModel = ProductCategoryListViewModel(product: product)
+
+        // When
+        for category in categories {
+            let isCategorySelected = viewModel.isCategorySelected(category)
+
+            // Then
+            XCTAssertTrue(isCategorySelected)
+        }
+    }
+
+    func testCategoryIsNotSelectedIfItsNotPartOfMainProduct() {
+        // Given
+        let category = sampleCategory(categoryID: 1, name: "1")
+        let product = MockProduct().product(categories: [])
+        let viewModel = ProductCategoryListViewModel(product: product)
+
+        // When
+        let isCategorySelected = viewModel.isCategorySelected(category)
+
+        // Then
+        XCTAssertFalse(isCategorySelected)
+    }
+}
+
+private extension ProductCategoryListViewModelTests {
+    func sampleCategory(categoryID: Int64, name: String) -> ProductCategory {
+        return ProductCategory(categoryID: categoryID, siteID: 123, parentID:0, name: name, slug: "")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
@@ -38,6 +38,6 @@ final class ProductCategoryListViewModelTests: XCTestCase {
 
 private extension ProductCategoryListViewModelTests {
     func sampleCategory(categoryID: Int64, name: String) -> ProductCategory {
-        return ProductCategory(categoryID: categoryID, siteID: 123, parentID:0, name: name, slug: "")
+        return ProductCategory(categoryID: categoryID, siteID: 123, parentID: 0, name: name, slug: "")
     }
 }


### PR DESCRIPTION
References https://github.com/woocommerce/woocommerce-ios/issues/2000

# Why 

After adding the ability to synchronize product categories in #2079. This PR makes sure that when the user taps on the category section in the product detail screen, the app navigates to the category selector screen.

## Notes
- In order to keep this PR small, here I only render categories in the most simple way. Following PRs will take care of pagination, loading states, and category selection.

# How
- Adds `ProductCategoryListViewController` that holds a table view to display `ProductCategoryTableViewCell` items
- Adds `ProductCategoryListViewModel` to hold state and interact with the `Yosemite` layer by handling a `ResultsController` instance to feed the table view and by dispatching the `synchronizeProductCategories` action.

# GIF
![RenderCategories](https://user-images.githubusercontent.com/562080/78839155-73fd9580-79bd-11ea-936b-35f3e1dbba05.gif)


Light|Dark
---|---
<img src="https://user-images.githubusercontent.com/562080/78839254-b8893100-79bd-11ea-8d9d-366c14b1249a.png" width="300" />|<img src="https://user-images.githubusercontent.com/562080/78839249-b6bf6d80-79bd-11ea-9171-792ad4bcd634.png" width="300" />

