### PR TITLE
Product short description row should show maximum one line

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -196,7 +196,8 @@ private extension DefaultProductFormTableViewModel {
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
-                                                        details: details)
+                                                        details: details,
+                                                        numberOfLinesForDetails: 1)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -7,7 +7,7 @@ private extension ProductFormSection.SettingsRow.ViewModel {
                                                            text: details,
                                                            image: icon,
                                                            imageTintColor: .textSubtle,
-                                                           numberOfLinesForText: 0)
+                                                           numberOfLinesForText: numberOfLinesForDetails)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -22,6 +22,14 @@ enum ProductFormSection {
             let icon: UIImage
             let title: String?
             let details: String?
+            let numberOfLinesForDetails: Int
+
+            init(icon: UIImage, title: String?, details: String?, numberOfLinesForDetails: Int = 0) {
+                self.icon = icon
+                self.title = title
+                self.details = details
+                self.numberOfLinesForDetails = numberOfLinesForDetails
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2287 

## Changes

- Added `numberOfLinesForDetails: Int` to `ProductFormSection.SettingsRow.ViewModel` with default value 0 (any number of lines since most of the settings rows have multiline details)
- Set `numberOfLinesForDetails` to 1 for the brief/short description row

## Testing

- Go to the Products tab
- Tap on a simple product with multiline short description --> the short description row should show only one line 

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-05-14 at 17 07 35](https://user-images.githubusercontent.com/1945542/81915622-6b742c80-9605-11ea-9bfc-15f2c066f9da.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-14 at 17 05 54](https://user-images.githubusercontent.com/1945542/81915487-37990700-9605-11ea-8efb-4019584b779f.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
