### PR TITLE
Removed productList feature flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -1,8 +1,6 @@
 struct DefaultFeatureFlagService: FeatureFlagService {
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
-        case .productList:
-            return true
         case .editProducts:
             return true
         case .editProductsRelease2:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -6,10 +6,6 @@ enum FeatureFlag: Int {
     /// `An enum with no cases cannot declare a raw type`
     case null
 
-    /// Product list
-    ///
-    case productList
-
     /// Edit products
     ///
     case editProducts

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -142,16 +142,14 @@ private extension SettingsViewController {
         #endif
 
         if couldShowBetaFeaturesRow() {
-            rowsForImproveTheAppSection { [weak self] improveTheAppRows in
-                self?.sections = [
-                    Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
-                    Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
-                    Section(title: improveTheAppTitle, rows: improveTheAppRows, footerHeight: UITableView.automaticDimension),
-                    Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
-                    otherSection,
-                    Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
-                ]
-            }
+            sections = [
+                Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
+                Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
+                Section(title: improveTheAppTitle, rows: [.privacy, .betaFeatures, .featureRequest], footerHeight: UITableView.automaticDimension),
+                Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
+                otherSection,
+                Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
+            ]
         } else {
             sections = [
                 Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
@@ -162,26 +160,6 @@ private extension SettingsViewController {
                 Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
             ]
         }
-    }
-
-    func rowsForImproveTheAppSection(onCompletion: @escaping (_ rows: [Row]) -> Void) {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productList) {
-            onCompletion([.privacy, .betaFeatures, .featureRequest])
-            return
-        }
-
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            assertionFailure("Cannot find store ID")
-            return
-        }
-        let action = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
-            guard eligibleStatsVersion == .v4 else {
-                onCompletion([.privacy, .featureRequest])
-                return
-            }
-            onCompletion([.privacy, .betaFeatures, .featureRequest])
-        }
-        ServiceLocator.stores.dispatch(action)
     }
 
     func registerTableViewCells() {

--- a/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
@@ -1,22 +1,17 @@
 @testable import WooCommerce
 
 struct MockFeatureFlagService: FeatureFlagService {
-    private let isProductListFeatureOn: Bool
     private let isEditProductsRelease2On: Bool
     private let isEditProductsRelease3On: Bool
 
-    init(isProductListFeatureOn: Bool = true,
-         isEditProductsRelease2On: Bool = false,
+    init(isEditProductsRelease2On: Bool = false,
          isEditProductsRelease3On: Bool = false) {
-        self.isProductListFeatureOn = isProductListFeatureOn
         self.isEditProductsRelease2On = isEditProductsRelease2On
         self.isEditProductsRelease3On = isEditProductsRelease3On
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
-        case .productList:
-            return isProductListFeatureOn
         case .editProductsRelease2:
             return isEditProductsRelease2On
         case .editProductsRelease3:


### PR DESCRIPTION
Fixes #1897 

This PR removes the unused `productList` feature flag, which is now obsolete after the Products Milestone 1 release.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
