### PR TITLE
Products: now we use always the site currency instead of order currency

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -25,9 +25,11 @@ final class ProductDetailsViewModel {
         }
     }
 
-    /// Yosemite.Order.currency
+    /// The default currency configured on the store
     ///
-    let currency: String
+    var currency: String {
+        return CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode)
+    }
 
     /// Nav bar title
     ///
@@ -118,9 +120,8 @@ final class ProductDetailsViewModel {
 
     /// Designated initializer.
     ///
-    init(product: Product, currency: String) {
+    init(product: Product) {
         self.product = product
-        self.currency = currency
 
         refreshResultsController()
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -89,11 +89,10 @@ final class ProductFormViewController: UIViewController {
     private var cancellable: ObservationToken?
 
     init(product: Product,
-         currency: String,
          presentationStyle: PresentationStyle,
          isEditProductsRelease2Enabled: Bool,
          isEditProductsRelease3Enabled: Bool) {
-        self.currency = currency
+        self.currency = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode)
         self.presentationStyle = presentationStyle
         self.isEditProductsRelease2Enabled = isEditProductsRelease2Enabled
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -89,10 +89,11 @@ final class ProductFormViewController: UIViewController {
     private var cancellable: ObservationToken?
 
     init(product: Product,
+         currency: String = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode),
          presentationStyle: PresentationStyle,
          isEditProductsRelease2Enabled: Bool,
          isEditProductsRelease3Enabled: Bool) {
-        self.currency = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode)
+        self.currency = currency
         self.presentationStyle = presentationStyle
         self.isEditProductsRelease2Enabled = isEditProductsRelease2Enabled
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -45,19 +45,16 @@ private extension ProductDetailsFactory {
                                isEditProductsEnabled: Bool,
                                isEditProductsRelease2Enabled: Bool,
                                isEditProductsRelease3Enabled: Bool) -> UIViewController {
-        let currencyCode = currencySettings.currencyCode
-        let currency = currencySettings.symbol(from: currencyCode)
         let vc: UIViewController
         if isEditProductsEnabled {
             vc = ProductFormViewController(product: product,
-                                           currency: currency,
                                            presentationStyle: presentationStyle,
                                            isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
                                            isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
             // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
             vc.hidesBottomBarWhenPushed = true
         } else {
-            let viewModel = ProductDetailsViewModel(product: product, currency: currency)
+            let viewModel = ProductDetailsViewModel(product: product)
             vc = ProductDetailsViewController(viewModel: viewModel)
         }
         return vc


### PR DESCRIPTION
Fixes #2240 

## Description
If the product form is navigated from an order (e.g. from refund details or order details) we incorrectly use the order's currency which can be different from the site's currency.
Now in products, we use the site currency in all cases to be consistent with the price settings.

## Testing
1) Open an order that uses a currency different from the one used by default on the website.
2) Open a product -> Make sure that the price showed uses the site currency


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
