### PR TITLE
Handled the Swipe Back gesture that triggers the "Discard Changes" action sheet

### DIFF
--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -93,7 +93,7 @@ extension UIViewController: NavigationSwipeBackHandler {
 }
 
 extension UIViewController: UIGestureRecognizerDelegate {
-    
+
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureRecognizer.isEqual(navigationController?.interactivePopGestureRecognizer) {
             return shouldPopOnSwipeBack()
@@ -101,7 +101,7 @@ extension UIViewController: UIGestureRecognizerDelegate {
 
         return false
     }
-    
+
     func handleSwipeBackGesture() {
         navigationController?.interactivePopGestureRecognizer?.delegate = self
     }

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -43,7 +43,7 @@ protocol UINavigationBarBackButtonHandler {
 
 extension UIViewController: UINavigationBarBackButtonHandler {
     //Do not block the "Back" button action by default, otherwise, override this function in the specified viewcontroller
-    @objc func  shouldPopOnBackButton() -> Bool {
+    @objc func shouldPopOnBackButton() -> Bool {
         return true
     }
 }
@@ -73,5 +73,36 @@ extension UINavigationController: UINavigationBarDelegate {
             }
         }
         return false
+    }
+}
+
+// MARK: - Handle the swipe back gesture
+protocol NavigationSwipeBackHandler {
+
+    /// Should block the 'SwipeBack' gesture
+    ///
+    /// - Returns: true - don't block，false - block
+    func shouldPopOnSwipeBack() -> Bool
+}
+
+extension UIViewController: NavigationSwipeBackHandler {
+    //Do not block the "Swipe back" gesture by default, otherwise, override this function in the specified viewcontroller
+    @objc func shouldPopOnSwipeBack() -> Bool {
+        return true
+    }
+}
+
+extension UIViewController: UIGestureRecognizerDelegate {
+    
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer.isEqual(navigationController?.interactivePopGestureRecognizer) {
+            return shouldPopOnSwipeBack()
+        }
+
+        return false
+    }
+    
+    func handleSwipeBackGesture() {
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -258,7 +258,7 @@ extension AztecEditorViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -131,6 +131,7 @@ final class AztecEditorViewController: UIViewController, Editor {
         content = getHTML()
 
         refreshPlaceholderVisibility()
+        handleSwipeBackGesture()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -256,6 +257,10 @@ extension AztecEditorViewController {
             return false
         }
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -137,7 +137,7 @@ extension ProductPriceSettingsViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -139,11 +139,7 @@ extension ProductPriceSettingsViewController {
     }
     
     override func shouldPopOnSwipeBack() -> Bool {
-        if viewModel.hasUnsavedChanges() {
-            presentBackNavigationActionSheet()
-            return false
-        }
-        return true
+        return shouldPopOnBackButton()
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -62,6 +62,7 @@ final class ProductPriceSettingsViewController: UIViewController {
         configureSections()
         configureTableView()
         retrieveProductTaxClass()
+        handleSwipeBackGesture()
     }
 }
 
@@ -130,6 +131,14 @@ private extension ProductPriceSettingsViewController {
 extension ProductPriceSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
+        if viewModel.hasUnsavedChanges() {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
         if viewModel.hasUnsavedChanges() {
             presentBackNavigationActionSheet()
             return false

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -73,6 +73,7 @@ final class ProductInventorySettingsViewController: UIViewController {
         configureMainView()
         configureTableView()
         reloadSections()
+        handleSwipeBackGesture()
     }
 }
 
@@ -191,6 +192,10 @@ extension ProductInventorySettingsViewController {
             return false
         }
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -193,7 +193,7 @@ extension ProductInventorySettingsViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -77,7 +77,7 @@ extension ProductSettingsViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -31,6 +31,7 @@ final class ProductSettingsViewController: UIViewController {
         configureNavigationBar()
         configureMainView()
         configureTableView()
+        handleSwipeBackGesture()
         viewModel.onReload = {  [weak self] in
             self?.tableView.reloadData()
         }
@@ -75,6 +76,10 @@ extension ProductSettingsViewController {
             return false
         }
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -88,7 +88,7 @@ final class ProductFormViewController: UIViewController {
 
         startListeningToNotifications()
         handleSwipeBackGesture()
-        
+
         productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
             guard let self = self else {
                 return
@@ -426,7 +426,7 @@ extension ProductFormViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -87,7 +87,8 @@ final class ProductFormViewController: UIViewController {
         configureTableView()
 
         startListeningToNotifications()
-
+        handleSwipeBackGesture()
+        
         productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
             guard let self = self else {
                 return
@@ -424,6 +425,10 @@ extension ProductFormViewController {
             return false
         }
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -130,7 +130,7 @@ extension ProductShippingSettingsViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -66,6 +66,7 @@ final class ProductShippingSettingsViewController: UIViewController {
         configureMainView()
         configureTableView()
         retrieveProductShippingClass()
+        handleSwipeBackGesture()
     }
 }
 
@@ -128,6 +129,10 @@ extension ProductShippingSettingsViewController {
             return false
         }
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     @objc private func completeUpdating() {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -177,7 +177,7 @@ extension ProductImagesViewController {
         resetProductImages()
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -86,6 +86,7 @@ final class ProductImagesViewController: UIViewController {
         configureAddButtonBottomBorderView()
         configureImagesContainerView()
         configureProductImagesObservation()
+        handleSwipeBackGesture()
     }
 }
 
@@ -175,6 +176,10 @@ extension ProductImagesViewController {
         }
         resetProductImages()
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     private func presentDiscardChangesActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -68,6 +68,7 @@ final class TextViewViewController: UIViewController {
         configurePlaceholderLabel()
         refreshPlaceholderVisibility()
         startListeningToNotifications()
+        handleSwipeBackGesture()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -86,6 +87,10 @@ extension TextViewViewController {
             return false
         }
         return true
+    }
+    
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
     }
 
     @objc private func completeEditing() {

--- a/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Text View Screen/TextViewViewController.swift
@@ -88,7 +88,7 @@ extension TextViewViewController {
         }
         return true
     }
-    
+
     override func shouldPopOnSwipeBack() -> Bool {
         return shouldPopOnBackButton()
     }


### PR DESCRIPTION
Fixes #2123

## Prologue
As iOS users, if there’s one thing we really love on the iPhone/iPad is the global (mostly) swipe-back gesture.
This is a function that we want to continue to guarantee to our users, but there are some cases in which we need to prevent the user from going back through a swipe back gesture.
One of these cases is our needs to show the Discard Changes Action Sheet, that we started to use extensively in our new Add/Edit Products feature. Basically, the Discard Changes Action sheet will be shown when a user presses the back button, but there are changes to the data on the screen. To prevent him from inadvertently losing the data he has modified, we ask him if he really wants to discard the information.
<img src="https://user-images.githubusercontent.com/495617/79454804-2354f080-7fec-11ea-9f07-0a1f098b1028.png" width=300 />

But, @shiki discovered here #2123 that when the user uses the swipe back gesture, he can go back, and we don't show him the action sheet.
After some discussions and the precious feedback of @Garance91540  we came to the conclusion that it would be good to follow the same behavior as Android, which shows the action sheet even when the swipe back is performed.

## Description
After several tests, I found a working solution to handle the swipe back gesture, and manage its behavior from our code.
I implemented a protocol called `NavigationSwipeBackHandler` and an extension of `UIViewController` which conforms to the protocol, pretty similar to the one I previously implemented to handle the back button item.
Then I implemented another extension of `UIViewController` which conforms to `UIGestureRecognizerDelegate`, and using the delegate method `func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool` I was able to check if the pop gesture is the one managed by our navigation controller, and in this case, I'll manage the behavior from the method `shouldPopOnSwipeBack:` that we will override in our specific view controller.
In our view controllers where we need to use this method, we need also to assign the delegate of `interactivePopGestureRecognizer`, so I exposed a new method `handleSwipeBackGesture:` that can be declared inside the `viewDidLoad` of the view controller.

It's interesting to notice that using the (wrong?) delegate method `func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool`, we are unable to use the swipe back gesture in other view controllers. 

This PR also enables the handler for the swipe back gesture in all the view controllers that need to show the Discard Changes Action Sheet.

## Testing
1) Navigate to simple product detail.
2) Try to edit product info (price, shipping, inventory, etc...).
3) Do a swipe back.
4) Make sure that the Discard Changes Action Sheet will be presented.
5) Try to do the same on other screens.
7) Make sure that when there are no changes, you can use as usual the swipe back gesture.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
