### PR TITLE
Product Settings: Menu Order now allow negative values

### DIFF
--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 struct IntegerInputFormatter: UnitInputFormatter {
 
-    /// The default value used by format() when the text is empty or the number formatter return a nil value
+    /// The default value used by format() when the text is empty or the number formatter returns a nil value
     ///
     let defaultValue: String
 

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -3,6 +3,11 @@ import Foundation
 /// `UnitInputFormatter` implementation for integer number input (positive, negative, or zero)
 ///
 struct IntegerInputFormatter: UnitInputFormatter {
+    
+    /// The default value used by format() when the text is empty or the number formatter return a nil value
+    ///
+    let defaultValue: String
+    
     private let numberFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.allowsFloats = false
@@ -11,18 +16,28 @@ struct IntegerInputFormatter: UnitInputFormatter {
 
     func isValid(input: String) -> Bool {
         guard input.isEmpty == false else {
-            // Allows empty input to be replaced by 0.
+            // Allows empty input to be replaced by defaultValue
             return true
         }
-        return numberFormatter.number(from: input) != nil
+        return numberFormatter.number(from: input) != nil || input == "-"
     }
 
     func format(input text: String?) -> String {
         guard let text = text, text.isEmpty == false else {
-            return "0"
+            return defaultValue
         }
-
-        let formattedText = numberFormatter.number(from: text)?.stringValue ?? "0"
+        
+        var formattedText = numberFormatter.number(from: text)?.stringValue ?? defaultValue
+        
+        // The minus sign is mantained if present
+        let minus: Character = "-"
+        if text.first == minus {
+            formattedText = String(minus) + formattedText.replacingOccurrences(of: "-", with: "")
+        }
         return formattedText
+    }
+    
+    init(defaultValue: String = "0") {
+        self.defaultValue = defaultValue
     }
 }

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -8,6 +8,8 @@ struct IntegerInputFormatter: UnitInputFormatter {
     ///
     let defaultValue: String
 
+    private let minus: Character = "-"
+
     private let numberFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.allowsFloats = false
@@ -19,7 +21,7 @@ struct IntegerInputFormatter: UnitInputFormatter {
             // Allows empty input to be replaced by defaultValue
             return true
         }
-        return numberFormatter.number(from: input) != nil || input == "-"
+        return numberFormatter.number(from: input) != nil || input == String(minus)
     }
 
     func format(input text: String?) -> String {
@@ -29,8 +31,7 @@ struct IntegerInputFormatter: UnitInputFormatter {
 
         var formattedText = numberFormatter.number(from: text)?.stringValue ?? defaultValue
 
-        // The minus sign is mantained if present
-        let minus: Character = "-"
+        // The minus sign is maintained if present
         if text.first == minus {
             formattedText = String(minus) + formattedText.replacingOccurrences(of: "-", with: "")
         }

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -3,11 +3,11 @@ import Foundation
 /// `UnitInputFormatter` implementation for integer number input (positive, negative, or zero)
 ///
 struct IntegerInputFormatter: UnitInputFormatter {
-    
+
     /// The default value used by format() when the text is empty or the number formatter return a nil value
     ///
     let defaultValue: String
-    
+
     private let numberFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.allowsFloats = false
@@ -26,9 +26,9 @@ struct IntegerInputFormatter: UnitInputFormatter {
         guard let text = text, text.isEmpty == false else {
             return defaultValue
         }
-        
+
         var formattedText = numberFormatter.number(from: text)?.stringValue ?? defaultValue
-        
+
         // The minus sign is mantained if present
         let minus: Character = "-"
         if text.first == minus {
@@ -36,7 +36,7 @@ struct IntegerInputFormatter: UnitInputFormatter {
         }
         return formattedText
     }
-    
+
     init(defaultValue: String = "0") {
         self.defaultValue = defaultValue
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
@@ -146,7 +146,7 @@ private extension ProductMenuOrderViewController {
             }
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
-        }, inputFormatter: IntegerInputFormatter())
+        }, inputFormatter: IntegerInputFormatter(defaultValue: ""))
         cell.configure(viewModel: viewModel)
         cell.textField.applyBodyStyle()
         cell.textField.keyboardType = .numbersAndPunctuation

--- a/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import WooCommerce
 
 final class IntegerInputFormatterTests: XCTestCase {
-    private let formatter = IntegerInputFormatter()
+    private let formatter = IntegerInputFormatter(defaultValue: "0")
 
     // MARK: test cases for `isValid(input:)`
 

--- a/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/IntegerInputFormatterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import WooCommerce
 
 final class IntegerInputFormatterTests: XCTestCase {
-    private let formatter = IntegerInputFormatter(defaultValue: "0")
+    private let formatter = IntegerInputFormatter(defaultValue: "1")
 
     // MARK: test cases for `isValid(input:)`
 
@@ -37,11 +37,16 @@ final class IntegerInputFormatterTests: XCTestCase {
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
+    func testMinusSignInputIsValid() {
+        let input = "-"
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
     // MARK: test cases for `format(input:)`
 
     func testFormattingEmptyInput() {
         let input = ""
-        XCTAssertEqual(formatter.format(input: input), "0")
+        XCTAssertEqual(formatter.format(input: input), "1")
     }
 
     func testFormattingInputWithLeadingZeros() {
@@ -57,5 +62,15 @@ final class IntegerInputFormatterTests: XCTestCase {
     func testFormattingNegativeIntegerInput() {
         let input = "-3412424214"
         XCTAssertEqual(formatter.format(input: input), "-3412424214")
+    }
+
+    func testFormattingMinusSignInput() {
+        let input = "-"
+        XCTAssertEqual(formatter.format(input: input), "-1")
+    }
+
+    func testFormattingMultipleMinusSignInput() {
+        let input = "--"
+        XCTAssertEqual(formatter.format(input: input), "-1")
     }
 }


### PR DESCRIPTION
Fixes #2205 

## Description
Initially, it wasn't possible to set a negative value in Product Settings -> Menu Order, if you start typing the - sign or edit a negative value.
This PR modifies the `IntegerInputFormatter` which now allows the minus sign, and which has a new initializer which allows us to set a default value used by format() when the text is empty or the number formatter returns a nil value.

## Testing
1. Open a simple product.
2. Open product settings.
3. Tap in "Menu Order" cell.
4. Try to edit the menu order value adding a negative value.
5. Press back and save the product.
6. Go to this product from wp-admin and make sure the value was saved correctly.
7. Repeat the operation, and make sure that if you add only a minus sign `-` or you left the text field empty and you press back, the previous menu order value is shown.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
