### PR TITLE
UL&S: Remove .showLoginMethods segue from Site Address VC

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,8 +33,8 @@ target 'WooCommerce' do
 
   # pod 'WordPressAuthenticator', '~> 1.16.0-beta.4'
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/270-remove-showLoginMethod'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '966deace721cbefd69951ea9a375a4a9b0c0a6ea'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/Podfile
+++ b/Podfile
@@ -31,10 +31,11 @@ target 'WooCommerce' do
 
   pod 'Gridicons', '~> 1.0'
 
-  #pod 'WordPressAuthenticator', '~> 1.16.0-beta.4'
+  # pod 'WordPressAuthenticator', '~> 1.16.0-beta.4'
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/270-remove-showLoginMethod'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
   pod 'WordPressShared', '~> 1.8.16'

--- a/Podfile
+++ b/Podfile
@@ -31,10 +31,10 @@ target 'WooCommerce' do
 
   pod 'Gridicons', '~> 1.0'
 
-  # pod 'WordPressAuthenticator', '~> 1.16.0-beta.4'
+  pod 'WordPressAuthenticator', '~> 1.16.0-beta.4'
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '966deace721cbefd69951ea9a375a4a9b0c0a6ea'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/Podfile
+++ b/Podfile
@@ -31,9 +31,9 @@ target 'WooCommerce' do
 
   pod 'Gridicons', '~> 1.0'
 
-  pod 'WordPressAuthenticator', '~> 1.15.0'
+  #pod 'WordPressAuthenticator', '~> 1.16.0-beta.4'
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/270-remove-showLoginMethod'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
 
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -49,7 +49,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.15.0):
+  - WordPressAuthenticator (1.16.0-beta.4):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -101,7 +101,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.15.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/270-remove-showLoginMethod`)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.6.0)
   - Wormholy (~> 1.6.0)
@@ -133,7 +133,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -148,6 +147,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: issue/270-remove-showLoginMethod
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: c91f1961b71b782eb212300b5e2a8815989d440d
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -172,7 +181,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 17e102eabef6f43959bd24e6da3aa5ba531daa38
+  WordPressAuthenticator: c1325eaa78b55e6d76a036ccad58f00221133d55
   WordPressKit: 84045e236949248632a2c644149e5657733011bb
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: cbe8cce4bd529caf5969750c34ba2d2026a342a9
@@ -188,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 96ae784af35ea94499d911b29a97d3e5ecc1fa5f
+PODFILE CHECKSUM: acf2694d6984aa4e24f323c84f64ad1ff087a0a2
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -101,7 +101,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `966deace721cbefd69951ea9a375a4a9b0c0a6ea`)
+  - WordPressAuthenticator (~> 1.16.0-beta.4)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.6.0)
   - Wormholy (~> 1.6.0)
@@ -133,6 +133,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -147,16 +148,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :commit: 966deace721cbefd69951ea9a375a4a9b0c0a6ea
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 966deace721cbefd69951ea9a375a4a9b0c0a6ea
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -197,6 +188,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: e1c5bb39f272c27d7d7f48f77537aa357b74bf78
+PODFILE CHECKSUM: dbb315153e9e7c8dd4dd49950c6913a8613dbe84
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -155,7 +155,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: c91f1961b71b782eb212300b5e2a8815989d440d
+    :commit: e765a71cbdcfaa393bede74884c68e37d66a90ee
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -197,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: acf2694d6984aa4e24f323c84f64ad1ff087a0a2
+PODFILE CHECKSUM: e016402008fcb8e4128ff37827f395135b4538c8
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -101,7 +101,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/270-remove-showLoginMethod`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `966deace721cbefd69951ea9a375a4a9b0c0a6ea`)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.6.0)
   - Wormholy (~> 1.6.0)
@@ -150,12 +150,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :branch: issue/270-remove-showLoginMethod
+    :commit: 966deace721cbefd69951ea9a375a4a9b0c0a6ea
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: e765a71cbdcfaa393bede74884c68e37d66a90ee
+    :commit: 966deace721cbefd69951ea9a375a4a9b0c0a6ea
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -197,6 +197,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: e016402008fcb8e4128ff37827f395135b4538c8
+PODFILE CHECKSUM: e1c5bb39f272c27d7d7f48f77537aa357b74bf78
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
Ref. #2003 
Ref. https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/271

This PR removes the `.showLoginMethods` segue from `Login.storyboard` and presents the "3 button" view programmatically.

Note: although this view is not currently presented in Woo, we are keeping it up-to-date in case you'll need it when presenting SIWA as a login option. I realize the Login flows are currently being redesigned and this code may be obsolete soon.

### To Test
1. Check out this branch
2. In `AuthenticatorManager`, add a new param: `showLoginOptionsFromSiteAddress: true` to the configuration.
3. `rake dependencies`
4. Build and run (run on a device if you wish to view the "Sign in with Apple" button)
5. Log out if logged in
6. Log In > Enter the site address... > choose a WP.com hosted site with Woo installed, such as `hellotester1234.blog` > Next 
7. **Expected:** the "3 button" view is presented as a modal. On a simulator, it will look like this:

<a href="https://user-images.githubusercontent.com/1062444/81104059-94930f80-8ed7-11ea-8fc1-5811b1c84fc5.png"><img src="https://user-images.githubusercontent.com/1062444/81104059-94930f80-8ed7-11ea-8fc1-5811b1c84fc5.png" width="350" /></a>

#### Do not merge until
1. The Authenticator PR has been merged. Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/271
2. A new Authenticator release has been created 
3. The release is published on Cocoapods trunk 
4. This PR points to the new release 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
