### PR TITLE
Edit Products: fix "..." more menu popover appearance

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -296,7 +296,7 @@ private extension ProductFormViewController {
         let moreButton = UIBarButtonItem(image: .moreImage,
                                      style: .plain,
                                      target: self,
-                                     action: #selector(presentMoreOptionsActionSheet))
+                                     action: #selector(presentMoreOptionsActionSheet(_:)))
         moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
         moreButton.accessibilityIdentifier = "edit-product-more-options-button"
         return moreButton
@@ -626,7 +626,7 @@ private extension ProductFormViewController {
 
     /// More Options Action Sheet
     ///
-    @objc func presentMoreOptionsActionSheet() {
+    @objc func presentMoreOptionsActionSheet(_ sender: UIBarButtonItem) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
@@ -646,8 +646,7 @@ private extension ProductFormViewController {
         }
 
         let popoverController = actionSheet.popoverPresentationController
-        popoverController?.sourceView = view
-        popoverController?.sourceRect = view.bounds
+        popoverController?.barButtonItem = sender
 
         present(actionSheet, animated: true)
     }


### PR DESCRIPTION
Fixes #2232 

## Changes

In `ProductFormViewController`, passed the `UIBarButtonItem` sender to the `presentMoreOptionsActionSheet` handler, and used the sender to set the action sheet's `popoverPresentationController`'s `barButtonItem`.

## Testing

- Build the app on a tablet
- Open the Products tab
- Tap on a simple product (same from tapping a simple product in an order in the Orders tab order Top Performers)
- Tap on the "..." in the navigation bar and try rotating --> the popover should be fully visible

## Example screenshots

\ | before | after
-- | -- | --
modal - landscape | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 13 24](https://user-images.githubusercontent.com/1945542/80947675-3b69a400-8e23-11ea-80d8-a32899e123ad.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 14 46](https://user-images.githubusercontent.com/1945542/80947704-49b7c000-8e23-11ea-993a-2316e20464ce.png)
modal - portrait | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 13 29](https://user-images.githubusercontent.com/1945542/80947690-43294880-8e23-11ea-88a1-d5a8df99de49.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 14 49](https://user-images.githubusercontent.com/1945542/80947956-c8acf880-8e23-11ea-8424-e6c3c3eb2948.png)
Products tab - landscape | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 13 43](https://user-images.githubusercontent.com/1945542/80947695-458ba280-8e23-11ea-8682-9f032aa5a5f0.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 15 01](https://user-images.githubusercontent.com/1945542/80947971-cfd40680-8e23-11ea-9d87-4095ecba4d62.png)
Products tab - landscape | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 13 47](https://user-images.githubusercontent.com/1945542/80947697-47edfc80-8e23-11ea-948b-3715bda2bf42.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-04 at 16 15 04](https://user-images.githubusercontent.com/1945542/80947980-d2cef700-8e23-11ea-84b1-5e37d2097876.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
