### PR TITLE
Update bottom sheet list selector to fit to content height

### DIFF
--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -41,6 +41,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
 
         configureMainView()
         configureTableView()
+        configurePreferredContentSize()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -124,5 +125,11 @@ private extension BottomSheetListSelectorViewController {
     func registerTableViewHeaderFooters() {
         let type = BottomSheetListSelectorSectionHeaderView.self
         tableView.register(type.loadNib(), forHeaderFooterViewReuseIdentifier: type.reuseIdentifier)
+    }
+
+    func configurePreferredContentSize() {
+        let size = contentSize
+        let height = contentSize.height + BottomSheetViewController.Constants.additionalContentTopMargin
+        preferredContentSize = CGSize(width: size.width, height: height)
     }
 }


### PR DESCRIPTION
iPad improvements to fit to height for #2054 

## Changes

Configured `BottomSheetListSelectorViewController`'s `preferredContentSize` so that the popover fits to the content height 

## Testing

- Launch the app on a tablet
- Go to the Products tab
- Tap on the "Sort by" CTA --> the popover should fit to the content height

## Example screenshots

device | before | after
-- | -- | --
iPad Air 2 (Dark) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-12 at 14 07 16](https://user-images.githubusercontent.com/1945542/81644748-eb11c800-945a-11ea-91bd-88b5f8eaf099.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-12 at 14 09 24](https://user-images.githubusercontent.com/1945542/81644762-f107a900-945a-11ea-8e5f-f1d6b648f311.png)
iPad Air 2 (Light) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-12 at 14 07 37](https://user-images.githubusercontent.com/1945542/81644756-ef3de580-945a-11ea-8acc-58e3b3416c16.png) | ![Simulator Screen Shot - iPad Air 2 - 2020-05-12 at 14 09 13](https://user-images.githubusercontent.com/1945542/81644758-efd67c00-945a-11ea-835c-4fc670b62faf.png)
sanity check on iPhone 11 | ![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 14 14 49](https://user-images.githubusercontent.com/1945542/81644859-1dbbc080-945b-11ea-9418-22ac7581ab62.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-12 at 14 11 26](https://user-images.githubusercontent.com/1945542/81644847-1a283980-945b-11ea-9505-92b40d63b069.png)







Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
