### PR TITLE
Convert KeyboardFrameObserver to class

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Observes the keyboard frame and notifies its subscriber.
-struct KeyboardFrameObserver {
+final class KeyboardFrameObserver {
     private let onKeyboardFrameUpdate: OnKeyboardFrameUpdate
 
     /// Provides the last known keyboard state.
@@ -36,19 +36,16 @@ struct KeyboardFrameObserver {
     ///
     /// - Parameter sendInitialEvent: If true, the subscriber will be immediately notified
     ///                               using the last known keyboard frame.
-    mutating func startObservingKeyboardFrame(sendInitialEvent: Bool = false) {
-        var observer = self
-        notificationCenter.addObserver(forName: UIResponder.keyboardWillShowNotification,
-                                       object: nil,
-                                       queue: nil) { notification in
-                                        observer.keyboardWillShow(notification)
-        }
+    func startObservingKeyboardFrame(sendInitialEvent: Bool = false) {
+        notificationCenter.addObserver(self,
+                                       selector: #selector(keyboardWillShow(_:)),
+                                       name: UIResponder.keyboardWillShowNotification,
+                                       object: nil)
 
-        notificationCenter.addObserver(forName: UIResponder.keyboardWillHideNotification,
-                                       object: nil,
-                                       queue: nil) { notification in
-                                        observer.keyboardWillHide(notification)
-        }
+        notificationCenter.addObserver(self,
+                                       selector: #selector(keyboardWillHide(_:)),
+                                       name: UIResponder.keyboardWillHideNotification,
+                                       object: nil)
 
         if sendInitialEvent {
             keyboardFrame = keyboardStateProvider.state.frameEnd
@@ -57,14 +54,14 @@ struct KeyboardFrameObserver {
 }
 
 private extension KeyboardFrameObserver {
-    mutating func keyboardWillShow(_ notification: Foundation.Notification) {
+    @objc func keyboardWillShow(_ notification: Foundation.Notification) {
         guard let keyboardFrame = keyboardRect(from: notification) else {
             return
         }
         self.keyboardFrame = keyboardFrame
     }
 
-    mutating func keyboardWillHide(_ notification: Foundation.Notification) {
+    @objc func keyboardWillHide(_ notification: Foundation.Notification) {
         self.keyboardFrame = .zero
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -16,7 +16,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         var actualFrames = [CGRect]()
 
-        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             actualFrames.append(keyboardFrame)
             if actualFrames.count >= expectedFrames.count {
                 XCTAssertEqual(actualFrames, expectedFrames)
@@ -47,7 +47,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         var actualFrames = [CGRect]()
 
-        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             actualFrames.append(keyboardFrame)
             if actualFrames.count >= expectedFrames.count {
                 XCTAssertEqual(actualFrames, expectedFrames)
@@ -70,7 +70,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
-        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             expectationForKeyboardFrame.fulfill()
         }
         keyboardFrameObserver.startObservingKeyboardFrame()
@@ -88,7 +88,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
-        var keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
             expectationForKeyboardFrame.fulfill()
         }
         keyboardFrameObserver.startObservingKeyboardFrame()
@@ -135,7 +135,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
         let keyboardStateProvider = MockKeyboardStateProvider(state: expectedKeyboardState)
 
         var actualKeyboardFrame: CGRect = .zero
-        var keyboardFrameObserver = KeyboardFrameObserver(keyboardStateProvider: keyboardStateProvider) { frame in
+        let keyboardFrameObserver = KeyboardFrameObserver(keyboardStateProvider: keyboardStateProvider) { frame in
             actualKeyboardFrame = frame
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -101,6 +101,31 @@ final class KeyboardFrameObserverTests: XCTestCase {
         waitForExpectations(timeout: 0.1)
     }
 
+    func testItWillNotEmitNewEventsWhenItIsDeallocated() {
+        // Arrange
+        let notificationCenter = NotificationCenter()
+
+        var eventsLogged = 0
+        var keyboardFrameObserver: KeyboardFrameObserver? = KeyboardFrameObserver(notificationCenter: notificationCenter) { _ in
+            eventsLogged += 1
+        }
+
+        keyboardFrameObserver?.startObservingKeyboardFrame()
+
+        // These should be logged
+        notificationCenter.postKeyboardWillShowNotification(keyboardFrame: CGRect(x: 1, y: 1, width: 1, height: 1))
+        notificationCenter.postKeyboardWillShowNotification(keyboardFrame: CGRect(x: 2, y: 2, width: 2, height: 2))
+
+        // Act
+        keyboardFrameObserver = nil
+
+        // This should not be logged anymore
+        notificationCenter.postKeyboardWillShowNotification(keyboardFrame: CGRect(x: 3, y: 3, width: 3, height: 3))
+
+        // Assert
+        XCTAssertEqual(eventsLogged, 2)
+    }
+
     func testItCanSendInitialEvents() {
         // Arrange
         let expectedKeyboardState = KeyboardState(


### PR DESCRIPTION
Fixes #2173

I needed to debug a strange and inconsistent vertical alignment issue for #2245. But it's quite confusing because I keep getting events from _supposed-to-be-dead_ `KeyboardFrameObserver` 
instances. 😅 

## Changes 

Before making any changes to `KeyboardFrameObserver`, I added a **failing test** (dbb69be) to prove what we're trying to do here: we want to remove the observer from `NSNotificationCenter` when `KeyboardFrameObserver` is deallocated. 

And then I converted it to a `final class` in 94fec86. I used the selector-based `NSNotificationCenter` observation so we don't need any extra code to remove observers in `deinit`. 

## Testing

Please test for possible regressions. 

1. Navigate to Orders → Search. 
2. Enter a search text that will return lots of Orders. 
3. Confirm that the table's content inset is correctly being set and that you can see all the table's contents. 
4. If you're using the simulator, dismiss the keyboard. Confirm that the content inset is updated and the table covers most of the screen. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

