### PR TITLE
Filter Products: navigate to screens for filtering products by stock status, product status, and product type

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListCommand.swift
@@ -55,7 +55,53 @@ final class FilterProductListCommand: FilterListCommand {
     }
 
     func onFilterSelected(_ filter: ProductListFilter, viewController: ListSelectorCommand.ViewController) {
-        // TODO-2037: navigate to the filter option list selector
+        let filterOptionListSelector: UIViewController
+        switch filter {
+        case .stockStatus:
+            let command = FilterProductsByStockStatusListSelectorCommand(selected: filterListSelectorCommand.filters.stockStatus) { [weak self] selected in
+                guard let self = self else {
+                    return
+                }
+
+                /// TODO: update to use `Copiable`.
+                let currentFilters = self.filterListSelectorCommand.filters
+                let newFilters = Filters(stockStatus: selected ?? nil, productStatus: currentFilters.productStatus, productType: currentFilters.productType)
+                self.onFiltersUpdate(filters: newFilters) { [weak viewController] in
+                    viewController?.reloadData()
+                }
+            }
+            filterOptionListSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
+        case .productStatus:
+            let command = FilterProductsByProductStatusListSelectorCommand(selected: filterListSelectorCommand.filters.productStatus) { [weak self] selected in
+                guard let self = self else {
+                    return
+                }
+
+                /// TODO: update to use `Copiable`.
+                let currentFilters = self.filterListSelectorCommand.filters
+                let newFilters = Filters(stockStatus: currentFilters.stockStatus, productStatus: selected ?? nil, productType: currentFilters.productType)
+                self.onFiltersUpdate(filters: newFilters) { [weak viewController] in
+                    viewController?.reloadData()
+                }
+            }
+            filterOptionListSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
+        case .productType:
+            let command = FilterProductsByProductTypeListSelectorCommand(selected: filterListSelectorCommand.filters.productType) { [weak self] selected in
+                guard let self = self else {
+                    return
+                }
+
+                /// TODO: update to use `Copiable`.
+                let currentFilters = self.filterListSelectorCommand.filters
+                let newFilters = Filters(stockStatus: currentFilters.stockStatus, productStatus: currentFilters.productStatus, productType: selected ?? nil)
+                self.onFiltersUpdate(filters: newFilters) { [weak viewController] in
+                    viewController?.reloadData()
+                }
+            }
+            filterOptionListSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
+        }
+
+        viewController.navigationController?.pushViewController(filterOptionListSelector, animated: true)
     }
 
     func onFilterActionTapped() {

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListCommand.swift
@@ -66,9 +66,7 @@ final class FilterProductListCommand: FilterListCommand {
                 /// TODO: update to use `Copiable`.
                 let currentFilters = self.filterListSelectorCommand.filters
                 let newFilters = Filters(stockStatus: selected ?? nil, productStatus: currentFilters.productStatus, productType: currentFilters.productType)
-                self.onFiltersUpdate(filters: newFilters) { [weak viewController] in
-                    viewController?.reloadData()
-                }
+                self.onFiltersUpdate(filters: newFilters)
             }
             filterOptionListSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
         case .productStatus:
@@ -80,9 +78,7 @@ final class FilterProductListCommand: FilterListCommand {
                 /// TODO: update to use `Copiable`.
                 let currentFilters = self.filterListSelectorCommand.filters
                 let newFilters = Filters(stockStatus: currentFilters.stockStatus, productStatus: selected ?? nil, productType: currentFilters.productType)
-                self.onFiltersUpdate(filters: newFilters) { [weak viewController] in
-                    viewController?.reloadData()
-                }
+                self.onFiltersUpdate(filters: newFilters)
             }
             filterOptionListSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
         case .productType:
@@ -94,9 +90,7 @@ final class FilterProductListCommand: FilterListCommand {
                 /// TODO: update to use `Copiable`.
                 let currentFilters = self.filterListSelectorCommand.filters
                 let newFilters = Filters(stockStatus: currentFilters.stockStatus, productStatus: currentFilters.productStatus, productType: selected ?? nil)
-                self.onFiltersUpdate(filters: newFilters) { [weak viewController] in
-                    viewController?.reloadData()
-                }
+                self.onFiltersUpdate(filters: newFilters)
             }
             filterOptionListSelector = ListSelectorViewController(command: command, onDismiss: { _ in })
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductStatusListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductStatusListSelectorCommand.swift
@@ -6,7 +6,8 @@ final class FilterProductsByProductStatusListSelectorCommand: ListSelectorComman
     typealias Model = ProductStatus?
     typealias Cell = BasicTableViewCell
 
-    let navigationBarTitle: String? = NSLocalizedString("Product status", comment: "Navigation bar title of the selector for filtering products by stock status.")
+    let navigationBarTitle: String? = NSLocalizedString("Product status",
+                                                        comment: "Navigation bar title of the selector for filtering products by product status.")
 
     let data: [ProductStatus?] = [nil, .publish, .draft, .pending]
 

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductStatusListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductStatusListSelectorCommand.swift
@@ -1,0 +1,38 @@
+import UIKit
+import Yosemite
+
+/// `ListSelectorCommand` for filtering a list of products by product status.
+final class FilterProductsByProductStatusListSelectorCommand: ListSelectorCommand {
+    typealias Model = ProductStatus?
+    typealias Cell = BasicTableViewCell
+
+    let navigationBarTitle: String? = NSLocalizedString("Product status", comment: "Navigation bar title of the selector for filtering products by stock status.")
+
+    let data: [ProductStatus?] = [nil, .publish, .draft, .pending]
+
+    private(set) var selected: ProductStatus??
+
+    private let onSelectedChange: (_ selected: ProductStatus?) -> Void
+
+    init(selected: ProductStatus?, onSelectedChange: @escaping (_ selected: ProductStatus?) -> Void) {
+        self.selected = selected
+        self.onSelectedChange = onSelectedChange
+    }
+
+    func handleSelectedChange(selected: ProductStatus?, viewController: ViewController) {
+        self.selected = selected
+        onSelectedChange(selected ?? nil)
+    }
+
+    func isSelected(model: ProductStatus?) -> Bool {
+        return model == selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: ProductStatus?) {
+        cell.textLabel?.text = model?.description ?? Constant.noFilterValueTitle
+    }
+
+    private enum Constant {
+        static let noFilterValueTitle = NSLocalizedString("Any", comment: "Title when there is no filter set.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductTypeListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductTypeListSelectorCommand.swift
@@ -1,0 +1,38 @@
+import UIKit
+import Yosemite
+
+/// `ListSelectorCommand` for filtering a list of products by product type.
+final class FilterProductsByProductTypeListSelectorCommand: ListSelectorCommand {
+    typealias Model = ProductType?
+    typealias Cell = BasicTableViewCell
+
+    let navigationBarTitle: String? = NSLocalizedString("Product type", comment: "Navigation bar title of the selector for filtering products by product type.")
+
+    let data: [ProductType?] = [nil, .simple, .variable, .grouped, .affiliate]
+
+    private(set) var selected: ProductType??
+
+    private let onSelectedChange: (_ selected: ProductType?) -> Void
+
+    init(selected: ProductType?, onSelectedChange: @escaping (_ selected: ProductType?) -> Void) {
+        self.selected = selected
+        self.onSelectedChange = onSelectedChange
+    }
+
+    func handleSelectedChange(selected: ProductType?, viewController: ViewController) {
+        self.selected = selected
+        onSelectedChange(selected ?? nil)
+    }
+
+    func isSelected(model: ProductType?) -> Bool {
+        return model == selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: ProductType?) {
+        cell.textLabel?.text = model?.description ?? Constant.noFilterValueTitle
+    }
+
+    private enum Constant {
+        static let noFilterValueTitle = NSLocalizedString("Any", comment: "Title when there is no filter set.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByStockStatusListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByStockStatusListSelectorCommand.swift
@@ -1,0 +1,38 @@
+import UIKit
+import Yosemite
+
+/// `ListSelectorCommand` for filtering a list of products by stock status.
+final class FilterProductsByStockStatusListSelectorCommand: ListSelectorCommand {
+    typealias Model = ProductStockStatus?
+    typealias Cell = BasicTableViewCell
+
+    let navigationBarTitle: String? = NSLocalizedString("Stock status", comment: "Navigation bar title of the selector for filtering products by stock status.")
+
+    let data: [ProductStockStatus?] = [nil, .inStock, .outOfStock, .onBackOrder]
+
+    private(set) var selected: ProductStockStatus??
+
+    private let onSelectedChange: (_ selected: ProductStockStatus?) -> Void
+
+    init(selected: ProductStockStatus?, onSelectedChange: @escaping (_ selected: ProductStockStatus?) -> Void) {
+        self.selected = selected
+        self.onSelectedChange = onSelectedChange
+    }
+
+    func handleSelectedChange(selected: ProductStockStatus?, viewController: ViewController) {
+        self.selected = selected
+        onSelectedChange(selected ?? nil)
+    }
+
+    func isSelected(model: ProductStockStatus?) -> Bool {
+        return model == selected
+    }
+
+    func configureCell(cell: BasicTableViewCell, model: ProductStockStatus?) {
+        cell.textLabel?.text = model?.description ?? Constant.noFilterValueTitle
+    }
+
+    private enum Constant {
+        static let noFilterValueTitle = NSLocalizedString("Any", comment: "Title when there is no filter set.")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -112,6 +112,12 @@
 		0248B3512457C41000A271A4 /* FilterProductListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B3502457C41000A271A4 /* FilterProductListSelectorCommand.swift */; };
 		0248B3542457CF3E00A271A4 /* FilterProductListCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B3532457CF3E00A271A4 /* FilterProductListCommandTests.swift */; };
 		0248B3572457D47900A271A4 /* FilterProductListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B3562457D47900A271A4 /* FilterProductListSelectorCommandTests.swift */; };
+		0248B359245813B300A271A4 /* FilterProductsByStockStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B358245813B300A271A4 /* FilterProductsByStockStatusListSelectorCommand.swift */; };
+		0248B35B245813E700A271A4 /* FilterProductsByProductStatusListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B35A245813E700A271A4 /* FilterProductsByProductStatusListSelectorCommand.swift */; };
+		0248B35D245814E600A271A4 /* FilterProductsByProductTypeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B35C245814E600A271A4 /* FilterProductsByProductTypeListSelectorCommand.swift */; };
+		0248B35F2458163D00A271A4 /* FilterProductsByStockStatusListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B35E2458163D00A271A4 /* FilterProductsByStockStatusListSelectorCommandTests.swift */; };
+		0248B3612458185600A271A4 /* FilterProductsByProductStatusListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B3602458185600A271A4 /* FilterProductsByProductStatusListSelectorCommandTests.swift */; };
+		0248B3632458191800A271A4 /* FilterProductsByProductTypeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0248B3622458191800A271A4 /* FilterProductsByProductTypeListSelectorCommandTests.swift */; };
 		024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */; };
 		024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */; };
 		024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024DF3042372ADCD006658FE /* KeyboardScrollable.swift */; };
