### PR TITLE
Make sure PushNotificationManagerTests test objects are cleared

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -7,7 +7,7 @@ import Yosemite
 
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
 ///
-class PushNotificationsManager: PushNotesManager {
+final class PushNotificationsManager: PushNotesManager {
 
     /// PushNotifications Configuration
     ///

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -6,51 +6,69 @@ import Yosemite
 
 /// PushNotificationsManager Tests
 ///
-class PushNotificationsManagerTests: XCTestCase {
+final class PushNotificationsManagerTests: XCTestCase {
 
     /// PushNotifications Manager
     ///
-    private lazy var manager: PushNotificationsManager = {
-        let configuration = PushNotificationsConfiguration(application: self.application,
-                                                           defaults: self.defaults,
-                                                           storesManager: self.storesManager,
-                                                           supportManager: self.supportManager,
-                                                           userNotificationsCenter: self.userNotificationCenter)
-
-        return PushNotificationsManager(configuration: configuration)
-    }()
+    private var manager: PushNotificationsManager!
 
     /// Mockup: UIApplication
     ///
-    private let application = MockupApplicationAdapter()
+    private var application: MockupApplicationAdapter!
 
     /// UserDefaults: Testing Suite
     ///
-    private let defaults = UserDefaults(suiteName: Sample.defaultSuiteName)!
+    private var defaults: UserDefaults!
 
     /// Mockup: Stores Manager
     ///
-    private let storesManager = MockupStoresManager(sessionManager: .testingInstance)
+    private var storesManager: MockupStoresManager!
 
     /// Mockup: Support Manager
     ///
-    private let supportManager = MockupSupportManager()
+    private var supportManager: MockupSupportManager!
 
     /// Mockup: UserNotificationCenter
     ///
-    private let userNotificationCenter = MockupUserNotificationsCenterAdapter()
-
-
+    private var userNotificationCenter: MockupUserNotificationsCenterAdapter!
 
     // MARK: - Overridden Methods
 
     override func setUp() {
+        super.setUp()
+
+        application = MockupApplicationAdapter()
+
+        defaults = UserDefaults(suiteName: Sample.defaultSuiteName)
         defaults.removePersistentDomain(forName: Sample.defaultSuiteName)
-        application.reset()
-        storesManager.reset()
-        userNotificationCenter.reset()
+
+        storesManager = MockupStoresManager(sessionManager: .testingInstance)
+        supportManager = MockupSupportManager()
+        userNotificationCenter = MockupUserNotificationsCenterAdapter()
+
+        manager = {
+            let configuration = PushNotificationsConfiguration(application: self.application,
+                                                               defaults: self.defaults,
+                                                               storesManager: self.storesManager,
+                                                               supportManager: self.supportManager,
+                                                               userNotificationsCenter: self.userNotificationCenter)
+
+            return PushNotificationsManager(configuration: configuration)
+        }()
     }
 
+    override func tearDown() {
+        manager = nil
+        userNotificationCenter = nil
+        supportManager = nil
+        storesManager = nil
+
+        defaults.removePersistentDomain(forName: Sample.defaultSuiteName)
+        defaults = nil
+
+        application = nil
+        super.tearDown()
+    }
 
     /// Verifies that the PushNotificationsManager calls `registerForRemoteNotifications` in the UIApplication's Wrapper.
     ///


### PR DESCRIPTION
This is just a small improvement to slowly update our tests to [use `tearDown`](https://qualitycoding.org/xctestcase-teardown/). 

I also changed `PushNotificationsManager` to be `final` because it can be. I think `final` should be the default for our classes. 

## Testing

The unit tests passing should be good enough. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

