### PR TITLE
Only request Photo Library permission when adding images from Photo Library in image upload

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.1
 -----
 - Fix an intermittent crash when downloading Orders
+- The Photo Library permission alert shouldn't be prompted except for when uploading images in debug builds with Products M2 enabled.
 - [internal] Updated the empty search result views for Products and Orders. https://git.io/Jvdap
 
  

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 4.1
 -----
 - Fix an intermittent crash when downloading Orders
-- The Photo Library permission alert shouldn't be prompted except for when uploading images in debug builds with Products M2 enabled.
+- The Photo Library permission alert shouldn't be prompted when opening the readonly product details or edit product for simple products, which is reproducible on iOS 11 or 12 devices. (The permission is only triggered when uploading images in Zendesk support or in debug builds with Products M2 enabled.)
 - [internal] Updated the empty search result views for Products and Orders. https://git.io/Jvdap
 
  

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1,3 +1,4 @@
+import Photos
 import UIKit
 import Yosemite
 
@@ -59,8 +60,9 @@ final class ProductFormViewController: UIViewController {
         self.product = product
         self.viewModel = DefaultProductFormTableViewModel(product: product, currency: currency)
         self.productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
-                                                         product: product)
-        self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler)
+                                                                   product: product)
+        self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
+                                                                phAssetImageLoaderProvider: { PHImageManager.default() })
         self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel,
                                                                   productImageStatuses: productImageActionHandler.productImageStatuses,
                                                                   productUIImageLoader: productUIImageLoader)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -10,21 +10,32 @@ import Yosemite
 final class DefaultProductUIImageLoader: ProductUIImageLoader {
     private var imagesByProductImageID: [Int64: UIImage] = [:]
     private let imageService: ImageService
-    private let phAssetImageLoader: PHAssetImageLoader
 
     private let productImageActionHandler: ProductImageActionHandler?
+
+    private let phAssetImageLoaderProvider: (() -> PHAssetImageLoader)?
+    /// `PHAssetImageLoader` is lazy loaded to avoid triggering permission alert by initializing `PHImageManager` before it is used.
+    private lazy var phAssetImageLoader: PHAssetImageLoader = {
+        guard let phAssetImageLoaderProvider = phAssetImageLoaderProvider else {
+            assertionFailure("Trying to call `PHAssetImageLoader` without setting a provider during initialization")
+            return PHImageManager.default()
+        }
+        return phAssetImageLoaderProvider()
+    }()
 
     /// - Parameters:
     ///   - productImageActionHandler: if non-nil, the asset image is used after being uploaded to a remote image to avoid an extra network call.
     ///     Set this property when images are being uploaded in the scope.
     ///   - imageService: provides images given a URL.
-    ///   - phAssetImageLoader: provides images given a `PHAsset` asset.
+    ///   - phAssetImageLoaderProvider: provides a `PHAssetImageLoader` instance that loads an image given a `PHAsset` asset.
+    ///     Only non-nil if `PHAsset` image request is used (e.g. image upload).
+    ///     It is a callback because we lazy load `PHAssetImageLoader` to avoid triggering permission alert by initializing `PHImageManager` before it is used.
     init(productImageActionHandler: ProductImageActionHandler? = nil,
          imageService: ImageService = ServiceLocator.imageService,
-         phAssetImageLoader: PHAssetImageLoader = PHImageManager.default()) {
+         phAssetImageLoaderProvider: (() -> PHAssetImageLoader)? = nil) {
         self.productImageActionHandler = productImageActionHandler
         self.imageService = imageService
-        self.phAssetImageLoader = phAssetImageLoader
+        self.phAssetImageLoaderProvider = phAssetImageLoaderProvider
 
         productImageActionHandler?.addAssetUploadObserver(self) { [weak self] asset, productImage in
             self?.update(from: asset, to: productImage)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
@@ -27,7 +27,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
 
     func testRequestingImageWithRemoteProductImage() {
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
-        let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoader: mockPHAssetImageLoader)
+        let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })
         let productImage = ProductImage(imageID: mockProductImageID,
                                         dateCreated: Date(),
                                         dateModified: Date(),
@@ -46,7 +46,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
     func testRequestingImageWithPHAsset() {
         let asset = PHAsset()
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [asset: testImage])
-        let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoader: mockPHAssetImageLoader)
+        let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })
 
         let expectation = self.expectation(description: "Wait for image request")
         imageLoader.requestImage(asset: asset, targetSize: .zero) { image in


### PR DESCRIPTION
"The app shouldn't request Photos permission when opening Edit Product for the first time" for #1713 

## Problem

Since just initializing a `PHImageManager` or its subclass could trigger the Photo Library permission alert ([SO post](https://stackoverflow.com/questions/38213857/what-triggers-photo-library-authorization-request-ios)), the permission alert could be shown when opening the readonly Product Details screen or Edit Product screen without any image upload actions. This is reproducible consistently in iOS 12, but not in iOS 13.

edit product (without any image upload action) | readonly product details
-- | --
![Simulator Screen Shot - iPhone 8 - 2020-04-10 at 18 03 59](https://user-images.githubusercontent.com/1945542/78982981-da1d2080-7b55-11ea-88c2-a2324b3f9034.png) | ![Simulator Screen Shot - iPhone 8 - 2020-04-10 at 18 04 44](https://user-images.githubusercontent.com/1945542/78982987-ddb0a780-7b55-11ea-85bd-1e400701246f.png)

## Changes

- Updated the `PHAssetImageLoader` property to be a lazy var and the instance is provided by the `phAssetImageLoaderProvider: (() -> PHAssetImageLoader)? = nil` callback in the initializer

## Testing

Note: It's the easiest to test on an iOS 12 simulator

Prerequisite: erase all content and settings of the simulator beforehand, if the Photo Library permission alert has been accepted or declined

- Launch the app and log in to a store if needed
- Go to the Products tab
- Tap on a non-simple product --> the Photo Library permission alert shouldn't show up
- Go back to the Products tab
- Tap on a simple product --> the Photo Library permission alert shouldn't show up
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Tap "Choose from device" --> the Photo Library permission alert should show up (if you don't take any actions and restart the simulator, it will be prompted again next time)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