@@ -937,6 +943,12 @@
 		0248B3502457C41000A271A4 /* FilterProductListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListSelectorCommand.swift; sourceTree = "<group>"; };
 		0248B3532457CF3E00A271A4 /* FilterProductListCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListCommandTests.swift; sourceTree = "<group>"; };
 		0248B3562457D47900A271A4 /* FilterProductListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		0248B358245813B300A271A4 /* FilterProductsByStockStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductsByStockStatusListSelectorCommand.swift; sourceTree = "<group>"; };
+		0248B35A245813E700A271A4 /* FilterProductsByProductStatusListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductsByProductStatusListSelectorCommand.swift; sourceTree = "<group>"; };
+		0248B35C245814E600A271A4 /* FilterProductsByProductTypeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductsByProductTypeListSelectorCommand.swift; sourceTree = "<group>"; };
+		0248B35E2458163D00A271A4 /* FilterProductsByStockStatusListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductsByStockStatusListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		0248B3602458185600A271A4 /* FilterProductsByProductStatusListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductsByProductStatusListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		0248B3622458191800A271A4 /* FilterProductsByProductTypeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductsByProductTypeListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		024A543322BA6F8F00F4F38E /* DeveloperEmailChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailChecker.swift; sourceTree = "<group>"; };
 		024A543522BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperEmailCheckerTests.swift; sourceTree = "<group>"; };
 		024DF3042372ADCD006658FE /* KeyboardScrollable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollable.swift; sourceTree = "<group>"; };
@@ -1875,6 +1887,9 @@
 			isa = PBXGroup;
 			children = (
 				0248B3502457C41000A271A4 /* FilterProductListSelectorCommand.swift */,
