### PR TITLE
Fix the potential empty more details bottom sheet when Products M3 feature flag is off

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -286,7 +286,9 @@ private extension ProductFormViewController {
             return
         }
 
-        let moreDetailsActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editShippingSettings, .editCategories, .editBriefDescription]
+        let moreDetailsActions: [ProductFormBottomSheetAction] = isEditProductsRelease3Enabled ?
+            [.editInventorySettings, .editShippingSettings, .editCategories, .editBriefDescription]:
+            [.editInventorySettings, .editShippingSettings, .editBriefDescription]
         let hasVisibleActions = moreDetailsActions.map({ $0.isVisible(product: product) }).contains(true)
         moreDetailsContainerView.isHidden = hasVisibleActions == false
     }


### PR DESCRIPTION
Fixes #2284 

- [x] ⚠️ Update PR base to `develop` after https://github.com/woocommerce/woocommerce-ios/pull/2275 is merged ⚠️ 

## Changes

For all the possible actions in the product form more details bottom sheet, `editCategories` is now excluded when the Products M3 feature flag is off

## Testing

Prerequisite: prepare a simple product that has non-empty data for all the M1/M2 features (inventory, shipping, short description), but no categories (M3 feature).

- Turn off M3 feature flag (e.g. in `DefaultFeatureFlagService`)
- Go to the Products tab
- Open the simple product as in the prerequisite --> there should be no "Add more details" CTA at the bottom; on `develop`, the CTA is shown and tapping on it brings up an empty action sheet / popover

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-05-14 at 16 03 37](https://user-images.githubusercontent.com/1945542/81908968-89895f00-95fc-11ea-8e86-4265f90d780d.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-14 at 15 24 44](https://user-images.githubusercontent.com/1945542/81908952-84c4ab00-95fc-11ea-9043-26c482392900.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
