### PR TITLE
LoginPrologue: Remove "Jetpack" text from Log In button

### DIFF
--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -112,7 +112,7 @@ private extension LoginPrologueViewController {
     }
 
     func setupLoginButton() {
-        let title = NSLocalizedString("Log in with Jetpack", comment: "Authentication Login Button")
+        let title = NSLocalizedString("Log In", comment: "Authentication Login Button")
         loginButton.titleLabel?.adjustsFontForContentSizeCategory = true
         loginButton.setTitle(title, for: .normal)
         loginButton.accessibilityIdentifier = "login-prologue-login-with-jetpack"

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -59,7 +59,7 @@ L3</string>
                             <constraints>
                                 <constraint firstAttribute="height" constant="50" id="Np7-w5-zh4"/>
                             </constraints>
-                            <state key="normal" title="Log in with Jetpack"/>
+                            <state key="normal" title="Log In"/>
                             <connections>
                                 <action selector="loginWasPressed" destination="-1" eventType="touchUpInside" id="TN0-aw-ptZ"/>
                             </connections>
@@ -79,10 +79,10 @@ L3</string>
                     </constraints>
                 </view>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1" image="prologue-slanted-rectangle" translatesAutoresizingMaskIntoConstraints="NO" id="Rhn-8s-tRs" userLabel="Slanted ImageView">
-                    <rect key="frame" x="0.0" y="365.5" width="414" height="320"/>
+                    <rect key="frame" x="0.0" y="525.5" width="414" height="160"/>
                 </imageView>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="200" image="prologue-bubbles" translatesAutoresizingMaskIntoConstraints="NO" id="pzF-Fz-byr" userLabel="Bubbles View">
-                    <rect key="frame" x="158" y="273" width="216" height="350"/>
+                    <rect key="frame" x="266" y="360.5" width="108" height="175"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="pzF-Fz-byr" secondAttribute="height" multiplier="108:175" id="Rsb-pu-GHs"/>
                     </constraints>


### PR DESCRIPTION
Refs p91TBi-2Cm-p2#comment-563

This removes the "Jetpack" text from the Log In button. The blurb mentioning "Jetpack" above the button is currently kept because we don't have an alternative for that yet. 

Before | After | After (Dark)
--------|-------|----
![before](https://user-images.githubusercontent.com/198826/80390694-04672180-886a-11ea-9684-65b3ca21da53.png)        |       ![iphone-11](https://user-images.githubusercontent.com/198826/80390717-0b8e2f80-886a-11ea-99e0-bed007c24dd9.png) | ![iphone-11-dark](https://user-images.githubusercontent.com/198826/80390703-06c97b80-886a-11ea-94dc-d68bbe238c3a.png)




## Testing

1. Remove the app from the device
2. Run the app
3. Confirm the button title is showing just "Log In"

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

