### PR TITLE
Image upload UX: after adding product images, automatically commit the changes locally

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -228,21 +228,16 @@ private extension ProductImagesViewController {
 //
 private extension ProductImagesViewController {
     func onDeviceMediaLibraryPickerCompletion(assets: [PHAsset]) {
-        let shouldCommitChanges = assets.isNotEmpty
-        defer {
-            dismiss(animated: !shouldCommitChanges) { [weak self] in
-                guard shouldCommitChanges else {
-                    return
-                }
-
-                self?.commitAndDismiss()
+        let shouldAnimateMediaLibraryDismissal = assets.isEmpty
+        dismiss(animated: shouldAnimateMediaLibraryDismissal) { [weak self] in
+            guard let self = self, assets.isNotEmpty else {
+                return
             }
-        }
-        guard assets.isEmpty == false else {
-            return
-        }
-        assets.forEach { asset in
-            uploadMediaAssetToSiteMediaLibrary(asset: asset)
+
+            assets.forEach { asset in
+                self.uploadMediaAssetToSiteMediaLibrary(asset: asset)
+            }
+            self.commitAndDismiss()
         }
     }
 }
@@ -251,15 +246,15 @@ private extension ProductImagesViewController {
 //
 private extension ProductImagesViewController {
     func onWPMediaPickerCompletion(mediaItems: [Media]) {
-        let shouldCommitChanges = mediaItems.isNotEmpty
-        dismiss(animated: !shouldCommitChanges) { [weak self] in
-            guard shouldCommitChanges else {
+        let shouldAnimateWPMediaPickerDismissal = mediaItems.isEmpty
+        dismiss(animated: shouldAnimateWPMediaPickerDismissal) { [weak self] in
+            guard let self = self, mediaItems.isNotEmpty else {
                 return
             }
 
-            self?.commitAndDismiss()
+            self.productImageActionHandler.addSiteMediaLibraryImagesToProduct(mediaItems: mediaItems)
+            self.commitAndDismiss()
         }
-        productImageActionHandler.addSiteMediaLibraryImagesToProduct(mediaItems: mediaItems)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -216,6 +216,8 @@ private extension ProductImagesViewController {
             return
         }
         uploadMediaAssetToSiteMediaLibrary(asset: asset)
+        // Commits product image changes automatically.
+        doneButtonTapped()
     }
 }
 
@@ -223,8 +225,16 @@ private extension ProductImagesViewController {
 //
 private extension ProductImagesViewController {
     func onDeviceMediaLibraryPickerCompletion(assets: [PHAsset]) {
+        let shouldCommitChanges = assets.isNotEmpty
         defer {
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: !shouldCommitChanges) { [weak self] in
+                guard shouldCommitChanges else {
+                    return
+                }
+
+                // Commits product image changes automatically.
+                self?.doneButtonTapped()
+            }
         }
         guard assets.isEmpty == false else {
             return
@@ -239,7 +249,15 @@ private extension ProductImagesViewController {
 //
 private extension ProductImagesViewController {
     func onWPMediaPickerCompletion(mediaItems: [Media]) {
-        dismiss(animated: true, completion: nil)
+        let shouldCommitChanges = mediaItems.isNotEmpty
+        dismiss(animated: !shouldCommitChanges) { [weak self] in
+            guard shouldCommitChanges else {
+                return
+            }
+
+            // Commits product image changes automatically.
+            self?.doneButtonTapped()
+        }
         productImageActionHandler.addSiteMediaLibraryImagesToProduct(mediaItems: mediaItems)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -152,6 +152,10 @@ private extension ProductImagesViewController {
     }
 
     @objc func doneButtonTapped() {
+        commitAndDismiss()
+    }
+
+    func commitAndDismiss() {
         onCompletion(productImages)
     }
 
@@ -216,8 +220,7 @@ private extension ProductImagesViewController {
             return
         }
         uploadMediaAssetToSiteMediaLibrary(asset: asset)
-        // Commits product image changes automatically.
-        doneButtonTapped()
+        commitAndDismiss()
     }
 }
 
@@ -232,8 +235,7 @@ private extension ProductImagesViewController {
                     return
                 }
 
-                // Commits product image changes automatically.
-                self?.doneButtonTapped()
+                self?.commitAndDismiss()
             }
         }
         guard assets.isEmpty == false else {
@@ -255,8 +257,7 @@ private extension ProductImagesViewController {
                 return
             }
 
-            // Commits product image changes automatically.
-            self?.doneButtonTapped()
+            self?.commitAndDismiss()
         }
         productImageActionHandler.addSiteMediaLibraryImagesToProduct(mediaItems: mediaItems)
     }


### PR DESCRIPTION
Fixes #2072 

The goal of this PR/fix is to save users one step of tapping the "Done" button back on the edit product images screen after they add/pick any image(s) from any of the sources.

## Changes

- In `ProductImagesViewController`, called `doneButtonTapped()` and disabled dismiss animation when applicable in the following scenarios:
  - The user finished picking image(s) from the device picker
  - The user finished picking image(s) from the WP media library picker
  - The user took a photo from the camera

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Tap "Choose from device" and pick some photos from the device library --> after the selection, it should go back to the edit product main screen instead of the edit product images screen
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Tap "Take a photo" and take a photo with the camera --> after using the photo, it should go back to the edit product main screen instead of the edit product images screen
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Tap "WordPress Media Library" and pick some photos from the WP media library --> after the selection, it should go back to the edit product main screen instead of the edit product images screen

## Example screencast

![add_product_images](https://user-images.githubusercontent.com/1945542/80950542-9fdb3200-8e28-11ea-9511-070b8c3bd75d.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
