### PR TITLE
Add Copiable Foundation

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ED4F11239E8C57004F1BE3 /* taxes-classes.json */; };
 		45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */; };
 		5726F72E2460A2820031CAAC /* Copiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726F72D2460A2820031CAAC /* Copiable.swift */; };
+		5726F7312460A8510031CAAC /* ProductImage+Copiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726F7302460A8510031CAAC /* ProductImage+Copiable.swift */; };
+		5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726F7332460A8F00031CAAC /* CopiableTests.swift */; };
 		57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */ = {isa = PBXBuildFile; fileRef = 57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */; };
 		6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */; };
 		6856DE98F90AC6E4743D18CA /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1228ADBC14D8202E49D /* XCTestCase+Wait.swift */; };
@@ -395,6 +397,8 @@
 		45ED4F11239E8C57004F1BE3 /* taxes-classes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "taxes-classes.json"; sourceTree = "<group>"; };
 		45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemoteTests.swift; sourceTree = "<group>"; };
 		5726F72D2460A2820031CAAC /* Copiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Copiable.swift; sourceTree = "<group>"; };
+		5726F7302460A8510031CAAC /* ProductImage+Copiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductImage+Copiable.swift"; sourceTree = "<group>"; };
+		5726F7332460A8F00031CAAC /* CopiableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopiableTests.swift; sourceTree = "<group>"; };
 		573B448C242422DB00E71ADC /* orders-load-all-2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "orders-load-all-2.json"; sourceTree = "<group>"; };
 		57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-missing-avatar-urls.json"; sourceTree = "<group>"; };
 		6856D1228ADBC14D8202E49D /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
@@ -723,6 +727,22 @@
 			path = Copiable;
 			sourceTree = "<group>";
 		};
+		5726F72F2460A83D0031CAAC /* Copiable */ = {
+			isa = PBXGroup;
+			children = (
+				5726F7302460A8510031CAAC /* ProductImage+Copiable.swift */,
+			);
+			path = Copiable;
+			sourceTree = "<group>";
+		};
+		5726F7322460A8E30031CAAC /* Copiable */ = {
+			isa = PBXGroup;
+			children = (
+				5726F7332460A8F00031CAAC /* CopiableTests.swift */,
+			);
+			path = Copiable;
+			sourceTree = "<group>";
+		};
 		6856DE4E23A475D8CEBD10C1 /* Testing */ = {
 			isa = PBXGroup;
 			children = (
@@ -882,6 +902,7 @@
 		B557D9F0209753AA005962F4 /* NetworkingTests */ = {
 			isa = PBXGroup;
 			children = (
+				5726F7322460A8E30031CAAC /* Copiable */,
 				B559EBA820A0B5B100836CD4 /* Responses */,
 				B518663220A0A2E800037A38 /* Settings */,
 				B5C6FCC620A32E3100A4F8E4 /* Extensions */,
@@ -950,6 +971,7 @@
 		B557DA1B20979E6D005962F4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				5726F72F2460A83D0031CAAC /* Copiable */,
 				B50A583A21AD872E00617455 /* Devices */,
 				020D07B623D852AB00FD9580 /* Media */,
 				CE6BFEE62236CF0D005C79FB /* Product */,
@@ -1645,6 +1667,7 @@
 				026CF61A237D607A009563D4 /* ProductVariationAttribute.swift in Sources */,
 				748D424A210F92EA00CF7D1B /* OrderStatsItem.swift in Sources */,
 				D8FBFF1A22D4DF7A006E3336 /* OrderStatsV4.swift in Sources */,
+				5726F7312460A8510031CAAC /* ProductImage+Copiable.swift in Sources */,
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
 				B505F6EC20BEFDC200BB1B69 /* Loader.swift in Sources */,
 				74D3BD142114FE6900A6E85E /* MIContainer.swift in Sources */,
@@ -1707,6 +1730,7 @@
 				74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */,
 				B524194921AC659500D6FC0A /* DevicesRemoteTests.swift in Sources */,
 				B505F6D320BEE3A500BB1B69 /* AccountMapperTests.swift in Sources */,
+				5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */,
 				26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */,
 				B5C6FCC820A32E4800A4F8E4 /* DateFormatterWooTests.swift in Sources */,
 				74C8F06A20EEBC8C00B6EDC9 /* OrderMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */; };
 		45ED4F12239E8C57004F1BE3 /* taxes-classes.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ED4F11239E8C57004F1BE3 /* taxes-classes.json */; };
 		45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */; };
+		5726F72E2460A2820031CAAC /* Copiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726F72D2460A2820031CAAC /* Copiable.swift */; };
 		57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */ = {isa = PBXBuildFile; fileRef = 57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */; };
 		6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */; };
 		6856DE98F90AC6E4743D18CA /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1228ADBC14D8202E49D /* XCTestCase+Wait.swift */; };