+				0248B358245813B300A271A4 /* FilterProductsByStockStatusListSelectorCommand.swift */,
+				0248B35A245813E700A271A4 /* FilterProductsByProductStatusListSelectorCommand.swift */,
+				0248B35C245814E600A271A4 /* FilterProductsByProductTypeListSelectorCommand.swift */,
 			);
 			path = ListSelectorCommand;
 			sourceTree = "<group>";
@@ -1892,6 +1907,9 @@
 			isa = PBXGroup;
 			children = (
 				0248B3562457D47900A271A4 /* FilterProductListSelectorCommandTests.swift */,
+				0248B35E2458163D00A271A4 /* FilterProductsByStockStatusListSelectorCommandTests.swift */,
+				0248B3602458185600A271A4 /* FilterProductsByProductStatusListSelectorCommandTests.swift */,
+				0248B3622458191800A271A4 /* FilterProductsByProductTypeListSelectorCommandTests.swift */,
 			);
 			path = ListSelectorCommand;
 			sourceTree = "<group>";
@@ -4491,6 +4509,7 @@
 				02EA6BF82435E80600FFF90A /* ImageDownloader.swift in Sources */,
 				CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */,
 				02357B2A23CDB3E300147C2B /* ProductImageViewController.swift in Sources */,
+				0248B35D245814E600A271A4 /* FilterProductsByProductTypeListSelectorCommand.swift in Sources */,
 				B53B3F39219C817800DF1EB6 /* UIStoryboard+Woo.swift in Sources */,
 				021E2A1723A9FE5A00B1DE07 /* ProductInventorySettingsViewController.swift in Sources */,
 				020F41E823176F8E00776C4D /* TopBannerPresenter.swift in Sources */,
