### PR TITLE
Products: tapping on row begin editing of the text field

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+4.2
+-----
+- Products: now tapping anywhere on a product cell where you need to insert data, like in Product Price and Product Shipping settings, you start to edit the text field.
+
+
 4.1
 -----
 - Fix an intermittent crash when downloading Orders

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -77,8 +77,8 @@ private extension TitleAndTextFieldTableViewCell {
     func configureContentStackView() {
         contentStackView.spacing = 30
     }
-    
-    func configureTapGestureRecognizer(){
+
+    func configureTapGestureRecognizer() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
         tapGesture.cancelsTouchesInView = false
         addGestureRecognizer(tapGesture)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -42,6 +42,7 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         configureTextField()
         configureContentStackView()
         applyDefaultBackgroundStyle()
+        configureTapGestureRecognizer()
     }
 
     func configure(viewModel: ViewModel) {
@@ -76,7 +77,22 @@ private extension TitleAndTextFieldTableViewCell {
     func configureContentStackView() {
         contentStackView.spacing = 30
     }
+    
+    func configureTapGestureRecognizer(){
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
+        tapGesture.cancelsTouchesInView = false
+        addGestureRecognizer(tapGesture)
+    }
 }
+
+private extension TitleAndTextFieldTableViewCell {
+    /// When the cell is tapped, the text field become the first responder
+    ///
+    @objc func cellTapped(sender: UIView) {
+        textField.becomeFirstResponder()
+    }
+}
+
 
 private extension TitleAndTextFieldTableViewCell {
     @objc func textFieldDidChange(textField: UITextField) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -125,8 +125,8 @@ private extension UnitInputTableViewCell {
         unitLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         unitLabel.setContentHuggingPriority(.required, for: .horizontal)
     }
-    
-    func configureTapGestureRecognizer(){
+
+    func configureTapGestureRecognizer() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
         tapGesture.cancelsTouchesInView = false
         addGestureRecognizer(tapGesture)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -39,6 +39,7 @@ final class UnitInputTableViewCell: UITableViewCell {
         configureInputTextField()
         configureUnitLabel()
         applyDefaultBackgroundStyle()
+        configureTapGestureRecognizer()
     }
 
     func configure(viewModel: UnitInputViewModel) {
@@ -123,6 +124,20 @@ private extension UnitInputTableViewCell {
         unitLabel.applyBodyStyle()
         unitLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         unitLabel.setContentHuggingPriority(.required, for: .horizontal)
+    }
+    
+    func configureTapGestureRecognizer(){
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
+        tapGesture.cancelsTouchesInView = false
+        addGestureRecognizer(tapGesture)
+    }
+}
+
+private extension UnitInputTableViewCell {
+    /// When the cell is tapped, the text field become the first responder
+    ///
+    @objc func cellTapped(sender: UIView) {
+        inputTextField.becomeFirstResponder()
     }
 }
 


### PR DESCRIPTION
Fixes #2148 

## Description
Now when a user taps on the row of an editable field in Products, we begin editing that field, since it was hard to tap on the UITextField directly when the content is tiny.

## Testing
1. Go to a product
2. Tap in prices
3. Tap everywhere inside the regular price cell or inside the sale price cell. You will see the text field which becomes the first responder.
4. Do the same with the Shipping fields.
5. Do the same with the SKU field in Inventory.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
