### PR TITLE
Fix Age.from returning `today` instead of `upcoming`

### DIFF
--- a/WooCommerce/Classes/Model/Age.swift
+++ b/WooCommerce/Classes/Model/Age.swift
@@ -54,8 +54,10 @@ extension Age {
         }
 
         if let month = dateComponents.month,
+           let weekOfYear = dateComponents.weekOfYear,
            let day = dateComponents.day,
            month == 0,
+           weekOfYear == 0,
            day == 0 {
             return .today
         }

--- a/WooCommerce/Classes/Model/Age.swift
+++ b/WooCommerce/Classes/Model/Age.swift
@@ -53,7 +53,10 @@ extension Age {
             return .yesterday
         }
 
-        if let day = dateComponents.day, day == 0 {
+        if let month = dateComponents.month,
+           let day = dateComponents.day,
+           month == 0,
+           day == 0 {
             return .today
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -1,6 +1,7 @@
 
 import Foundation
 import Yosemite
+import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
 
 /// ViewModel for `OrdersViewController`.
@@ -89,7 +90,17 @@ final class OrdersViewModel {
     ///
     func activateAndForwardUpdates(to tableView: UITableView) {
         resultsController.startForwardingEvents(to: tableView)
-        try? resultsController.performFetch()
+        performFetch()
+    }
+
+    /// Execute the `resultsController` query, logging the error if there's any.
+    ///
+    private func performFetch() {
+        do {
+            try resultsController.performFetch()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 
     /// Returns what `OrderAction` should be used when synchronizing.

--- a/WooCommerce/WooCommerceTests/Model/AgeTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/AgeTests.swift
@@ -140,4 +140,13 @@ final class AgeTests: XCTestCase {
 
         XCTAssertEqual(age, .upcoming)
     }
+
+    func testItReturnsUpcomingIfTheDateFromIsExactlyAYearAfterDateTo() {
+        let dateFrom = dateFormatter.date(from: "2021-03-08T00:00:00Z")!
+        let dateTo = dateFormatter.date(from: "2020-03-08T00:00:00Z")!
+
+        let age = Age.from(startDate: dateFrom, toDate: dateTo, using: calendar)
+
+        XCTAssertEqual(age, .upcoming)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Model/AgeTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/AgeTests.swift
@@ -122,4 +122,13 @@ final class AgeTests: XCTestCase {
 
         XCTAssertEqual(age, .upcoming)
     }
+
+    func testItReturnsUpcomingIfTheDateFromIsExactlyAMonthAfterDateTo() {
+        let dateFrom = dateFormatter.date(from: "2020-04-08T00:00:00Z")!
+        let dateTo = dateFormatter.date(from: "2020-03-08T00:00:00Z")!
+
+        let age = Age.from(startDate: dateFrom, toDate: dateTo, using: calendar)
+
+        XCTAssertEqual(age, .upcoming)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Model/AgeTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/AgeTests.swift
@@ -131,4 +131,13 @@ final class AgeTests: XCTestCase {
 
         XCTAssertEqual(age, .upcoming)
     }
+
+    func testItReturnsUpcomingIfTheDateFromIsExactlyAWeekAfterDateTo() {
+        let dateFrom = dateFormatter.date(from: "2020-03-15T00:00:00Z")!
+        let dateTo = dateFormatter.date(from: "2020-03-08T00:00:00Z")!
+
+        let age = Age.from(startDate: dateFrom, toDate: dateTo, using: calendar)
+
+        XCTAssertEqual(age, .upcoming)
+    }
 }


### PR DESCRIPTION
This fixes an issue in the Order List not getting loaded if an order is **exactly 1 month to the future**. The cause was the incorrect `today` calculation I added [here](https://github.com/woocommerce/woocommerce-ios/pull/2150/files#diff-3f6b3ad11392ac895822f7be127855b7). I didn't consider that `month` should be zero too. 

Luckily, the PR where that was introduced (#2150) is still in `develop`. 

This PR fixes the problem. In addition, I also added logging for `performFetch` so we can catch issues like this in the future. 

https://github.com/woocommerce/woocommerce-ios/blob/fb1f8566b689b2e579472a7e4f1d017c7c7d90f2/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L99-L103

## Testing

1. Create a _processing_ order that is **exactly a month into the future**. For example, if today is Apr 22nd, create an order with `dateCreated` set to May 22nd.
2. Create a _processing_ order that is **exactly a week into the future**. For example, if today is Apr 22nd, create an order with `dateCreated` set to Apr 29th.
3. Run the app. Navigate to Orders → Processing.
4. Confirm that the newly created orders are visible in the Upcoming section.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

