### PR TITLE
Support Result<> Type

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		5726F7312460A8510031CAAC /* ProductImage+Copiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726F7302460A8510031CAAC /* ProductImage+Copiable.swift */; };
 		5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726F7332460A8F00031CAAC /* CopiableTests.swift */; };
 		57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */ = {isa = PBXBuildFile; fileRef = 57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */; };
+		57E8FED3246616AC0057CD68 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E8FED2246616AC0057CD68 /* Result+Extensions.swift */; };
 		6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */; };
 		6856DE98F90AC6E4743D18CA /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1228ADBC14D8202E49D /* XCTestCase+Wait.swift */; };
 		74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */; };
@@ -401,6 +402,7 @@
 		5726F7332460A8F00031CAAC /* CopiableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopiableTests.swift; sourceTree = "<group>"; };
 		573B448C242422DB00E71ADC /* orders-load-all-2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "orders-load-all-2.json"; sourceTree = "<group>"; };
 		57BE08D72409B63700F6DCED /* reviews-missing-avatar-urls.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-missing-avatar-urls.json"; sourceTree = "<group>"; };
+		57E8FED2246616AC0057CD68 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		6856D1228ADBC14D8202E49D /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NetworkingTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74002D692118B26000A63C19 /* SiteVisitStatsMapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVisitStatsMapperTests.swift; sourceTree = "<group>"; };
@@ -1196,6 +1198,7 @@
 				B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */,
 				021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */,
 				02BDB83423EA98C800BCC63E /* String+HTML.swift */,
+				57E8FED2246616AC0057CD68 /* Result+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1592,6 +1595,7 @@
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
+				57E8FED3246616AC0057CD68 /* Result+Extensions.swift in Sources */,
 				020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */,
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
 				743E84EC22171F4600FAC9D7 /* ShipmentTracking.swift in Sources */,

--- a/Networking/Networking/Extensions/Result+Extensions.swift
+++ b/Networking/Networking/Extensions/Result+Extensions.swift
@@ -16,4 +16,14 @@ extension Result {
     public var isFailure: Bool {
         !isSuccess
     }
+
+    /// Returns the value of `.failure()` if `self` is a failure.
+    ///
+    public var failure: Failure? {
+        guard case let .failure(error) = self else {
+            return nil
+        }
+
+        return error
+    }
 }

--- a/Networking/Networking/Extensions/Result+Extensions.swift
+++ b/Networking/Networking/Extensions/Result+Extensions.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+
+extension Result {
+    /// Indicates whether `self` is a `.success`.
+    ///
+    public var isSuccess: Bool {
+        guard case .success = self else {
+            return false
+        }
+        return true
+    }
+
+    /// Indicates whether `self` is a `.failure`.
+    ///
+    public var isFailure: Bool {
+        !isSuccess
+    }
+}

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -47,6 +47,23 @@ public class AlamofireNetwork: Network {
             }
     }
 
