### PR TITLE
CircleCI: Update Xcode to 11.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   Build Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.4.1"
     steps:
       - git/shallow-checkout
       - fix-circleci
@@ -36,10 +36,10 @@ jobs:
   Unit Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.4.1"
     steps:
       - ios/boot-simulator:
-          xcode-version: "11.2.1"
+          xcode-version: "11.4.1"
           device: iPhone 11
       - attach_workspace:
           at: ./
@@ -51,7 +51,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.4.1"
     steps:
       - git/shallow-checkout
       - fix-circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - ios/wait-for-simulator
       - ios/xcodebuild:
           command: test-without-building
-          arguments: -xctestrun DerivedData/Build/Products/WooCommerce_UnitTests_iphonesimulator13.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
+          arguments: -xctestrun DerivedData/Build/Products/WooCommerce_UnitTests_iphonesimulator13.4-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
       - ios/save-xcodebuild-artifacts
   Installable Build:
     executor:


### PR DESCRIPTION
In the [`issue/927-observables`](https://github.com/woocommerce/woocommerce-ios/tree/issue/927-observables) branch, I wanted to use [`XCTSkipIf`](https://developer.apple.com/documentation/xctest/3521325-xctskipif) to conditionally skip a unit test if the simulator is less than 13.0. Example:

https://github.com/woocommerce/woocommerce-ios/blob/c5d0cff51d44b957a1772bed5efc1804be0cfee1/WooCommerce/WooCommerceTests/Tools/Observables/PublishSubjectTests.swift#L234-L238

Using `XCTSkipIf()` allows better messaging when the tests are executed using an older simulator. The skipped tests are mentioned in the result:

```
Test Suite 'PublishSubjectTests' passed at 2020-04-24 09:20:55.451.
	 Executed 10 tests, with 5 tests skipped and 0 failures (0 unexpected) in 0.024 (0.068) seconds
Test Suite 'WooCommerceTests.xctest' passed at 2020-04-24 09:20:55.452.
	 Executed 10 tests, with 5 tests skipped and 0 failures (0 unexpected) in 0.024 (0.069) seconds
Test Suite 'Selected tests' passed at 2020-04-24 09:20:55.452.
	 Executed 10 tests, with 5 tests skipped and 0 failures (0 unexpected) in 0.024 (0.070) seconds
```

However, `XCTSkipIf` is only available for Xcode 11.4+. This PR updates the CircleCI config from 11.2.1 to 11.4.1 to solve this. 

## Questions

Is this okay? 😬Will this affect any of the release processes? 

## Testing

I believe checking if the build passed is good enough. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

---

Heads up @pmusolino @jaclync. This shouldn't be a problem for us too, right? 