### PR TITLE
Strip geolocation data from images for upload by default

### DIFF
--- a/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
+++ b/Yosemite/Yosemite/Tools/Media/MediaExportService.swift
@@ -79,7 +79,7 @@ private extension DefaultMediaExportService {
         ///
         static let imageExportOptions = MediaImageExportOptions(maximumImageSize: 3000,
                                                                 imageCompressionQuality: 0.85,
-                                                                stripsGeoLocationIfNeeded: false)
+                                                                stripsGeoLocationIfNeeded: true)
 
         static let allowableFileExtensions = Set<String>(["jpg", "jpeg", "png", "gif"])
     }


### PR DESCRIPTION
Fixes #1836 

## Changes

- Set `MediaImageExportOptions`'s `stripsGeoLocationIfNeeded` option to be `true` by default, so that the geolocation is stripped from the image

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo that has geolocation data or take one with camera with geolocation enabled (in camera settings)
- After the image is uploaded to wp-admin > Media, check the metadata of the image (I used http://metapicz.com/ with the public image link) and make sure the geolocation isn't available (if you repeat the above on `develop`, you'd see the geolocation like in the screenshots below)


## Example screenshots

before | after
-- | --
<img width="933" alt="Screen Shot 2020-04-15 at 9 13 31 AM" src="https://user-images.githubusercontent.com/1945542/79288878-7fd7e300-7efa-11ea-9d65-97464da08b60.png"> | <img width="957" alt="Screen Shot 2020-04-15 at 9 16 55 AM" src="https://user-images.githubusercontent.com/1945542/79288949-aac23700-7efa-11ea-809d-fb13bd9e71d4.png">


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