@@ -4579,6 +4598,7 @@
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
 				0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */,
 				022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */,
+				0248B35B245813E700A271A4 /* FilterProductsByProductStatusListSelectorCommand.swift in Sources */,
 				D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */,
 				7441E1D221503F77004E6ECE /* IntrinsicTableView.swift in Sources */,
 				B517EA1D218B41F200730EC4 /* String+Woo.swift in Sources */,
@@ -4630,6 +4650,7 @@
 				B5D1AFB820BC510200DB0E8C /* UIImage+Woo.swift in Sources */,
 				B5980A6121AC878900EBF596 /* UIDevice+Woo.swift in Sources */,
 				02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */,
+				0248B359245813B300A271A4 /* FilterProductsByStockStatusListSelectorCommand.swift in Sources */,
 				5754727F24520B2A00A94C3C /* Observer.swift in Sources */,
 				02404EDC2314CD3600FF1170 /* StatsV4ToV3BannerActionHandler.swift in Sources */,
 				027B8BBA23FE0D0C0040944E /* ObservationToken.swift in Sources */,
@@ -4855,6 +4876,7 @@
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,
 				45EF798624509B4C00B22BA2 /* ArrayIndexPathTests.swift in Sources */,
 				5798191324526FE8000817F8 /* PublishSubjectTests.swift in Sources */,
