### PR TITLE
Image upload: attach the product ID to an image uploaded from edit product

### DIFF
--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -4,7 +4,13 @@ import Alamofire
 /// Constructs `multipart/form-data` for uploads within an HTTP or HTTPS body.
 ///
 public protocol MultipartFormData {
+    /// Appends a file with file URL for a name to form data.
+    ///
     func append(_ fileURL: URL, withName name: String, fileName: String, mimeType: String)
+
+    /// Appends data for a name to form data.
+    ///
+    func append(_ data: Data, withName name: String)
 }
 
 /// Defines all of the Network Operations we'll be performing. This allows us to swap the actual Wrapper in our

--- a/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/MediaRemoteTests.swift
@@ -10,6 +10,10 @@ final class MediaRemoteTests: XCTestCase {
     ///
     let sampleSiteID: Int64 = 1234
 
+    /// Dummy Product ID
+    ///
+    private let sampleProductID: Int64 = 586
+
     /// Repeat always!
     ///
     override func setUp() {
@@ -64,6 +68,7 @@ final class MediaRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: path, filename: "media-upload")
 
         remote.uploadMedia(for: sampleSiteID,
+                           productID: sampleProductID,
                            mediaItems: []) { mediaItems, error in
             XCTAssertNil(error)
             XCTAssertNotNil(mediaItems)
@@ -81,6 +86,7 @@ final class MediaRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Upload one media item")
 
         remote.uploadMedia(for: sampleSiteID,
+                           productID: sampleProductID,
                            mediaItems: []) { mediaItems, error in
             XCTAssertNil(mediaItems)
             XCTAssertNotNil(error)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -9,6 +9,7 @@ final class ProductImageActionHandler {
     typealias OnAssetUpload = (PHAsset, ProductImage) -> Void
 
     private let siteID: Int64
+    private let productID: Int64
 
     var productImageStatuses: [ProductImageStatus] {
         return allStatuses.productImageStatuses
@@ -29,6 +30,7 @@ final class ProductImageActionHandler {
 
     init(siteID: Int64, product: Product) {
         self.siteID = siteID
+        self.productID = product.productID
         self.allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
     }
 
@@ -98,6 +100,7 @@ final class ProductImageActionHandler {
         allStatuses = (productImageStatuses: imageStatuses, error: nil)
 
         let action = MediaAction.uploadMedia(siteID: siteID,
+                                             productID: productID,
                                              mediaAsset: asset) { [weak self] (media, error) in
                                                 guard let self = self else {
                                                     return

--- a/WooCommerce/WooCommerceTests/Mockups/MockMediaStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockMediaStoresManager.swift
@@ -26,7 +26,7 @@ final class MockMediaStoresManager: DefaultStoresManager {
 
     private func onMediaAction(action: MediaAction) {
         switch action {
-        case .uploadMedia(_, _, let onCompletion):
+        case .uploadMedia(_, _, _, let onCompletion):
             onCompletion(media, nil)
         case .retrieveMediaLibrary(_, _, _, let onCompletion):
             guard let media = media else {

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -18,5 +18,8 @@ public enum MediaAction: Action {
 
     /// Uploads an exportable media asset to the site's WP Media Library.
     ///
-    case uploadMedia(siteID: Int64, mediaAsset: ExportableAsset, onCompletion: (_ uploadedMedia: Media?, _ error: Error?) -> Void)
+    case uploadMedia(siteID: Int64,
+        productID: Int64,
+        mediaAsset: ExportableAsset,
+        onCompletion: (_ uploadedMedia: Media?, _ error: Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -36,8 +36,8 @@ public final class MediaStore: Store {
         switch action {
         case .retrieveMediaLibrary(let siteID, let pageNumber, let pageSize, let onCompletion):
             retrieveMediaLibrary(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .uploadMedia(let siteID, let mediaAsset, let onCompletion):
-            uploadMedia(siteID: siteID, mediaAsset: mediaAsset, onCompletion: onCompletion)
+        case .uploadMedia(let siteID, let productID, let mediaAsset, let onCompletion):
+            uploadMedia(siteID: siteID, productID: productID, mediaAsset: mediaAsset, onCompletion: onCompletion)
         }
     }
 }
@@ -60,6 +60,7 @@ private extension MediaStore {
     /// 2) Uploads the exported media file to the server
     ///
     func uploadMedia(siteID: Int64,
+                     productID: Int64,
                      mediaAsset: ExportableAsset,
                      onCompletion: @escaping (_ uploadedMedia: Media?, _ error: Error?) -> Void) {
         mediaExportService.export(mediaAsset,
@@ -69,16 +70,19 @@ private extension MediaStore {
                                         return
                                     }
                                     self?.uploadMedia(siteID: siteID,
+                                                      productID: productID,
                                                       uploadableMedia: uploadableMedia,
                                                       onCompletion: onCompletion)
         })
     }
 
     func uploadMedia(siteID: Int64,
+                     productID: Int64,
                      uploadableMedia media: UploadableMedia,
                      onCompletion: @escaping (_ uploadedMedia: Media?, _ error: Error?) -> Void) {
         let remote = MediaRemote(network: network)
         remote.uploadMedia(for: siteID,
+                           productID: productID,
                            mediaItems: [media]) { (uploadedMediaItems, error) in
                             // Removes local media after the upload API request.
                             do {

--- a/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/MediaStoreTests.swift
@@ -20,6 +20,10 @@ final class MediaStoreTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 123
 
+    /// Testing Product ID
+    ///
+    private let sampleProductID: Int64 = 586
+
     // MARK: - Overridden Methods
 
     override func setUp() {
@@ -140,7 +144,7 @@ final class MediaStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: path, filename: "media-upload")
 
         let asset = PHAsset()
-        let action = MediaAction.uploadMedia(siteID: sampleSiteID, mediaAsset: asset) { (uploadedMedia, error) in
+        let action = MediaAction.uploadMedia(siteID: sampleSiteID, productID: sampleProductID, mediaAsset: asset) { (uploadedMedia, error) in
             XCTAssertNotNil(uploadedMedia)
             XCTAssertNil(error)
 
@@ -184,7 +188,7 @@ final class MediaStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: path, filename: "generic_error")
 
         let asset = PHAsset()
-        let action = MediaAction.uploadMedia(siteID: sampleSiteID, mediaAsset: asset) { (uploadedMedia, error) in
+        let action = MediaAction.uploadMedia(siteID: sampleSiteID, productID: sampleProductID, mediaAsset: asset) { (uploadedMedia, error) in
             XCTAssertNil(uploadedMedia)
             XCTAssertNotNil(error)
 


### PR DESCRIPTION
Fixes #1988

## Changes

- Added `productID` to `uploadMedia` media action/store/remote
- Added `func append(_ data: Data, withName name: String)` to `MultipartFormData` protocol that `Alamofire.MultipartFormData` implements ([Alamofire reference](https://github.com/Alamofire/Alamofire/blob/master/Documentation/Usage.md#uploading-multipart-form-data))
- In `MediaRemote`, appended the product ID as each media item's parent ID in the multipart form data

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera
- After the photo is uploaded (the spinner disappears), check that the image on `wp-admin > Media` includes the product name and link

## Example screenshots

before | after
-- | --
<img width="1920" alt="Screen Shot 2020-04-15 at 2 29 31 PM" src="https://user-images.githubusercontent.com/1945542/79306529-f5a67380-7f27-11ea-9d4e-5da96a177604.png"> | <img width="1919" alt="Screen Shot 2020-04-15 at 2 29 20 PM" src="https://user-images.githubusercontent.com/1945542/79306507-e9221b00-7f27-11ea-9c95-aa4d35241b4b.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
