### PR TITLE
Fix localisation issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: d00351ee4e04d8a5f3305116dab017b2c389b1cf
-  tag: 0.9.1
+  revision: 07f5bb78a6c7537c5f7504cdff93c05896df7dfa
+  ref: 07f5bb78a6c7537c5f7504cdff93c05896df7dfa
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.1)
       activesupport (~> 4)
@@ -198,7 +198,7 @@ GEM
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.10.5)
+    oj (3.10.6)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 07f5bb78a6c7537c5f7504cdff93c05896df7dfa
-  ref: 07f5bb78a6c7537c5f7504cdff93c05896df7dfa
+  revision: e426345db3afc839ee463ec1ce8432f584880957
+  tag: 0.9.2
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.1)
+    fastlane-plugin-wpmreleasetoolkit (0.9.2)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -593,6 +593,11 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
       configure_validate()
   end
 
+  desc "Run localization only"
+  lane :update_localization do | options |
+    ios_localize_project()
+  end
+
   def write_file(path, contents)
     begin
       FileUtils.rm_f(path)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,6 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '07f5bb78a6c7537c5f7504cdff93c05896df7dfa'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,6 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '07f5bb78a6c7537c5f7504cdff93c05896df7dfa'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.2'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
This PR updates `release-toolkit` in order to fix two localisation issues we saw during the last code freeze where the last version of the pods was not installed before the localization script runs and where the `localizable.strings` file was not automatically committed on changes. 

**To Test:**
1. Run `bundle install`.
2. Checkout a new test branch out of this one. 
3. Run `bundle exec fastlane update_localization`. It will run the same `ios_localize_project` step that is run during the code freeze.
4. Verify that the log contains the `pod install` step.
5. Verify that the strings are updated, committed and pushed. 
6. Run `bundle exec fastlane update_localization` again.
7. Verify that the script doesn't fail when there are no changes.
8. Delete the test branch from GitHub.

**Note:**
After approval, before merging we want to do a proper `release-toolkit` release and update the reference here. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
