### PR TITLE
Update filter list screen background color to match the bottom CTA container

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -179,7 +179,7 @@ private extension FilterListViewController {
     }
 
     func configureMainView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = .basicBackground
     }
 
     func observeListSelectorCommandItemSelection() {


### PR DESCRIPTION
Update bottom CTA container background color so that it looks right in Light mode for #2037 

## Changes

Update filter list screen background color to match the filter action container on devices with a notch

## Testing

- Launch the app in a simulator/device with a notch (e.g. iPhone X series)
- Go to the Products tab
- Tap on the "Filter" CTA --> the background color covering the notch should match the color of the bottom CTA container in both Dark and Light modes

## Example screenshots

Note the difference at the notch area in Light mode!

mode | before | after
-- | -- | --
Light | ![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 13 26 35](https://user-images.githubusercontent.com/1945542/81642305-a9325300-9455-11ea-974a-66076b15a8cd.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 13 32 27](https://user-images.githubusercontent.com/1945542/81642368-d41ca700-9455-11ea-99b3-727e3de8d417.png)
Dark | ![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 13 34 02](https://user-images.githubusercontent.com/1945542/81642314-af283400-9455-11ea-8080-28ff936e4399.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 13 32 39](https://user-images.githubusercontent.com/1945542/81642312-ae8f9d80-9455-11ea-9795-70cf9c190425.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
