### PR TITLE
Docs: Add Coding Guidelines about Structs vs Classes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,15 @@
 # WooCommerce for iOS 
 
-## Getting Started
-
-- [Coding Style Guide](coding-style-guide.md)
-
 ## Architecture
 
 - [Architecture](ARCHITECTURE.md)
 - [Networking](NETWORKING.md)
 - [Storage](STORAGE.md)
 - [Yosemite](YOSEMITE.md)
+
+## Coding Guidelines
+
+### Coding Style
+
+The guidelines for how Swift should be written and formatted can be found in the [Coding Style Guide](coding-style-guide.md).
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,14 @@
 
 The guidelines for how Swift should be written and formatted can be found in the [Coding Style Guide](coding-style-guide.md).
 
+### Choosing Between Structures and Classes
+
+In addition to the [Apple guidelines](https://developer.apple.com/documentation/swift/choosing_between_structures_and_classes), we generally prefer to use `struct` for: 
+
+- Value types like the [Networking Models](../../../Networking/Networking/Model)
+- Stateless helpers 
+
+But consider using `class` instead if:
+
+- You need to manage mutable states. Especially if there are more than a few `mutating` functions, the `struct` becomes harder to reason about.
+- You have to set a `struct` property declaration as `var` because it has a `mutating` function. In this case, a constant (`let`) `class` property may be easier to reason about.


### PR DESCRIPTION
I added a new **Coding Guidelines** section in the docs README. This is where we can add more guidelines like the storyboard vs xib files. For now, I only added the "Choosing Between Structures and Classes" section based on the discussion in https://github.com/woocommerce/woocommerce-ios/pull/2156#discussion_r411941983. 

Please feel free to comment on anything that I've written here. The guidelines are something that we have to agree about after all. 🙂 I also may have misunderstood the discussion! And if you have any suggestions, please feel free to suggest them. I feel like we can add more here but nothing comes to mind at the moment. 

## Testing

You may view the full README [here](https://github.com/woocommerce/woocommerce-ios/blob/update/docs-coding-guidelines/docs/README.md).

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

