### PR TITLE
Product images header shouldn't scroll back on image status updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -21,6 +21,10 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
     ///
     var onAddImage: (() -> Void)?
 
+    /// Keeps track of the cell config to update collection view layout on change.
+    ///
+    private var config: ProductImagesCellConfig?
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -120,6 +124,13 @@ private extension ProductImagesHeaderTableViewCell {
         collectionView.dataSource = dataSource
         collectionView.backgroundColor = .systemColor(.secondarySystemGroupedBackground)
         collectionView.showsHorizontalScrollIndicator = false
+
+        guard config != self.config else {
+            return
+        }
+
+        self.config = config
+
         switch config {
         case .extendedAddImages:
             collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: frame.size, config: config)


### PR DESCRIPTION
Fix images header scrolling back on image status changes: https://github.com/woocommerce/woocommerce-ios/pull/1878#discussion_r384669536 for #1713 

## Changes

After looking into what triggers the images header to scroll back to the beginning, I noticed it's when we reset `collectionView.collectionViewLayout` on every table view reload. This PR added a `config` internal property so that we only reset `collectionView.collectionViewLayout` on `config` change

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a few photos or take one with camera --> there should be a spinner cell after picking a photo
- Quickly tap "Done" on the edit product images screen --> the product images header view should stay at the previous scroll position with the "+" cell
- Wait for the image(s) to be uploaded --> the product images header view should stay at the current scroll position (on `develop`, it always scrolls back to the beginning on any image status changes)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
