### PR TITLE
Product Settings: edit the Purchase Note

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -460,6 +460,7 @@ public struct Product: Codable {
         try container.encode(featured, forKey: .featured)
         try container.encode(catalogVisibilityKey, forKey: .catalogVisibilityKey)
         try container.encode(slug, forKey: .slug)
+        try container.encode(purchaseNote, forKey: .purchaseNote)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -140,7 +140,7 @@ private extension NewNoteViewController {
             NSLocalizedString("Private note",
                               comment: "Spoken accessibility label for an icon image that indicates it's a private note and is not seen by the customer.")
 
-        cell.onTextChange = { [weak self] (text) in
+        cell.noteTextView.onTextChange = { [weak self] (text) in
             self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
             self?.noteText = text
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -124,7 +124,7 @@ enum ProductSettingsRows {
 
         let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
     }
-    
+
     struct PurchaseNote: ProductSettingsRowMediator {
         private let settings: ProductSettings
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -137,14 +137,14 @@ enum ProductSettingsRows {
                 return
             }
 
-            let titleView = NSLocalizedString("Purchase Note", comment: "Slug label in Product Settings")
-            cell.updateUI(title: titleView, value: "purchase note placeholder")
+            let titleView = NSLocalizedString("Purchase Note", comment: "Purchase note label in Product Settings")
+            cell.updateUI(title: titleView, value: settings.purchaseNote)
             cell.accessoryType = .disclosureIndicator
         }
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
             let viewController = ProductSlugViewController(settings: settings) { (productSettings) in
-                //self.settings.slug = productSettings.slug
+                self.settings.purchaseNote = productSettings.purchaseNote
                 onCompletion(self.settings)
             }
             sourceViewController.navigationController?.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -143,7 +143,7 @@ enum ProductSettingsRows {
         }
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
-            let viewController = ProductSlugViewController(settings: settings) { (productSettings) in
+            let viewController = ProductPurchaseNoteViewController(settings: settings) { (productSettings) in
                 self.settings.purchaseNote = productSettings.purchaseNote
                 onCompletion(self.settings)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -138,7 +138,7 @@ enum ProductSettingsRows {
             }
 
             let titleView = NSLocalizedString("Purchase Note", comment: "Purchase note label in Product Settings")
-            cell.updateUI(title: titleView, value: settings.purchaseNote)
+            cell.updateUI(title: titleView, value: settings.purchaseNote?.strippedHTML)
             cell.accessoryType = .disclosureIndicator
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -124,4 +124,34 @@ enum ProductSettingsRows {
 
         let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
     }
+    
+    struct PurchaseNote: ProductSettingsRowMediator {
+        private let settings: ProductSettings
+
+        init(_ settings: ProductSettings) {
+            self.settings = settings
+        }
+
+        func configure(cell: UITableViewCell) {
+            guard let cell = cell as? SettingTitleAndValueTableViewCell else {
+                return
+            }
+
+            let titleView = NSLocalizedString("Purchase Note", comment: "Slug label in Product Settings")
+            cell.updateUI(title: titleView, value: "purchase note placeholder")
+            cell.accessoryType = .disclosureIndicator
+        }
+
+        func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
+            let viewController = ProductSlugViewController(settings: settings) { (productSettings) in
+                //self.settings.slug = productSettings.slug
+                onCompletion(self.settings)
+            }
+            sourceViewController.navigationController?.pushViewController(viewController, animated: true)
+        }
+
+        let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
+
+        let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -32,7 +32,7 @@ enum ProductSettingsSections {
         let rows: [ProductSettingsRowMediator]
 
         init(_ settings: ProductSettings) {
-            rows = [ProductSettingsRows.Slug(settings)]
+            rows = [ProductSettingsRows.Slug(settings), ProductSettingsRows.PurchaseNote(settings)]
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ProductPurchaseNoteViewController.swift
+//  WooCommerce
+//
+//  Created by Paolo Musolino on 13/04/2020.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class ProductPurchaseNoteViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -125,7 +125,8 @@ private extension ProductPurchaseNoteViewController {
     }
 
     func configurePurchaseNote(cell: TextViewTableViewCell) {
-        cell.noteTextView.text = productSettings.purchaseNote
+        cell.iconImage = nil
+        cell.noteTextView.text = productSettings.purchaseNote?.strippedHTML
         cell.onTextChange = { [weak self] (text) in
             self?.productSettings.purchaseNote = text
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Yosemite
 
-class ProductPurchaseNoteViewController: UIViewController {
+final class ProductPurchaseNoteViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
     

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -128,7 +128,7 @@ private extension ProductPurchaseNoteViewController {
         cell.iconImage = nil
         cell.noteTextView.placeholder = NSLocalizedString("Add a purchase note...", comment: "Placeholder text in Product Purchase Note screen")
         cell.noteTextView.text = productSettings.purchaseNote?.strippedHTML
-        cell.onTextChange = { [weak self] (text) in
+        cell.noteTextView.onTextChange = { [weak self] (text) in
             self?.productSettings.purchaseNote = text
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -14,6 +14,13 @@ final class ProductPurchaseNoteViewController: UIViewController {
 
     private let sections: [Section]
 
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
+            self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
+        }
+        return keyboardFrameObserver
+    }()
+
     /// Init
     ///
     init(settings: ProductSettings, completion: @escaping Completion) {
@@ -34,6 +41,7 @@ final class ProductPurchaseNoteViewController: UIViewController {
         configureNavigationBar()
         configureMainView()
         configureTableView()
+        startListeningToNotifications()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -131,6 +139,22 @@ private extension ProductPurchaseNoteViewController {
         cell.noteTextView.onTextChange = { [weak self] (text) in
             self?.productSettings.purchaseNote = text
         }
+    }
+}
+
+// MARK: - Keyboard management
+//
+private extension ProductPurchaseNoteViewController {
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        keyboardFrameObserver.startObservingKeyboardFrame()
+    }
+}
+
+extension ProductPurchaseNoteViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return tableView
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -126,6 +126,7 @@ private extension ProductPurchaseNoteViewController {
 
     func configurePurchaseNote(cell: TextViewTableViewCell) {
         cell.iconImage = nil
+        cell.noteTextView.placeholder = NSLocalizedString("Add a purchase note...", comment: "Placeholder text in Product Purchase Note screen")
         cell.noteTextView.text = productSettings.purchaseNote?.strippedHTML
         cell.onTextChange = { [weak self] (text) in
             self?.productSettings.purchaseNote = text

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class ProductPurchaseNoteViewController: UIViewController {
 
+    @IBOutlet private weak var tableView: UITableView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -4,16 +4,16 @@ import Yosemite
 final class ProductPurchaseNoteViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
-    
+
     // Completion callback
     //
     typealias Completion = (_ productSettings: ProductSettings) -> Void
     private let onCompletion: Completion
 
     private let productSettings: ProductSettings
-    
+
     private let sections: [Section]
-    
+
     /// Init
     ///
     init(settings: ProductSettings, completion: @escaping Completion) {
@@ -28,13 +28,108 @@ final class ProductPurchaseNoteViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        configureNavigationBar()
+        configureMainView()
+        configureTableView()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        onCompletion(productSettings)
+    }
+
+}
+
+// MARK: - View Configuration
+//
+private extension ProductPurchaseNoteViewController {
+
+    func configureNavigationBar() {
+        title = NSLocalizedString("Purchase Note", comment: "Product Note navigation title")
+
+        removeNavigationBackBarButtonText()
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.register(TextViewTableViewCell.loadNib(), forCellReuseIdentifier: TextViewTableViewCell.reuseIdentifier)
+
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        tableView.backgroundColor = .listBackground
+        tableView.removeLastCellSeparator()
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductPurchaseNoteViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductPurchaseNoteViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+}
+
+// MARK: - Support for UITableViewDataSource
+//
+private extension ProductPurchaseNoteViewController {
+    /// Configure cellForRowAtIndexPath:
+    ///
+   func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TextViewTableViewCell:
+            configurePurchaseNote(cell: cell)
+        default:
+            fatalError("Unidentified product catalog visibility row type")
+        }
+    }
+
+    func configurePurchaseNote(cell: TextViewTableViewCell) {
+        cell.noteTextView.text = productSettings.purchaseNote
+        cell.onTextChange = { [weak self] (text) in
+            self?.productSettings.purchaseNote = text
+        }
+    }
 }
 
 // MARK: - Constants

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -128,7 +128,7 @@ private extension ProductPurchaseNoteViewController {
         case let cell as TextViewTableViewCell:
             configurePurchaseNote(cell: cell)
         default:
-            fatalError("Unidentified product catalog visibility row type")
+            fatalError("Unidentified product purchase row type")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -1,16 +1,33 @@
-//
-//  ProductPurchaseNoteViewController.swift
-//  WooCommerce
-//
-//  Created by Paolo Musolino on 13/04/2020.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import UIKit
+import Yosemite
 
 class ProductPurchaseNoteViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
+    
+    // Completion callback
+    //
+    typealias Completion = (_ productSettings: ProductSettings) -> Void
+    private let onCompletion: Completion
+
+    private let productSettings: ProductSettings
+    
+    private let sections: [Section]
+    
+    /// Init
+    ///
+    init(settings: ProductSettings, completion: @escaping Completion) {
+        productSettings = settings
+        let footerText = NSLocalizedString("An optional note to send the customer after purchase",
+                                           comment: "Footer text in Product Purchase Note screen")
+        sections = [Section(footer: footerText, rows: [.purchaseNote])]
+        onCompletion = completion
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -18,15 +35,35 @@ class ProductPurchaseNoteViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
 
+}
 
-    /*
-    // MARK: - Navigation
+// MARK: - Constants
+//
+private extension ProductPurchaseNoteViewController {
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    /// Table Rows
+    ///
+    enum Row {
+        /// Listed in the order they appear on screen
+        case purchaseNote
+
+        var reuseIdentifier: String {
+            switch self {
+            case .purchaseNote:
+                return TextViewTableViewCell.reuseIdentifier
+            }
+        }
     }
-    */
 
+    /// Table Sections
+    ///
+    struct Section {
+        let footer: String?
+        let rows: [Row]
+
+        init(footer: String? = nil, rows: [Row]) {
+            self.footer = footer
+            self.rows = rows
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -128,7 +128,7 @@ private extension ProductPurchaseNoteViewController {
         case let cell as TextViewTableViewCell:
             configurePurchaseNote(cell: cell)
         default:
-            fatalError("Unidentified product purchase row type")
+            fatalError("Unidentified product purchase note row type")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.xib
@@ -1,22 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductPurchaseNoteViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductPurchaseNoteViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="S3x-N3-wbe" id="3rj-CH-DeB"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="S3x-N3-wbe">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="S3x-N3-wbe" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="H1C-V5-w8C"/>
+                <constraint firstItem="S3x-N3-wbe" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="fAu-IQ-sXB"/>
+                <constraint firstItem="S3x-N3-wbe" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="gXQ-hS-6R0"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="S3x-N3-wbe" secondAttribute="bottom" id="kQp-Tx-em8"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="132" y="153"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductPurchaseNoteViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -120,7 +120,7 @@ private extension ProductSlugViewController {
         case let cell as TextFieldTableViewCell:
             configureSlug(cell: cell)
         default:
-            fatalError("Unidentified product catalog visibility row type")
+            fatalError("Unidentified product slug row type")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -4,6 +4,8 @@ import UIKit
 ///
 final class EnhancedTextView: UITextView {
 
+    var onTextChange: ((String) -> Void)?
+
     var placeholder: String? {
         didSet {
             placeholderLabel?.text = placeholder
@@ -78,6 +80,6 @@ extension EnhancedTextView: UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
         self.animatePlaceholder()
+        onTextChange?(textView.text)
     }
-
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -92,4 +92,3 @@ private extension EnhancedTextView {
         static let animationDuration    = 0.2
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+/// A text view which support the placeholder label.
+///
 final class EnhancedTextView: UITextView {
 
     var placeholder: String? {
@@ -10,13 +12,22 @@ final class EnhancedTextView: UITextView {
     }
     private var placeholderLabel: UILabel?
     
+    override var text: String! {
+        didSet {
+            if text.isEmpty {
+                animatePlaceholder()
+            }
+            else {
+                hidePlaceholder()
+            }
+        }
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         delegate = self
         placeholderLabel = UILabel(frame: self.bounds)
-        //placeholderLabel?.font = UIFont(name: "HelveticaNeue", size: 15.0)
-        placeholderLabel?.numberOfLines = 0
-        placeholderLabel?.textColor = .gray
+        configureLabels()
         if let unwrappedLabel = placeholderLabel {
             addSubview(unwrappedLabel)
         }
@@ -42,6 +53,19 @@ final class EnhancedTextView: UITextView {
 
 }
 
+
+// MARK: Configurations
+//
+private extension EnhancedTextView {
+    func configureLabels() {
+        placeholderLabel?.numberOfLines = 0
+        placeholderLabel?.applyBodyStyle()
+        placeholderLabel?.textColor = .textSubtle
+    }
+}
+
+// MARK: UITextViewDelegate conformance
+//
 extension EnhancedTextView: UITextViewDelegate{
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -28,7 +28,7 @@ final class EnhancedTextView: UITextView {
     override func awakeFromNib() {
         super.awakeFromNib()
         delegate = self
-        placeholderLabel = UILabel(frame: self.bounds)
+        placeholderLabel = UILabel(frame: bounds)
         configureLabels()
         if let unwrappedLabel = placeholderLabel {
             addSubview(unwrappedLabel)
@@ -71,15 +71,15 @@ private extension EnhancedTextView {
 extension EnhancedTextView: UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
-        self.hidePlaceholder()
+        hidePlaceholder()
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        self.animatePlaceholder()
+        animatePlaceholder()
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        self.animatePlaceholder()
+        animatePlaceholder()
         onTextChange?(textView.text)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -28,15 +28,11 @@ final class EnhancedTextView: UITextView {
     override func awakeFromNib() {
         super.awakeFromNib()
         delegate = self
-        placeholderLabel = UILabel(frame: bounds)
-        configureLabels()
-        if let unwrappedLabel = placeholderLabel {
-            addSubview(unwrappedLabel)
-        }
+        configurePlaceholderLabel()
     }
 
     private func animatePlaceholder() {
-        UIView.animate(withDuration: 0.2) { [weak self] in
+        UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
             guard let self = self else {
                 return
             }
@@ -45,7 +41,7 @@ final class EnhancedTextView: UITextView {
     }
 
     private func hidePlaceholder() {
-        UIView.animate(withDuration: 0.2) { [weak self] in
+        UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
             guard let self = self else {
                 return
             }
@@ -59,7 +55,11 @@ final class EnhancedTextView: UITextView {
 // MARK: Configurations
 //
 private extension EnhancedTextView {
-    func configureLabels() {
+    func configurePlaceholderLabel() {
+        placeholderLabel = UILabel(frame: bounds)
+        if let unwrappedLabel = placeholderLabel {
+            addSubview(unwrappedLabel)
+        }
         placeholderLabel?.numberOfLines = 0
         placeholderLabel?.applyBodyStyle()
         placeholderLabel?.textColor = .textSubtle
@@ -83,3 +83,13 @@ extension EnhancedTextView: UITextViewDelegate {
         onTextChange?(textView.text)
     }
 }
+
+// MARK: - Constants!
+//
+private extension EnhancedTextView {
+
+    enum Constants {
+        static let animationDuration    = 0.2
+    }
+}
+

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -11,7 +11,7 @@ final class EnhancedTextView: UITextView {
         }
     }
     private var placeholderLabel: UILabel?
-    
+
     override var text: String! {
         didSet {
             if text.isEmpty {
@@ -22,7 +22,7 @@ final class EnhancedTextView: UITextView {
             }
         }
     }
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
         delegate = self
@@ -33,7 +33,7 @@ final class EnhancedTextView: UITextView {
         }
     }
 
-    private func animatePlaceholder(){
+    private func animatePlaceholder() {
         UIView.animate(withDuration: 0.2) { [weak self] in
             guard let self = self else {
                 return
@@ -41,8 +41,8 @@ final class EnhancedTextView: UITextView {
             self.placeholderLabel?.alpha = self.text.isEmpty && !self.isFirstResponder ? 1 : 0
         }
     }
-    
-    private func hidePlaceholder(){
+
+    private func hidePlaceholder() {
         UIView.animate(withDuration: 0.2) { [weak self] in
             guard let self = self else {
                 return
@@ -66,18 +66,18 @@ private extension EnhancedTextView {
 
 // MARK: UITextViewDelegate conformance
 //
-extension EnhancedTextView: UITextViewDelegate{
-    
+extension EnhancedTextView: UITextViewDelegate {
+
     func textViewDidBeginEditing(_ textView: UITextView) {
         self.hidePlaceholder()
     }
-    
+
     func textViewDidEndEditing(_ textView: UITextView) {
         self.animatePlaceholder()
     }
-    
+
     func textViewDidChange(_ textView: UITextView) {
         self.animatePlaceholder()
     }
-    
+
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -1,0 +1,59 @@
+import UIKit
+
+final class EnhancedTextView: UITextView {
+
+    var placeholder: String? {
+        didSet {
+            placeholderLabel?.text = placeholder
+            placeholderLabel?.sizeToFit()
+        }
+    }
+    private var placeholderLabel: UILabel?
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        delegate = self
+        placeholderLabel = UILabel(frame: self.bounds)
+        //placeholderLabel?.font = UIFont(name: "HelveticaNeue", size: 15.0)
+        placeholderLabel?.numberOfLines = 0
+        placeholderLabel?.textColor = .gray
+        if let unwrappedLabel = placeholderLabel {
+            addSubview(unwrappedLabel)
+        }
+    }
+
+    private func animatePlaceholder(){
+        UIView.animate(withDuration: 0.2) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.placeholderLabel?.alpha = self.text.isEmpty && !self.isFirstResponder ? 1 : 0
+        }
+    }
+    
+    private func hidePlaceholder(){
+        UIView.animate(withDuration: 0.2) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.placeholderLabel?.alpha = 0
+        }
+    }
+
+}
+
+extension EnhancedTextView: UITextViewDelegate{
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        self.hidePlaceholder()
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        self.animatePlaceholder()
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        self.animatePlaceholder()
+    }
+    
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -3,6 +3,9 @@ import Gridicons
 
 class TextViewTableViewCell: UITableViewCell {
 
+    @IBOutlet private weak var stackView: UIStackView!
+    
+    @IBOutlet weak var noteIconView: UIView!
     @IBOutlet var noteIconButton: UIButton!
 
     @IBOutlet var noteTextView: UITextView!
@@ -15,6 +18,7 @@ class TextViewTableViewCell: UITableViewCell {
             noteIconButton.setImage(newValue, for: .normal)
             noteIconButton.tintColor = .listForeground
             noteIconButton.layer.cornerRadius = noteIconButton.frame.width / 2
+            noteIconView.isHidden = newValue == nil
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -31,8 +31,6 @@ class TextViewTableViewCell: UITableViewCell {
         }
     }
 
-    var onTextChange: ((String) -> Void)?
-
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -43,20 +41,12 @@ class TextViewTableViewCell: UITableViewCell {
     }
 }
 
-
-extension TextViewTableViewCell: UITextViewDelegate {
-    func textViewDidChange(_ textView: UITextView) {
-        onTextChange?(noteTextView.text)
-    }
-}
-
 private extension TextViewTableViewCell {
     func configureBackground() {
         applyDefaultBackgroundStyle()
     }
 
     func configureTextView() {
-        noteTextView.delegate = self
         noteTextView.backgroundColor = .listForeground
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -3,7 +3,7 @@ import Gridicons
 
 class TextViewTableViewCell: UITableViewCell {
 
-    @IBOutlet weak var noteIconView: UIView!
+    @IBOutlet private weak var noteIconView: UIView!
     @IBOutlet var noteIconButton: UIButton!
 
     @IBOutlet var noteTextView: EnhancedTextView!

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -3,8 +3,6 @@ import Gridicons
 
 class TextViewTableViewCell: UITableViewCell {
 
-    @IBOutlet private weak var stackView: UIStackView!
-
     @IBOutlet weak var noteIconView: UIView!
     @IBOutlet var noteIconButton: UIButton!
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -8,7 +8,7 @@ class TextViewTableViewCell: UITableViewCell {
     @IBOutlet weak var noteIconView: UIView!
     @IBOutlet var noteIconButton: UIButton!
 
-    @IBOutlet var noteTextView: UITextView!
+    @IBOutlet var noteTextView: EnhancedTextView!
 
     var iconImage: UIImage? {
         get {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -4,7 +4,7 @@ import Gridicons
 class TextViewTableViewCell: UITableViewCell {
 
     @IBOutlet private weak var stackView: UIStackView!
-    
+
     @IBOutlet weak var noteIconView: UIView!
     @IBOutlet var noteIconButton: UIButton!
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
@@ -38,7 +38,7 @@
                                     <constraint firstAttribute="trailing" secondItem="WYv-eb-Aor" secondAttribute="trailing" id="zzY-V2-A9p"/>
                                 </constraints>
                             </view>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ath-1M-eR6">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ath-1M-eR6" customClass="EnhancedTextView" customModule="WooCommerce" customModuleProvider="target">
                                 <rect key="frame" x="40" y="0.0" width="250" height="146"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
@@ -1,55 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="182" id="KGk-i7-Jjw" customClass="TextViewTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="174" id="KGk-i7-Jjw" customClass="TextViewTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="174"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="173.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="174"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ath-1M-eR6">
-                        <rect key="frame" x="56" y="13.5" width="248" height="145"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="8gO-gt-5sc">
+                        <rect key="frame" x="15" y="13" width="290" height="146"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pmR-Dp-2I7">
+                                <rect key="frame" x="0.0" y="0.0" width="24" height="146"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WYv-eb-Aor">
+                                        <rect key="frame" x="0.0" y="7" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="Cf8-HO-VjA"/>
+                                            <constraint firstAttribute="width" constant="24" id="jl5-OT-sho"/>
+                                        </constraints>
+                                        <inset key="imageEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="WYv-eb-Aor" firstAttribute="top" secondItem="pmR-Dp-2I7" secondAttribute="top" constant="7" id="JR0-oy-tCj"/>
+                                    <constraint firstItem="WYv-eb-Aor" firstAttribute="leading" secondItem="pmR-Dp-2I7" secondAttribute="leading" id="QmP-h5-VQV"/>
+                                    <constraint firstAttribute="trailing" secondItem="WYv-eb-Aor" secondAttribute="trailing" id="zzY-V2-A9p"/>
+                                </constraints>
+                            </view>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ath-1M-eR6">
+                                <rect key="frame" x="40" y="0.0" width="250" height="146"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="145" id="0oa-fJ-Z0a"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="146" id="eNh-b6-Kat"/>
                         </constraints>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                    </textView>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WYv-eb-Aor">
-                        <rect key="frame" x="16" y="16.5" width="24" height="24"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="24" id="Cf8-HO-VjA"/>
-                            <constraint firstAttribute="width" constant="24" id="jl5-OT-sho"/>
-                        </constraints>
-                        <inset key="imageEdgeInsets" minX="4" minY="4" maxX="4" maxY="4"/>
-                    </button>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Ath-1M-eR6" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="2.5" id="4vV-bo-cyA"/>
-                    <constraint firstItem="WYv-eb-Aor" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="7wf-vV-EAH"/>
-                    <constraint firstItem="Ath-1M-eR6" firstAttribute="leading" secondItem="WYv-eb-Aor" secondAttribute="trailing" constant="16" id="B4Q-vS-iOG"/>
-                    <constraint firstItem="WYv-eb-Aor" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="5.5" id="eNQ-BL-NSi"/>
-                    <constraint firstItem="Ath-1M-eR6" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="uAF-E1-L8T"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="Ath-1M-eR6" secondAttribute="bottom" constant="4.5" id="yYC-k4-ejo"/>
+                    <constraint firstAttribute="bottom" secondItem="8gO-gt-5sc" secondAttribute="bottom" constant="15" id="1ga-S8-Ec3"/>
+                    <constraint firstAttribute="trailing" secondItem="8gO-gt-5sc" secondAttribute="trailing" constant="15" id="Gwo-v6-d3E"/>
+                    <constraint firstItem="8gO-gt-5sc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="Vx3-3a-3Fo"/>
+                    <constraint firstItem="8gO-gt-5sc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="13" id="yDM-uQ-kCz"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="noteIconButton" destination="WYv-eb-Aor" id="xbs-pE-r7t"/>
+                <outlet property="noteIconView" destination="pmR-Dp-2I7" id="U2C-nH-hCb"/>
                 <outlet property="noteTextView" destination="Ath-1M-eR6" id="P9H-JP-Ibj"/>
+                <outlet property="stackView" destination="8gO-gt-5sc" id="0dE-nW-mh3"/>
             </connections>
             <point key="canvasLocation" x="34" y="141"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
@@ -62,7 +62,6 @@
                 <outlet property="noteIconButton" destination="WYv-eb-Aor" id="xbs-pE-r7t"/>
                 <outlet property="noteIconView" destination="pmR-Dp-2I7" id="U2C-nH-hCb"/>
                 <outlet property="noteTextView" destination="Ath-1M-eR6" id="P9H-JP-Ibj"/>
-                <outlet property="stackView" destination="8gO-gt-5sc" id="0dE-nW-mh3"/>
             </connections>
             <point key="canvasLocation" x="34" y="141"/>
         </tableViewCell>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -245,6 +245,8 @@
 		453DBF8E2387F34A006762A5 /* UICollectionViewCell+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */; };
 		453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
+		456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */; };
+		456CB50E2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */; };
 		457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */; };
 		457151AC243B6E8000EB2DFA /* ProductSlugViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */; };
 		4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7223F192D400B5F764 /* ProductSettingsViewController.swift */; };
@@ -1034,6 +1036,8 @@
 		453DBF8D2387F34A006762A5 /* UICollectionViewCell+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Helpers.swift"; sourceTree = "<group>"; };
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
+		456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaseNoteViewController.swift; sourceTree = "<group>"; };
+		456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductPurchaseNoteViewController.xib; sourceTree = "<group>"; };
 		457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSlugViewController.swift; sourceTree = "<group>"; };
 		457151AA243B6E8000EB2DFA /* ProductSlugViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSlugViewController.xib; sourceTree = "<group>"; };
 		4580BA7223F192D400B5F764 /* ProductSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewController.swift; sourceTree = "<group>"; };
@@ -2127,6 +2131,15 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		456CB50A2444BF8400992A05 /* Purchase Note */ = {
+			isa = PBXGroup;
+			children = (
+				456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */,
+				456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */,
+			);
+			path = "Purchase Note";
+			sourceTree = "<group>";
+		};
 		457151A8243B6E6200EB2DFA /* Slug */ = {
 			isa = PBXGroup;
 			children = (
@@ -2155,6 +2168,7 @@
 				451C77702404518600413F73 /* ProductSettingsRows.swift */,
 				45739F2E2436302600480C95 /* Catalog Visibility */,
 				457151A8243B6E6200EB2DFA /* Slug */,
+				456CB50A2444BF8400992A05 /* Purchase Note */,
 				4524CD9F242D023300B2F20A /* List Selector Data Source */,
 			);
 			path = "Product Settings";
@@ -3858,6 +3872,7 @@
 				B59D1EE821908A08009D1978 /* Noticons.ttf in Resources */,
 				D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */,
 				0290E276238E4F8100B5C466 /* PaginatedListSelectorViewController.xib in Resources */,
+				456CB50E2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib in Resources */,
 				023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */,
 				026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */,
 				CE27258021925AE8002B22EB /* ValueOneTableViewCell.xib in Resources */,
@@ -4156,6 +4171,7 @@
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */,
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
+				456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */,
 				0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		265BCA092430E6E0004E53EE /* ProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */; };
 		265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA0B2430E741004E53EE /* ProductCategoryTableViewCell.swift */; };
 		265BCA0E2430E771004E53EE /* ProductCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */; };
+		451750B224470CD5004FDA65 /* EnhancedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451750B124470CD5004FDA65 /* EnhancedTextView.swift */; };
 		451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */; };
 		451A04E72386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */; };
 		451A04EA2386D28300E368C9 /* ProductImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */; };
@@ -1017,6 +1018,7 @@
 		265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
+		451750B124470CD5004FDA65 /* EnhancedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedTextView.swift; sourceTree = "<group>"; };
 		451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImagesHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesViewModel.swift; sourceTree = "<group>"; };
@@ -3433,6 +3435,7 @@
 				02E8B17923E2C4BD00A43403 /* CircleSpinnerView.swift */,
 				02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */,
 				02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */,
+				451750B124470CD5004FDA65 /* EnhancedTextView.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -4347,6 +4350,7 @@
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				B56DB3CA2049BFAA00D4AA8E /* AppDelegate.swift in Sources */,
+				451750B224470CD5004FDA65 /* EnhancedTextView.swift in Sources */,
 				02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */,
 				B5A82EE7210263460053ADC8 /* UIViewController+Helpers.swift in Sources */,
 				CE1F512B206985DF00C6C810 /* PaddedLabel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -17,7 +17,7 @@ final class ProductSettingsViewModelTests: XCTestCase {
         }
 
         // Update settings. Section data changed. This will update the view model, and will fire the `onReload` closure.
-        viewModel.productSettings = ProductSettings(status: product.productStatus, featured: true, catalogVisibility: .search, slug: "this-is-a-slug")
+        viewModel.productSettings = ProductSettings(status: product.productStatus, featured: true, catalogVisibility: .search, slug: "this-is-a-slug", purchaseNote: "This is a purchase note")
 
         waitForExpectations(timeout: 1.5, handler: nil)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -17,7 +17,11 @@ final class ProductSettingsViewModelTests: XCTestCase {
         }
 
         // Update settings. Section data changed. This will update the view model, and will fire the `onReload` closure.
-        viewModel.productSettings = ProductSettings(status: product.productStatus, featured: true, catalogVisibility: .search, slug: "this-is-a-slug", purchaseNote: "This is a purchase note")
+        viewModel.productSettings = ProductSettings(status: product.productStatus,
+                                                    featured: true,
+                                                    catalogVisibility: .search,
+                                                    slug: "this-is-a-slug",
+                                                    purchaseNote: "This is a purchase note")
 
         waitForExpectations(timeout: 1.5, handler: nil)
     }

--- a/Yosemite/Yosemite/Model/Products/ProductSettings.swift
+++ b/Yosemite/Yosemite/Model/Products/ProductSettings.swift
@@ -19,7 +19,11 @@ public final class ProductSettings {
     }
 
     public convenience init(from product: Product) {
-        self.init(status: product.productStatus, featured: product.featured, catalogVisibility: product.productCatalogVisibility, slug: product.slug, purchaseNote: product.purchaseNote)
+        self.init(status: product.productStatus,
+                  featured: product.featured,
+                  catalogVisibility: product.productCatalogVisibility,
+                  slug: product.slug,
+                  purchaseNote: product.purchaseNote)
     }
 }
 

--- a/Yosemite/Yosemite/Model/Products/ProductSettings.swift
+++ b/Yosemite/Yosemite/Model/Products/ProductSettings.swift
@@ -8,16 +8,18 @@ public final class ProductSettings {
     public var featured: Bool
     public var catalogVisibility: ProductCatalogVisibility
     public var slug: String
+    public var purchaseNote: String?
 
-    public init(status: ProductStatus, featured: Bool, catalogVisibility: ProductCatalogVisibility, slug: String) {
+    public init(status: ProductStatus, featured: Bool, catalogVisibility: ProductCatalogVisibility, slug: String, purchaseNote: String?) {
         self.status = status
         self.featured = featured
         self.catalogVisibility = catalogVisibility
         self.slug = slug
+        self.purchaseNote = purchaseNote
     }
 
     public convenience init(from product: Product) {
-        self.init(status: product.productStatus, featured: product.featured, catalogVisibility: product.productCatalogVisibility, slug: product.slug)
+        self.init(status: product.productStatus, featured: product.featured, catalogVisibility: product.productCatalogVisibility, slug: product.slug, purchaseNote: product.purchaseNote)
     }
 }
 
@@ -28,6 +30,7 @@ extension ProductSettings: Equatable {
         return lhs.status.rawValue == rhs.status.rawValue &&
             lhs.featured == rhs.featured &&
             lhs.catalogVisibility.rawValue == rhs.catalogVisibility.rawValue &&
-            lhs.slug == rhs.slug
+            lhs.slug == rhs.slug &&
+            lhs.purchaseNote == rhs.purchaseNote
     }
 }

--- a/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
+++ b/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
@@ -524,7 +524,7 @@ extension Product: ProductUpdater {
                        upsellIDs: upsellIDs,
                        crossSellIDs: crossSellIDs,
                        parentID: parentID,
-                       purchaseNote: purchaseNote,
+                       purchaseNote: settings.purchaseNote,
                        categories: categories,
                        tags: tags,
                        images: images,

--- a/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
+++ b/Yosemite/YosemiteTests/Model/Updaters/Product+UpdaterTestCases.swift
@@ -121,15 +121,18 @@ final class Product_UpdaterTestCases: XCTestCase {
         let featured = true
         let catalogVisibility = "search"
         let slug = "this-is-a-test"
+        let purchaseNote = "This is a purchase note"
         let productSettings = ProductSettings(status: .pending,
                                                                 featured: featured,
                                                                 catalogVisibility: .search,
-                                                                slug: slug)
+                                                                slug: slug,
+                                                                purchaseNote: purchaseNote)
         let updatedProduct = product.productSettingsUpdated(settings: productSettings)
         XCTAssertEqual(updatedProduct.statusKey, newStatus)
         XCTAssertEqual(updatedProduct.featured, featured)
         XCTAssertEqual(updatedProduct.catalogVisibilityKey, catalogVisibility)
         XCTAssertEqual(updatedProduct.slug, slug)
+        XCTAssertEqual(updatedProduct.purchaseNote, purchaseNote)
     }
 }
 


### PR DESCRIPTION
Resolve #2121 

This PR implement the edit product purchase note under Product Settings, part of milestone 2.

## Changes
- Encoded the `purchaseNote` field in Product model
- New Product Setting row `PurchaseNote`
- Implemented the new `ProductPurchaseNoteViewController`
- Implemented the new `EnhancedTextView` that support the placeholder label inside the text view, and implement the new `onTextChange:` closure.
- Refactored `TextViewTableViewCell` that now uses the `EnhancedTextView` and that allows us to hide the note icon.
- Updated tests to support the new `purchaseNote` field
- Updated the `ProductUpdated`

## Testing
1. Navigate to a product detail
2. Press the "more" button in the navigation bar
3. Tap "Product Settings" -> You are able to see the cell "Purchase Note" with the current purchase note.
4. Tap the "Purchase Note" cell, you will be able to see the current purchase note. A placeholder in case there is no content.
5. Try to change the purchase note. Press back.
6. Press "done", and update the product. -> Reopening the Purchase Note view, you will be able to see the new purchase note updated.

## Screenshots
| Product Settings             |  Empty Purchase Note |  populated Purchase Note  |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone Xs - 2020-04-15 at 13 16 50](https://user-images.githubusercontent.com/495617/79332321-ed950680-7f1c-11ea-92dc-64c06d734122.png) | ![Simulator Screen Shot - iPhone Xs - 2020-04-15 at 13 16 28](https://user-images.githubusercontent.com/495617/79332381-07364e00-7f1d-11ea-850b-cadbe89d57cc.png) | ![Simulator Screen Shot - iPhone Xs - 2020-04-15 at 13 16 44](https://user-images.githubusercontent.com/495617/79332384-09001180-7f1d-11ea-97a4-ac5baa562316.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
