### PR TITLE
Refresh Order List on app activation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - Products: now the keyboard pop up automatically in Edit Description (M1), in Edit Short Description (M2), Edit Slug (M2), Edit Purchase Note (M2)
 - The Processing orders list will now show upcoming (future) orders.
 - Improved stats: fixed the incorrect time range on "This Week" tab when loading improved stats on a day when daily saving time changes.
+- The Orders list are now automatically refreshed when reopening the app. 
 
 
 4.1

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -137,6 +137,17 @@ private extension OrdersViewController {
     /// Initialize ViewModel operations
     ///
     func configureViewModel() {
+        viewModel.onShouldResynchronizeAfterAppActivation = { [weak self] in
+            guard let self = self,
+                  // Avoid synchronizing if the view is not visible. The refresh will be handled in
+                  // `viewWillAppear` instead.
+                  self.viewIfLoaded?.window != nil else {
+                return
+            }
+
+            self.syncingCoordinator.resynchronize()
+        }
+
         viewModel.activateAndForwardUpdates(to: tableView)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -28,9 +28,6 @@ final class OrdersViewModel {
 
     /// The block called if self requests a resynchronization of the first page.
     ///
-    /// In the future, if the `SyncCoordinator` should be managed by this `ViewModel`, then we
-    /// wouldn't need this block at all.
-    ///
     var onShouldResynchronizeAfterAppActivation: (() -> ())?
 
     /// OrderStatus that must be matched by retrieved orders.


### PR DESCRIPTION
⚠️ Please review #2177 first. 

Refs #927. 

This adds an automatic refresh when the app is placed in the foreground. I had thought that the `viewWillAppear` implementation in #2017 handles this. I was very wrong. I didn't realize that `viewWillAppear` doesn't get triggered when the app is placed in the foreground. 🤦 I don't know why I thought it did. 🤷 

## Changes

NSNotification observations were added in the `ViewModel` to detect app activation (foreground): 

https://github.com/woocommerce/woocommerce-ios/blob/68d63689435e0fb981aabd8ad457e1ad0749c5a1/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L105-L108

The `ViewController` waits for the `ViewModel` to notify it when to perform a re-synchronization. 

https://github.com/woocommerce/woocommerce-ios/blob/68d63689435e0fb981aabd8ad457e1ad0749c5a1/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift#L140-L149

The re-sync only happens if the view is still visible. That's because we already have a re-sync instruction in `viewWillAppear` which will sufficiently handle scenarios like main tab switching and switching between navigation views.

https://github.com/woocommerce/woocommerce-ios/blob/68d63689435e0fb981aabd8ad457e1ad0749c5a1/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift#L122-L125

## Closing #927

I think this and the `viewWillAppear` auto-refresh is enough to close the use case described in #927. But I'm gonna attempt first to implement auto-refresh when the app receives a push notification while it is active. 

<img src="https://user-images.githubusercontent.com/198826/80025054-43c5f480-849d-11ea-8ba1-65e8400b8350.png" width="300">

## Testing

1. Run the app. 
2. Navigate to Orders → Processing 
3. Place the app in the background. 
4. In the website, create new orders (Processing)
5. Open the app. 
6. Without doing anything, confirm that the newly created orders are **eventually** shown in the Order List.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] Get #2177 merged first.
- [x] Change the target branch to `develop`
- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

