### PR TITLE
Array utility to get the IndexPath of a Section that conform to RowIterable

### DIFF
--- a/WooCommerce/Classes/Extensions/Array+IndexPath.swift
+++ b/WooCommerce/Classes/Extensions/Array+IndexPath.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+
+protocol RowIterable {
+    associatedtype Row: Equatable
+    var rows: [Row] { get }
+}
+
+/// Extension: [Array of Sections that conform to RowIterable]
+///
+extension Array where Element: RowIterable {
+    func getIndexPathForRow(_ row: Element.Row) -> IndexPath? {
+        for s in 0 ..< count {
+            let rows = self[s].rows
+            for r in 0 ..< rows.count {
+                if rows[r] == row {
+                    return IndexPath(row: r, section: s)
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/WooCommerce/Classes/Extensions/Array+IndexPath.swift
+++ b/WooCommerce/Classes/Extensions/Array+IndexPath.swift
@@ -9,13 +9,10 @@ protocol RowIterable {
 /// Extension: [Array of Sections that conform to RowIterable]
 ///
 extension Array where Element: RowIterable {
-    func getIndexPathForRow(_ row: Element.Row) -> IndexPath? {
-        for s in 0 ..< count {
-            let rows = self[s].rows
-            for r in 0 ..< rows.count {
-                if rows[r] == row {
-                    return IndexPath(row: r, section: s)
-                }
+    func indexPathForRow(_ row: Element.Row) -> IndexPath? {
+        for (sectionIndex, section) in enumerated() {
+            if let rowIndex = section.rows.firstIndex(of: row) {
+                return IndexPath(row: rowIndex, section: sectionIndex)
             }
         }
         return nil

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -459,7 +459,7 @@ private extension ProductInventorySettingsViewController {
     }
 
     func getSkuCell() -> TitleAndTextFieldTableViewCell? {
-        guard let indexPath = sections.getIndexPathForRow(.sku) else {
+        guard let indexPath = sections.indexPathForRow(.sku) else {
             return nil
         }
         return tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -458,19 +458,8 @@ private extension ProductInventorySettingsViewController {
         return sections[indexPath.section].rows[indexPath.row]
     }
 
-    func getIndexPathForRow(_ row: Row) -> IndexPath? {
-        for s in 0 ..< sections.count {
-            for r in 0 ..< sections[s].rows.count {
-                if sections[s].rows[r] == row {
-                    return IndexPath(row: r, section: s)
-                }
-            }
-        }
-        return nil
-    }
-
     func getSkuCell() -> TitleAndTextFieldTableViewCell? {
-        guard let indexPath = getIndexPathForRow(.sku) else {
+        guard let indexPath = sections.getIndexPathForRow(.sku) else {
             return nil
         }
         return tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell
@@ -483,7 +472,7 @@ private extension ProductInventorySettingsViewController {
         static let estimatedSectionHeaderHeight: CGFloat = 44
     }
 
-    struct Section {
+    struct Section: RowIterable {
         let errorTitle: String?
         let rows: [Row]
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -84,7 +84,7 @@ private extension ProductPurchaseNoteViewController {
     /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
     ///
     func configureTextViewFirstResponder() {
-        if let indexPath = sections.getIndexPathForRow(.purchaseNote) {
+        if let indexPath = sections.indexPathForRow(.purchaseNote) {
             let cell = tableView.cellForRow(at: indexPath) as? TextViewTableViewCell
             cell?.noteTextView.becomeFirstResponder()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -84,7 +84,7 @@ private extension ProductPurchaseNoteViewController {
     /// Since there is only a text view in this view, the text view become the first responder immediately when the view did appear
     ///
     func configureTextViewFirstResponder() {
-        if let indexPath = getIndexPathForRow(.purchaseNote) {
+        if let indexPath = sections.getIndexPathForRow(.purchaseNote) {
             let cell = tableView.cellForRow(at: indexPath) as? TextViewTableViewCell
             cell?.noteTextView.becomeFirstResponder()
         }
@@ -155,17 +155,6 @@ private extension ProductPurchaseNoteViewController {
             self?.productSettings.purchaseNote = text
         }
     }
-
-    func getIndexPathForRow(_ row: Row) -> IndexPath? {
-        for s in 0 ..< sections.count {
-            for r in 0 ..< sections[s].rows.count {
-                if sections[s].rows[r] == row {
-                    return IndexPath(row: r, section: s)
-                }
-            }
-        }
-        return nil
-    }
 }
 
 // MARK: - Keyboard management
@@ -204,7 +193,7 @@ private extension ProductPurchaseNoteViewController {
 
     /// Table Sections
     ///
-    struct Section {
+    struct Section: RowIterable {
         let footer: String?
         let rows: [Row]
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -74,7 +74,7 @@ private extension ProductSlugViewController {
     /// Since there is only a text field in this view, the text field become the first responder immediately when the view did appear
     ///
     func configureTextFieldFirstResponder() {
-        if let indexPath = getIndexPathForRow(.slug) {
+        if let indexPath = sections.getIndexPathForRow(.slug) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
             cell?.textField.becomeFirstResponder()
         }
@@ -152,17 +152,6 @@ private extension ProductSlugViewController {
         cell.configure(viewModel: viewModel)
         cell.textField.applyBodyStyle()
     }
-
-    func getIndexPathForRow(_ row: Row) -> IndexPath? {
-        for s in 0 ..< sections.count {
-            for r in 0 ..< sections[s].rows.count {
-                if sections[s].rows[r] == row {
-                    return IndexPath(row: r, section: s)
-                }
-            }
-        }
-        return nil
-    }
 }
 
 // MARK: - Constants
@@ -185,7 +174,7 @@ private extension ProductSlugViewController {
 
     /// Table Sections
     ///
-    struct Section {
+    struct Section: RowIterable {
         let footer: String?
         let rows: [Row]
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -74,7 +74,7 @@ private extension ProductSlugViewController {
     /// Since there is only a text field in this view, the text field become the first responder immediately when the view did appear
     ///
     func configureTextFieldFirstResponder() {
-        if let indexPath = sections.getIndexPathForRow(.slug) {
+        if let indexPath = sections.indexPathForRow(.slug) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
             cell?.textField.becomeFirstResponder()
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 		45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */; };
 		45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FD23D0FB25005F87D0 /* Throttler.swift */; };
 		45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EF7983244F26BB00B22BA2 /* Array+IndexPath.swift */; };
+		45EF798624509B4C00B22BA2 /* ArrayIndexPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EF798524509B4C00B22BA2 /* ArrayIndexPathTests.swift */; };
 		45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */; };
 		45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */; };
 		45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */; };
@@ -1086,6 +1087,7 @@
 		45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatusListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D685FD23D0FB25005F87D0 /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
 		45EF7983244F26BB00B22BA2 /* Array+IndexPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+IndexPath.swift"; sourceTree = "<group>"; };
+		45EF798524509B4C00B22BA2 /* ArrayIndexPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayIndexPathTests.swift; sourceTree = "<group>"; };
 		45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputFormatter.swift; sourceTree = "<group>"; };
 		45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputFormatterTests.swift; sourceTree = "<group>"; };
 		45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
@@ -2696,6 +2698,7 @@
 		B57C744F20F56ED300EEFC87 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				45EF798524509B4C00B22BA2 /* ArrayIndexPathTests.swift */,
 				D85B833C2230DC9D002168F3 /* StringWooTests.swift */,
 				B5980A6621AC91AA00EBF596 /* BundleWooTests.swift */,
 				B57C5C9821B80E7100FF82B2 /* DataWooTests.swift */,
@@ -4651,6 +4654,7 @@
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
+				45EF798624509B4C00B22BA2 /* ArrayIndexPathTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */; };
 		45D1CF4723BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */; };
 		45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685FD23D0FB25005F87D0 /* Throttler.swift */; };
+		45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EF7983244F26BB00B22BA2 /* Array+IndexPath.swift */; };
 		45F5A3C123DF206B007D40E5 /* ShippingInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */; };
 		45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */; };
 		45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */; };
@@ -1084,6 +1085,7 @@
 		45D1CF4423BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxClassListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D1CF4623BAC89A00945A36 /* ProductTaxStatusListSelectorDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatusListSelectorDataSource.swift; sourceTree = "<group>"; };
 		45D685FD23D0FB25005F87D0 /* Throttler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttler.swift; sourceTree = "<group>"; };
+		45EF7983244F26BB00B22BA2 /* Array+IndexPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+IndexPath.swift"; sourceTree = "<group>"; };
 		45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputFormatter.swift; sourceTree = "<group>"; };
 		45F5A3C223DF31D2007D40E5 /* ShippingInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingInputFormatterTests.swift; sourceTree = "<group>"; };
 		45FBDF2A238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
@@ -3093,6 +3095,7 @@
 			children = (
 				B58B4ABF2108FF6100076FDD /* Array+Helpers.swift */,
 				B59C09D82188CBB100AB41D6 /* Array+Notes.swift */,
+				45EF7983244F26BB00B22BA2 /* Array+IndexPath.swift */,
 				B5980A6221AC879F00EBF596 /* Bundle+Woo.swift */,
 				CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */,
 				B57C5C9321B80E4700FF82B2 /* Data+Woo.swift */,
@@ -4283,6 +4286,7 @@
 				D8C2A28823190B2300F503E9 /* StorageProductReview+Woo.swift in Sources */,
 				02784A03238B8BC800BDD6A8 /* UIView+Border.swift in Sources */,
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
+				45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */,
 				02E6B97823853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift in Sources */,
 				45CDAFAE2434CFCA00F83C22 /* ProductCatalogVisibilityViewController.swift in Sources */,
 				D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/ArrayIndexPathTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/ArrayIndexPathTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import WooCommerce
+
+
+/// Array+IndexPath: Unit Tests
+///
+import XCTest
+
+final class ArrayIndexPathTests: XCTestCase {
+
+    private var sections: [Section] = [Section(rows: [.simplenote, .wordpress]), Section(rows: [.woocommerce]), Section(rows: [.wordpress])]
+
+    func testIndexPathForRowReturnTheRightIndexPath() {
+
+        /// Row in section 1
+        ///
+        let expectedIndexPath = IndexPath(row: 0, section: 1)
+        let result = sections.indexPathForRow(.woocommerce)
+        XCTAssertEqual(expectedIndexPath, result)
+    }
+
+    func testIndexPathForRowReturnTheFirstRowFound() {
+        /// .wordpress is a row present in two different section. The indexPath returned should be the first found
+        ///
+        let expectedIndexPath = IndexPath(row: 1, section: 0)
+        let result = sections.indexPathForRow(.wordpress)
+
+        XCTAssertEqual(expectedIndexPath, result)
+    }
+
+    func testIndexPathForRowReturnNull() {
+        /// This row doesn't exist in the initial sections array. The method should return nil
+        ///
+        let result = sections.indexPathForRow(.tumblr)
+        XCTAssertNil(result)
+    }
+}
+
+// MARK: - Row and Sections which conform to RowIterable
+//
+private extension ArrayIndexPathTests {
+
+    /// Table Rows
+    ///
+    enum Row {
+        case woocommerce
+        case wordpress
+        case simplenote
+        case tumblr
+
+
+        var reuseIdentifier: String {
+            return "The same identifier for every row"
+        }
+    }
+
+    /// Table Sections
+    ///
+    struct Section: RowIterable {
+        let rows: [Row]
+
+        init(rows: [Row]) {
+            self.rows = rows
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/ArrayIndexPathTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/ArrayIndexPathTests.swift
@@ -47,11 +47,6 @@ private extension ArrayIndexPathTests {
         case wordpress
         case simplenote
         case tumblr
-
-
-        var reuseIdentifier: String {
-            return "The same identifier for every row"
-        }
     }
 
     /// Table Sections

--- a/WooCommerce/WooCommerceTests/Extensions/ArrayIndexPathTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/ArrayIndexPathTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 final class ArrayIndexPathTests: XCTestCase {
 
-    private var sections: [Section] = [Section(rows: [.simplenote, .wordpress]), Section(rows: [.woocommerce]), Section(rows: [.wordpress])]
+    private let sections: [Section] = [Section(rows: [.simplenote, .wordpress]), Section(rows: [.woocommerce]), Section(rows: [.wordpress])]
 
     func testIndexPathForRowReturnTheRightIndexPath() {
 


### PR DESCRIPTION
Fixes #2161 

## Description
In various points of the app, we need to get a cell at a particular IndexPath. We used the `getIndexPathForRow()` method, to get the index path of a cell, and get the text field inside that cell to make it the first responder.
Since the method `getIndexPathForRow()` started to become duplicated (until now in 3 different view controllers), to avoid duplication @jaclync suggested implementing an utility extension, where a Section need to conform to `RowIterable`.

## Testing
1. Open a product detail
2. Navigate to the product slug screen -> The keyboard should pop up.
3. Navigate to the product purchase note -> The keyboard should pop up.
4. Navigate to product inventory. Try to edit the SKU adding an invalid SKU. Try to re-edit it using a valid SKU.  -> The keyboard should close.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