@@ -393,6 +394,7 @@
 		45ED4F0F239E8A54004F1BE3 /* TaxClassListMapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassListMapperTest.swift; sourceTree = "<group>"; };
 		45ED4F11239E8C57004F1BE3 /* taxes-classes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "taxes-classes.json"; sourceTree = "<group>"; };
 		45ED4F13239E8F2E004F1BE3 /* TaxClassRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassRemoteTests.swift; sourceTree = "<group>"; };
+		5726F72D2460A2820031CAAC /* Copiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Copiable.swift; sourceTree = "<group>"; };
 		573B448C242422DB00E71ADC /* orders-load-all-2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "orders-load-all-2.json"; sourceTree = "<group>"; };
 		57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-missing-avatar-urls.json"; sourceTree = "<group>"; };
 		6856D1228ADBC14D8202E49D /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
@@ -713,6 +715,14 @@
 			path = Refund;
 			sourceTree = "<group>";
 		};
+		5726F72C2460A25F0031CAAC /* Copiable */ = {
+			isa = PBXGroup;
+			children = (
+				5726F72D2460A2820031CAAC /* Copiable.swift */,
+			);
+			path = Copiable;
+			sourceTree = "<group>";
+		};
 		6856DE4E23A475D8CEBD10C1 /* Testing */ = {
 			isa = PBXGroup;
 			children = (
@@ -852,6 +862,7 @@
 		B557D9E5209753AA005962F4 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				5726F72C2460A25F0031CAAC /* Copiable */,
 				B5A0369F214C0F4C00774E2C /* Internal */,
 				B5BB1D0A20A204F400112D92 /* Extensions */,
 				B567AF2720A0FA0A00AB6C62 /* Mapper */,
@@ -1585,6 +1596,7 @@
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
 				B557DA0D20975DB1005962F4 /* WordPressAPIVersion.swift in Sources */,
 				7412A8EC21B6E286005D182A /* ReportOrderTotalsMapper.swift in Sources */,
+				5726F72E2460A2820031CAAC /* Copiable.swift in Sources */,
 				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
 				74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */,

--- a/Networking/Networking/Copiable/Copiable.swift
+++ b/Networking/Networking/Copiable/Copiable.swift
@@ -1,0 +1,108 @@
+
+import Foundation
+
+/// A typealias for arguments of `copy()` methods signifying that the required property's value
+/// will be copied by default if no value is given.
+///
+/// For example:
+///
+/// ```
+/// struct Person {
+///     let id: Int
+///     let name: String
+///
+///     func copy(id: CopiableProp<Int> = .copy,
+///               name: CopiableProp<String> = .copy) -> Person {
+///         Person(id: id ?? self.id,
+///                name: name ?? self.name)
+///     }
+/// }
+///
+/// let luke = Person(id: 1, name: "Luke")
+///
+/// let leia = luke.copy(name: "Leia")
+/// ```
+///
+/// The variable `leia` will have the same `id` as `luke`:
+///
+/// ```
+/// { id: 1, name: "Leia" }
+/// ```
+///
+public typealias CopiableProp<Wrapped> = Optional<Wrapped>
+
+/// A typealias for arguments of `copy()` methods signifying that the property is `Optional` and
+/// that the existing value will be copied by default if no value is given.
+///
+/// Using `NullableCopiableProp` allows us to set an `Optional` property to `nil` when copying.
+/// For example, if passing a variable as an argument, the property will be set to `nil` as
+/// expected:
+///
+/// ```
+/// struct Person {
+///     let id: Int
+///     let name: String
+///     let address: String?
+///
+///     func copy(id: CopiableProp<Int> = .copy,
+///               name: CopiableProp<String> = .copy,
+///               address: NullableCopiableProp<String> = .copy) -> Person {
+///         Person(id: id ?? self.id,
+///                name: name ?? self.name,
+///                address: address ?? self.address)
+///     }
+/// }
+///
+/// let luke = Person(id: 1, name: "Luke", address: "Jakku")
+///
+/// let address: String? = nil
+///
+/// let lukeWithNoAddress = luke.copy(address: address)
+/// ```
+///
+/// The variable `lukeWithNoAddress` will have a `nil` `address` as expected:
+///
+/// ```
+/// { id: 1, name: "Luke", address: nil }
+/// ```
+///
+/// In order to **directly** set a `NullableCopiableProp` to `nil`, the argument `.some(nil)`
+/// must be passed:
+///
+/// ```
+/// let lukeWithNoAddress = luke.copy(address: .some(nil))
+/// ```
+///
+/// We will still end up with the same result:
+///
+/// ```
+/// { id: 1, name: "Luke", address: nil }
+/// ```
+///
+public typealias NullableCopiableProp<Wrapped> = CopiableProp<Wrapped?>
+
+// MARK: - Support for `.copy` alias
+
+extension CopiableProp {
+    /// Allow `CopiableProp<>` declarations to use a `.copy` alias as the default value instead of
+    /// using `nil`.
+    ///
+    /// For example, instead of declaring `copy()` arguments like this:
+    ///
+    /// ```
+    /// func copy(orderID: CopiableProp<Int> = nil)
+    /// ```
+    ///
+    /// We can declare them like this:
+    ///
+    /// ```
+    /// func copy(orderID: CopiableProp<Int> = .copy)
+    /// ```
+    ///
+    /// Using `.copy` makes it a bit more clearer what will happen if you don't declare or
+    /// provide a different value.
+    ///
+    public static var copy: Wrapped? {
+        nil
+    }
+}

--- a/Networking/Networking/Model/Copiable/ProductImage+Copiable.swift
+++ b/Networking/Networking/Model/Copiable/ProductImage+Copiable.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// TODO This will soon be generated instead.
+
+extension ProductImage {
+    public func copy(
+        imageID: CopiableProp<Int64> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        dateModified: NullableCopiableProp<Date> = .copy,
+        src: CopiableProp<String> = .copy,
+        name: NullableCopiableProp<String> = .copy,
+        alt: NullableCopiableProp<String> = .copy
+    ) -> ProductImage {
+        /// Declare local variables because the Swift compiler will sometimes choke if there are
+        /// too many arguments with default values.
+        let imageID = imageID ?? self.imageID
+        let dateCreated = dateCreated ?? self.dateCreated
+        let dateModified = dateModified ?? self.dateModified
+        let src = src ?? self.src
+        let name = name ?? self.name
+        let alt = alt ?? self.alt
+
+        return ProductImage(
+            imageID: imageID,
+            dateCreated: dateCreated,
+            dateModified: dateModified,
+            src: src,
+            name: name,
+            alt: alt
+        )
+    }
+}

--- a/Networking/NetworkingTests/Copiable/CopiableTests.swift
+++ b/Networking/NetworkingTests/Copiable/CopiableTests.swift
@@ -1,0 +1,179 @@
+import XCTest
+
+@testable import Networking
+
+/// Tests the concepts of the `CopiableProp` and `NullableCopiableProp` in the `copy()` methods.
+///
+/// We are using `ProductImage` as a guinea pig only.
+///
+final class CopiableTests: XCTestCase {
+
+    func testItCanReplaceAllPropertyValues() {
+        // Given
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(),
+            dateModified: nil,
+            src: "__src__",
+            name: nil,
+            alt: nil
+        )
+
+        // When
+        let copy = original.copy(
+            imageID: 3_000,
+            dateCreated: Date(timeIntervalSince1970: 100),
+            dateModified: Date(timeIntervalSince1970: 200),
+            src: "_src_copy_",
+            name: "_name_copy_",
+            alt: "_alt_copy_"
+        )
+
+        // Then
+        XCTAssertEqual(copy.imageID, 3_000)
+        XCTAssertEqual(copy.dateCreated, Date(timeIntervalSince1970: 100))
+        XCTAssertEqual(copy.dateModified, Date(timeIntervalSince1970: 200))
+        XCTAssertEqual(copy.src, "_src_copy_")
+        XCTAssertEqual(copy.name, "_name_copy_")
+        XCTAssertEqual(copy.alt, "_alt_copy_")
+    }
+
+    func testItCanReplaceSomePropertyValues() {
+        // Given
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(),
+            dateModified: nil,
+            src: "__src__",
+            name: nil,
+            alt: nil
+        )
+
+        // When
+        let copy = original.copy(
+            dateCreated: Date(timeIntervalSince1970: 100),
+            src: "_src_copy_",
+            alt: "_alt_copy_"
+        )
+
+        // Then
+        XCTAssertEqual(copy.imageID, original.imageID)
+        XCTAssertEqual(copy.dateCreated, Date(timeIntervalSince1970: 100))
+        XCTAssertEqual(copy.dateModified, original.dateModified)
+        XCTAssertEqual(copy.src, "_src_copy_")
+        XCTAssertEqual(copy.name, original.name)
+        XCTAssertEqual(copy.alt, "_alt_copy_")
+    }
+
+    func testItCanSetNonNilPropertiesBackToNilUsingSomeNil() {
+        // Given
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(timeIntervalSince1970: 900),
+            dateModified: Date(timeIntervalSince1970: 700),
+            src: "_src_original_",
+            name: "_name_original_",
+            alt: "_alt_original"
+        )
+
+        // When
+        let copy = original.copy(name: .some(nil))
+
+        // Then
+        XCTAssertNil(copy.name)
+    }
+
+    func testWhenPassingNilItWillCopyThePropertyInsteadOfSettingItToNil() {
+        // Given
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(timeIntervalSince1970: 900),
+            dateModified: Date(timeIntervalSince1970: 700),
+            src: "_src_original_",
+            name: "_name_original_",
+            alt: "_alt_original"
+        )
+
+        // When
+        let copy = original.copy(name: nil)
+
+        // Then
+        XCTAssertEqual(copy.name, "_name_original_")
+    }
+
+    func testItCanSetNonNilPropertiesBackToNilUsingAStructValueSource() {
+        // Given
+        struct ValueSource {
+            let alt: String?
+        }
+
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(timeIntervalSince1970: 900),
+            dateModified: Date(timeIntervalSince1970: 700),
+            src: "_src_original_",
+            name: "_name_original_",
+            alt: "_alt_original"
+        )
+
+        let valueSource = ValueSource(alt: nil)
+
+        XCTAssertNotNil(original.alt)
+
+        // When
+        let copy = original.copy(alt: valueSource.alt)
+
+        // Then
+        XCTAssertNil(copy.alt)
+    }
+
+    func testItCanSetNonNilPropertiesBackToNilUsingAVariableValueSource() {
+        // Given
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(timeIntervalSince1970: 900),
+            dateModified: Date(timeIntervalSince1970: 700),
+            src: "_src_original_",
+            name: "_name_original_",
+            alt: "_alt_original"
+        )
+
+        let valueSource: Date? = nil
+
+        XCTAssertNotNil(original.dateModified)
+
+        // When
+        let copy = original.copy(dateModified: valueSource)
+
+        // Then
+        XCTAssertNil(copy.dateModified)
+    }
+
+    func testItWillLeaveTheUnspecifiedPropertiesUnchanged() {
+        // Given
+        let original = ProductImage(
+            imageID: 1_000,
+            dateCreated: Date(timeIntervalSince1970: 900),
+            dateModified: Date(timeIntervalSince1970: 700),
+            src: "_src_original_",
+            name: "_name_original_",
+            alt: "_alt_original"
+        )
+
+        // When
+        let copy = original.copy(imageID: 9_000)
+
+        // Then
+        XCTAssertNotEqual(copy, original)
+
+        // Specified properties are changed
+        XCTAssertEqual(copy.imageID, 9_000)
+
+        // Unspecified properties are copied
+        XCTAssertEqual(copy.dateCreated, original.dateCreated)
+        XCTAssertEqual(copy.dateModified, original.dateModified)
+        XCTAssertEqual(copy.src, original.src)
+        XCTAssertEqual(copy.name, original.name)
+        XCTAssertEqual(copy.alt, original.alt)
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ But consider using `class` instead if:
 
 ### Copiable 
 
-In the WooCommerce module, we generally work with [immutable objects](../Yosemite/Yosemite/Model/Model). Mutation only happens within Yosemite and Storage. This is an intentional design and promotes clarity of [where and when those objects will be updated](https://git.io/JvALp). 
+In the WooCommerce module, we generally work with [immutable objects](../Yosemite/Yosemite/Model/Model.swift). Mutation only happens within Yosemite and Storage. This is an intentional design and promotes clarity of [where and when those objects will be updated](https://git.io/JvALp). 
 
 But in order to _update_ something, we still need to pass an _updated_ object to Yosemite. For example, to use the [`ProductAction.updateProduct`](../Yosemite/Yosemite/Actions/ProductAction.swift) action, we'd probably have to create a new [`Product`](../Networking/Networking/Model/Product/Product.swift) object: 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,14 @@
 # WooCommerce for iOS 
 
+**Table of Contents**
+
+- [Architecture](#architecture)
+- [Coding Guidelines](#coding-guidelines)
+    - [Coding Style](#coding-style)
+    - [Choosing Between Structures and Classes](#choosing-between-structures-and-classes)
+- [Design Patterns](#design-patterns)
+    - [Copiable](#copiable)
+
 ## Architecture
 
 - [Architecture](ARCHITECTURE.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@ let leia = luke.copy(name: "Leia")
 
 In the above, `leia` would have the same `id` and `address` as `luke` because those arguments were not given. 
 
-```json
+```swift
 { id: 1, name: "Leia", address: "Jakku" }
 ```
 
@@ -113,7 +113,7 @@ let lukeWithNoAddress = luke.copy(address: address)
 
 The `lukeWithNoAddress` variable will have a `nil` address as expected:
 
-```json
+```swift
 { id: 1, name: "Luke", address: nil }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,120 @@ The guidelines for how Swift should be written and formatted can be found in the
 
 In addition to the [Apple guidelines](https://developer.apple.com/documentation/swift/choosing_between_structures_and_classes), we generally prefer to use `struct` for: 
 
-- Value types like the [Networking Models](../../../Networking/Networking/Model)
+- Value types like the [Networking Models](../Networking/Networking/Model)
 - Stateless helpers 
 
 But consider using `class` instead if:
 
 - You need to manage mutable states. Especially if there are more than a few `mutating` functions, the `struct` becomes harder to reason about.
 - You have to set a `struct` property declaration as `var` because it has a `mutating` function. In this case, a constant (`let`) `class` property may be easier to reason about.
+
+## Design Patterns
+
+### Copiable 
+
+In the WooCommerce module, we generally work with [immutable objects](../Yosemite/Yosemite/Model/Model). Mutation only happens within Yosemite and Storage. This is an intentional design and promotes clarity of [where and when those objects will be updated](https://git.io/JvALp). 
+
+But in order to _update_ something, we still need to pass an _updated_ object to Yosemite. For example, to use the [`ProductAction.updateProduct`](../Yosemite/Yosemite/Actions/ProductAction.swift) action, we'd probably have to create a new [`Product`](../Networking/Networking/Model/Product/Product.swift) object: 
+
+```swift
+// An existing Product instance given by Yosemite
+let currentProduct: Product 
+
+// Update the Product instance with a new `name`
+let updatedProduct = Product(
+    productID: currentProduct.productID,
+    name: "A new name", // The only updated property
+    slug: currentProduct.slug,
+    permalink: currentProduct.permalink,
+    dateCreated: currentProduct.dateCreated,
+    dateModified: currentProduct.dateModified,
+    dateOnSaleStart: currentProduct.dateOnSaleStart,
+
+    // And so on...
+)
+
+let action = ProductAction.updateProduct(product: updatedProduct, ...)
+store.dispatch(action)
+```
+
+This is quite cumbersome, especially since `Product` has more than 50 properties. 
+
+To help with this, we create `copy()` methods for these objects. These `copy()` methods follow a specific pattern and will make use of the [`CopiableProp` and `NullableCopiableProp` typealiases](../Networking/Networking/Copiable/Copiable.swift).
+
+Here is an example implementation on a `Person` `struct`:
+
+```swift
+struct Person {
+    let id: Int
+    let name: String
+    let address: String?
+
+    func copy(
+        id: CopiableProp<Int> = .copy,
+        name: CopiableProp<String> = .copy,
+        address: NullableCopiableProp<String> = .copy
+    ) -> Person {
+        // Create local variables to reduce Swift compilation complexity.
+        let id = id ?? self.id 
+        let name = name ?? self.name
+        let address = address ?? self.address
+
+        return Person(
+            id: id 
+            name: name 
+            address: address 
+        )
+    }
+}
+```
+
+The `copy()` arguments match the `Person`'s properties. For the `Optional` properties like `address`, the `NullableCopiableProp` typealias is used.
+
+By default, not passing any argument would only create a _copy_ of the `Person` instance. Passing an argument would _replace_ that property's value:
+
+```swift
+let luke = Person(id: 1, name: "Luke", address: "Jakku")
+
+let leia = luke.copy(name: "Leia")
+```
+
+In the above, `leia` would have the same `id` and `address` as `luke` because those arguments were not given. 
+
+```json
+{ id: 1, name: "Leia", address: "Jakku" }
+```
+
+The `address` property, declared as `NullableCopiableProp<String>` has an additional functionality. Because it is `Optional`, we should be able to set its value to `nil`. We can do that by passing an `Optional` variable as the argument:
+
+```swift
+let luke = Person(id: 1, name: "Luke", address: "Jakku")
+
+let address: String? = nil
+
+let lukeWithNoAddress = luke.copy(address: address)
+```
+
+The `lukeWithNoAddress` variable will have a `nil` address as expected:
+
+```json
+{ id: 1, name: "Luke", address: nil }
+```
+
+If we want to _directly_ set the `address` to `nil`, we should **not** pass just `nil`. This is because `nil` is just the same as `.copy` in this context. Instead, we should pass `.some(nil)` instead.
+
+```swift 
+let luke = Person(id: 1, name: "Luke", address: "Jakku")
+
+// DO NOT
+// Result will be incorrect: { id: 1, name: "Luke", address: "Jakku" }
+let lukeWithNoAddress = luke.copy(address: nil)
+
+// DO
+// Result will be { id: 1, name: "Luke", address: nil }
+let lukeWithNoAddress = luke.copy(address: .some(nil))
+```
+
+### Code Generation
+
+These `copy()` methods will be automatically generated in the future.


### PR DESCRIPTION
I went about this the wrong way. I've been running in circles, trying to figure out how to _generate_ this. I just realized I _could_ submit this foundational code first, along with some documentation. 

## Changes 

This is mostly the same as what was discussed in p91TBi-2BL-p2. 

- I added the `CopiableProp` and `NullableCopiableProp` `typealiases` in [Copiable.swift](https://github.com/woocommerce/woocommerce-ios/blob/feat/copiable-framework/Networking/Networking/Copiable/Copiable.swift)
- I created a temporary [`ProductImage+Copiable`](https://github.com/woocommerce/woocommerce-ios/blob/feat/copiable-framework/Networking/Networking/Model/Copiable/ProductImage+Copiable.swift) implementation so that I can add a unit test against it. 

## Code Generation

I'll propose how the code generation should work for this in a post. 

## Testing

- Please review the **main documentation** [here](https://github.com/woocommerce/woocommerce-ios/tree/feat/copiable-framework/docs). 
- Please review the [unit tests](https://github.com/woocommerce/woocommerce-ios/blob/feat/copiable-framework/Networking/NetworkingTests/Copiable/CopiableTests.swift). 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

