### PR TITLE
Updated Wormholy to version 1.6.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ target 'WooCommerce' do
   pod 'Charts', '~> 3.3.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
   pod 'Kingfisher', '~> 5.11.0'
-  pod 'Wormholy', '~> 1.5.2', :configurations => ['Debug']
+  pod 'Wormholy', '~> 1.6.0', :configurations => ['Debug']
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.2)
-  - Wormholy (1.5.2)
+  - Wormholy (1.6.0)
   - WPMediaPicker (1.6.0)
   - wpxmlrpc (0.8.5)
   - XLPagerTabStrip (9.0.0)
@@ -104,7 +104,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.13.0-beta.4)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.5.2)
-  - Wormholy (~> 1.5.2)
+  - Wormholy (~> 1.6.0)
   - WPMediaPicker (~> 1.6.0)
   - XLPagerTabStrip (~> 9.0)
   - ZendeskSupportSDK (~> 5.0)
@@ -176,7 +176,7 @@ SPEC CHECKSUMS:
   WordPressKit: 0602e8188245b3267269570d3d78c138e64a4eba
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 70cc58a253c352330b23cd8fa6dd6a2021570e18
-  Wormholy: 3344d3591d78488d957402d51dccfbfafd6f9641
+  Wormholy: f52cd3c384fb49ae3e8fdb2b1398b66746a65104
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
@@ -188,6 +188,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 1fdc82d9f06d4aef1372b814f6a800315cf8d526
+PODFILE CHECKSUM: d6407f91a2035eaacd9966958ce158f5b818db8a
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
I updated [Wormholy](https://github.com/pmusolino/Wormholy) to the new release 1.6.0.

The new version includes the possibility to:
- share cURL representation of requests
- share requests and responses (as examples) as [Postman](https://www.postman.com) collection (v2.1)


## Testing
1) Launch Wormholy from the settings in debug mode.
2) Try to export as cURL the list of requests or a single request.
3) Try a cURL on your console, or better here: https://reqbin.com/curl
4) Share the list of requests or a single request for Postman.
5) Launch Postman, and import the output.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
