### PR TITLE
Removes extraneous old XIB from build (not visible in Xcode)

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -4177,7 +4177,6 @@
 				021E2A1823A9FE5A00B1DE07 /* ProductInventorySettingsViewController.xib in Resources */,
 				57448D2A242E777700A56A74 /* EmptyStateViewController.xib in Resources */,
 				0286B27A23C7051F003D784B /* ProductImagesCollectionViewController.xib in Resources */,
-				0290E270238E3CE400B5C466 /* ListSelectorViewController.xib in Resources */,
 				4512055324655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib in Resources */,
 				B59D1EE821908A08009D1978 /* Noticons.ttf in Resources */,
 				D81F2D35225F0CF70084BF9C /* EmptyListMessageWithActionView.xib in Resources */,


### PR DESCRIPTION
CocoaPods was complaining about this XIB still being in the build phase. Xcode didn't show it at all so I removed it from the XML directly.

> [!] `<PBXResourcesBuildPhase UUID=`B56DB3C42049BFAA00D4AA8E`>` attempted to initialize an object with an unknown UUID. `0290E270238E3CE400B5C466` for attribute: `files`. This can be the result of a merge and the unknown UUID is being discarded.

### Testing steps:

1. Before switching to this branch, perform a `bundle exec pod install`. Notice the warning.
2. Switch to this branch and do the same command. Notice no warning.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
