### PR TITLE
CameraCaptureCoordinator: Call completion block on main thread

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/CameraCaptureCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/CameraCaptureCoordinator.swift
@@ -1,5 +1,6 @@
 import MobileCoreServices
 import WPMediaPicker
+import Photos
 
 /// Encapsulates capturing media from a device camera.
 ///
@@ -83,7 +84,11 @@ private extension CameraCaptureCoordinator {
 
     func requestPhotoLibraryPermission(completion: @escaping (_ authorized: Bool) -> Void) {
         PHPhotoLibrary.requestAuthorization { status in
-            completion(status == .authorized)
+            // The requestAuthorization block can be called on a serial queue so we're making sure
+            // the completion block is called on the main thread.
+            DispatchQueue.main.async {
+                completion(status == .authorized)
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2257

[Apple docs](https://developer.apple.com/documentation/photokit/phphotolibrary/1620736-requestauthorization?language=objc) say this:

> Photos may call your handler block on an arbitrary serial queue. If your handler needs to interact with user interface elements, dispatch such work to the main queue.

The crash was happening because we call the `completion` block right away (on a serial queue) and somewhere along the line we present a `UIAlertController`, which causes the crash. 

## Testing

1. Delete the app from the device
2. Run the app
3. Navigate to Product → Photos → Add Photo → Pick from Library
4. Deny the permission request
5. Re-run the app
6. Navigate to Product → Photos → Add Photo → Camera
7. Confirm that there is no crash and you see this alert instead:

    <img src="https://user-images.githubusercontent.com/198826/81348386-3141e280-907b-11ea-9cce-777e59c8b879.png" width="240">

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

