### PR TITLE
Refactor OrderSearchStarterViewModel for Testability

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -36,7 +36,7 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
 
         configureTableView()
 
-        viewModel.activate(using: tableView)
+        viewModel.activateAndForwardUpdates(to: tableView)
     }
 
     private func configureTableView() {

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -40,13 +40,38 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
     }
 
     private func configureTableView() {
-        tableView.backgroundColor = .listBackground
-        tableView.delegate = self
-
         tableView.register(BasicTableViewCell.loadNib(),
                            forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
 
+        tableView.backgroundColor = .listBackground
+        tableView.delegate = self
+        tableView.dataSource = self
+
         keyboardFrameObserver.startObservingKeyboardFrame()
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension OrderSearchStarterViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.numberOfObjects
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: BasicTableViewCell.reuseIdentifier,
+                                                 for: indexPath)
+        let orderStatus = viewModel.orderStatus(at: indexPath)
+
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = orderStatus.name
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        NSLocalizedString("Order Status", comment: "The section title for the list of Order statuses in the Order Search.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -43,6 +43,9 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
         tableView.backgroundColor = .listBackground
         tableView.delegate = self
 
+        tableView.register(BasicTableViewCell.loadNib(),
+                           forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
+
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -3,6 +3,8 @@ import Foundation
 import UIKit
 import Yosemite
 
+import class AutomatticTracks.CrashLogging
+
 /// ViewModel for `OrderSearchStarterViewController`.
 ///
 /// This encapsulates all the `OrderStatus` data loading and `UITableViewCell` presentation.
@@ -29,7 +31,17 @@ final class OrderSearchStarterViewModel {
     func activate(using tableView: UITableView) {
         resultsController.startForwardingEvents(to: tableView)
 
-        try? resultsController.performFetch()
+        performFetch()
+    }
+
+    /// Fetch and log the error if there's any.
+    ///
+    private func performFetch() {
+        do {
+            try resultsController.performFetch()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -28,7 +28,7 @@ final class OrderSearchStarterViewModel {
     /// - Parameters:
     ///     - tableView: The table to use for the results. This is not retained by this class.
     ///
-    func activate(using tableView: UITableView) {
+    func activateAndForwardUpdates(to tableView: UITableView) {
         resultsController.startForwardingEvents(to: tableView)
 
         performFetch()

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -20,7 +20,6 @@ final class OrderSearchStarterViewModel {
     func activate(using tableView: UITableView) {
         tableView.dataSource = dataSource
 
-        dataSource.registerCells(for: tableView)
         dataSource.startForwardingEvents(to: tableView)
 
         try? dataSource.performFetch()
@@ -61,15 +60,6 @@ private extension OrderSearchStarterViewModel {
         ///
         func startForwardingEvents(to tableView: UITableView) {
             resultsController.startForwardingEvents(to: tableView)
-        }
-
-        /// Register the `UITableViewCells` that will be used.
-        ///
-        /// This should only be called once.
-        ///
-        func registerCells(for tableView: UITableView) {
-            tableView.register(BasicTableViewCell.loadNib(),
-                               forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
         }
 
         /// The `OrderStatus` located at `indexPath`.

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -8,7 +8,16 @@ import Yosemite
 /// This encapsulates all the `OrderStatus` data loading and `UITableViewCell` presentation.
 ///
 final class OrderSearchStarterViewModel {
-    private lazy var dataSource = DataSource()
+    private let storageManager = ServiceLocator.storageManager
+    private let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
+
+    private lazy var resultsController: ResultsController<StorageOrderStatus> = {
+        let descriptor = NSSortDescriptor(key: "slug", ascending: true)
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        return ResultsController<StorageOrderStatus>(storageManager: storageManager,
+                                                     matching: predicate,
+                                                     sortedBy: [descriptor])
+    }()
 
     /// Start all the operations that this `ViewModel` is responsible for.
     ///
@@ -18,9 +27,9 @@ final class OrderSearchStarterViewModel {
     ///     - tableView: The table to use for the results. This is not retained by this class.
     ///
     func activate(using tableView: UITableView) {
-        dataSource.startForwardingEvents(to: tableView)
+        resultsController.startForwardingEvents(to: tableView)
 
-        try? dataSource.performFetch()
+        try? resultsController.performFetch()
     }
 }
 
@@ -30,43 +39,12 @@ extension OrderSearchStarterViewModel {
     /// The number of DB results
     ///
     var numberOfObjects: Int {
-        dataSource.resultsController.numberOfObjects
+        resultsController.numberOfObjects
     }
 
     /// The `OrderStatus` located at `indexPath`.
     ///
     func orderStatus(at indexPath: IndexPath) -> OrderStatus {
-        dataSource.resultsController.object(at: indexPath)
-    }
-}
-
-private extension OrderSearchStarterViewModel {
-    /// Encpsulates data loading and presentation of the `UITableViewCells`.
-    ///
-    final class DataSource: NSObject {
-        private let storageManager = ServiceLocator.storageManager
-        private let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
-
-        private(set) lazy var resultsController: ResultsController<StorageOrderStatus> = {
-            let descriptor = NSSortDescriptor(key: "slug", ascending: true)
-            let predicate = NSPredicate(format: "siteID == %lld", siteID)
-            return ResultsController<StorageOrderStatus>(storageManager: storageManager,
-                                                         matching: predicate,
-                                                         sortedBy: [descriptor])
-        }()
-
-        /// Run the query to fetch all the `OrderStatus`.
-        ///
-        func performFetch() throws {
-            try resultsController.performFetch()
-        }
-
-        /// Attach events so the `tableView` is always kept up to date.
-        ///
-        /// This should only be called once.
-        ///
-        func startForwardingEvents(to tableView: UITableView) {
-            resultsController.startForwardingEvents(to: tableView)
-        }
+        resultsController.object(at: indexPath)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -22,12 +22,6 @@ final class OrderSearchStarterViewModel {
 
         try? dataSource.performFetch()
     }
-
-    /// The `OrderStatus` located at `indexPath`.
-    ///
-    func orderStatus(at indexPath: IndexPath) -> OrderStatus {
-        dataSource.resultsController.object(at: indexPath)
-    }
 }
 
 // MARK: - TableView Support
@@ -37,6 +31,12 @@ extension OrderSearchStarterViewModel {
     ///
     var numberOfObjects: Int {
         dataSource.resultsController.numberOfObjects
+    }
+
+    /// The `OrderStatus` located at `indexPath`.
+    ///
+    func orderStatus(at indexPath: IndexPath) -> OrderStatus {
+        dataSource.resultsController.object(at: indexPath)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -4,14 +4,15 @@ import UIKit
 import Yosemite
 
 import class AutomatticTracks.CrashLogging
+import protocol Storage.StorageManagerType
 
 /// ViewModel for `OrderSearchStarterViewController`.
 ///
 /// This encapsulates all the `OrderStatus` data loading and `UITableViewCell` presentation.
 ///
 final class OrderSearchStarterViewModel {
-    private let storageManager = ServiceLocator.storageManager
-    private let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
+    private let siteID: Int64
+    private let storageManager: StorageManagerType
 
     private lazy var resultsController: ResultsController<StorageOrderStatus> = {
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
@@ -20,6 +21,12 @@ final class OrderSearchStarterViewModel {
                                                      matching: predicate,
                                                      sortedBy: [descriptor])
     }()
+
+    init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.siteID = siteID
+        self.storageManager = storageManager
+    }
 
     /// Start all the operations that this `ViewModel` is responsible for.
     ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45FBDF36238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.xib */; };
 		45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF35238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.swift */; };
 		45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */; };
+		573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */; };
 		57448D28242E775000A56A74 /* EmptySearchResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57448D27242E775000A56A74 /* EmptySearchResultsViewController.swift */; };
 		57448D2A242E777700A56A74 /* EmptySearchResultsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57448D29242E777700A56A74 /* EmptySearchResultsViewController.xib */; };
 		5754727B2451F14600A94C3C /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727A2451F14600A94C3C /* Observable.swift */; };
@@ -1128,6 +1129,7 @@
 		45FBDF35238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		45FBDF36238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ExtendedAddProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
+		573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
 		57448D27242E775000A56A74 /* EmptySearchResultsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptySearchResultsViewController.swift; sourceTree = "<group>"; };
 		57448D29242E777700A56A74 /* EmptySearchResultsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptySearchResultsViewController.xib; sourceTree = "<group>"; };
 		5754727A2451F14600A94C3C /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
@@ -2339,6 +2341,22 @@
 				45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */,
 			);
 			path = "Collection View Cells";
+			sourceTree = "<group>";
+		};
+		573D0ACC2458665C004DE614 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				573D0ACD2458665C004DE614 /* Order */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		573D0ACD2458665C004DE614 /* Order */ = {
+			isa = PBXGroup;
+			children = (
+				573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */,
+			);
+			path = Order;
 			sourceTree = "<group>";
 		};
 		57448D26242E772300A56A74 /* EmptySearchResultsViewController */ = {
@@ -3621,13 +3639,13 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
-				57A3C0E0245761DD004FB211 /* Search */,
 				57F34A9F2423D44000E38AFB /* Orders */,
 				0290E27C238E5B4A00B5C466 /* ListSelector */,
 				0227958E237A5D5200787C63 /* Editor */,
 				0269576B237263F3001BA0BF /* Keyboard */,
 				02E4FD7F2306AA770049610C /* Dashboard */,
 				0269177E23260090002AFC20 /* Products */,
+				573D0ACC2458665C004DE614 /* Search */,
 				D85B833E2230F268002168F3 /* SummaryTableViewCellTests.swift */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
@@ -4765,7 +4783,6 @@
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
-				57A3C0E324576207004FB211 /* OrderSearchStarterViewModelTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,
 				D83A6A782379097A00419D48 /* MurielColorTests.swift in Sources */,
 				020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */,
@@ -4867,6 +4884,7 @@
 				0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorDataSourceTests.swift in Sources */,
 				020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */,
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
+				573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */,
 				D85136DD231E613900DD0539 /* ReviewsViewModelTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
+		57A3C0E324576207004FB211 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A3C0E224576207004FB211 /* OrderSearchStarterViewModelTests.swift */; };
 		57AE0B0123ECD6D400237009 /* OrdersViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57AE0B0023ECD6D400237009 /* OrdersViewController.xib */; };
 		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
@@ -1128,6 +1129,7 @@
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
+		57A3C0E224576207004FB211 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
 		57AE0B0023ECD6D400237009 /* OrdersViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersViewController.xib; sourceTree = "<group>"; };
 		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
@@ -2336,6 +2338,22 @@
 				57448D29242E777700A56A74 /* EmptySearchResultsViewController.xib */,
 			);
 			path = EmptySearchResultsViewController;
+			sourceTree = "<group>";
+		};
+		57A3C0E0245761DD004FB211 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				57A3C0E1245761EE004FB211 /* Order */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		57A3C0E1245761EE004FB211 /* Order */ = {
+			isa = PBXGroup;
+			children = (
+				57A3C0E224576207004FB211 /* OrderSearchStarterViewModelTests.swift */,
+			);
+			path = Order;
 			sourceTree = "<group>";
 		};
 		57F34A9F2423D44000E38AFB /* Orders */ = {
@@ -3588,6 +3606,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				57A3C0E0245761DD004FB211 /* Search */,
 				57F34A9F2423D44000E38AFB /* Orders */,
 				0290E27C238E5B4A00B5C466 /* ListSelector */,
 				0227958E237A5D5200787C63 /* Editor */,
@@ -4726,6 +4745,7 @@
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
+				57A3C0E324576207004FB211 /* OrderSearchStarterViewModelTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,
 				D83A6A782379097A00419D48 /* MurielColorTests.swift in Sources */,
 				020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
@@ -1,0 +1,98 @@
+
+import XCTest
+import Foundation
+import Yosemite
+import Storage
+
+@testable import WooCommerce
+
+/// Tests for `OrderSearchStarterViewModel`
+///
+final class OrderSearchStarterViewModelTests: XCTestCase {
+    private let siteID: Int64 = 1_000_000
+
+    private var storageManager: StorageManagerType!
+
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        storageManager = MockupStorageManager()
+        super.setUp()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func testItLoadsAllTheOrderStatusForTheGivenSite() {
+        // Given
+        let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
+
+        let expectedItems = [
+            insertOrderStatus(siteID: siteID, status: .completed),
+            insertOrderStatus(siteID: siteID, status: .failed),
+            insertOrderStatus(siteID: siteID, status: .processing),
+        ]
+
+        let unexpectedItem = insertOrderStatus(siteID: 511_315, status: .pending)
+
+        // When
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Then
+        XCTAssertEqual(viewModel.numberOfObjects, expectedItems.count)
+        XCTAssertFalse(viewModel.fetchedOrderStatuses.contains(where: { $0.siteID != siteID }))
+        XCTAssertFalse(viewModel.fetchedOrderStatuses.contains(unexpectedItem))
+    }
+
+    func testItSortsTheOrderStatusesBySlug() {
+        // Given
+        let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
+
+        insertOrderStatus(siteID: siteID, status: .completed, slug: "delta")
+        insertOrderStatus(siteID: siteID, status: .processing, slug: "charlie")
+        insertOrderStatus(siteID: siteID, status: .failed, slug: "echo")
+        insertOrderStatus(siteID: siteID, status: .cancelled, slug: "alpha")
+        insertOrderStatus(siteID: siteID, status: .cancelled, slug: "beta")
+
+        // When
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // Then
+        let expectedSlugs = ["alpha", "beta", "charlie", "delta", "echo"]
+        let actualSlugs = viewModel.fetchedOrderStatuses.map(\.slug)
+        XCTAssertEqual(actualSlugs, expectedSlugs)
+    }
+}
+
+// MARK: - Helpers
+
+private extension OrderSearchStarterViewModel {
+    /// Returns the `OrderStatus` for all the rows
+    ///
+    var fetchedOrderStatuses: [Yosemite.OrderStatus] {
+        (0..<numberOfObjects).map { orderStatus(at: IndexPath(row: $0, section: 0)) }
+    }
+}
+
+// MARK: - Fixtures
+
+private extension OrderSearchStarterViewModelTests {
+    @discardableResult
+    func insertOrderStatus(siteID: Int64,
+                           status: OrderStatusEnum,
+                           slug: String? = nil) -> Yosemite.OrderStatus {
+        let readOnlyOrderStatus = OrderStatus(name: status.rawValue,
+                                              siteID: siteID,
+                                              slug: slug ?? status.rawValue,
+                                              total: 0)
+
+        let storageOrderStatus = storage.insertNewObject(ofType: StorageOrderStatus.self)
+        storageOrderStatus.update(with: readOnlyOrderStatus)
+
+        return readOnlyOrderStatus
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
@@ -18,8 +18,8 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
     }
 
     override func setUp() {
-        storageManager = MockupStorageManager()
         super.setUp()
+        storageManager = MockupStorageManager()
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
@@ -44,6 +44,7 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.numberOfObjects, expectedItems.count)
+        XCTAssertEqual(viewModel.fetchedOrderStatuses, expectedItems)
         XCTAssertFalse(viewModel.fetchedOrderStatuses.contains(where: { $0.siteID != siteID }))
         XCTAssertFalse(viewModel.fetchedOrderStatuses.contains(unexpectedItem))
     }


### PR DESCRIPTION
Refs #2171. 

Before I tackle any changes for #2171, I'd like to first fix my horrible mistake which is [`OrderSearchStarterViewModel`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift). When I created that, I wanted to find a way to hide many implementation details from the `ViewController` and take away a lot of boilerplate from working with `ResultsController`. It didn't work too well. 

Here are the mistakes from that attempt:

- The cell **view creation** is in the `ViewModel`. I should have realized this from the start. 😞 
- It was difficult to test because the methods are hidden.

## Changes

This PR refactors `OrderSearchStarterViewModel` so that:

- The cell view creation is now in the `ViewController`. 
- It now [has unit tests](https://github.com/woocommerce/woocommerce-ios/blob/issue/2171-refactor-order-starter-vm/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift)!

There should be no feature changes. All the operations should be the same. The only tiny addition is the logging of errors in `performFetch`: 

https://github.com/woocommerce/woocommerce-ios/blob/87fa2974ffe824061eb498ae9ccb44e02337b13c/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift#L44-L52

## Testing

Please test for regression: 

1. Navigate to Orders → Search.
2. Confirm that order statuses are still loaded. 
3. Confirm that you can still tap on them and view a filtered orders list. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

