### PR TITLE
Orders → Move ResultsController to ViewModel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -410,12 +410,6 @@ private extension OrdersViewController {
 //
 private extension OrdersViewController {
 
-    func detailsViewModel(at indexPath: IndexPath) -> OrderDetailsViewModel {
-        let order = resultsController.object(at: indexPath)
-
-        return OrderDetailsViewModel(order: order)
-    }
-
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {
         for orderStatus in currentSiteStatuses where orderStatus.slug == order.statusKey {
             return orderStatus
@@ -443,9 +437,9 @@ extension OrdersViewController: UITableViewDataSource {
             fatalError()
         }
 
-        let viewModel = detailsViewModel(at: indexPath)
-        let orderStatus = lookUpOrderStatus(for: viewModel.order)
-        cell.configureCell(viewModel: viewModel, orderStatus: orderStatus)
+        let detailsViewModel = viewModel.detailsViewModel(at: indexPath)
+        let orderStatus = lookUpOrderStatus(for: detailsViewModel.order)
+        cell.configureCell(detailsViewModel: detailsViewModel, orderStatus: orderStatus)
         cell.layoutIfNeeded()
         return cell
     }
@@ -482,7 +476,7 @@ extension OrdersViewController: UITableViewDelegate {
             assertionFailure("Expected OrderDetailsViewController to be instantiated")
             return
         }
-        orderDetailsVC.viewModel = detailsViewModel(at: indexPath)
+        orderDetailsVC.viewModel = viewModel.detailsViewModel(at: indexPath)
 
         navigationController?.pushViewController(orderDetailsVC, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -109,6 +109,8 @@ class OrdersViewController: UIViewController {
         configureGhostableTableView()
         configureResultsControllers()
 
+        configureViewModel()
+
         startListeningToNotifications()
     }
 
@@ -127,8 +129,10 @@ class OrdersViewController: UIViewController {
 // MARK: - User Interface Initialization
 //
 private extension OrdersViewController {
-    /// Setup: Order filtering
+    /// Initialize ViewModel operations
     ///
+    func configureViewModel() {
+        viewModel.activateAndForwardUpdates(to: tableView)
     }
 
     /// Setup: Order status predicate
@@ -150,10 +154,6 @@ private extension OrdersViewController {
     /// Setup: Results Controller
     ///
     func configureResultsControllers() {
-        // Orders FRC
-        resultsController.startForwardingEvents(to: tableView)
-        try? resultsController.performFetch()
-
         // Order status FRC
         try? statusResultsController.performFetch()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -101,7 +101,6 @@ class OrdersViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        refreshResultsPredicate()
         refreshStatusPredicate()
         registerTableViewHeadersAndCells()
 
@@ -130,22 +129,6 @@ class OrdersViewController: UIViewController {
 private extension OrdersViewController {
     /// Setup: Order filtering
     ///
-    func refreshResultsPredicate() {
-        resultsController.predicate = {
-            let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
-            let excludeNonMatchingStatus = statusFilter.map { NSPredicate(format: "statusKey = %@", $0.slug) }
-
-            var predicates = [ excludeSearchCache, excludeNonMatchingStatus ].compactMap { $0 }
-            if let tomorrow = Date.tomorrow() {
-                let dateSubPredicate = NSPredicate(format: "dateCreated < %@", tomorrow as NSDate)
-                predicates.append(dateSubPredicate)
-            }
-
-            return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-        }()
-
-        tableView.setContentOffset(.zero, animated: false)
-        tableView.reloadData()
     }
 
     /// Setup: Order status predicate

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -260,7 +260,6 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
 
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: statusFilter?.slug,
             pageNumber: pageNumber,
             pageSize: pageSize,
             reason: SyncReason(rawValue: reason ?? "")) { [weak self] error in
@@ -272,7 +271,8 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
                     DDLogError("⛔️ Error synchronizing orders: \(error)")
                     self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize, reason: reason)
                 } else {
-                    ServiceLocator.analytics.track(.ordersListLoaded, withProperties: ["status": self.statusFilter?.slug ?? String()])
+                    let status = self.viewModel.statusFilter?.slug ?? String()
+                    ServiceLocator.analytics.track(.ordersListLoaded, withProperties: ["status": status])
                 }
 
                 self.transitionToResultsUpdatedState()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -71,12 +71,6 @@ class OrdersViewController: UIViewController {
         return statusResultsController.fetchedObjects
     }
 
-    /// Indicates if there are no results onscreen.
-    ///
-    private var isEmpty: Bool {
-        return resultsController.isEmpty
-    }
-
     /// Indicates if there's a filter being applied.
     ///
     private var isFiltered: Bool {
@@ -581,14 +575,14 @@ private extension OrdersViewController {
     /// we've got cached results, or not.
     ///
     func transitionToSyncingState() {
-        state = isEmpty ? .placeholder : .syncing
+        state = viewModel.isEmpty ? .placeholder : .syncing
     }
 
     /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
     /// Transitions to `.results` / `.emptyFiltered` / `.emptyUnfiltered` accordingly.
     ///
     func transitionToResultsUpdatedState() {
-        if isEmpty == false {
+        if viewModel.isEmpty == false {
             state = .results
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -46,15 +46,6 @@ class OrdersViewController: UIViewController {
         return FooterSpinnerView(tableViewStyle: tableView.style)
     }()
 
-    /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Orders in sync.
-    ///
-    private lazy var resultsController: ResultsController<StorageOrder> = {
-        let storageManager = ServiceLocator.storageManager
-        let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
-
-        return ResultsController<StorageOrder>(storageManager: storageManager, sectionNameKeyPath: "normalizedAgeAsString", sortedBy: [descriptor])
-    }()
-
     /// Used for looking up the `OrderStatus` to show in the `OrderTableViewCell`.
     ///
     /// The `OrderStatus` data is fetched from the API by `OrdersMasterViewModel`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -305,7 +305,7 @@ extension OrdersViewController {
             return false
         }
 
-        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > resultsController.numberOfObjects
+        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > viewModel.numberOfObjects
     }
 
     /// Stops animating the Footer Spinner.
@@ -425,11 +425,11 @@ private extension OrdersViewController {
 extension OrdersViewController: UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return resultsController.sections.count
+        viewModel.numberOfSections
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return resultsController.sections[section].numberOfObjects
+        viewModel.numberOfRows(in: section)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -439,7 +439,7 @@ extension OrdersViewController: UITableViewDataSource {
 
         let detailsViewModel = viewModel.detailsViewModel(at: indexPath)
         let orderStatus = lookUpOrderStatus(for: detailsViewModel.order)
-        cell.configureCell(detailsViewModel: detailsViewModel, orderStatus: orderStatus)
+        cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
         cell.layoutIfNeeded()
         return cell
     }
@@ -451,7 +451,7 @@ extension OrdersViewController: UITableViewDataSource {
         }
 
         header.leftText = {
-            let rawAge = resultsController.sections[section].name
+            let rawAge = viewModel.sectionInfo(at: section).name
             return Age(rawValue: rawAge)?.description
         }()
         header.rightText = nil
@@ -482,7 +482,7 @@ extension OrdersViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let orderIndex = resultsController.objectIndex(from: indexPath)
+        let orderIndex = viewModel.objectIndex(from: indexPath)
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -67,12 +67,6 @@ class OrdersViewController: UIViewController {
         return statusResultsController.fetchedObjects
     }
 
-    /// Indicates if there's a filter being applied.
-    ///
-    private var isFiltered: Bool {
-        return statusFilter != nil
-    }
-
     /// UI Active State
     ///
     private var state: State = .results {
@@ -583,7 +577,7 @@ private extension OrdersViewController {
             return
         }
 
-        if isFiltered {
+        if viewModel.isFiltered {
             state = .emptyFiltered
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -22,7 +22,7 @@ class OrdersViewController: UIViewController {
 
     weak var delegate: OrdersViewControllerDelegate?
 
-    private lazy var viewModel = OrdersViewModel()
+    private let viewModel: OrdersViewModel
 
     /// Main TableView.
     ///
@@ -61,10 +61,6 @@ class OrdersViewController: UIViewController {
     ///
     private let syncingCoordinator = SyncingCoordinator()
 
-    /// OrderStatus that must be matched by retrieved orders.
-    ///
-    private let statusFilter: OrderStatus?
-
     /// The current list of order statuses for the default site
     ///
     private var currentSiteStatuses: [OrderStatus] {
@@ -97,7 +93,7 @@ class OrdersViewController: UIViewController {
     /// - Parameter statusFilter The filter to use.
     ///
     init(title: String, statusFilter: OrderStatus? = nil) {
-        self.statusFilter = statusFilter
+        viewModel = OrdersViewModel(statusFilter: statusFilter)
 
         super.init(nibName: Self.nibName, bundle: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -176,6 +176,20 @@ final class OrdersViewModel {
     }
 }
 
+// MARK: - TableView Support
+
+extension OrdersViewModel {
+    /// Returns an `OrdersViewModel` instance for the `StorageOrder` at the given `indexPath`.
+    ///
+    func detailsViewModel(at indexPath: IndexPath) -> OrderDetailsViewModel {
+        let order = resultsController.object(at: indexPath)
+
+        return OrderDetailsViewModel(order: order)
+    }
+}
+
+// MARK: - Constants
+
 extension OrdersViewModel {
     enum Defaults {
         static let pageFirstIndex = SyncingCoordinator.Defaults.pageFirstIndex

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -186,6 +186,36 @@ extension OrdersViewModel {
 
         return OrderDetailsViewModel(order: order)
     }
+
+    /// The number of DB results
+    ///
+    var numberOfObjects: Int {
+        resultsController.numberOfObjects
+    }
+
+    /// Converts the `rowIndexPath` to an `index` belonging to `numberOfObjects`.
+    ///
+    func objectIndex(from rowIndexPath: IndexPath) -> Int {
+        resultsController.objectIndex(from: rowIndexPath)
+    }
+
+    /// The number of sections that should be displayed
+    ///
+    var numberOfSections: Int {
+        resultsController.sections.count
+    }
+
+    /// Returns the number of rows in the given `section` index.
+    ///
+    func numberOfRows(in section: Int) -> Int {
+        resultsController.sections[section].numberOfObjects
+    }
+
+    /// Returns the `SectionInfo` for the given section index.
+    ///
+    func sectionInfo(at index: Int) -> ResultsController<StorageOrder>.SectionInfo {
+        resultsController.sections[index]
+    }
 }
 
 // MARK: - Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -39,6 +39,12 @@ final class OrdersViewModel {
         resultsController.isEmpty
     }
 
+    /// Indicates if there's a filter being applied.
+    ///
+    var isFiltered: Bool {
+        statusFilter != nil
+    }
+
     /// OrderStatus that must be matched by retrieved orders.
     ///
     private let statusFilter: OrderStatus?

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -76,12 +76,6 @@ final class OrdersViewModel {
     ///
     func activateAndForwardUpdates(to tableView: UITableView) {
         resultsController.startForwardingEvents(to: tableView)
-        performFetch()
-    }
-
-    /// Fetch DB results from the database.
-    ///
-    func performFetch() {
         try? resultsController.performFetch()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -1,6 +1,7 @@
 
 import Foundation
 import Yosemite
+import protocol Storage.StorageManagerType
 
 /// ViewModel for `OrdersViewController`.
 ///
@@ -19,6 +20,21 @@ final class OrdersViewModel {
     ///
     enum SyncReason: String {
         case pullToRefresh = "pull_to_refresh"
+    }
+
+    private let storageManager: StorageManagerType
+
+    /// Should be bound to the UITableView to auto-update the list of Orders.
+    ///
+    private(set) lazy var resultsController: ResultsController<StorageOrder> = {
+        let storageManager = ServiceLocator.storageManager
+        let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
+
+        return ResultsController<StorageOrder>(storageManager: storageManager, sectionNameKeyPath: "normalizedAgeAsString", sortedBy: [descriptor])
+    }()
+
+    init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.storageManager = storageManager
     }
 
     /// Returns what `OrderAction` should be used when synchronizing.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -26,7 +26,7 @@ final class OrdersViewModel {
 
     /// Should be bound to the UITableView to auto-update the list of Orders.
     ///
-    private(set) lazy var resultsController: ResultsController<StorageOrder> = {
+    private lazy var resultsController: ResultsController<StorageOrder> = {
         let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -24,6 +24,10 @@ final class OrdersViewModel {
 
     private let storageManager: StorageManagerType
 
+    /// OrderStatus that must be matched by retrieved orders.
+    ///
+    let statusFilter: OrderStatus?
+
     /// Should be bound to the UITableView to auto-update the list of Orders.
     ///
     private lazy var resultsController: ResultsController<StorageOrder> = {
@@ -60,10 +64,6 @@ final class OrdersViewModel {
     var isFiltered: Bool {
         statusFilter != nil
     }
-
-    /// OrderStatus that must be matched by retrieved orders.
-    ///
-    private let statusFilter: OrderStatus?
 
     init(storageManager: StorageManagerType = ServiceLocator.storageManager, statusFilter: OrderStatus?) {
         self.storageManager = storageManager
@@ -149,11 +149,13 @@ final class OrdersViewModel {
     /// | Load next page   | All Orders  | .          | .                      | y               |
     ///
     func synchronizationAction(siteID: Int64,
-                               statusKey: String?,
                                pageNumber: Int,
                                pageSize: Int,
                                reason: SyncReason?,
                                completionHandler: @escaping (Error?) -> Void) -> OrderAction {
+
+        let statusKey = statusFilter?.slug
+
         if pageNumber == Defaults.pageFirstIndex {
             let deleteAllBeforeSaving = reason == SyncReason.pullToRefresh
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -31,7 +31,6 @@ final class OrdersViewModel {
     /// Should be bound to the UITableView to auto-update the list of Orders.
     ///
     private lazy var resultsController: ResultsController<StorageOrder> = {
-        let storageManager = ServiceLocator.storageManager
         let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
 
         let resultsController = ResultsController<StorageOrder>(storageManager: storageManager,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -33,6 +33,12 @@ final class OrdersViewModel {
         return ResultsController<StorageOrder>(storageManager: storageManager, sectionNameKeyPath: "normalizedAgeAsString", sortedBy: [descriptor])
     }()
 
+    /// Indicates if there are no results.
+    ///
+    var isEmpty: Bool {
+        resultsController.isEmpty
+    }
+
     init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.storageManager = storageManager
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -70,6 +70,22 @@ final class OrdersViewModel {
         self.statusFilter = statusFilter
     }
 
+    /// Start fetching DB results and forward new changes to the given `tableView`.
+    ///
+    /// This is the main activation method for this ViewModel. This should only be called once.
+    /// And only when the corresponding view was loaded.
+    ///
+    func activateAndForwardUpdates(to tableView: UITableView) {
+        resultsController.startForwardingEvents(to: tableView)
+        performFetch()
+    }
+
+    /// Fetch DB results from the database.
+    ///
+    func performFetch() {
+        try? resultsController.performFetch()
+    }
+
     /// Returns what `OrderAction` should be used when synchronizing.
     ///
     /// Pulling to refresh on filtered lists, like the Processing tab, will perform 2 network GET

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -39,8 +39,13 @@ final class OrdersViewModel {
         resultsController.isEmpty
     }
 
-    init(storageManager: StorageManagerType = ServiceLocator.storageManager) {
+    /// OrderStatus that must be matched by retrieved orders.
+    ///
+    private let statusFilter: OrderStatus?
+
+    init(storageManager: StorageManagerType = ServiceLocator.storageManager, statusFilter: OrderStatus?) {
         self.storageManager = storageManager
+        self.statusFilter = statusFilter
     }
 
     /// Returns what `OrderAction` should be used when synchronizing.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -188,7 +188,7 @@ final class OrdersViewModelTests: XCTestCase {
         XCTAssertEqual(pageSize, self.pageSize)
     }
 
-    func testItLoadsTheFilteredOrdersFromTheDatabase() {
+    func testGivenAFilterItLoadsTheOrdersMatchingThatFilterFromTheDB() {
         // Arrange
         let viewModel = OrdersViewModel(storageManager: storageManager,
                                         statusFilter: orderStatus(with: .processing))
@@ -206,9 +206,34 @@ final class OrdersViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isEmpty)
         XCTAssertEqual(viewModel.numberOfObjects, processingOrders.count)
 
-        let fetchedOrderIds = Set(viewModel.orders.map { $0.orderID })
-        let processingOrderIds = Set(processingOrders.map { $0.orderID })
-        XCTAssertEqual(fetchedOrderIds, processingOrderIds)
+        let fetchedOrderIDs = Set(viewModel.orders.map { $0.orderID })
+        let processingOrderIDs = Set(processingOrders.map { $0.orderID })
+        XCTAssertEqual(fetchedOrderIDs, processingOrderIDs)
+    }
+
+    func testGivenNoFilterItLoadsAllTheOrdersFromTheDB() {
+        // Arrange
+        let viewModel = OrdersViewModel(storageManager: storageManager, statusFilter: nil)
+
+        let allInsertedOrders = [
+            (0..<10).map { insertOrder(id: $0, status: .processing) },
+            (100..<105).map { insertOrder(id: $0, status: .completed) },
+            (200..<203).map { insertOrder(id: $0, status: .pending) },
+        ].flatMap { $0 }
+
+        XCTAssertEqual(storage.countObjects(ofType: StorageOrder.self), allInsertedOrders.count)
+
+        // Act
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Assert
+        XCTAssertFalse(viewModel.isFiltered)
+        XCTAssertFalse(viewModel.isEmpty)
+        XCTAssertEqual(viewModel.numberOfObjects, allInsertedOrders.count)
+
+        let fetchedOrderIDs = Set(viewModel.orders.map { $0.orderID })
+        let allInsertedOrderIDs = Set(allInsertedOrders.map { $0.orderID })
+        XCTAssertEqual(fetchedOrderIDs, allInsertedOrderIDs)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -290,4 +290,3 @@ private extension OrdersViewModelTests {
         return readonlyOrder
     }
 }
-

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -26,12 +26,11 @@ final class OrdersViewModelTests: XCTestCase {
     //
     func testPullingToRefreshOnFilteredListItDeletesAndPerformsDualFetch() {
         // Arrange
-        let viewModel = OrdersViewModel()
+        let viewModel = OrdersViewModel(statusFilter: orderStatus(with: .processing))
 
         // Act
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: OrderStatusEnum.processing.rawValue,
             pageNumber: Defaults.pageFirstIndex,
             pageSize: pageSize,
             reason: SyncReason.pullToRefresh,
@@ -53,12 +52,11 @@ final class OrdersViewModelTests: XCTestCase {
     //
     func testFirstPageLoadOnFilteredListWithNonPullToRefreshReasonsWillOnlyPerformDualFetch() {
         // Arrange
-        let viewModel = OrdersViewModel()
+        let viewModel = OrdersViewModel(statusFilter: orderStatus(with: .processing))
 
         // Act
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: OrderStatusEnum.processing.rawValue,
             pageNumber: Defaults.pageFirstIndex,
             pageSize: pageSize,
             reason: nil,
@@ -81,12 +79,11 @@ final class OrdersViewModelTests: XCTestCase {
     //
     func testPullingToRefreshOnAllOrdersListDeletesAndFetchesFirstPageOfAllOrdersOnly() {
         // Arrange
-        let viewModel = OrdersViewModel()
+        let viewModel = OrdersViewModel(statusFilter: nil)
 
         // Act
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: nil,
             pageNumber: Defaults.pageFirstIndex,
             pageSize: pageSize,
             reason: SyncReason.pullToRefresh,
@@ -108,12 +105,11 @@ final class OrdersViewModelTests: XCTestCase {
     //
     func testFirstPageLoadOnAllOrdersListWithNonPullToRefreshReasonsWillOnlyPerformSingleFetch() {
         // Arrange
-        let viewModel = OrdersViewModel()
+        let viewModel = OrdersViewModel(statusFilter: nil)
 
         // Act
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: nil,
             pageNumber: Defaults.pageFirstIndex,
             pageSize: pageSize,
             reason: nil,
@@ -131,12 +127,11 @@ final class OrdersViewModelTests: XCTestCase {
 
     func testSubsequentPageLoadsOnFilteredListWillFetchTheGivenPageOnThatList() {
         // Arrange
-        let viewModel = OrdersViewModel()
+        let viewModel = OrdersViewModel(statusFilter: orderStatus(with: .pending))
 
         // Act
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: OrderStatusEnum.pending.rawValue,
             pageNumber: Defaults.pageFirstIndex + 3,
             pageSize: pageSize,
             reason: nil,
@@ -155,12 +150,11 @@ final class OrdersViewModelTests: XCTestCase {
 
     func testSubsequentPageLoadsOnAllOrdersListWillFetchTheGivenPageOnThatList() {
         // Arrange
-        let viewModel = OrdersViewModel()
+        let viewModel = OrdersViewModel(statusFilter: nil)
 
         // Act
         let action = viewModel.synchronizationAction(
             siteID: siteID,
-            statusKey: nil,
             pageNumber: Defaults.pageFirstIndex + 5,
             pageSize: pageSize,
             reason: nil,
@@ -175,5 +169,13 @@ final class OrdersViewModelTests: XCTestCase {
         XCTAssertNil(statusKey)
         XCTAssertEqual(pageNumber, Defaults.pageFirstIndex + 5)
         XCTAssertEqual(pageSize, self.pageSize)
+    }
+}
+
+// MARK: - Builders
+
+private extension OrdersViewModelTests {
+    func orderStatus(with status: OrderStatusEnum) -> OrderStatus {
+        OrderStatus(name: nil, siteID: siteID, slug: status.rawValue, total: 0)
     }
 }


### PR DESCRIPTION
This is just a step towards implementing Future Orders (#956). 

This continues the migration of the data loading logic from `OrdersViewController` to the `OrdersViewModel`. This mainly moves the `ResultsController<StorageOrder>` to the `ViewModel`. 

There should be no new feature changes in this PR. 

## Changes

### ResultsController Initialization

The previous `ResultsController` initialization was a bit scattered. Mostly because of my recent changes to the Orders list. 😅 They should now be in a single location inside the `ViewModel`:

https://github.com/woocommerce/woocommerce-ios/blob/fbadea3b32c8a709de9167aa358e3643191f9263/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L31-L53

### UITableView Support

Because of the move, I had to add new methods in `OrdersViewModel` to support the `UITableView`:

https://github.com/woocommerce/woocommerce-ios/blob/fbadea3b32c8a709de9167aa358e3643191f9263/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L180-L219

### Clarity in Provisioning

I added a new `activate*` method in the `ViewModel` to better clarify what method should be called to start the data loading. 

https://github.com/woocommerce/woocommerce-ios/blob/19f0be06b706a7e7810c14b993a955ace33260c0/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L72-L80

### Unit Tests

With the move to the `ViewModel` and the changes in https://github.com/woocommerce/woocommerce-ios/pull/2049, I was now able to add [a couple of unit tests](https://github.com/woocommerce/woocommerce-ios/blob/19f0be06b706a7e7810c14b993a955ace33260c0/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift#L191-L237). They don't cover everything but I think this is a good start. 

## Testing

1. Navigate to Orders
2. Confirm that the Processing and All Orders tabs still show the correct filtered list. 
3. Navigate to Search. 
4. Tap on a filter. Confirm that the resulting list is still filtered using the selected filter. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

