### PR TITLE
Update README to recommend rake dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,21 @@ A Jetpack-powered companion app for WooCommerce.
 1. Download Xcode
 
     At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 10.2 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
-2. Clone project by `git clone https://github.com/woocommerce/woocommerce-ios.git` in the folder of your preference
-3. Enter the project directory by `cd woocommerce-ios`
+2. Clone project in the folder of your preference
+
+    ```bash
+    git clone https://github.com/woocommerce/woocommerce-ios.git
+    ````
+
+3. Enter the project directory 
+
+    ```bash
+    cd woocommerce-ios
+    ```
+    
 4. Install the third party dependencies and tools required to run the project
     
-    We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line:
+    We use a few tools to help with development. To install or update the required dependencies, run:
     
     ```bash
     rake dependencies

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ A Jetpack-powered companion app for WooCommerce.
 3. Enter the project directory by `cd woocommerce-ios`
 4. Install the third party dependencies and tools required to run the project
     
-    We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line: `bundle exec pod install`
+    We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line:
     
-    In some cases, you may also have to: `bundle install`
+    ```bash
+    rake dependencies
+    ```
+    
 5. Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
 
 #### Credentials for external contributors

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ A Jetpack-powered companion app for WooCommerce.
 
 ## Build Instructions
 
-- Download Xcode
+1. Download Xcode
 
     At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 10.2 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
-- Clone project by `git clone https://github.com/woocommerce/woocommerce-ios.git` in the folder of your preference
-- Enter the project directory by `cd woocommerce-ios`
-- Install the third party dependencies and tools required to run the project
+2. Clone project by `git clone https://github.com/woocommerce/woocommerce-ios.git` in the folder of your preference
+3. Enter the project directory by `cd woocommerce-ios`
+4. Install the third party dependencies and tools required to run the project
     
     We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line: `bundle exec pod install`
     
     In some cases, you may also have to: `bundle install`
-- Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
+5. Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
 
 #### Credentials for external contributors
 In order to login to WordPress.com using the app:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Jetpack-powered companion app for WooCommerce.
 
 1. Download Xcode
 
-    At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 10.2 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
+    At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 11.2.1 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
 2. Clone project in the folder of your preference
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ A Jetpack-powered companion app for WooCommerce.
 ## Build Instructions
 
 - Download Xcode
-  - At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 10.2 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
+
+    At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 10.2 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
 - Clone project by `git clone https://github.com/woocommerce/woocommerce-ios.git` in the folder of your preference
 - Enter the project directory by `cd woocommerce-ios`
 - Install the third party dependencies and tools required to run the project
-  - We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line: `bundle exec pod install`
-  - In some cases, you may also have to: `bundle install`
+    
+    We use a few tools to help with development. To install or update the required dependencies, run the follow command on the command line: `bundle exec pod install`
+    
+    In some cases, you may also have to: `bundle install`
 - Open the project by double clicking on `WooCommerce.xcworkspace` file, or launching Xcode and choose File > Open and browse to `WooCommerce.xcworkspace`
 
 #### Credentials for external contributors


### PR DESCRIPTION
I mainly updated this to recommend `rake dependencies` since it does everything so there will be less to explain. 

I changed the instructions to use code blocks. Please let me know what you think about how that looks. Is it too much? 

## Testing

Please view the changes in https://github.com/woocommerce/woocommerce-ios/blob/update/readme-doc/README.md

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

