### PR TITLE
Edit Product: update inventory row details text

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -122,11 +122,11 @@ private extension DefaultProductFormTableViewModel {
             inventoryDetails.append(String.localizedStringWithFormat(Constants.skuFormat, sku))
         }
 
-        if let stockQuantity = product.stockQuantity {
+        if let stockQuantity = product.stockQuantity, product.manageStock {
             inventoryDetails.append(String.localizedStringWithFormat(Constants.stockQuantityFormat, stockQuantity))
-        } else {
+        } else if product.manageStock == false {
             let stockStatus = product.productStockStatus
-            inventoryDetails.append(String.localizedStringWithFormat(Constants.stockStatusFormat, stockStatus.description))
+            inventoryDetails.append(stockStatus.description)
         }
 
         let details = inventoryDetails.isEmpty ? nil: inventoryDetails.joined(separator: "\n")
@@ -230,8 +230,6 @@ private extension DefaultProductFormTableViewModel {
                                                  comment: "Format of the SKU on the Inventory Settings row")
         static let stockQuantityFormat = NSLocalizedString("Quantity: %ld",
                                                            comment: "Format of the stock quantity on the Inventory Settings row")
-        static let stockStatusFormat = NSLocalizedString("Stock status: %@",
-                                                         comment: "Format of the stock status on the Inventory Settings row")
 
         // Shipping
         static let weightFormat = NSLocalizedString("Weight: %1$@%2$@",


### PR DESCRIPTION
Fixes #2295 

## Changes

- Updated the copy when we show the stock status from `Stock status: \(stockStatus)` to just the stock status
- Additionally, I noticed a bug where we still show the stock quantity when stock management is disabled (`manageStock == false`). The logic to show the stock info:
  - If stock management is enabled, we show the **stock quantity** if it's available
  - Otherwise (stock management is disabled), we show the **stock status**

## Testing

- Go to the Products tab
- Tap on a simple product
- Tap on the inventory settings row if available, or tap "Add more details" at the bottom to go to inventory settings
- Turn off the "Manage stock" switch and set the stock status
- Tap "Done" to go back to the product form --> the stock status selected in the previous step should be shown in the inventory row
- Tap on the inventory settings row
- Turn on the "Manage stock" switch and set a stock quantity
- Tap "Done" to go back to the product form --> the stock quantity set in the previous step should be shown in the inventory row

## Example screenshots

Please note the inventory row in the product form!

\ | Inventory settings | Inventory row
-- | -- | --
stock management is enabled | ![Simulator Screen Shot - iPhone 11 - 2020-05-15 at 09 29 43](https://user-images.githubusercontent.com/1945542/82001960-10871780-968f-11ea-9a1c-51335b59dedf.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-15 at 09 29 45](https://user-images.githubusercontent.com/1945542/82001965-13820800-968f-11ea-9703-00e775d0a77c.png)
stock management is disabled | ![Simulator Screen Shot - iPhone 11 - 2020-05-15 at 09 32 21](https://user-images.githubusercontent.com/1945542/82001970-17158f00-968f-11ea-8711-6155081df080.png) | ![Simulator Screen Shot - iPhone 11 - 2020-05-15 at 09 29 52](https://user-images.githubusercontent.com/1945542/82001968-14b33500-968f-11ea-936f-452d542eb6b7.png)





Product form inventory row: only show stock quantity when stock management is enabled; just show the stock status when the stock management is disabled.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
