### PR TITLE
Fix test cases in `CurrencyFormatterTests` from locale, singleton usage, and negative value with RTL

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -73,11 +73,13 @@ public class CurrencyFormatter {
 
     /// Returns a string that displays the amount using all of the specified currency settings
     /// - Parameters:
-    ///     - amount: a formatted string, preferably converted using `localize(_:in:with:including:)`.
+    ///     - stringValue: a formatted string, preferably converted using `localize(_:in:with:including:)`.
     ///     - position: the currency position enum, either right, left, right_space, or left_space.
     ///     - symbol: the currency symbol as a string, to be used with the amount.
+    ///     - isNegative: whether the value is negative or not.
+    ///     - locale: the locale that is used to format the currency amount string.
     ///
-    func formatCurrency(using stringValue: String,
+    func formatCurrency(using amount: String,
                         at position: CurrencySettings.CurrencyPosition,
                         with symbol: String,
                         isNegative: Bool,
@@ -87,10 +89,6 @@ public class CurrencyFormatter {
 
         // We're relying on the phone's Locale to assist with language direction
         let languageCode = locale.languageCode
-
-        // Remove all occurences of the minus sign from the string amount.
-        // We want to position the minus sign manually.
-        let amount = stringValue
 
         // Detect the language direction
         var languageDirection: Locale.LanguageDirection = .unknown
@@ -128,12 +126,12 @@ public class CurrencyFormatter {
     /// Applies currency option settings to the amount (as String) for the given currency.
     ///
     /// - Parameters:
-    ///     - stringAmount: a raw string representation of the amount, from the API, with no formatting applied. e.g. "19.87"
+    ///     - amount: a raw string representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
     ///
-    func formatAmount(_ stringAmount: String, with currency: String? = nil, locale: Locale = .current) -> String? {
-        guard let decimalAmount = convertToDecimal(from: stringAmount, locale: locale) else {
+    func formatAmount(_ amount: String, with currency: String? = nil, locale: Locale = .current) -> String? {
+        guard let decimalAmount = convertToDecimal(from: amount, locale: locale) else {
             return nil
         }
 
@@ -177,6 +175,7 @@ public class CurrencyFormatter {
                                    roundSmallNumbers: Bool = true,
                                    locale: Locale = .current) -> String? {
         guard let amount = convertToDecimal(from: stringAmount, locale: locale) else {
+            assertionFailure("Cannot convert the amount \"\(stringAmount)\" to decimal value with locale \(locale.identifier)")
             return nil
         }
 
@@ -205,11 +204,11 @@ public class CurrencyFormatter {
 
     /// Applies currency option settings to the amount for the given currency.
     /// - Parameters:
-    ///     - decimalAmount: a NSDecimalNumber representation of the amount, from the API, with no formatting applied. e.g. "19.87"
+    ///     - amount: a NSDecimalNumber representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///     - locale: the locale that is used to format the currency amount string.
     ///
-    func formatAmount(_ decimalAmount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current) -> String? {
+    func formatAmount(_ amount: NSDecimalNumber, with currency: String? = nil, locale: Locale = .current) -> String? {
         let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
         let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
@@ -222,7 +221,7 @@ public class CurrencyFormatter {
 
         // Put all the pieces of user preferences on currency formatting together
         // and spit out a string that has the formatted amount.
-        let localized = localize(decimalAmount,
+        let localized = localize(amount,
                                  with: separator,
                                  in: numberOfDecimals,
                                  including: thousandSeparator)
@@ -236,7 +235,7 @@ public class CurrencyFormatter {
         let formattedAmount = formatCurrency(using: localizedAmount,
                                              at: position,
                                              with: symbol,
-                                             isNegative: decimalAmount.isNegative(),
+                                             isNegative: amount.isNegative(),
                                              locale: locale)
 
         return formattedAmount

--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -127,12 +127,12 @@ public class CurrencyFormatter {
     ///     - amount: a raw string representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///
-    func formatAmount(_ stringAmount: String, with currency: String = CurrencySettings.shared.currencyCode.rawValue) -> String? {
+    func formatAmount(_ stringAmount: String, with currency: String? = nil) -> String? {
         guard let decimalAmount = convertToDecimal(from: stringAmount) else {
             return nil
         }
 
-        return formatAmount(decimalAmount, with: currency)
+        return formatAmount(decimalAmount, with: currency ?? currencySettings.currencyCode.rawValue)
     }
 
 
@@ -167,11 +167,13 @@ public class CurrencyFormatter {
     ///  - 5800199.56 becomes "$5.8m"
     ///
     func formatHumanReadableAmount(_ stringAmount: String,
-                                   with currency: String = CurrencySettings.shared.currencyCode.rawValue,
+                                   with currency: String? = nil,
                                    roundSmallNumbers: Bool = true) -> String? {
         guard let amount = convertToDecimal(from: stringAmount) else {
             return nil
         }
+
+        let currency = currency ?? currencySettings.currencyCode.rawValue
 
         let humanReadableAmount = amount.humanReadableString(roundSmallNumbers: roundSmallNumbers)
         if humanReadableAmount == amount.stringValue, roundSmallNumbers == false {
@@ -198,7 +200,8 @@ public class CurrencyFormatter {
     ///     - amount: a NSDecimalNumber representation of the amount, from the API, with no formatting applied. e.g. "19.87"
     ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
     ///
-    func formatAmount(_ decimalAmount: NSDecimalNumber, with currency: String = CurrencySettings.shared.currencyCode.rawValue) -> String? {
+    func formatAmount(_ decimalAmount: NSDecimalNumber, with currency: String? = nil) -> String? {
+        let currency = currency ?? currencySettings.currencyCode.rawValue
         // Get the currency code
         let code = CurrencySettings.CurrencyCode(rawValue: currency) ?? currencySettings.currencyCode
         // Grab the read-only currency options. These are set by the user in Site > Settings.

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -6,10 +6,11 @@ import XCTest
 /// Currency Formatter Tests - Decimals
 ///
 class CurrencyFormatterTests: XCTestCase {
+    private lazy var sampleCurrencySettings = CurrencySettings(siteSettings: setUpSampleSiteSettings())
 
     /// Sample Site Settings
     ///
-    func setUpSampleSiteSettings() -> [SiteSetting] {
+    private func setUpSampleSiteSettings() -> [SiteSetting] {
         let settings = mapLoadGeneralSiteSettingsResponse()
         var siteSettings = [SiteSetting]()
 
@@ -28,7 +29,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "9.99"
         let expectedResult = NSDecimalNumber(string: stringValue)
 
-        let converted = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
 
         // check the formatted decimal exists
         guard let actualResult = converted else {
@@ -55,7 +56,7 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "9.9999"
         let expectedResult = NSDecimalNumber(string: stringValue)
 
-        let actualResult = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
         XCTAssertEqual(expectedResult, actualResult)
     }
 
@@ -65,14 +66,14 @@ class CurrencyFormatterTests: XCTestCase {
         let separator = ","
         let stringValue = "1.17"
         let expectedResult = "1,17"
-        let converted = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
 
         guard let convertedDecimal = converted else {
             XCTFail()
             return
         }
 
-        let actualResult = CurrencyFormatter().localize(convertedDecimal, with: separator)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal, with: separator)
 
         XCTAssertEqual(expectedResult, actualResult)
     }
@@ -81,7 +82,7 @@ class CurrencyFormatterTests: XCTestCase {
     ///
     func testBadDataInStringDoesNotConvertToDecimal() {
         let badInput = "~HUKh*(&Y3HkJ8"
-        let actualResult = CurrencyFormatter().convertToDecimal(from: badInput)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: badInput)
 
         XCTAssertNil(actualResult)
     }
@@ -91,7 +92,7 @@ class CurrencyFormatterTests: XCTestCase {
     func testNegativeNumbersSuccessfullyConvertToDecimal() {
         let negativeNumber = "-81346.45"
         let expectedResult = NSDecimalNumber(string: negativeNumber)
-        let actualResult = CurrencyFormatter().convertToDecimal(from: negativeNumber)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: negativeNumber)
 
         XCTAssertEqual(expectedResult, actualResult)
     }
@@ -107,14 +108,14 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "1204.67"
         let expectedResult = "1,204.67"
 
-        let convertedDecimal = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let convertedDecimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
 
         guard let decimal = convertedDecimal else {
             XCTFail()
             return
         }
 
-        let formattedString = CurrencyFormatter().localize(decimal, including: comma)
+        let formattedString = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimal, including: comma)
         guard let actualResult = formattedString else {
             XCTFail()
             return
@@ -131,13 +132,13 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "1204.67"
         let expectedResult = "1204.67"
 
-        let convertedDecimal = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let convertedDecimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
         guard let decimal = convertedDecimal else {
             XCTFail()
             return
         }
 
-        let localizedAmount = CurrencyFormatter().localize(decimal,
+        let localizedAmount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimal,
                                                            with: decimalSeparator,
                                                            including: thousandSeparator)
 
@@ -156,14 +157,14 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "45958320.97"
         let expectedResult = "45,958,320,97"
 
-        let converted = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
         guard let convertedDecimal = converted else {
             XCTFail()
             return
         }
 
         let position = 2
-        let localizedAmount = CurrencyFormatter().localize(convertedDecimal,
+        let localizedAmount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal,
                                                            with: separator,
                                                            in: position,
                                                            including: separator)
@@ -183,13 +184,13 @@ class CurrencyFormatterTests: XCTestCase {
         let stringValue = "45958320.97"
         let expectedResult = "45,958,320,970"
 
-        let converted = CurrencyFormatter().convertToDecimal(from: stringValue)
+        let converted = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringValue)
         guard let convertedDecimal = converted else {
             XCTFail()
             return
         }
 
-        let formattedAmount = CurrencyFormatter().localize(convertedDecimal,
+        let formattedAmount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(convertedDecimal,
                                                            with: separator,
                                                            in: position,
                                                            including: separator)
@@ -217,13 +218,13 @@ class CurrencyFormatterTests: XCTestCase {
         let stringAmount = "-7867818684.64"
         let expectedResult = "-7.867.818.684,640 £"
 
-        let decimal = CurrencyFormatter().convertToDecimal(from: stringAmount)
+        let decimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringAmount)
         guard let decimalAmount = decimal else {
             XCTFail("Error: invalid string amount. Cannot convert to decimal.")
             return
         }
 
-        let amount = CurrencyFormatter().localize(decimalAmount,
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimalAmount,
                                                   with: decimalSeparator,
                                                   in: decimalPosition,
                                                   including: thousandSeparator)
@@ -233,9 +234,9 @@ class CurrencyFormatterTests: XCTestCase {
             return
         }
 
-        let symbol = CurrencySettings.shared.symbol(from: currencyCode)
+        let symbol = sampleCurrencySettings.symbol(from: currencyCode)
         let isNegative = decimalAmount.isNegative()
-        let actualResult = CurrencyFormatter().formatCurrency(using: localizedAmount,
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatCurrency(using: localizedAmount,
                                                               at: currencyPosition,
                                                               with: symbol,
                                                               isNegative: isNegative)
@@ -254,7 +255,7 @@ class CurrencyFormatterTests: XCTestCase {
         let decimalAmount = NSDecimalNumber(floatLiteral: -7867818684.64)
         let expectedResult = "-7.867.818.684,640 £"
 
-        let amount = CurrencyFormatter().localize(decimalAmount,
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimalAmount,
                                                   with: decimalSeparator,
                                                   in: decimalPosition,
                                                   including: thousandSeparator)
@@ -264,9 +265,9 @@ class CurrencyFormatterTests: XCTestCase {
             return
         }
 
-        let symbol = CurrencySettings.shared.symbol(from: currencyCode)
+        let symbol = sampleCurrencySettings.symbol(from: currencyCode)
         let isNegative = decimalAmount.isNegative()
-        let actualResult = CurrencyFormatter().formatCurrency(using: localizedAmount,
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatCurrency(using: localizedAmount,
                                                               at: currencyPosition,
                                                               with: symbol,
                                                               isNegative: isNegative)
@@ -280,8 +281,7 @@ class CurrencyFormatterTests: XCTestCase {
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallDecimalValue() {
         // Create a "standard" set of currency settings for the human readable formatter tests
-        _ = CurrencySettings(siteSettings: setUpSampleSiteSettings())
-        let formatter = CurrencyFormatter()
+        let formatter = CurrencyFormatter(currencySettings: sampleCurrencySettings)
 
         let inputValue = "97.64"
         let expectedResult = "$97"
@@ -292,77 +292,77 @@ class CurrencyFormatterTests: XCTestCase {
     func testFormatHumanReadableWorksUsingSmallDecimalValue() {
         let inputValue = "97.64"
         let expectedResult = "$97.64"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, roundSmallNumbers: false)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, roundSmallNumbers: false)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallDecimalValueAndSpecificCountryCode() {
         let inputValue = "97.64"
         let expectedResult = "£97"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "GBP")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallDecimalValueAndSpecificCountryCode() {
         let inputValue = "97.64"
         let expectedResult = "£97.64"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "GBP", roundSmallNumbers: false)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", roundSmallNumbers: false)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallNegativeDecimalValue() {
         let inputValue = "-7.64"
         let expectedResult = "-$7"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallNegativeDecimalValue() {
         let inputValue = "-7.64"
         let expectedResult = "-$7.64"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, roundSmallNumbers: false)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, roundSmallNumbers: false)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallNegativeDecimalValueAndSpecificCountryCode() {
         let inputValue = "-7.64"
         let expectedResult = "-£7"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "GBP")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallNegativeDecimalValueAndSpecificCountryCode() {
         let inputValue = "-7.64"
         let expectedResult = "-£7.64"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "GBP", roundSmallNumbers: false)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", roundSmallNumbers: false)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeDecimalValue() {
         let inputValue = "7867818684.64"
         let expectedResult = "$7.9b"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeNegativeDecimalValue() {
         let inputValue = "-7867818684.64"
         let expectedResult = "-$7.9b"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "USD")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "USD")
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeDecimalValueAndSpecificCountryCode() {
         let inputValue = "7867818684.64"
         let expectedResult = "£7.9b"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "GBP")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeNegativeDecimalValueAndSpecificCountryCode() {
         let inputValue = "-7867818684.64"
         let expectedResult = "-£7.9b"
-        let amount = CurrencyFormatter().formatHumanReadableAmount(inputValue, with: "GBP")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
         XCTAssertEqual(amount, expectedResult)
     }
 
@@ -370,17 +370,17 @@ class CurrencyFormatterTests: XCTestCase {
 
     func testFormatAmountUsingDecimalValueWithPointSeparator() {
         let inputValue = "13.21"
-        let expectedResult = "$13" + CurrencySettings.shared.decimalSeparator + "21"
+        let expectedResult = "$13" + sampleCurrencySettings.decimalSeparator + "21"
 
-        let amount = CurrencyFormatter().formatAmount(inputValue, with: "USD")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatAmount(inputValue, with: "USD")
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatAmountUsingDecimalValueWithCommaSeparator() {
         let inputValue = "13,21"
-        let expectedResult = "$13" + CurrencySettings.shared.decimalSeparator + "21"
+        let expectedResult = "$13" + sampleCurrencySettings.decimalSeparator + "21"
 
-        let amount = CurrencyFormatter().formatAmount(inputValue, with: "USD")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatAmount(inputValue, with: "USD")
         XCTAssertEqual(amount, expectedResult)
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CurrencyFormatterTests.swift
@@ -6,6 +6,8 @@ import XCTest
 /// Currency Formatter Tests - Decimals
 ///
 class CurrencyFormatterTests: XCTestCase {
+    private let sampleLocale = Locale(identifier: "en")
+
     private lazy var sampleCurrencySettings = CurrencySettings(siteSettings: setUpSampleSiteSettings())
 
     /// Sample Site Settings
@@ -218,16 +220,18 @@ class CurrencyFormatterTests: XCTestCase {
         let stringAmount = "-7867818684.64"
         let expectedResult = "-7.867.818.684,640 £"
 
-        let decimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringAmount)
+        let locale = sampleLocale
+        let decimal = CurrencyFormatter(currencySettings: sampleCurrencySettings).convertToDecimal(from: stringAmount, locale: locale)
         guard let decimalAmount = decimal else {
             XCTFail("Error: invalid string amount. Cannot convert to decimal.")
             return
         }
 
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimalAmount,
-                                                  with: decimalSeparator,
-                                                  in: decimalPosition,
-                                                  including: thousandSeparator)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .localize(decimalAmount,
+                      with: decimalSeparator,
+                      in: decimalPosition,
+                      including: thousandSeparator)
 
         guard let localizedAmount = amount else {
             XCTFail()
@@ -236,10 +240,12 @@ class CurrencyFormatterTests: XCTestCase {
 
         let symbol = sampleCurrencySettings.symbol(from: currencyCode)
         let isNegative = decimalAmount.isNegative()
-        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatCurrency(using: localizedAmount,
-                                                              at: currencyPosition,
-                                                              with: symbol,
-                                                              isNegative: isNegative)
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatCurrency(using: localizedAmount,
+                            at: currencyPosition,
+                            with: symbol,
+                            isNegative: isNegative,
+                            locale: locale)
 
         XCTAssertEqual(expectedResult, actualResult)
     }
@@ -255,10 +261,11 @@ class CurrencyFormatterTests: XCTestCase {
         let decimalAmount = NSDecimalNumber(floatLiteral: -7867818684.64)
         let expectedResult = "-7.867.818.684,640 £"
 
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).localize(decimalAmount,
-                                                  with: decimalSeparator,
-                                                  in: decimalPosition,
-                                                  including: thousandSeparator)
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .localize(decimalAmount,
+                      with: decimalSeparator,
+                      in: decimalPosition,
+                      including: thousandSeparator)
 
         guard let localizedAmount = amount else {
             XCTFail()
@@ -267,10 +274,13 @@ class CurrencyFormatterTests: XCTestCase {
 
         let symbol = sampleCurrencySettings.symbol(from: currencyCode)
         let isNegative = decimalAmount.isNegative()
-        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatCurrency(using: localizedAmount,
-                                                              at: currencyPosition,
-                                                              with: symbol,
-                                                              isNegative: isNegative)
+        let locale = sampleLocale
+        let actualResult = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatCurrency(using: localizedAmount,
+                            at: currencyPosition,
+                            with: symbol,
+                            isNegative: isNegative,
+                            locale: locale)
 
         XCTAssertEqual(expectedResult, actualResult)
     }
@@ -285,84 +295,107 @@ class CurrencyFormatterTests: XCTestCase {
 
         let inputValue = "97.64"
         let expectedResult = "$97"
-        let amount = formatter.formatHumanReadableAmount(inputValue, with: "USD")
+        let locale = sampleLocale
+        let amount = formatter.formatHumanReadableAmount(inputValue, with: "USD", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallDecimalValue() {
         let inputValue = "97.64"
         let expectedResult = "$97.64"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, roundSmallNumbers: false)
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatHumanReadableAmount(inputValue,
+                                       roundSmallNumbers: false,
+                                       locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallDecimalValueAndSpecificCountryCode() {
         let inputValue = "97.64"
         let expectedResult = "£97"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallDecimalValueAndSpecificCountryCode() {
         let inputValue = "97.64"
         let expectedResult = "£97.64"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", roundSmallNumbers: false)
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatHumanReadableAmount(inputValue,
+                                       with: "GBP",
+                                       roundSmallNumbers: false,
+                                       locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallNegativeDecimalValue() {
-        let inputValue = "-7.64"
-        let expectedResult = "-$7"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue)
+        let inputValue = "-76.64"
+        let expectedResult = "-$76"
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallNegativeDecimalValue() {
         let inputValue = "-7.64"
         let expectedResult = "-$7.64"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, roundSmallNumbers: false)
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, roundSmallNumbers: false, locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWithRoundingWorksUsingSmallNegativeDecimalValueAndSpecificCountryCode() {
         let inputValue = "-7.64"
         let expectedResult = "-£7"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingSmallNegativeDecimalValueAndSpecificCountryCode() {
         let inputValue = "-7.64"
         let expectedResult = "-£7.64"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", roundSmallNumbers: false)
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings)
+            .formatHumanReadableAmount(inputValue,
+                                       with: "GBP",
+                                       roundSmallNumbers: false,
+                                       locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeDecimalValue() {
         let inputValue = "7867818684.64"
         let expectedResult = "$7.9b"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue)
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeNegativeDecimalValue() {
         let inputValue = "-7867818684.64"
         let expectedResult = "-$7.9b"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "USD")
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "USD", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeDecimalValueAndSpecificCountryCode() {
         let inputValue = "7867818684.64"
         let expectedResult = "£7.9b"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatHumanReadableWorksUsingLargeNegativeDecimalValueAndSpecificCountryCode() {
         let inputValue = "-7867818684.64"
         let expectedResult = "-£7.9b"
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP")
+        let locale = sampleLocale
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatHumanReadableAmount(inputValue, with: "GBP", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
@@ -371,16 +404,18 @@ class CurrencyFormatterTests: XCTestCase {
     func testFormatAmountUsingDecimalValueWithPointSeparator() {
         let inputValue = "13.21"
         let expectedResult = "$13" + sampleCurrencySettings.decimalSeparator + "21"
+        let locale = sampleLocale
 
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatAmount(inputValue, with: "USD")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatAmount(inputValue, with: "USD", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 
     func testFormatAmountUsingDecimalValueWithCommaSeparator() {
         let inputValue = "13,21"
         let expectedResult = "$13" + sampleCurrencySettings.decimalSeparator + "21"
+        let locale = sampleLocale
 
-        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatAmount(inputValue, with: "USD")
+        let amount = CurrencyFormatter(currencySettings: sampleCurrencySettings).formatAmount(inputValue, with: "USD", locale: locale)
         XCTAssertEqual(amount, expectedResult)
     }
 }


### PR DESCRIPTION
Hopefully fixes all cases in #1409

In [a previous PR](https://github.com/woocommerce/woocommerce-ios/pull/2008), it enabled DI'ing `CurrencySettings` to `CurrencyFormatter` for testing `PriceInputFormatter`, but we still use the initializer that uses the singleton values in `CurrencyFormatterTests`.

## Changes

There are multiple factors that cause the test failures in `CurrencyFormatterTests`:
- `CurrencyFormatter` was using `Locale.current` for language code for manual RTL/LTR & negative formatting, so it failed on RTL device languages
  - This PR DI'ed the `Locale` to each function that uses it, with default value to `.current`
- `CurrencyFormatter` and `CurrencyFormatterTests` were using `CurrencySettings.shared` (singleton) values, which could be any values if the simulator has launched previously that updated the `CurrencySettings.shared` values (e.g. having run the app on a site with different currency options than expected in the test cases)
  - This PR replaced all the `CurrencySettings.shared` singleton usage in `CurrencyFormatter` with its `currencySettings` instance, and replaced all the`CurrencySettings.shared` usage in `CurrencyFormatterTests` with its sample `currencySettings` instance from `settings-general.json` site settings that were expected in the test cases
- As @pmusolino pointed out in the thread in the project channel, the Left-to-Right character (0x200E in hex) is in the string from `Formatters.smallNumberFormatter` **for a negative value with RTL device languages**: https://github.com/woocommerce/woocommerce-ios/blob/3a72ae9fc621c6dda1c3a360484f746b057a75d2/WooCommerce/Classes/Extensions/Double+Woo.swift#L38
  - Since we already manually format a negative value by the negative sign, space, and absolute value, this PR just uses the absolute value of the amount for formatting: https://github.com/woocommerce/woocommerce-ios/commit/2c1fae198b5641b0ac1f56742df65555fa343ed0#diff-9602fa47bdc00e54d6c27795709e94acR185

## Testing

Prerequisite: have a site with currency options different from [`settings-general.json` (under ID `woocommerce_currency`)](https://github.com/woocommerce/woocommerce-ios/blob/3a72ae9fc621c6dda1c3a360484f746b057a75d2/Networking/NetworkingTests/Responses/settings-general.json)

- Launch the app, logged in to the site in the prerequisite
- Run tests in `WooCommerceTests` with a LTR device language that is not English --> all 632 tests should pass
- Repeat the above 2 steps, with a RTL device language (e.g. Arabic) --> all 632 tests should pass

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
