### PR TITLE
Fixed release notes for release 4.2

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,7 @@
 4.2
 -----
- 
 - Products: now tapping anywhere on a product cell where you need to insert data, like in Product Price and Product Shipping settings, you start to edit the text field.
-- Products: now the keyboard pop up automatically in Edit Description (M1), in Edit Short Description (M2), Edit Slug (M2), Edit Purchase Note (M2)
+- Products: now the keyboard pop up automatically in Edit Description
 - The Processing orders list will now show upcoming (future) orders.
 - Improved stats: fixed the incorrect time range on "This Week" tab when loading improved stats on a day when daily saving time changes.
 


### PR DESCRIPTION
After a discussion (see [here](https://a8c.slack.com/archives/CGPNUU63E/p1587580089008500)), we decided to not include in RELEASE-NOTES things not related to items for features users can't see yet.
This PR update the release notes for the next release 4.2.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
