### PR TITLE
Show discard changes prompt when dismissing filter products screen with filter changes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.xib
@@ -21,14 +21,14 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0Hi-U6-ohm">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pgc-1V-BCe">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="768"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="812"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0sS-tG-DzA">
-                            <rect key="frame" x="0.0" y="768" width="414" height="50"/>
+                            <rect key="frame" x="0.0" y="812" width="414" height="50"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="50" placeholder="YES" id="Tq2-i3-6qV"/>
@@ -39,7 +39,7 @@
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="0Hi-U6-ohm" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Sny-jC-qtZ"/>
+                <constraint firstItem="0Hi-U6-ohm" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Sny-jC-qtZ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="0Hi-U6-ohm" secondAttribute="trailing" id="hbI-xD-9g6"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="0Hi-U6-ohm" secondAttribute="bottom" id="jyt-Qs-ekO"/>
                 <constraint firstItem="0Hi-U6-ohm" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="yfB-fN-j1x"/>


### PR DESCRIPTION
Show discard changes action sheet when dismissing with outstanding changes on the filters for #2037 

## Changes

In `FilterListViewController`, kept track of the original filtering criteria (now conforming to `Equatable`) from the view model, and used it to compare with the latest criteria when the user taps to dismiss the filter list UI

## Testing

- Go to the Products tab
- Tap on the "Filter" CTA
- Tap on the "Dismiss" CTA --> it should go back to the Products tab without any prompt
- Tap on the "Filter" CTA again
- Tap into a row, select a different value, then tap "<" to go back to the filter list screen
- Tap on the "Dismiss" CTA --> a discard changes action sheet should show up
- Tap outside of the action sheet to go back to the filter list screen
- Tap on the "Clear all" CTA
- Tap on the "Dismiss" CTA --> it should go back to the Products tab without any prompt

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/81641390-75eec480-9453-11ea-9839-66a152c465b8.gif)

iPhone 11 | iPad Air 2
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 13 20 55](https://user-images.githubusercontent.com/1945542/81641388-74bd9780-9453-11ea-90fd-59339510df0b.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-12 at 13 10 05](https://user-images.githubusercontent.com/1945542/81641375-6bccc600-9453-11ea-9ce4-5e68b73de031.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
