### PR TITLE
Use a Separate Ghost VC for TopPerformerDataViewController

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableView+HeaderFooterHelpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+HeaderFooterHelpers.swift
@@ -41,4 +41,14 @@ extension UITableView {
         tableFooterView = UIView(frame: CGRect(origin: .zero,
                                                size: CGSize(width: frame.width, height: 1)))
     }
+
+    /// Change `self.tableFooterView` to an empty view in order to hide the `UITableView`'s
+    /// default row placeholders (with separators).
+    ///
+    /// This intentionally have an absurdingly long method name because we want to be clear that
+    /// we are replacing the `tableFooterView` property.
+    ///
+    func applyFooterViewForHidingExtraRowPlaceholders() {
+        tableFooterView = UIView(frame: .zero)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -148,7 +148,7 @@ private extension TopPerformerDataViewController {
         tableView.separatorColor = TableViewStyle.separatorColor
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.tableFooterView = Constants.emptyView
+        tableView.applyFooterViewForHidingExtraRowPlaceholders()
     }
 
     func configureResultsController() {
@@ -321,7 +321,6 @@ private extension TopPerformerDataViewController {
         static let estimatedSectionHeight       = CGFloat(125)
         static let numberOfSections             = 1
         static let emptyStateRowCount           = 1
-        static let emptyView                    = UIView(frame: .zero)
         static let placeholderRowsPerSection    = [3]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -5,7 +5,7 @@ import XLPagerTabStrip
 import WordPressUI
 
 
-class TopPerformerDataViewController: UIViewController {
+final class TopPerformerDataViewController: UIViewController {
 
     // MARK: - Properties
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -332,6 +332,12 @@ private extension TopPerformerDataViewController {
         override func viewDidLoad() {
             super.viewDidLoad()
 
+            // Make sure that Ghost will not have any dataSource or delegate to _swap_. This is
+            // just to reduce the chance of having ”invalid number of rows” crashes because of
+            // delegate swapping.
+            tableView.dataSource = nil
+            tableView.delegate = nil
+
             tableView.backgroundColor = TableViewStyle.backgroundColor
             tableView.separatorStyle = .none
             tableView.estimatedRowHeight = Constants.estimatedRowHeight

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -9,7 +9,7 @@ final class TopPerformerDataViewController: UIViewController {
 
     // MARK: - Properties
 
-    let granularity: StatGranularity
+    private let granularity: StatGranularity
 
     var hasTopEarnerStatsItems: Bool {
         return (topEarnerStats?.items?.count ?? 0) > 0
@@ -316,7 +316,7 @@ private extension TopPerformerDataViewController {
     }
 }
 
-// MARK: - Ghost View 
+// MARK: - Ghost View
 
 private extension TopPerformerDataViewController {
     final class GhostTableViewController: UITableViewController {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -3,6 +3,7 @@ import Yosemite
 import Charts
 import XLPagerTabStrip
 import WordPressUI
+import class AutomatticTracks.CrashLogging
 
 
 final class TopPerformerDataViewController: UIViewController {
@@ -174,7 +175,12 @@ private extension TopPerformerDataViewController {
         resultsController.onDidResetContent = { [weak self] in
             self?.tableView.reloadData()
         }
-        try? resultsController.performFetch()
+
+        do {
+            try resultsController.performFetch()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 
     func registerTableViewCells() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -144,8 +144,8 @@ private extension TopPerformerDataViewController {
     }
 
     func configureTableView() {
-        tableView.backgroundColor = .basicBackground
-        tableView.separatorColor = .systemColor(.separator)
+        tableView.backgroundColor = TableViewStyle.backgroundColor
+        tableView.separatorColor = TableViewStyle.separatorColor
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
         tableView.tableFooterView = Constants.emptyView
@@ -309,6 +309,11 @@ private extension TopPerformerDataViewController {
                                                           comment: "Description for Top Performers section of My Store tab.")
         static let sectionLeftColumn = NSLocalizedString("Product", comment: "Description for Top Performers left column header")
         static let sectionRightColumn = NSLocalizedString("Total Spend", comment: "Description for Top Performers right column header")
+    }
+
+    enum TableViewStyle {
+        static let backgroundColor = UIColor.basicBackground
+        static let separatorColor = UIColor.systemColor(.separator)
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift
@@ -3,7 +3,7 @@ import Yosemite
 import XLPagerTabStrip
 
 
-class TopPerformersViewController: ButtonBarPagerTabStripViewController {
+final class TopPerformersViewController: ButtonBarPagerTabStripViewController {
 
     // MARK: - Properties
 


### PR DESCRIPTION
Hopefully fixes #1711.

Looking at the crash events of #1711, I'm betting that it is because we're using Ghost on the same `UITableView` used for showing real data in `TopPerformerDataViewController`. We've discovered a few months ago that this can cause race conditions (https://github.com/wordpress-mobile/WordPress-iOS/pull/12974) and crash the app. 

This PR adds a new [`GhostTableViewController`](https://github.com/woocommerce/woocommerce-ios/blob/d24dd81ee131cdc7331c6a1d29f56f32ca9903ec/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift#L322) that serves as the ghost view of `TopPerformerDataViewController`. It is added and removed as a child ViewController:

https://github.com/woocommerce/woocommerce-ios/blob/d24dd81ee131cdc7331c6a1d29f56f32ca9903ec/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift#L125-L135

I could not reproduce the crash, unfortunately. 😐 

## Testing

1. Comment this out or add a delay:

    https://github.com/woocommerce/woocommerce-ios/blob/d24dd81ee131cdc7331c6a1d29f56f32ca9903ec/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformersViewController.swift#L101-L102

2. Run the app
3. Confirm that you see the placeholder:

    <kbd><img src="https://user-images.githubusercontent.com/198826/81333956-8291a800-9062-11ea-8473-0899b021272a.gif" width="320"></kbd>

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] Mark Sentry issue as fixed

