### PR TITLE
Products: present the keyboard in screens with only one textfield

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+4.2
+-----
+- Products: now the keyboard pop up automatically when a view with only one text field is opened.
+
+
 4.1
 -----
 - Fix an intermittent crash when downloading Orders

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 4.2
 -----
-- Products: now the keyboard pop up automatically when a view with only one text field is opened.
+- Products: now the keyboard pop up automatically in Edit Description (M1), in Edit Short Description (M2), Edit Slug (M2), Edit Purchase Note (M2)
 
 
 4.1

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -138,6 +138,11 @@ final class AztecEditorViewController: UIViewController, Editor {
         super.viewWillAppear(animated)
         startListeningToNotifications()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        richTextView.becomeFirstResponder()
+    }
 }
 
 private extension AztecEditorViewController {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -138,7 +138,7 @@ final class AztecEditorViewController: UIViewController, Editor {
         super.viewWillAppear(animated)
         startListeningToNotifications()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         richTextView.becomeFirstResponder()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -48,6 +48,17 @@ final class ProductPurchaseNoteViewController: UIViewController {
         super.viewWillDisappear(animated)
         onCompletion(productSettings)
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
+        ///
+        if let indexPath = getIndexPathForRow(.purchaseNote) {
+            let cell = tableView.cellForRow(at: indexPath) as? TextViewTableViewCell
+            cell?.noteTextView.becomeFirstResponder()
+        }
+    }
 
 }
 
@@ -139,6 +150,17 @@ private extension ProductPurchaseNoteViewController {
         cell.noteTextView.onTextChange = { [weak self] (text) in
             self?.productSettings.purchaseNote = text
         }
+    }
+    
+    func getIndexPathForRow(_ row: Row) -> IndexPath? {
+        for s in 0 ..< sections.count {
+            for r in 0 ..< sections[s].rows.count {
+                if sections[s].rows[r] == row {
+                    return IndexPath(row: r, section: s)
+                }
+            }
+        }
+        return nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -52,12 +52,7 @@ final class ProductPurchaseNoteViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
-        ///
-        if let indexPath = getIndexPathForRow(.purchaseNote) {
-            let cell = tableView.cellForRow(at: indexPath) as? TextViewTableViewCell
-            cell?.noteTextView.becomeFirstResponder()
-        }
+        configureTextViewFirstResponder()
     }
 
 }
@@ -84,6 +79,15 @@ private extension ProductPurchaseNoteViewController {
 
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
+    }
+    
+    /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
+    ///
+    func configureTextViewFirstResponder() {
+        if let indexPath = getIndexPathForRow(.purchaseNote) {
+            let cell = tableView.cellForRow(at: indexPath) as? TextViewTableViewCell
+            cell?.noteTextView.becomeFirstResponder()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -80,7 +80,7 @@ private extension ProductPurchaseNoteViewController {
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
     }
-    
+
     /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
     ///
     func configureTextViewFirstResponder() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -48,10 +48,10 @@ final class ProductPurchaseNoteViewController: UIViewController {
         super.viewWillDisappear(animated)
         onCompletion(productSettings)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
         ///
         if let indexPath = getIndexPathForRow(.purchaseNote) {
@@ -151,7 +151,7 @@ private extension ProductPurchaseNoteViewController {
             self?.productSettings.purchaseNote = text
         }
     }
-    
+
     func getIndexPathForRow(_ row: Row) -> IndexPath? {
         for s in 0 ..< sections.count {
             for r in 0 ..< sections[s].rows.count {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -41,6 +41,16 @@ final class ProductSlugViewController: UIViewController {
         onCompletion(productSettings)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        /// Since there is only a text field in this view, the text field become the first responder immediately when the view did appear
+        ///
+        if let indexPath = getIndexPathForRow(.slug) {
+            let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
+            cell?.textField.becomeFirstResponder()
+        }
+    }
 }
 
 // MARK: - View Configuration
@@ -138,6 +148,17 @@ private extension ProductSlugViewController {
         })
         cell.configure(viewModel: viewModel)
         cell.textField.applyBodyStyle()
+    }
+
+    func getIndexPathForRow(_ row: Row) -> IndexPath? {
+        for s in 0 ..< sections.count {
+            for r in 0 ..< sections[s].rows.count {
+                if sections[s].rows[r] == row {
+                    return IndexPath(row: r, section: s)
+                }
+            }
+        }
+        return nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -43,13 +43,7 @@ final class ProductSlugViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        /// Since there is only a text field in this view, the text field become the first responder immediately when the view did appear
-        ///
-        if let indexPath = getIndexPathForRow(.slug) {
-            let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
-            cell?.textField.becomeFirstResponder()
-        }
+        configureTextFieldFirstResponder()
     }
 }
 
@@ -75,6 +69,15 @@ private extension ProductSlugViewController {
 
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
+    }
+    
+    /// Since there is only a text field in this view, the text field become the first responder immediately when the view did appear
+    ///
+    func configureTextFieldFirstResponder() {
+        if let indexPath = getIndexPathForRow(.slug) {
+            let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
+            cell?.textField.becomeFirstResponder()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -70,7 +70,7 @@ private extension ProductSlugViewController {
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
     }
-    
+
     /// Since there is only a text field in this view, the text field become the first responder immediately when the view did appear
     ///
     func configureTextFieldFirstResponder() {


### PR DESCRIPTION
Fixes #2149 

## Description
Now in all the product screens where there is only one text field or only a text view, the keyboard pop up automatically.

## Changes
- In `AztecEditorViewController` the `richTextView` become the first responder when the view did appear.
- In `ProductSlugViewController` and in `ProductPurchaseNoteViewController` the textfield/textview inside the cell become the first responder when the view did appear. 

## Testing
1. Open a simple product
2. Open the product description. The keyboard should pop up.
3. Open the product short description. The keyboard should pop up.
3. Open the product settings, then open the product slug. The keyboard should pop up.
4. From product settings, open the product purchase note. The keyboard should pop up.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