+    /// Executes the specified Network Request. Upon completion, the payload will be sent back to the caller as a Data instance.
+    ///
+    /// - Important:
+    ///     - Authentication Headers will be injected, based on the Network's Credentials.
+    ///
+    /// - Parameters:
+    ///     - request: Request that should be performed.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
+        let authenticated = AuthenticatedRequest(credentials: credentials, request: request)
+
+        Alamofire.request(authenticated).responseData { response in
+            completion(response.result.toSwiftResult())
+        }
+    }
+
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
                                         to request: URLRequestConvertible,
                                         completion: @escaping (Data?, Error?) -> Void) {
@@ -90,6 +107,19 @@ private extension Alamofire.DataResponse {
 
         return response.flatMap { response in
             NetworkError(from: response.statusCode)
+        }
+    }
+}
+
+// MARK: - Swift.Result Conversion
+
+private extension Alamofire.Result {
+    func toSwiftResult() -> Swift.Result<Value, Error> {
+        switch self {
+        case .success(let value):
+            return .success(value)
+        case .failure(let error):
+            return .failure(error)
         }
     }
 }

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -114,6 +114,8 @@ private extension Alamofire.DataResponse {
 // MARK: - Swift.Result Conversion
 
 private extension Alamofire.Result {
+    /// Convert this `Alamofire.Result` to a `Swift.Result`.
+    ///
     func toSwiftResult() -> Swift.Result<Value, Error> {
         switch self {
         case .success(let value):

--- a/Networking/Networking/Network/MockupNetwork.swift
+++ b/Networking/Networking/Network/MockupNetwork.swift
@@ -52,19 +52,33 @@ class MockupNetwork: Network {
     /// Otherwise, an error will be relayed back (.notFound!).
     ///
     func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+        responseData(for: request) { result in
+            switch result {
+            case .success(let data):
+                completion(data, nil)
+            case .failure(let error):
+                completion(nil, error)
+            }
+        }
+    }
+
+    /// Whenever the Request's URL matches any of the "Mocked Up Patterns", we'll return the
+    /// specified response file, loaded as *Data*. Otherwise, an error will be relayed back (.notFound!).
+    ///
+    func responseData(for request: URLRequestConvertible, completion: @escaping (Swift.Result<Data, Error>) -> Void) {
         requestsForResponseData.append(request)
 
         if let error = error(for: request) {
-            completion(nil, error)
+            completion(.failure(error))
             return
         }
 
         guard let name = filename(for: request), let data = Loader.contentsOf(name) else {
-            completion(nil, NetworkError.notFound)
+            completion(.failure(NetworkError.notFound))
             return
         }
 
-        completion(data, nil)
+        completion(.success(data))
     }
 
     func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -31,7 +31,18 @@ public protocol Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
+    @available(*, deprecated, message: "Use the responseData() with a Result callback instead")
     func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void)
+
+    /// Executes the specified Network Request. Upon completion, the payload will be sent back to
+    /// the caller as a Data instance.
+    ///
+    /// - Parameters:
+    ///     - request: Request that should be performed.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    func responseData(for request: URLRequestConvertible,
+                      completion: @escaping (Swift.Result<Data, Error>) -> Void)
 
     /// Executes the specified Network Request for file uploads. Upon completion, the payload will be sent back to the caller as a Data instance.
     ///

--- a/Networking/Networking/Network/Network.swift
+++ b/Networking/Networking/Network/Network.swift
@@ -31,7 +31,6 @@ public protocol Network {
     ///     - request: Request that should be performed.
     ///     - completion: Closure to be executed upon completion.
     ///
-    @available(*, deprecated, message: "Use the responseData() with a Result callback instead")
     func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void)
 
     /// Executes the specified Network Request. Upon completion, the payload will be sent back to

--- a/Networking/Networking/Network/NullNetwork.swift
+++ b/Networking/Networking/Network/NullNetwork.swift
@@ -11,6 +11,11 @@ public final class NullNetwork: Network {
 
     public func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) { }
 
+    public func responseData(for request: URLRequestConvertible,
+                             completion: @escaping (Swift.Result<Data, Error>) -> Void) {
+
+    }
+
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
                                         to request: URLRequestConvertible,
                                         completion: @escaping (Data?, Error?) -> Void) { }

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Alamofire
-
 
 /// Order: Remote Endpoints
 ///
@@ -22,7 +20,7 @@ public class OrdersRemote: Remote {
                               before: Date? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
-                              completion: @escaping ([Order]?, Error?) -> Void) {
+                              completion: @escaping (Result<[Order], Error>) -> Void) {
         let utcDateFormatter = DateFormatter.Defaults.iso8601
 
         let parameters: [String: Any] = {

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -57,7 +57,7 @@ public class Remote {
     ///
     /// - Parameters:
     ///     - request: Request that should be performed.
-    ///     - mapper: Mapper entitity that will be used to attempt to parse the Backend's Response.
+    ///     - mapper: Mapper entity that will be used to attempt to parse the Backend's Response.
     ///     - completion: Closure to be executed upon completion.
     ///
     func enqueue<M: Mapper>(_ request: URLRequestConvertible, mapper: M, completion: @escaping (M.Output?, Error?) -> Void) {
@@ -90,7 +90,7 @@ public class Remote {
     ///
     /// - Parameters:
     ///     - request: Request that should be performed.
-    ///     - mapper: Mapper entitity that will be used to attempt to parse the Backend's Response.
+    ///     - mapper: Mapper entity that will be used to attempt to parse the Backend's Response.
     ///     - completion: Closure to be executed upon completion.
     ///
     func enqueue<M: Mapper>(_ request: URLRequestConvertible, mapper: M,

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -36,42 +36,48 @@ final class OrdersRemoteTests: XCTestCase {
         network.removeAllSimulatedResponses()
     }
 
-
     // MARK: - Load All Orders Tests
 
     /// Verifies that loadAllOrders properly parses the `orders-load-all` sample response.
     ///
-    func testLoadAllOrdersProperlyReturnsParsedOrders() {
+    func testLoadAllOrdersProperlyReturnsParsedOrders() throws {
+        // Given
         let remote = OrdersRemote(network: network)
-        let expectation = self.expectation(description: "Load All Orders")
 
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
 
-        remote.loadAllOrders(for: sampleSiteID) { orders, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(orders)
-            XCTAssert(orders!.count == 4)
-            expectation.fulfill()
+        // When
+        var result: Result<[Order], Error>?
+        waitForExpectation { expectation in
+            remote.loadAllOrders(for: sampleSiteID) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        let orders = try XCTUnwrap(result?.get())
+        XCTAssert(orders.count == 4)
     }
 
     /// Verifies that loadAllOrders properly relays Networking Layer errors.
     ///
-    func testLoadAllOrdersProperlyRelaysNetwokingErrors() {
+    func testLoadAllOrdersProperlyRelaysNetwokingErrors() throws {
+        // Given
         let remote = OrdersRemote(network: network)
-        let expectation = self.expectation(description: "Load All Orders")
 
-        remote.loadAllOrders(for: sampleSiteID) { orders, error in
-            XCTAssertNil(orders)
-            XCTAssertNotNil(error)
-            expectation.fulfill()
+        // When
+        var result: Result<[Order], Error>?
+        waitForExpectation { expectation in
+            remote.loadAllOrders(for: sampleSiteID) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
     }
-
 
     // MARK: - Load Order Tests
 

--- a/Networking/NetworkingTests/Testing/XCTestCase+Wait.swift
+++ b/Networking/NetworkingTests/Testing/XCTestCase+Wait.swift
@@ -7,6 +7,26 @@ extension XCTestCase {
     /// Example usage:
     ///
     /// ```
+    /// waitForExpectation(timeout: TimeInterval(10)) { expectation in
+    ///     doSomethingInTheBackground {
+    ///         expectation.fulfill()
+    ///     }
+    /// }
+    /// ```
+    ///
+    public func waitForExpectation(description: String? = nil,
+                                   timeout: TimeInterval,
+                                   _ block: (XCTestExpectation) -> ()) {
+        let exp = expectation(description: description ?? "")
+        block(exp)
+        wait(for: [exp], timeout: timeout)
+    }
+
+    /// Creates an XCTestExpectation and waits for `block` to call `fulfill()`.
+    ///
+    /// Example usage:
+    ///
+    /// ```
     /// waitForExpectation { expectation in
     ///     doSomethingInTheBackground {
     ///         expectation.fulfill()
@@ -15,10 +35,9 @@ extension XCTestCase {
     /// ```
     ///
     public func waitForExpectation(description: String? = nil,
-                                   timeout: TimeInterval = TimeInterval(10),
                                    _ block: (XCTestExpectation) -> ()) {
         let exp = expectation(description: description ?? "")
         block(exp)
-        wait(for: [exp], timeout: timeout)
+        wait(for: [exp], timeout: Constants.expectationTimeout)
     }
 }

--- a/Networking/NetworkingTests/Testing/XCTestCase+Wait.swift
+++ b/Networking/NetworkingTests/Testing/XCTestCase+Wait.swift
@@ -14,9 +14,9 @@ extension XCTestCase {
     /// }
     /// ```
     ///
-    func waitForExpectation(description: String? = nil,
-                            timeout: TimeInterval = Constants.expectationTimeout,
-                            _ block: (XCTestExpectation) -> ()) {
+    public func waitForExpectation(description: String? = nil,
+                                   timeout: TimeInterval = TimeInterval(10),
+                                   _ block: (XCTestExpectation) -> ()) {
         let exp = expectation(description: description ?? "")
         block(exp)
         wait(for: [exp], timeout: timeout)


### PR DESCRIPTION
Closes #1926

I have a possibly huge `Action` incoming with multiple API requests for fixing #2254. I foresee it being hairy and the lack of `Result` would just make it hairier. 😄  

This adds `Result` callbacks for:

1. `Network`:

    https://github.com/woocommerce/woocommerce-ios/blob/43ecd3e2eaa59def81751da3fa718aadf12f8088/Networking/Networking/Network/Network.swift#L43-L44

2. `AlamofireNetwork`:

    https://github.com/woocommerce/woocommerce-ios/blob/43ecd3e2eaa59def81751da3fa718aadf12f8088/Networking/Networking/Network/AlamofireNetwork.swift#L59-L65

3. `Remote.enqueue`:

    https://github.com/woocommerce/woocommerce-ios/blob/43ecd3e2eaa59def81751da3fa718aadf12f8088/Networking/Networking/Remote/Remote.swift#L96-L97

As a guinea pig, I changed `OrdersRemote.loadAllOrders` to now return a `Result` type:

https://github.com/woocommerce/woocommerce-ios/blob/43ecd3e2eaa59def81751da3fa718aadf12f8088/Networking/Networking/Remote/OrdersRemote.swift#L18-L23

That should be fairly covered by the `OrderStoreTests` and `OrderStoreTests_FetchFilteredAndAllOrders`. 

## Testing

1. Navigate to Orders → Processing.
2. Pull to refresh. Confirm that the orders can still be loaded. 
3. Go offline. 
4. Pull to refresh. Confirm that a notice is presented because of the failure. 

### Test Jetpack Errors (which are not HTTP errors)

1. While staying on the Orders → Processing tab and with orders already preloaded. 
2. Disconnect the current site from Jetpack. 
3. Pull to refresh. 
4. Confirm that a notice is presented because of the failure. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

