### PR TITLE
Added 8px padding between the "Limited editing available" banner and the first product

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -37,7 +37,7 @@ final class ProductsViewController: UIViewController {
         let subviews = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease2) ? [topBannerView, toolbar]: [topBannerView]
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.axis = .vertical
-        stackView.spacing = 0
+        stackView.spacing = 8
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()


### PR DESCRIPTION
Fixes #2291

Super minor changes (just 1 line of code!) for adding an 8px padding between the "Limited editing available" banner and the first product

| Compact             |  Expanded |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-05-14 at 12 05 11](https://user-images.githubusercontent.com/495617/81921784-7023eb00-95db-11ea-8df8-2285d4f54f3b.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-14 at 12 05 07](https://user-images.githubusercontent.com/495617/81921790-71edae80-95db-11ea-868c-5c0d61082f16.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