+				0248B3632458191800A271A4 /* FilterProductsByProductTypeListSelectorCommandTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
@@ -4871,6 +4893,7 @@
 				02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,
 				453904F523BB8BD5007C4956 /* ProductTaxClassListSelectorDataSourceTests.swift in Sources */,
+				0248B3612458185600A271A4 /* FilterProductsByProductStatusListSelectorCommandTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */,
 				024A543622BA84DB00F4F38E /* DeveloperEmailCheckerTests.swift in Sources */,
@@ -4919,6 +4942,7 @@
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
+				0248B35F2458163D00A271A4 /* FilterProductsByStockStatusListSelectorCommandTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,
 				D83A6A7A23792B2400419D48 /* UIColor+Muriel-Tests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductStatusListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductStatusListSelectorCommandTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class FilterProductsByProductStatusListSelectorCommandTests: XCTestCase {
+    func testSelectedIsSetCorrectlyAfterSelections() {
+        let productStatus = ProductStatus.privateStatus
+        var selectedProductStatus: ProductStatus? = productStatus
+        let command = FilterProductsByProductStatusListSelectorCommand(selected: productStatus) { selected in
+            selectedProductStatus = selected
+        }
+        let viewController = ListSelectorViewController(command: command, onDismiss: { _ in })
+        XCTAssertEqual(command.selected, productStatus)
+
+        let newProductStatus: ProductStatus? = nil
+        command.handleSelectedChange(selected: newProductStatus, viewController: viewController)
+        XCTAssertEqual(command.selected, newProductStatus)
+        XCTAssertEqual(selectedProductStatus, newProductStatus)
+
+        // Selecting the same data twice should not affect the selected data.
+        command.handleSelectedChange(selected: newProductStatus, viewController: viewController)
+        XCTAssertEqual(command.selected, newProductStatus)
+        XCTAssertEqual(selectedProductStatus, newProductStatus)
+    }
+
+    // MARK: Cell Configuration
+
+    func testCellConfigurationForNilValue() {
+        let productStatus: ProductStatus? = nil
+        let command = FilterProductsByProductStatusListSelectorCommand(selected: productStatus) { _ in }
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        command.configureCell(cell: cell, model: productStatus)
+
+        XCTAssertEqual(cell.textLabel?.text, NSLocalizedString("Any", comment: "Title when there is no filter set."))
+    }
+
+    func testCellConfigurationForNonNilValue() {
+        let productStatus = ProductStatus.pending
+        let command = FilterProductsByProductStatusListSelectorCommand(selected: productStatus) { _ in }
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        command.configureCell(cell: cell, model: productStatus)
+
+        XCTAssertEqual(cell.textLabel?.text, productStatus.description)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductTypeListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByProductTypeListSelectorCommandTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class FilterProductsByProductTypeListSelectorCommandTests: XCTestCase {
+    func testSelectedIsSetCorrectlyAfterSelections() {
+        let productType = ProductType.variable
+        var selectedProductType: ProductType? = productType
+        let command = FilterProductsByProductTypeListSelectorCommand(selected: productType) { selected in
+            selectedProductType = selected
+        }
+        let viewController = ListSelectorViewController(command: command, onDismiss: { _ in })
+        XCTAssertEqual(command.selected, productType)
+
+        let newProductType: ProductType? = nil
+        command.handleSelectedChange(selected: newProductType, viewController: viewController)
+        XCTAssertEqual(command.selected, newProductType)
+        XCTAssertEqual(selectedProductType, newProductType)
+
+        // Selecting the same data twice should not affect the selected data.
+        command.handleSelectedChange(selected: newProductType, viewController: viewController)
+        XCTAssertEqual(command.selected, newProductType)
+        XCTAssertEqual(selectedProductType, newProductType)
+    }
+
+    // MARK: Cell Configuration
+
+    func testCellConfigurationForNilValue() {
+        let productType: ProductType? = nil
+        let command = FilterProductsByProductTypeListSelectorCommand(selected: productType) { _ in }
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        command.configureCell(cell: cell, model: productType)
+
+        XCTAssertEqual(cell.textLabel?.text, NSLocalizedString("Any", comment: "Title when there is no filter set."))
+    }
+
+    func testCellConfigurationForNonNilValue() {
+        let productType = ProductType.grouped
+        let command = FilterProductsByProductTypeListSelectorCommand(selected: productType) { _ in }
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        command.configureCell(cell: cell, model: productType)
+
+        XCTAssertEqual(cell.textLabel?.text, productType.description)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByStockStatusListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/ListSelectorCommand/FilterProductsByStockStatusListSelectorCommandTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class FilterProductsByStockStatusListSelectorCommandTests: XCTestCase {
+    func testSelectedIsSetCorrectlyAfterSelections() {
+        let stockStatus = ProductStockStatus.outOfStock
+        var selectedStockStatus: ProductStockStatus? = stockStatus
+        let command = FilterProductsByStockStatusListSelectorCommand(selected: stockStatus) { selected in
+            selectedStockStatus = selected
+        }
+        let viewController = ListSelectorViewController(command: command, onDismiss: { _ in })
+        XCTAssertEqual(command.selected, stockStatus)
+
+        let newStockStatus: ProductStockStatus? = nil
+        command.handleSelectedChange(selected: newStockStatus, viewController: viewController)
+        XCTAssertEqual(command.selected, newStockStatus)
+        XCTAssertEqual(selectedStockStatus, newStockStatus)
+
+        // Selecting the same data twice should not affect the selected data.
+        command.handleSelectedChange(selected: newStockStatus, viewController: viewController)
+        XCTAssertEqual(command.selected, newStockStatus)
+        XCTAssertEqual(selectedStockStatus, newStockStatus)
+    }
+
+    // MARK: Cell Configuration
+
+    func testCellConfigurationForNilValue() {
+        let stockStatus: ProductStockStatus? = nil
+        let command = FilterProductsByStockStatusListSelectorCommand(selected: stockStatus) { _ in }
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        command.configureCell(cell: cell, model: stockStatus)
+
+        XCTAssertEqual(cell.textLabel?.text, NSLocalizedString("Any", comment: "Title when there is no filter set."))
+    }
+
+    func testCellConfigurationForNonNilValue() {
+        let stockStatus = ProductStockStatus.outOfStock
+        let command = FilterProductsByStockStatusListSelectorCommand(selected: stockStatus) { _ in }
+        let nib = Bundle.main.loadNibNamed(BasicTableViewCell.classNameWithoutNamespaces, owner: self, options: nil)
+        guard let cell = nib?.first as? BasicTableViewCell else {
+            XCTFail()
+            return
+        }
+
+        command.configureCell(cell: cell, model: stockStatus)
+
+        XCTAssertEqual(cell.textLabel?.text, stockStatus.description)
+    }
+}


### PR DESCRIPTION
Handle tapping on each filter row and changing the filter value (UI only) for #2037 

- [ ] ⚠️ Update PR base to `develop` after https://github.com/woocommerce/woocommerce-ios/pull/2204 is merged ⚠️ 

This PR adds navigation from the filter list selector screen to each filter option list selector. You can see the remaining subtasks in #2037.

## Changes

- Createed `FilterProductsByProductStatusListSelectorCommand`, `FilterProductsByProductTypeListSelectorCommand`, `FilterProductsByStockStatusListSelectorCommand` for filtering products by different attributes with basic unit tests
- In `FilterProductListCommand`, navigates to each filter option list selector screen and reload UI if filters change

## Testing

- Go to the Products tab
- Tap on the "Filter" CTA in the toolbar below the WIP banner --> should see the Filter Products screen **without "Clear All" CTA in the navigation bar**
- Tap on "Stock status" row --> it should navigate to the stock status list selector screen
- Select a different stock status (e.g. "Out of stock") filter and tap "Show Products" at the bottom --> it should go back to the Products tab without any changes to the product list
- Tap on the "Filter" CTA again --> should see the Filter Products screen as in the screenshots below, **with "Clear All" CTA in the navigation bar**, the navigation bar title should say "Filters (1)", and the "Stock status" row should say the selected stock status
- Repeat the same steps for "Product status" and "Product type" rows and notice the navigation bar title should update to the number of active filters
- Tap "Clear all" CTA in the navigation bar --> all filters should be cleared to "Any"


## Example screenshots

Similar to https://github.com/woocommerce/woocommerce-ios/pull/2204 @Garance91540 the list will be updated to be plain style (no space above the cells) in a later task

mode \ screen | filter products | filter products by stock status | filter products by product status | filter products by product type
-- | -- | -- | -- | --
Light | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 39](https://user-images.githubusercontent.com/1945542/80477961-5e0d4000-897f-11ea-87d4-0b0912fb3179.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 26](https://user-images.githubusercontent.com/1945542/80477945-5a79b900-897f-11ea-96d9-a2af047fe2e4.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 31 07](https://user-images.githubusercontent.com/1945542/80477888-48981600-897f-11ea-9996-1406e00e451d.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 30](https://user-images.githubusercontent.com/1945542/80477958-5cdc1300-897f-11ea-909a-6122a31aaea9.png)
Dark | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 49](https://user-images.githubusercontent.com/1945542/80477963-5ea5d680-897f-11ea-8fb5-ceb1e7f9bfa9.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 52](https://user-images.githubusercontent.com/1945542/80477966-5ea5d680-897f-11ea-8bc8-bddd495ba830.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 54](https://user-images.githubusercontent.com/1945542/80477968-5f3e6d00-897f-11ea-916f-eb4fa4804c37.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-28 at 18 35 56](https://user-images.githubusercontent.com/1945542/80477969-5fd70380-897f-11ea-8d41-586233023584.png)

iPad Air 2 (iOS 13.4)

mode \ screen | filter products | filter products by a filter
-- | -- | --
Dark (landscape) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 19](https://user-images.githubusercontent.com/1945542/80573890-6e7ef280-8a33-11ea-9162-52dcd6f4471a.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 03](https://user-images.githubusercontent.com/1945542/80573881-68891180-8a33-11ea-872f-f00eb391a019.png)
Dark (portrait) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 24](https://user-images.githubusercontent.com/1945542/80573897-6fb01f80-8a33-11ea-8427-9d8fa81911c4.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 27](https://user-images.githubusercontent.com/1945542/80573903-70e14c80-8a33-11ea-91fe-f245c338854f.png)
Light (landscape) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 44](https://user-images.githubusercontent.com/1945542/80573917-73dc3d00-8a33-11ea-9b3d-1cede246add5.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 47](https://user-images.githubusercontent.com/1945542/80573922-75a60080-8a33-11ea-9976-b9eb87935982.png)
Light (portrait) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 42](https://user-images.githubusercontent.com/1945542/80573913-7343a680-8a33-11ea-930a-e6581b2de67a.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-04-29 at 16 04 39](https://user-images.githubusercontent.com/1945542/80573910-72ab1000-8a33-11ea-8b7e-2eefa15d2a56.png)









Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
