### PR TITLE
Order List → Refresh When Receiving a new Order Notification While in the Foreground

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,8 @@
 - Products: now the keyboard pop up automatically in Edit Description
 - The Processing orders list will now show upcoming (future) orders.
 - Improved stats: fixed the incorrect time range on "This Week" tab when loading improved stats on a day when daily saving time changes.
-- The Orders list are now automatically refreshed when reopening the app. 
+- The Orders list is now automatically refreshed when reopening the app. 
+- The Orders list is automatically refreshed if a new order (push notification) comes in.
 
 
 4.1

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -251,8 +251,8 @@ private extension PushNotificationsManager {
             return false
         }
 
-        if let message = userInfo.dictionary(forKey: APNSKey.aps)?.string(forKey: APNSKey.alert) {
-            configuration.application.presentInAppNotification(message: message)
+        if let foregroundNotification = ForegroundNotification.from(userInfo: userInfo) {
+            configuration.application.presentInAppNotification(message: foregroundNotification.message)
         }
 
         synchronizeNotifications(completionHandler: completionHandler)
@@ -401,6 +401,20 @@ private extension PushNotificationsManager {
     }
 }
 
+// MARK: - ForegroundNotification Extension
+
+private extension ForegroundNotification {
+    static func from(userInfo: [AnyHashable: Any]) -> ForegroundNotification? {
+        guard let noteID = userInfo.integer(forKey: APNSKey.identifier),
+              let message = userInfo.dictionary(forKey: APNSKey.aps)?.string(forKey: APNSKey.alert),
+              let type = userInfo.string(forKey: APNSKey.type),
+              let noteKind = Note.Kind(rawValue: type) else {
+            return nil
+        }
+
+        return ForegroundNotification(noteID: noteID, kind: noteKind, message: message)
+    }
+}
 
 // MARK: - Private Types
 //

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -13,6 +13,16 @@ final class PushNotificationsManager: PushNotesManager {
     ///
     let configuration: PushNotificationsConfiguration
 
+    /// Mutable reference to `foregroundNotifications`.
+    private let foregroundNotificationsSubject = PublishSubject<ForegroundNotification>()
+
+    /// An observable that emits values when the Remote Notifications are received while the app is
+    /// in the foreground.
+    ///
+    var foregroundNotifications: Observable<ForegroundNotification> {
+        foregroundNotificationsSubject
+    }
+
     /// Returns the current Application's State
     ///
     private var applicationState: UIApplication.State {
@@ -253,6 +263,8 @@ private extension PushNotificationsManager {
 
         if let foregroundNotification = ForegroundNotification.from(userInfo: userInfo) {
             configuration.application.presentInAppNotification(message: foregroundNotification.message)
+
+            foregroundNotificationsSubject.send(foregroundNotification)
         }
 
         synchronizeNotifications(completionHandler: completionHandler)

--- a/WooCommerce/Classes/ServiceLocator/ForegroundNotification.swift
+++ b/WooCommerce/Classes/ServiceLocator/ForegroundNotification.swift
@@ -1,0 +1,12 @@
+
+import Foundation
+import struct Yosemite.Note
+
+/// Emitted by `PushNotificationsManager` when a remote notification is received while
+/// the app is active.
+///
+struct ForegroundNotification {
+    let noteID: Int
+    let kind: Note.Kind
+    let message: String
+}

--- a/WooCommerce/Classes/ServiceLocator/ForegroundNotification.swift
+++ b/WooCommerce/Classes/ServiceLocator/ForegroundNotification.swift
@@ -6,7 +6,13 @@ import struct Yosemite.Note
 /// the app is active.
 ///
 struct ForegroundNotification {
+    /// The `note_id` value received from the Remote Notification's `userInfo`.
+    ///
     let noteID: Int
+    /// The `type` value received from the Remote Notification's `userInfo`.
+    ///
     let kind: Note.Kind
+    /// The `alert` value received from the Remote Notification's `userInfo`.
+    ///
     let message: String
 }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -3,6 +3,11 @@ import UIKit
 
 protocol PushNotesManager {
 
+    /// An observable that emits values when the Remote Notifications are received while the app is
+    /// in the foreground.
+    ///
+    var foregroundNotifications: Observable<ForegroundNotification> { get }
+
     /// Resets the Badge Count.
     ///
     func resetBadgeCount()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -137,7 +137,7 @@ private extension OrdersViewController {
     /// Initialize ViewModel operations
     ///
     func configureViewModel() {
-        viewModel.onShouldResynchronizeAfterAppActivation = { [weak self] in
+        viewModel.onShouldResynchronizeIfViewIsVisible = { [weak self] in
             guard let self = self,
                   // Avoid synchronizing if the view is not visible. The refresh will be handled in
                   // `viewWillAppear` instead.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -24,7 +24,12 @@ final class OrdersViewModel {
     }
 
     private let storageManager: StorageManagerType
+    private let pushNotificationsManager: PushNotesManager
     private let notificationCenter: NotificationCenter
+
+    /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
+    ///
+    private var disposable: ObservationToken?
 
     /// The block called if self requests a resynchronization of the first page.
     ///
@@ -84,13 +89,19 @@ final class OrdersViewModel {
     }
 
     init(storageManager: StorageManagerType = ServiceLocator.storageManager,
+         pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
          statusFilter: OrderStatus?,
          includesFutureOrders: Bool = true) {
         self.storageManager = storageManager
+        self.pushNotificationsManager = pushNotificationsManager
         self.notificationCenter = notificationCenter
         self.statusFilter = statusFilter
         self.includesFutureOrders = includesFutureOrders
+    }
+
+    deinit {
+        stopObservingForegroundRemoteNotifications()
     }
 
     /// Start fetching DB results and forward new changes to the given `tableView`.
@@ -106,6 +117,8 @@ final class OrdersViewModel {
                                        name: UIApplication.willResignActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(handleAppActivation),
                                        name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        observeForegroundRemoteNotifications()
     }
 
     /// Execute the `resultsController` query, logging the error if there's any.
@@ -227,6 +240,29 @@ final class OrdersViewModel {
             pageSize: pageSize,
             onCompletion: completionHandler
         )
+    }
+}
+
+// MARK: - Remote Notifications Observation
+
+private extension OrdersViewModel {
+    /// Watch for "new order" Remote Notifications that are received while the app is in the
+    /// foreground.
+    ///
+    /// A refresh will be requested when receiving them.
+    ///
+    func observeForegroundRemoteNotifications() {
+        disposable = pushNotificationsManager.foregroundNotifications.subscribe { [weak self] notification in
+            guard notification.kind == .storeOrder else {
+                return
+            }
+
+            self?.onShouldResynchronizeAfterAppActivation?()
+        }
+    }
+
+    func stopObservingForegroundRemoteNotifications() {
+        disposable?.cancel()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -31,9 +31,10 @@ final class OrdersViewModel {
     ///
     private var cancellable: ObservationToken?
 
-    /// The block called if self requests a resynchronization of the first page.
+    /// The block called if self requests a resynchronization of the first page. The
+    /// resynchronization should only be done if the view is visible.
     ///
-    var onShouldResynchronizeAfterAppActivation: (() -> ())?
+    var onShouldResynchronizeIfViewIsVisible: (() -> ())?
 
     /// OrderStatus that must be matched by retrieved orders.
     ///
@@ -143,7 +144,7 @@ final class OrdersViewModel {
         }
 
         isAppActive = true
-        onShouldResynchronizeAfterAppActivation?()
+        onShouldResynchronizeIfViewIsVisible?()
     }
 
     /// Returns what `OrderAction` should be used when synchronizing.
@@ -257,7 +258,7 @@ private extension OrdersViewModel {
                 return
             }
 
-            self?.onShouldResynchronizeAfterAppActivation?()
+            self?.onShouldResynchronizeIfViewIsVisible?()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -29,7 +29,7 @@ final class OrdersViewModel {
 
     /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
     ///
-    private var disposable: ObservationToken?
+    private var cancellable: ObservationToken?
 
     /// The block called if self requests a resynchronization of the first page.
     ///
@@ -252,7 +252,7 @@ private extension OrdersViewModel {
     /// A refresh will be requested when receiving them.
     ///
     func observeForegroundRemoteNotifications() {
-        disposable = pushNotificationsManager.foregroundNotifications.subscribe { [weak self] notification in
+        cancellable = pushNotificationsManager.foregroundNotifications.subscribe { [weak self] notification in
             guard notification.kind == .storeOrder else {
                 return
             }
@@ -262,7 +262,7 @@ private extension OrdersViewModel {
     }
 
     func stopObservingForegroundRemoteNotifications() {
-        disposable?.cancel()
+        cancellable?.cancel()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */; };
 		6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */; };
 		6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */; };
+		6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */; };
 		6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */; };
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
@@ -1145,6 +1146,7 @@
 		57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModelTests.swift; sourceTree = "<group>"; };
 		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
 		6856D1A5F72A36AB3704D19D /* AgeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgeTests.swift; sourceTree = "<group>"; };
+		6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPushNotificationsManager.swift; sourceTree = "<group>"; };
 		6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardFrameAdjustmentProvider.swift; sourceTree = "<group>"; };
 		6856D66A1963092C34D20674 /* Calendar+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Calendar+Extensions.swift"; sourceTree = "<group>"; };
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
@@ -2452,6 +2454,7 @@
 				02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */,
 				02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */,
 				02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */,
+				6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */,
 			);
 			path = Mockups;
 			sourceTree = "<group>";
@@ -4872,6 +4875,7 @@
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
+				6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		5754727B2451F14600A94C3C /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727A2451F14600A94C3C /* Observable.swift */; };
 		5754727D2451F1D800A94C3C /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727C2451F1D800A94C3C /* PublishSubject.swift */; };
 		5754727F24520B2A00A94C3C /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727E24520B2A00A94C3C /* Observer.swift */; };
+		575472812452185300A94C3C /* ForegroundNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* ForegroundNotification.swift */; };
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
@@ -1131,6 +1132,7 @@
 		5754727A2451F14600A94C3C /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		5754727C2451F1D800A94C3C /* PublishSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSubject.swift; sourceTree = "<group>"; };
 		5754727E24520B2A00A94C3C /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
+		575472802452185300A94C3C /* ForegroundNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundNotification.swift; sourceTree = "<group>"; };
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
@@ -3669,6 +3671,7 @@
 				D831E2DB230E0558000037D0 /* Authentication.swift */,
 				D831E2DF230E0BA7000037D0 /* Logs.swift */,
 				02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */,
+				575472802452185300A94C3C /* ForegroundNotification.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -4664,6 +4667,7 @@
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
+				575472812452185300A94C3C /* ForegroundNotification.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
@@ -41,8 +41,10 @@ final class MockPushNotificationsManager: PushNotesManager {
 }
 
 extension MockPushNotificationsManager {
+    /// Send a ForegroundNotification that will be emitted by the `foregroundNotifications`
+    /// observable.
+    ///
     func sendForegroundNotification(_ notification: ForegroundNotification) {
         foregroundNotificationsSubject.send(notification)
     }
 }
-

--- a/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
@@ -1,0 +1,48 @@
+
+import Foundation
+import UIKit
+@testable import WooCommerce
+
+final class MockPushNotificationsManager: PushNotesManager {
+
+    var foregroundNotifications: Observable<ForegroundNotification> {
+        foregroundNotificationsSubject
+    }
+
+    private let foregroundNotificationsSubject = PublishSubject<ForegroundNotification>()
+
+    func resetBadgeCount() {
+
+    }
+
+    func registerForRemoteNotifications() {
+
+    }
+
+    func unregisterForRemoteNotifications() {
+
+    }
+
+    func ensureAuthorizationIsRequested(onCompletion: ((Bool) -> ())?) {
+
+    }
+
+    func registrationDidFail(with error: Error) {
+
+    }
+
+    func registerDeviceToken(with tokenData: Data, defaultStoreID: Int64) {
+
+    }
+
+    func handleNotification(_ userInfo: [AnyHashable: Any], completionHandler: @escaping (UIKit.UIBackgroundFetchResult) -> ()) {
+
+    }
+}
+
+extension MockPushNotificationsManager {
+    func sendForegroundNotification(_ notification: ForegroundNotification) {
+        foregroundNotificationsSubject.send(notification)
+    }
+}
+

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -339,6 +339,52 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         XCTAssertEqual(application.presentInAppMessages.first, Sample.defaultMessage)
     }
+
+    // MARK: - Foreground Notification Observable
+
+    func testItEmitsForegroundNotificationsWhenItReceivesANotificationWhileAppIsActive() {
+        // Given
+        application.applicationState = .active
+
+        var emittedNotifications = [ForegroundNotification]()
+        _ = manager.foregroundNotifications.subscribe { notification in
+            emittedNotifications.append(notification)
+        }
+
+        let userinfo = notificationPayload(noteID: 9_981, type: .storeOrder)
+
+        // When
+        manager.handleNotification(userinfo) { _ in
+            // noop
+        }
+
+        // Then
+        XCTAssertEqual(emittedNotifications.count, 1)
+
+        let emittedNotification = emittedNotifications.first!
+        XCTAssertEqual(emittedNotification.kind, .storeOrder)
+        XCTAssertEqual(emittedNotification.noteID, 9_981)
+    }
+
+    func testItDoesNotEmitForegroundNotificationsWhenItReceivesANotificationWhileAppIsNotActive() {
+        // Given
+        application.applicationState = .background
+
+        var emittedNotifications = [ForegroundNotification]()
+        _ = manager.foregroundNotifications.subscribe { notification in
+            emittedNotifications.append(notification)
+        }
+
+        let userinfo = notificationPayload(noteID: 9_981, type: .storeOrder)
+
+        // When
+        manager.handleNotification(userinfo) { _ in
+            // noop
+        }
+
+        // Then
+        XCTAssertTrue(emittedNotifications.isEmpty)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -364,6 +364,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let emittedNotification = emittedNotifications.first!
         XCTAssertEqual(emittedNotification.kind, .storeOrder)
         XCTAssertEqual(emittedNotification.noteID, 9_981)
+        XCTAssertEqual(emittedNotification.message, Sample.defaultMessage)
     }
 
     func testItDoesNotEmitForegroundNotificationsWhenItReceivesANotificationWhileAppIsNotActive() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -334,7 +334,7 @@ final class OrdersViewModelTests: XCTestCase {
         let viewModel = OrdersViewModel(notificationCenter: notificationCenter, statusFilter: nil)
 
         var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeAfterAppActivation = {
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
             resynchronizeRequested = true
         }
 
@@ -354,7 +354,7 @@ final class OrdersViewModelTests: XCTestCase {
         let viewModel = OrdersViewModel(notificationCenter: notificationCenter, statusFilter: nil)
 
         var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeAfterAppActivation = {
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
             resynchronizeRequested = true
         }
 
@@ -375,7 +375,7 @@ final class OrdersViewModelTests: XCTestCase {
         let viewModel = OrdersViewModel(pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
 
         var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeAfterAppActivation = {
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
             resynchronizeRequested = true
         }
 
@@ -395,7 +395,7 @@ final class OrdersViewModelTests: XCTestCase {
         let viewModel = OrdersViewModel(pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
 
         var resynchronizeRequested = false
-        viewModel.onShouldResynchronizeAfterAppActivation = {
+        viewModel.onShouldResynchronizeIfViewIsVisible = {
             resynchronizeRequested = true
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -366,6 +366,48 @@ final class OrdersViewModelTests: XCTestCase {
         // Assert
         XCTAssertFalse(resynchronizeRequested)
     }
+
+    // MARK: - Foreground Notifications
+
+    func testGivenANewOrderNotificationItRequestsAResynchronization() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        let viewModel = OrdersViewModel(pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeAfterAppActivation = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Act
+        let notification = ForegroundNotification(noteID: 1, kind: .storeOrder, message: "")
+        pushNotificationsManager.sendForegroundNotification(notification)
+
+        // Assert
+        XCTAssertTrue(resynchronizeRequested)
+    }
+
+    func testGivenANonOrderNotificationItDoesNotRequestAResynchronization() {
+        // Arrange
+        let pushNotificationsManager = MockPushNotificationsManager()
+        let viewModel = OrdersViewModel(pushNotificationsManager: pushNotificationsManager, statusFilter: nil)
+
+        var resynchronizeRequested = false
+        viewModel.onShouldResynchronizeAfterAppActivation = {
+            resynchronizeRequested = true
+        }
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Act
+        let notification = ForegroundNotification(noteID: 1, kind: .comment, message: "")
+        pushNotificationsManager.sendForegroundNotification(notification)
+
+        // Assert
+        XCTAssertFalse(resynchronizeRequested)
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
Closes #927. 

⚠️ This depends on #2191. Please review that first. 

This continues #2178 by making the Order List auto-refresh when receiving a new order remote notification while the Order List is visible. 

This GIF shows the list auto-refreshing as soon as a remote notification arrives.

<img src="https://user-images.githubusercontent.com/198826/80232036-785abd00-8611-11ea-80bd-7d1fa2aee810.gif" width="320">

The auto-refresh only happens if the remote notification was received:

- while the Order List is visible 
- and the app is in the foreground.  

## Changes

This utilizes the `PublishSubject` added in #2191. In `PushNotifictionsManager` (`PushNotesManager` protocol), I added an exposed `foregroundNotifications` Observable:

https://github.com/woocommerce/woocommerce-ios/blob/51227df78a70dc643e26e06bc57a2d27fca38ccc/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift#L6-L9

`PushNotificationsManager` emits a new value on this Observable whenever a remote notification is received while the app is in the foreground (line 267):

https://github.com/woocommerce/woocommerce-ios/blob/51227df78a70dc643e26e06bc57a2d27fca38ccc/WooCommerce/Classes/Notifications/PushNotificationsManager.swift#L264-L268 

The `OrdersViewModel` subscribes to the `foregroundNotifications` Observable and requests a refresh when it receives a new value:

https://github.com/woocommerce/woocommerce-ios/blob/ed3103b8b27972922429e4d9d4fbe1cebcd0f610/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L254-L261

## Testing

1. Enable push notifications in the sandbox.
2. Run the app on a device. 
3. Navigate to Orders → Processing.
4. Keep the app open. 
5. Create a new order on the website. 
6. Confirm that when you see the in-app notification, the Order list is also refreshed and shows the new order. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [ ] ~Wait for #2191 to be merged~
- [x] If #2191 is accepted and merged, change the target branch to `develop`. 
- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

