### PR TITLE
[WIP] Bottom sheet for Products tab sort options

### DIFF
--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetAnimationController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetAnimationController.swift
@@ -1,0 +1,46 @@
+class BottomSheetAnimationController: NSObject, UIViewControllerAnimatedTransitioning {
+    enum TransitionType {
+        case presenting
+        case dismissing
+    }
+
+    private let transitionType: TransitionType
+
+    init(transitionType: TransitionType) {
+        self.transitionType = transitionType
+        super.init()
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard let toView: UIView = transitionContext.view(forKey: .to) ?? transitionContext.viewController(forKey: .to)?.view,
+              let fromView: UIView = transitionContext.view(forKey: .from) ?? transitionContext.viewController(forKey: .from)?.view else {
+            return
+        }
+        let inView = transitionContext.containerView
+        let presentedViewController = transitionContext.viewController(forKey: .to)
+
+        let animationBlock: () -> Void
+        switch transitionType {
+        case .presenting:
+            let presentedFrame = presentedViewController?.presentationController?.frameOfPresentedViewInContainerView ?? .zero
+            toView.frame = presentedFrame.offsetBy(dx: 0, dy: inView.frame.maxY)
+            inView.addSubview(toView)
+            animationBlock = {
+                toView.frame = presentedFrame
+            }
+        case .dismissing:
+            let dismissingFrame = fromView.frame.offsetBy(dx: 0, dy: fromView.bounds.height)
+            animationBlock = {
+                fromView.frame = dismissingFrame
+            }
+        }
+
+        UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: animationBlock, completion: { finished in
+            transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+        })
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.25
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetAnimationController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetAnimationController.swift
@@ -1,4 +1,6 @@
-class BottomSheetAnimationController: NSObject, UIViewControllerAnimatedTransitioning {
+import UIKit
+
+final class BottomSheetAnimationController: NSObject, UIViewControllerAnimatedTransitioning {
     enum TransitionType {
         case presenting
         case dismissing

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresentationController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresentationController.swift
@@ -1,0 +1,120 @@
+/// A Presentation Controller which dims the background, allows the user to dismiss by tapping outside, and allows the user to swipit down
+class BottomSheetPresentationController: FancyAlertPresentationController {
+
+    private enum Constants {
+        static let maxWidthPercentage: CGFloat = 0.66 /// Used to constrain the width to a smaller size (instead of full width) when sheet is too wide
+    }
+
+    private weak var tapGestureRecognizer: UITapGestureRecognizer?
+    private weak var panGestureRecognizer: UIPanGestureRecognizer?
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+    }
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView = containerView else { /// If we don't have a container view we're out of luck
+            return .zero
+        }
+
+        /// Height calculated by autolayout, Width equal to the container view minus insets
+        let height: CGFloat = presentedViewController.view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        var width: CGFloat = containerView.bounds.width - (containerView.safeAreaInsets.left + containerView.safeAreaInsets.right)
+
+        /// If we're in a compact vertical size class, constrain the width a bit more so it doesn't get overly wide.
+        if traitCollection.verticalSizeClass == .compact {
+            width = width * Constants.maxWidthPercentage
+        }
+
+        /// If we constrain the width, this centers the view by applying the appropriate insets based on width
+        let leftInset: CGFloat = ((containerView.bounds.width - width) / 2)
+
+        return CGRect(x: leftInset, y: containerView.bounds.height - height, width: width, height: height)
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { _ in
+            self.presentedView?.frame = self.frameOfPresentedViewInContainerView
+        }, completion: nil)
+        super.viewWillTransition(to: size, with: coordinator)
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        presentedView?.frame = frameOfPresentedViewInContainerView
+    }
+
+    override func containerViewDidLayoutSubviews() {
+        super.containerViewDidLayoutSubviews()
+
+        if tapGestureRecognizer == nil {
+            addTapGestureRecognizer()
+        }
+
+        if panGestureRecognizer == nil {
+            addPanGestureRecognizer()
+        }
+    }
+
+    private func addTapGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismiss))
+        gestureRecognizer.cancelsTouchesInView = false
+        gestureRecognizer.delegate = self
+        containerView?.addGestureRecognizer(gestureRecognizer)
+        tapGestureRecognizer = gestureRecognizer
+    }
+
+    private func addPanGestureRecognizer() {
+        let gestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(hide(_:)))
+        presentedViewController.view.addGestureRecognizer(gestureRecognizer)
+        panGestureRecognizer = gestureRecognizer
+    }
+
+    var interactionController: UIPercentDrivenInteractiveTransition?
+
+    @objc func hide(_ gesture: UIPanGestureRecognizer) {
+        guard let gestureView = gesture.view else { return }
+
+        let translate = gesture.translation(in: gestureView)
+        let percent   = translate.y / gestureView.bounds.size.height
+
+        if gesture.state == .began {
+            /// Begin the dismissal transition
+            interactionController = UIPercentDrivenInteractiveTransition()
+            dismiss()
+        } else if gesture.state == .changed {
+            /// Update the transition based on our calculated percent of completion
+            interactionController?.update(percent)
+        } else if gesture.state == .ended {
+            /// Calculate the velocity of the ended gesture.
+            /// - If the gesture has no downward velocity but is greater than half way down, complete the dismissal
+            /// - If there is downward velocity, dismiss
+            /// - If the gesture has no downward velocity and is less than half way down, cancel the dismissal
+            let velocity = gesture.velocity(in: gesture.view)
+            if (percent > 0.5 && velocity.y == 0) || velocity.y > 0 {
+                interactionController?.finish()
+            } else {
+                interactionController?.cancel()
+            }
+            interactionController = nil
+        }
+    }
+
+    @objc func dismiss() {
+        presentedViewController.dismiss(animated: true, completion: nil)
+    }
+}
+
+extension BottomSheetPresentationController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        /// Shouldn't happen; should always have container & presented view when tapped
+        guard let containerView = containerView, let presentedView = presentedView else {
+            return false
+        }
+
+        let touchPoint = touch.location(in: containerView)
+        let isInPresentedView = presentedView.frame.contains(touchPoint)
+
+        /// Do not accept the touch if inside of the presented view
+        return (gestureRecognizer == tapGestureRecognizer) && isInPresentedView == false
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresentationController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetPresentationController.swift
@@ -1,3 +1,6 @@
+import WordPressUI
+import UIKit
+
 /// A Presentation Controller which dims the background, allows the user to dismiss by tapping outside, and allows the user to swipit down
 class BottomSheetPresentationController: FancyAlertPresentationController {
 

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetViewController.swift
@@ -1,0 +1,165 @@
+import UIKit
+
+class BottomSheetViewController: UIViewController {
+    enum Constants {
+        static let gripHeight: CGFloat = 5
+        static let cornerRadius: CGFloat = 8
+        static let buttonSpacing: CGFloat = 8
+        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        static let minimumWidth: CGFloat = 300
+
+        enum Header {
+            static let spacing: CGFloat = 16
+            static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
+        }
+
+        enum Button {
+            static let height: CGFloat = 54
+            static let contentInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 35)
+            static let titleInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+            static let imageTintColor: UIColor = .neutral(.shade30)
+            static let font: UIFont = .preferredFont(forTextStyle: .callout)
+            static let textColor: UIColor = .text
+        }
+
+        enum Stack {
+            static let insets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
+        }
+    }
+
+    private weak var childViewController: DrawerPresentableViewController?
+
+    init(childViewController: DrawerPresentableViewController) {
+        self.childViewController = childViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    func show(from presenting: UIViewController, sourceView: UIView? = nil) {
+        if UIDevice.isPad() {
+            modalPresentationStyle = .popover
+            popoverPresentationController?.sourceView = sourceView ?? UIView()
+            popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
+        } else {
+            transitioningDelegate = self
+            modalPresentationStyle = .custom
+        }
+
+        presenting.present(self, animated: true)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var gripButton: UIButton = {
+        let button = GripButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
+        return button
+    }()
+
+    @objc func buttonPressed() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+
+        view.clipsToBounds = true
+        view.layer.cornerRadius = Constants.cornerRadius
+        view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+        view.backgroundColor = .basicBackground
+
+        NSLayoutConstraint.activate([
+            gripButton.heightAnchor.constraint(equalToConstant: Constants.gripHeight)
+        ])
+
+        guard let childViewController = childViewController else {
+            return
+        }
+
+        addChild(childViewController)
+
+        let stackView = UIStackView(arrangedSubviews: [
+            gripButton,
+            childViewController.view
+        ])
+
+        stackView.setCustomSpacing(Constants.Header.spacing, after: gripButton)
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+
+        refreshForTraits()
+
+        view.addSubview(stackView)
+        view.pinSubviewToSafeArea(stackView, insets: Constants.Stack.insets)
+
+        childViewController.didMove(toParent: self)
+    }
+
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        refreshForTraits()
+    }
+
+    private func refreshForTraits() {
+        if presentingViewController?.traitCollection.horizontalSizeClass == .regular && presentingViewController?.traitCollection.verticalSizeClass != .compact {
+            gripButton.isHidden = true
+            additionalSafeAreaInsets = Constants.additionalSafeAreaInsetsRegular
+        } else {
+            gripButton.isHidden = false
+            additionalSafeAreaInsets = .zero
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        return preferredContentSize = CGSize(width: Constants.minimumWidth, height: view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)
+    }
+
+    @objc func keyboardWillShow(_ notification: NSNotification) {
+        self.presentedVC?.transition(to: .expanded)
+    }
+
+    @objc func keyboardWillHide(_ notification: NSNotification) {
+        self.presentedVC?.transition(to: .collapsed)
+    }
+}
+
+extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
+    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return BottomSheetAnimationController(transitionType: .presenting)
+    }
+
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return BottomSheetAnimationController(transitionType: .dismissing)
+    }
+
+    public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        return DrawerPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+}
+
+// MARK: - DrawerDelegate
+extension BottomSheetViewController: DrawerPresentable {
+    var compactWidth: DrawerWidth {
+        childViewController?.compactWidth ?? .percentage(0.66)
+    }
+
+    var expandedHeight: DrawerHeight {
+        return childViewController?.expandedHeight ?? .maxHeight
+    }
+
+    var collapsedHeight: DrawerHeight {
+        return childViewController?.collapsedHeight ?? .contentHeight(200)
+    }
+
+    var scrollableView: UIScrollView? {
+        return childViewController?.scrollableView
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetViewController.swift
@@ -4,7 +4,8 @@ class BottomSheetViewController: UIViewController {
     enum Constants {
         static let gripHeight: CGFloat = 5
         static let cornerRadius: CGFloat = 8
-        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        static let buttonSpacing: CGFloat = 8
+        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         static let minimumWidth: CGFloat = 300
 
         enum Header {
@@ -25,9 +26,10 @@ class BottomSheetViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    func show(from presenting: UIViewController, sourceView: UIView? = nil) {
+    func show(from presenting: UIViewController, sourceView: UIView? = nil, arrowDirections: UIPopoverArrowDirection = .any) {
         if UIDevice.isPad() {
             modalPresentationStyle = .popover
+            popoverPresentationController?.permittedArrowDirections = arrowDirections
             popoverPresentationController?.sourceView = sourceView ?? UIView()
             popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
         } else {
@@ -96,6 +98,15 @@ class BottomSheetViewController: UIViewController {
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         refreshForTraits()
+    }
+
+    override var preferredContentSize: CGSize {
+        set {
+            childViewController?.preferredContentSize = newValue
+        }
+        get {
+            return childViewController?.preferredContentSize ?? super.preferredContentSize
+        }
     }
 
     private func refreshForTraits() {

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/BottomSheetViewController.swift
@@ -4,7 +4,6 @@ class BottomSheetViewController: UIViewController {
     enum Constants {
         static let gripHeight: CGFloat = 5
         static let cornerRadius: CGFloat = 8
-        static let buttonSpacing: CGFloat = 8
         static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
         static let minimumWidth: CGFloat = 300
 
@@ -13,14 +12,6 @@ class BottomSheetViewController: UIViewController {
             static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
         }
 
-        enum Button {
-            static let height: CGFloat = 54
-            static let contentInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 35)
-            static let titleInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
-            static let imageTintColor: UIColor = .neutral(.shade30)
-            static let font: UIFont = .preferredFont(forTextStyle: .callout)
-            static let textColor: UIColor = .text
-        }
 
         enum Stack {
             static let insets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/DrawerPresentationController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/DrawerPresentationController.swift
@@ -1,0 +1,494 @@
+import UIKit
+
+public enum DrawerPosition {
+    case expanded
+    case collapsed
+    case closed
+}
+
+public enum DrawerHeight {
+    // The maximum height for the screen
+    case maxHeight
+
+    // Height is based on the specified margin from the top of the screen
+    case topMargin(CGFloat)
+
+    // Height will be equal to the the content height value
+    case contentHeight(CGFloat)
+}
+
+public enum DrawerWidth {
+    // Fills the whole screen width
+    case maxWidth
+
+    // When in compact mode, fills a percentage of the screen
+    case percentage(CGFloat)
+
+    // Width will be equal to the the content height value
+    case contentWidth(CGFloat)
+}
+
+public protocol DrawerPresentable: AnyObject {
+    /// The height of the drawer when it's in the expanded position
+    var expandedHeight: DrawerHeight { get }
+
+    /// The height of the drawer when it's in the collapsed position
+    var collapsedHeight: DrawerHeight { get }
+
+    /// The width of the Drawer in compact screen
+    var compactWidth: DrawerWidth { get }
+
+    /// Whether or not the user is allowed to swipe to switch between the expanded and collapsed position
+    var allowsUserTransition: Bool { get }
+
+    /// Whether or not the user is allowed to drag to dismiss the drawer
+    var allowsDragToDismiss: Bool { get }
+
+    /// Whether or not the user is allowed to tap outside the view to dismiss the drawer
+    var allowsTapToDismiss: Bool { get }
+
+    /// A scroll view that should have its insets adjusted when the drawer is expanded/collapsed
+    var scrollableView: UIScrollView? { get }
+}
+
+private enum Constants {
+    static let transitionDuration: TimeInterval = 0.5
+
+    static let flickVelocity: CGFloat = 300
+    static let bounceAmount: CGFloat = 0.01
+
+    enum Defaults {
+        static let expandedHeight: DrawerHeight = .topMargin(20)
+        static let collapsedHeight: DrawerHeight = .contentHeight(0)
+        static let compactWidth: DrawerWidth = .percentage(0.66)
+
+        static let allowsUserTransition: Bool = true
+        static let allowsTapToDismiss: Bool = true
+        static let allowsDragToDismiss: Bool = true
+    }
+}
+
+typealias DrawerPresentableViewController = DrawerPresentable & UIViewController
+
+public extension DrawerPresentable where Self: UIViewController {
+    // Default values
+    var allowsUserTransition: Bool {
+        return Constants.Defaults.allowsUserTransition
+    }
+
+    var expandedHeight: DrawerHeight {
+        return Constants.Defaults.expandedHeight
+    }
+
+    var collapsedHeight: DrawerHeight {
+        return Constants.Defaults.collapsedHeight
+    }
+
+    var compactWidth: DrawerWidth {
+        return Constants.Defaults.compactWidth
+    }
+
+    var scrollableView: UIScrollView? {
+        return nil
+    }
+
+    var allowsDragToDismiss: Bool {
+        return Constants.Defaults.allowsDragToDismiss
+    }
+
+    var allowsTapToDismiss: Bool {
+        return Constants.Defaults.allowsTapToDismiss
+    }
+
+    // Helpers
+
+    /// Try to determine the correct DrawerPresentationController to use
+
+    /// Returns the `DrawerPresentationController` for a view controller if there is one
+    /// This tries to determine the correct one to use in the following order:
+    /// - The view controller
+    /// - The navController
+    /// - The navController parentViewController
+    /// - The views parentViewController
+    var presentedVC: DrawerPresentationController? {
+        let presentationController = self.presentationController as? DrawerPresentationController
+        let navigationPresentationController = navigationController?.presentationController as? DrawerPresentationController
+        let navParentPresetationController = navigationController?.parent?.presentationController as? DrawerPresentationController
+        let parentPresentationController = parent?.presentationController as? DrawerPresentationController
+
+        return presentationController ?? navigationPresentationController ?? navParentPresetationController ?? parentPresentationController
+    }
+}
+
+public class DrawerPresentationController: FancyAlertPresentationController {
+    override public var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView = self.containerView else {
+            return .zero
+        }
+
+        var frame = containerView.frame
+        let y = collapsedYPosition
+        var width: CGFloat = containerView.bounds.width - (containerView.safeAreaInsets.left + containerView.safeAreaInsets.right)
+
+        frame.origin.y = y
+
+        /// If we're in a compact vertical size class, constrain the width a bit more so it doesn't get overly wide.
+        if let widthForCompactSizeClass = presentableViewController?.compactWidth,
+            traitCollection.verticalSizeClass == .compact {
+
+            switch widthForCompactSizeClass {
+            case .percentage(let percentage):
+                width = width * percentage
+            case .contentWidth(let givenWidth):
+                width = givenWidth
+            case .maxWidth:
+                break
+            }
+        }
+        frame.size.width = width
+
+        /// If we constrain the width, this centers the view by applying the appropriate insets based on width
+        frame.origin.x = ((containerView.bounds.width - width) / 2)
+
+        return frame
+    }
+
+    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { _ in
+            self.presentedView?.frame = self.frameOfPresentedViewInContainerView
+            self.transition(to: self.currentPosition)
+        }, completion: nil)
+        super.viewWillTransition(to: size, with: coordinator)
+    }
+
+    /// Returns the current position of the drawer
+    public var currentPosition: DrawerPosition = .collapsed
+
+
+    /// Animates between the drawer positions
+    /// - Parameter position: The position to animate to
+    public func transition(to position: DrawerPosition) {
+        currentPosition = position
+
+        if position == .closed {
+            dismiss()
+            return
+        }
+
+        var margin: CGFloat = 0
+
+        switch position {
+        case .expanded:
+            margin = expandedYPosition
+
+        case .collapsed:
+            margin = collapsedYPosition
+
+        default:
+            margin = 0
+        }
+
+        setTopMargin(margin)
+    }
+
+    @objc func dismiss() {
+        presentedViewController.dismiss(animated: true, completion: nil)
+    }
+
+    public override func presentationTransitionWillBegin() {
+        super.presentationTransitionWillBegin()
+
+        configureScrollViewInsets()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        transition(to: currentPosition)
+    }
+
+    public override func presentationTransitionDidEnd(_ completed: Bool) {
+        super.presentationTransitionDidEnd(completed)
+
+        configureScrollViewInsets()
+    }
+
+
+    // MARK: - Internal Positions
+    // Helpers to calculate the Y positions for the drawer positions
+
+    private var closedPosition: CGFloat {
+        guard let presentedView = self.presentedView else {
+            return 0
+        }
+
+        return presentedView.bounds.height
+    }
+
+    private var collapsedYPosition: CGFloat {
+        let height = presentableViewController?.collapsedHeight ?? Constants.Defaults.collapsedHeight
+
+        return topMargin(with: height)
+    }
+
+    private var expandedYPosition: CGFloat {
+        let height = presentableViewController?.expandedHeight ?? Constants.Defaults.expandedHeight
+
+        return topMargin(with: height)
+    }
+
+    /// Calculates the Y position for the view based on a DrawerHeight enum
+    /// - Parameter drawerHeight: The drawer height to calculate
+    private func topMargin(with drawerHeight: DrawerHeight) -> CGFloat {
+        var topMargin: CGFloat
+
+        switch drawerHeight {
+        case .contentHeight(let height):
+            topMargin = calculatedTopMargin(for: height)
+
+        case .topMargin(let margin):
+            topMargin = safeAreaInsets.top + margin
+
+        case .maxHeight:
+            topMargin = safeAreaInsets.top
+        }
+
+        return topMargin
+    }
+
+    // MARK: - Gestures
+    private lazy var tapGestureRecognizer: UITapGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dismiss(_:)))
+        gesture.delegate = self
+        return gesture
+    }()
+
+    private lazy var panGestureRecognizer: UIPanGestureRecognizer = {
+        return UIPanGestureRecognizer(target: self, action: #selector(self.pan(_:)))
+    }()
+
+    override public func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+
+        addGestures()
+    }
+
+    private var dragStartPoint: CGPoint?
+}
+
+// MARK: - Dragging
+private extension DrawerPresentationController {
+    private func addGestures() {
+        guard
+            let presentedView = self.presentedView,
+            let containerView = self.containerView
+            else { return }
+
+        presentedView.addGestureRecognizer(panGestureRecognizer)
+        containerView.addGestureRecognizer(tapGestureRecognizer)
+    }
+
+    /// Dismiss action for the tap gesture
+    /// Will prevent dismissal if the `allowsTapToDismiss` is false
+    /// - Parameter gesture: The tap gesture
+    @objc func dismiss(_ gesture: UIPanGestureRecognizer) {
+        let canDismiss = presentableViewController?.allowsTapToDismiss ?? Constants.Defaults.allowsTapToDismiss
+
+        guard canDismiss else {
+            return
+        }
+
+        dismiss()
+    }
+
+    @objc func pan(_ gesture: UIPanGestureRecognizer) {
+        guard let presentedView = self.presentedView else { return }
+
+        let translation = gesture.translation(in: presentedView)
+        let allowsUserTransition = presentableViewController?.allowsUserTransition ?? Constants.Defaults.allowsUserTransition
+        let allowDragToDismiss = presentableViewController?.allowsDragToDismiss ?? Constants.Defaults.allowsDragToDismiss
+
+        switch gesture.state {
+        case .began:
+            dragStartPoint = presentedView.frame.origin
+
+        case .changed:
+            let startY = dragStartPoint?.y ?? 0
+            var yTranslation = translation.y
+
+            if !allowsUserTransition || !allowDragToDismiss {
+                let maxBounce: CGFloat = (startY * Constants.bounceAmount)
+
+                if yTranslation < 0 {
+                    yTranslation = max(yTranslation, maxBounce * -1)
+                } else {
+                    if !allowDragToDismiss {
+                        yTranslation = min(yTranslation, maxBounce)
+                    }
+                }
+            }
+
+            let maxY = topMargin(with: .maxHeight)
+
+            setTopMargin(max((startY + yTranslation), maxY), animated: false)
+
+        case .ended:
+            /// Helper closure to prevent user transition/dismiss
+            let transition: (DrawerPosition) -> () = { pos in
+                if allowsUserTransition || pos == .closed && allowDragToDismiss {
+                    self.transition(to: pos)
+                } else {
+                    //Reset to the original position
+                    self.transition(to: self.currentPosition)
+                }
+            }
+
+            let velocity = gesture.velocity(in: presentedView).y
+            let startY = dragStartPoint?.y ?? 0
+
+            let currentPosition = (startY + translation.y)
+            let position = closestPosition(for: currentPosition)
+
+            // Determine how to handle flicking of the view
+            if (abs(velocity) - Constants.flickVelocity) > 0 {
+                //Flick up
+                if velocity < 0 {
+                    transition(.expanded)
+                }
+                else {
+                    if position == .expanded {
+                        transition(.collapsed)
+                    } else {
+                        transition(.closed)
+                    }
+                }
+
+                return
+            }
+
+            transition(position)
+
+            dragStartPoint = nil
+
+        default:
+            return
+        }
+    }
+}
+
+private extension UIScrollView {
+    /// A flag to determine if a scroll view is scrolling
+    var isScrolling: Bool {
+        return isDragging && !isDecelerating || isTracking
+    }
+}
+
+extension DrawerPresentationController: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        /// Shouldn't happen; should always have container & presented view when tapped
+        guard
+            let containerView = containerView,
+            let presentedView = presentedView
+        else {
+            return false
+        }
+
+        let touchPoint = touch.location(in: containerView)
+        let isInPresentedView = presentedView.frame.contains(touchPoint)
+
+        /// Do not accept the touch if inside of the presented view
+        return (gestureRecognizer == tapGestureRecognizer) && isInPresentedView == false
+    }
+}
+
+// MARK: - Private: Helpers
+private extension DrawerPresentationController {
+
+    private func configureScrollViewInsets() {
+        guard
+            let scrollView = presentableViewController?.scrollableView,
+            !scrollView.isScrolling,
+            let presentedView = self.presentedView
+            else { return }
+
+
+        let bottom = presentingViewController.view.safeAreaLayoutGuide.layoutFrame.origin.y
+        let margin = presentedView.frame.origin.y + bottom
+
+        scrollView.contentInset.bottom = margin
+    }
+
+    private var presentableViewController: DrawerPresentable? {
+        return presentedViewController as? DrawerPresentable
+    }
+
+    private func calculatedTopMargin(for height: CGFloat) -> CGFloat {
+        guard let containerView = self.containerView else {
+            return 0
+        }
+
+        let bounds = containerView.bounds
+        let margin = bounds.maxY - (safeAreaInsets.bottom + ((height > 0) ? height : (bounds.height * 0.5)))
+
+        // Limit the max height
+        return max(margin, safeAreaInsets.top)
+    }
+
+    private func setTopMargin(_ margin: CGFloat, animated: Bool = true) {
+        guard let presentedView = self.presentedView else {
+            return
+        }
+
+        var frame = presentedView.frame
+        frame.origin.y = margin
+
+        let animations = {
+            presentedView.frame = frame
+
+            self.configureScrollViewInsets()
+        }
+
+        if animated {
+            animate(animations)
+        } else {
+            animations()
+        }
+    }
+
+    private var safeAreaInsets: UIEdgeInsets {
+        guard let rootViewController = self.rootViewController else {
+            return .zero
+        }
+
+        return rootViewController.view.safeAreaInsets
+    }
+
+    func closestPosition(for yPosition: CGFloat) -> DrawerPosition {
+        let positions = [closedPosition, collapsedYPosition, expandedYPosition]
+        let closestVal = positions.min(by: { abs(yPosition - $0) < abs(yPosition - $1) }) ?? yPosition
+
+        var returnPosition: DrawerPosition = .closed
+
+        if closestVal == expandedYPosition {
+            returnPosition = .expanded
+        } else if closestVal == collapsedYPosition {
+            returnPosition = .collapsed
+        }
+
+        return returnPosition
+    }
+
+    private func animate(_ animations: @escaping () -> Void) {
+        UIView.animate(withDuration: Constants.transitionDuration,
+                       delay: 0,
+                       usingSpringWithDamping: 0.8,
+                       initialSpringVelocity: 0,
+                       options: .curveEaseInOut,
+                       animations: animations)
+    }
+
+    private var rootViewController: UIViewController? {
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+
+        return keyWindow?.rootViewController
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/DrawerPresentationController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/DrawerPresentationController.swift
@@ -1,3 +1,4 @@
+import WordPressUI
 import UIKit
 
 public enum DrawerPosition {

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/GripView.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/GripView.swift
@@ -1,0 +1,35 @@
+// A UIView with a centered "grip" view (like in Apple Maps)
+class GripButton: UIButton {
+
+    private enum Constants {
+        static let width: CGFloat = 32
+        static let height: CGFloat = 5
+    }
+
+    convenience init() {
+        let gripView = UIView()
+        gripView.layer.cornerRadius = Constants.height / 2
+        gripView.translatesAutoresizingMaskIntoConstraints = false
+        gripView.isUserInteractionEnabled = false
+        self.init(frame: .zero)
+
+        addSubview(gripView)
+
+        gripView.backgroundColor = .placeholderElement
+
+        NSLayoutConstraint.activate([
+            gripView.widthAnchor.constraint(equalToConstant: Constants.width),
+            gripView.heightAnchor.constraint(equalToConstant: Constants.height),
+            gripView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            gripView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/GripView.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/GripView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // A UIView with a centered "grip" view (like in Apple Maps)
 class GripButton: UIButton {
 
@@ -15,7 +17,8 @@ class GripButton: UIButton {
 
         addSubview(gripView)
 
-        gripView.backgroundColor = .placeholderElement
+        // TODO-jc: update color
+        gripView.backgroundColor = .lightGray
 
         NSLayoutConstraint.activate([
             gripView.widthAnchor.constraint(equalToConstant: Constants.width),

--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
@@ -32,7 +32,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where DataSource.Mo
 
     private let rowType = Cell.self
 
-    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet weak var tableView: UITableView!
 
     init(viewProperties: ListSelectorViewProperties,
          dataSource: DataSource,
@@ -116,6 +116,8 @@ private extension ListSelectorViewController {
         tableView.backgroundColor = .listBackground
 
         registerTableViewCells()
+
+        tableView.removeLastCellSeparator()
     }
 
     func registerTableViewCells() {

--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,9 +19,8 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="asM-ey-D7L">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="asM-ey-D7L">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                 </tableView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -5,18 +5,16 @@ import Yosemite
 extension ListSelectorViewController: DrawerPresentable {
     // TODO-jc: fix height to fit to content
     var collapsedHeight: DrawerHeight {
-        guard let scrollableView = scrollableView else {
+
+        guard let tableView = tableView else {
             return .maxHeight
         }
-        scrollableView.layoutIfNeeded()
-        let size = scrollableView.contentSize
+        tableView.layoutIfNeeded()
+        let size = tableView.contentSize
         let height = size.height + BottomSheetViewController.Constants.gripHeight + BottomSheetViewController.Constants.Header.spacing + BottomSheetViewController.Constants.Stack.insets.top
         return .contentHeight(height)
     }
 
-    var scrollableView: UIScrollView? {
-        tableView
-    }
 }
 
 /// `ListSelectorDataSource` for selecting a Product Backorders Setting.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -11,7 +11,9 @@ extension ListSelectorViewController: DrawerPresentable {
         }
         tableView.layoutIfNeeded()
         let size = tableView.contentSize
-        let height = size.height + BottomSheetViewController.Constants.gripHeight + BottomSheetViewController.Constants.Header.spacing + BottomSheetViewController.Constants.Stack.insets.top
+        let height = size.height +
+            // TODO-jc: move these to an extension?
+            BottomSheetViewController.Constants.gripHeight + BottomSheetViewController.Constants.Header.spacing + BottomSheetViewController.Constants.Stack.insets.top
         return .contentHeight(height)
     }
 
@@ -308,7 +310,7 @@ private extension ProductsViewController {
         let sortTitle = NSLocalizedString("Sort by", comment: "Title of the toolbar button to sort products in different ways.")
         let sortButton = UIButton(frame: .zero)
         sortButton.setTitle(sortTitle, for: .normal)
-        sortButton.addTarget(self, action: #selector(sortButtonTapped), for: .touchUpInside)
+        sortButton.addTarget(self, action: #selector(sortButtonTapped(button:)), for: .touchUpInside)
 
         let filterTitle = NSLocalizedString("Filter", comment: "Title of the toolbar button to filter products by different attributes.")
         let filterButton = UIButton(frame: .zero)
@@ -482,7 +484,7 @@ private extension ProductsViewController {
         }
     }
 
-    @objc func sortButtonTapped() {
+    @objc func sortButtonTapped(button: UIButton) {
         let viewProperties = ListSelectorViewProperties(navigationBarTitle: "Sort by")
         let dataSource = ProductSortOptionListSelectorDataSource(selected: sortOrder)
         let sortOptionListViewController = ListSelectorViewController(viewProperties: viewProperties, dataSource: dataSource) { [weak self] selectedSortOrder in
@@ -497,7 +499,7 @@ private extension ProductsViewController {
         }
 
         let bottomSheet = BottomSheetViewController(childViewController: sortOptionListViewController)
-        bottomSheet.show(from: self)
+        bottomSheet.show(from: self, sourceView: button, arrowDirections: .up)
     }
 
     @objc func filterButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Products/UIAlertController+SortProducts.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UIAlertController+SortProducts.swift
@@ -32,7 +32,7 @@ extension UIAlertController {
     }
 }
 
-private extension ProductsSortOrder {
+extension ProductsSortOrder {
     var actionSheetTitle: String {
         switch self {
         case .dateAscending:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -176,6 +176,11 @@
 		02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C323FE5B64005C560F /* MockPHAssetImageLoader.swift */; };
 		02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */; };
 		02A275C823FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */; };
+		02A502392448081100A64C00 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A502382448081100A64C00 /* BottomSheetViewController.swift */; };
+		02A5023E2448088F00A64C00 /* DrawerPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A5023A2448088F00A64C00 /* DrawerPresentationController.swift */; };
+		02A5023F2448088F00A64C00 /* BottomSheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A5023B2448088F00A64C00 /* BottomSheetPresentationController.swift */; };
+		02A502402448088F00A64C00 /* BottomSheetAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A5023C2448088F00A64C00 /* BottomSheetAnimationController.swift */; };
+		02A502412448088F00A64C00 /* GripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A5023D2448088F00A64C00 /* GripView.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
 		02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */; };
@@ -966,6 +971,11 @@
 		02A275C323FE5B64005C560F /* MockPHAssetImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPHAssetImageLoader.swift; sourceTree = "<group>"; };
 		02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureFlagService.swift; sourceTree = "<group>"; };
 		02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultProductFormTableViewModel+EditProductsM2Tests.swift"; sourceTree = "<group>"; };
+		02A502382448081100A64C00 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
+		02A5023A2448088F00A64C00 /* DrawerPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerPresentationController.swift; sourceTree = "<group>"; };
+		02A5023B2448088F00A64C00 /* BottomSheetPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetPresentationController.swift; sourceTree = "<group>"; };
+		02A5023C2448088F00A64C00 /* BottomSheetAnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetAnimationController.swift; sourceTree = "<group>"; };
+		02A5023D2448088F00A64C00 /* GripView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GripView.swift; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
 		02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SystemColors.swift"; sourceTree = "<group>"; };
@@ -2001,6 +2011,18 @@
 			path = "Stats v3";
 			sourceTree = "<group>";
 		};
+		02A5022D244806EC00A64C00 /* BottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				02A5023C2448088F00A64C00 /* BottomSheetAnimationController.swift */,
+				02A5023B2448088F00A64C00 /* BottomSheetPresentationController.swift */,
+				02A5023A2448088F00A64C00 /* DrawerPresentationController.swift */,
+				02A5023D2448088F00A64C00 /* GripView.swift */,
+				02A502382448081100A64C00 /* BottomSheetViewController.swift */,
+			);
+			path = BottomSheet;
+			sourceTree = "<group>";
+		};
 		02C0CD2823B5BAFB00F880B1 /* ImageService */ = {
 			isa = PBXGroup;
 			children = (
@@ -2556,6 +2578,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				02A5022D244806EC00A64C00 /* BottomSheet */,
 				02E262C3238D04DB00B79588 /* ListSelector */,
 				028296E9237D289900E84012 /* Text View Screen */,
 				025FDD3023717D1A00824006 /* Editor */,
@@ -4170,6 +4193,7 @@
 				02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */,
 				0218B4EC242E06F00083A847 /* MediaType+WPMediaType.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
+				02A502392448081100A64C00 /* BottomSheetViewController.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
@@ -4204,6 +4228,7 @@
 				025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */,
 				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
+				02A5023E2448088F00A64C00 /* DrawerPresentationController.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
 				021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */,
 				CE2A9FC623BFFADE002BEC1C /* RefundedProductsViewModel.swift in Sources */,
@@ -4223,6 +4248,7 @@
 				024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */,
 				B5AA7B3F20ED81C2004DA14F /* UserDefaults+Woo.swift in Sources */,
 				0274C25423162FB200EF1E40 /* DashboardTopBannerFactory.swift in Sources */,
+				02A502412448088F00A64C00 /* GripView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				B59D1EE321907C7B009D1978 /* NSAttributedString+Helpers.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
@@ -4333,6 +4359,7 @@
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
+				02A5023F2448088F00A64C00 /* BottomSheetPresentationController.swift in Sources */,
 				024DF31B23742E1C006658FE /* FormatBarItemViewProperties.swift in Sources */,
 				02E8B17C23E2C78A00A43403 /* ProductImageStatus.swift in Sources */,
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
@@ -4516,6 +4543,7 @@
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
+				02A502402448088F00A64C00 /* BottomSheetAnimationController.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				748D34DF214828DD00E21A2F /* TopPerformersViewController.swift in Sources */,
 				B509FED321C05121000076A9 /* SupportManagerAdapter.swift in Sources */,


### PR DESCRIPTION
TODO: 

- [x] fix sheet height to fit to table view (right now there's a ~15px gap at the bottom): https://github.com/woocommerce/woocommerce-ios/pull/2145/commits/a1e2861e997ce73bc4adb8bfb9edb7997837b8cc
![simulator](https://user-images.githubusercontent.com/1945542/79427645-99128980-7ff7-11ea-9ca3-97274d6845b6.gif)

- [ ] iPad polishes
- [ ] disable bounces in table view
- [ ] https://github.com/woocommerce/woocommerce-ios/commit/813937bea6ee15609477ad79a0c5764dd785d4ab

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
