### PR TITLE
UL&S: Remove .showWPUsernamePassword segue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,9 +31,9 @@ target 'WooCommerce' do
 
   pod 'Gridicons', '~> 1.0'
 
-  # pod 'WordPressAuthenticator', '~> 1.13.0-beta.4'
+  pod 'WordPressAuthenticator', '~> 1.14.0-beta.1'
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/244-remove-showWPUsernamePassword'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/Podfile
+++ b/Podfile
@@ -31,9 +31,9 @@ target 'WooCommerce' do
 
   pod 'Gridicons', '~> 1.0'
 
-  pod 'WordPressAuthenticator', '~> 1.13.0-beta.4'
+  # pod 'WordPressAuthenticator', '~> 1.13.0-beta.4'
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/244-remove-showWPUsernamePassword'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -49,7 +49,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.13.0-beta.4):
+  - WordPressAuthenticator (1.14.0-beta.1):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -101,7 +101,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.13.0-beta.4)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/244-remove-showWPUsernamePassword`)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.5.2)
   - Wormholy (~> 1.5.2)
@@ -133,7 +133,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -148,6 +147,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: issue/244-remove-showWPUsernamePassword
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 10714ee1ac3a42481dba0438c56c3dc05c07122b
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -172,7 +181,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: d55a86bb181478bb536b3fc8a9dd4eaa7f6bc3e0
+  WordPressAuthenticator: b16214617d8da183a19c3c3dac7230858071e50f
   WordPressKit: 0602e8188245b3267269570d3d78c138e64a4eba
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
@@ -188,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 1fdc82d9f06d4aef1372b814f6a800315cf8d526
+PODFILE CHECKSUM: 60533f2436705e6a85be6fd81324516291b3e004
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -58,10 +58,10 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.7.0)
+    - WordPressKit (~> 4.8.0)
     - WordPressShared (~> 1.8.16)
     - WordPressUI (~> 1.5.2)
-  - WordPressKit (4.7.0):
+  - WordPressKit (4.8.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -101,7 +101,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/244-remove-showWPUsernamePassword`)
+  - WordPressAuthenticator (~> 1.14.0-beta.1)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.5.2)
   - Wormholy (~> 1.5.2)
@@ -133,6 +133,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -147,16 +148,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: issue/244-remove-showWPUsernamePassword
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 10714ee1ac3a42481dba0438c56c3dc05c07122b
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -181,8 +172,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: b16214617d8da183a19c3c3dac7230858071e50f
-  WordPressKit: 0602e8188245b3267269570d3d78c138e64a4eba
+  WordPressAuthenticator: c3e9921cfef12384a32e3fc9e31a3ed65585e8f1
+  WordPressKit: 84045e236949248632a2c644149e5657733011bb
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
   Wormholy: 3344d3591d78488d957402d51dccfbfafd6f9641
@@ -197,6 +188,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 60533f2436705e6a85be6fd81324516291b3e004
+PODFILE CHECKSUM: 241533919f715d30f23901123d0a89d3dc3e80c5
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
Ref. #2003 

This PR removes the segue `.showWPUsernamePassword` that sends a user to the "Login with WP.com username and password" screen. It now navigates the user programmatically.

See also: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/245

## To test

#### Flow 1, login with site address
1. Check out this branch
2. `rake dependencies`
3. Build and run
4. Log out if logged in
5. Log in with Jetpack > tap the text link "Enter the address of the WordPress site you'd like to connect."
6. Enter a site address > Next
7. **Expected:** you are navigated to the WP.com username / password screen.

#### Flow 2, login with login options
This is a hidden option with login features that WCiOS may use in the future. Context: https://git.io/JfJ4s and pauD4L-li-p2/#comment-268.

1. Check out this branch
2. In the `AuthenticationManager`, add `showLoginOptionsFromSiteAddress: true` on L26.
3. `rake dependencies`
4. Build and run
5. Log in with Jetpack > tap the text link "Enter the address of the WordPress site you'd like to connect." 
6. Enter a WP.com AT site > Next
7. **Expected:** you are navigated to the WP.com username / password screen.

### Do not merge until:
1. The Authenticator PR has been merged: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/245
2. A new Authenticator release has been created  
3. The release is published on Cocoapods trunk 
4. This PR points to the new release  

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
