### PR TITLE
Create a wrapper to present `BottomSheetListSelectorPresenter`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorPresenter.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 final class BottomSheetListSelectorPresenter<Command: BottomSheetListSelectorCommand> {
     private let bottomSheetChildViewController: DrawerPresentableViewController
-    
+
     init(viewProperties: BottomSheetListSelectorViewProperties,
          command: Command,
          onDismiss: @escaping (_ selected: Command.Model?) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorPresenter.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// Presents a bottom sheet list selector specified in its initializer.
+///
+final class BottomSheetListSelectorPresenter<Command: BottomSheetListSelectorCommand> {
+    private let bottomSheetChildViewController: DrawerPresentableViewController
+    
+    init(viewProperties: BottomSheetListSelectorViewProperties,
+         command: Command,
+         onDismiss: @escaping (_ selected: Command.Model?) -> Void) {
+        bottomSheetChildViewController = BottomSheetListSelectorViewController(viewProperties: viewProperties,
+                                                                               command: command,
+                                                                               onDismiss: onDismiss)
+    }
+
+    func show(from presenting: UIViewController, sourceView: UIView? = nil, arrowDirections: UIPopoverArrowDirection = .any) {
+        let bottomSheet = BottomSheetViewController(childViewController: bottomSheetChildViewController)
+        bottomSheet.show(from: presenting, sourceView: sourceView, arrowDirections: arrowDirections)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -462,20 +462,18 @@ private extension ProductsViewController {
                                       comment: "Message title for sort products action bottom sheet")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: sortOrder)
-        let sortOrderListViewController = BottomSheetListSelectorViewController(viewProperties: viewProperties,
-                                                                                command: command) { [weak self] selectedSortOrder in
-                                                                                    defer {
-                                                                                        self?.dismiss(animated: true, completion: nil)
-                                                                                    }
+        let sortOrderListPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties,
+                                                                      command: command) { [weak self] selectedSortOrder in
+                                                                        defer {
+                                                                            self?.dismiss(animated: true, completion: nil)
+                                                                        }
 
-                                                                                    guard let selectedSortOrder = selectedSortOrder else {
-                                                                                        return
-                                                                                    }
-                                                                                    self?.sortOrder = selectedSortOrder
+                                                                        guard let selectedSortOrder = selectedSortOrder else {
+                                                                            return
+                                                                        }
+                                                                        self?.sortOrder = selectedSortOrder
         }
-
-        let bottomSheet = BottomSheetViewController(childViewController: sortOrderListViewController)
-        bottomSheet.show(from: self, sourceView: sender, arrowDirections: .up)
+        sortOrderListPresenter.show(from: self, sourceView: sender, arrowDirections: .up)
     }
 
     @objc func filterButtonTapped() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C323FE5B64005C560F /* MockPHAssetImageLoader.swift */; };
 		02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */; };
 		02A275C823FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */; };
+		02A652FF246A908D00755A01 /* BottomSheetListSelectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A652FE246A908D00755A01 /* BottomSheetListSelectorPresenter.swift */; };
 		02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A9A495244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift */; };
 		02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */; };
 		02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */; };
@@ -1021,6 +1022,7 @@
 		02A275C323FE5B64005C560F /* MockPHAssetImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPHAssetImageLoader.swift; sourceTree = "<group>"; };
 		02A275C523FE9EFC005C560F /* MockFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFeatureFlagService.swift; sourceTree = "<group>"; };
 		02A275C723FEA102005C560F /* DefaultProductFormTableViewModel+EditProductsM2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultProductFormTableViewModel+EditProductsM2Tests.swift"; sourceTree = "<group>"; };
+		02A652FE246A908D00755A01 /* BottomSheetListSelectorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetListSelectorPresenter.swift; sourceTree = "<group>"; };
 		02A9A495244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsSortOrderBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		02ADC7CB239762E0008D4BED /* PaginatedListSelectorViewProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewProperties.swift; sourceTree = "<group>"; };
 		02ADC7CD23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedProductShippingClassListSelectorDataSourceTests.swift; sourceTree = "<group>"; };
@@ -1855,6 +1857,7 @@
 				0235595A24496E88004BE2B8 /* BottomSheetListSelectorViewController+DrawerPresentable.swift */,
 				0212275B244972660042161F /* BottomSheetListSelectorSectionHeaderView.swift */,
 				0212275D2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib */,
+				02A652FE246A908D00755A01 /* BottomSheetListSelectorPresenter.swift */,
 			);
 			path = ListSelector;
 			sourceTree = "<group>";
@@ -4608,6 +4611,7 @@
 				CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */,
 				0230535B2374FB6800487A64 /* AztecSourceCodeFormatBarCommand.swift in Sources */,
 				B57C5C9221B80E3C00FF82B2 /* APNSDevice+Woo.swift in Sources */,
+				02A652FF246A908D00755A01 /* BottomSheetListSelectorPresenter.swift in Sources */,
 				D8CD710F237A49DB007148B9 /* UIColor+SemanticColors.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,


### PR DESCRIPTION
Wrapper for presenting a bottom sheet (discussion: https://github.com/woocommerce/woocommerce-ios/pull/2155#discussion_r412303534) for #2054 

## Changes

From [a previous discussion in a PR on bottom sheet list selector](https://github.com/woocommerce/woocommerce-ios/pull/2155#discussion_r412303534) with @shiki, we thought adding a wrapper for presenting the bottom sheet list selector would abstract how the dismissal works for future changes/improvements. This PR created `BottomSheetListSelectorPresenter` as the wrapper that presents a bottom sheet list selector, so that its caller (`ProductsViewController`) doesn't have to know how `BottomSheetViewController` works with the child view controller and how the dismissal is implemented.

## Testing

Just a check for regression:

- Go to the Products tab
- Tap on the "Sort by" CTA --> the bottom sheet or popover should behave as before

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
