### PR TITLE
Collapse the Products tab WIP banner by default

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 - [internal] Refactored some API calls for fetching a Note, Product, and Product Review. 
 - Products: we improved our VoiceOver support in Product Price settings
 - In Settings > Experimental Features, a Products switch is now available for turning Products M2 features on and off for simple products (default off for beta testing). Products M2 features: update product images, product settings, viewing and sharing a product.
-- The WIP banner on the Products tab is now collapsed by default.
+- The WIP banner on the Products tab is now collapsed by default for more vertical space.
 
 
 4.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [internal] Refactored some API calls for fetching a Note, Product, and Product Review. 
 - Products: we improved our VoiceOver support in Product Price settings
 - In Settings > Experimental Features, a Products switch is now available for turning Products M2 features on and off for simple products (default off for beta testing). Products M2 features: update product images, product settings, viewing and sharing a product.
+- The WIP banner on the Products tab is now collapsed by default.
 
 
 4.2

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -4,9 +4,11 @@ import Yosemite
 struct ProductsTopBannerFactory {
     /// Creates a products tab top banner asynchronously based on the app settings.
     /// - Parameters:
+    ///   - isExpanded: whether the top banner is expanded by default.
     ///   - expandedStateChangeHandler: called when the top banner expanded state changes.
     ///   - onCompletion: called when the view controller is created and ready for display.
-    static func topBanner(expandedStateChangeHandler: @escaping () -> Void,
+    static func topBanner(isExpanded: Bool,
+                          expandedStateChangeHandler: @escaping () -> Void,
                           onCompletion: @escaping (TopBannerView) -> Void) {
         let action = AppSettingsAction.loadProductsFeatureSwitch { isEditProductsRelease2Enabled in
             let title = isEditProductsRelease2Enabled ? Strings.titleWhenEditProductsRelease2IsEnabled: Strings.titleWhenEditProductsRelease2IsDisabled
@@ -14,6 +16,7 @@ struct ProductsTopBannerFactory {
             let viewModel = TopBannerViewModel(title: title,
                                                infoText: infoText,
                                                icon: .workInProgressBanner,
+                                               isExpanded: isExpanded,
                                                expandedStateChangeHandler: expandedStateChangeHandler)
             let topBannerView = TopBannerView(viewModel: viewModel)
             topBannerView.translatesAutoresizingMaskIntoConstraints = false

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -55,6 +55,10 @@ final class ProductsViewController: UIViewController {
     ///
     private lazy var topBannerContainerView: SwappableSubviewContainerView = SwappableSubviewContainerView()
 
+    /// Top banner that shows that the Products feature is still work in progress.
+    ///
+    private var topBannerView: TopBannerView?
+
     /// ResultsController: Surrounds us. Binds the galaxy together. And also, keeps the UITableView <> (Stored) Products in sync.
     ///
     private lazy var resultsController: ResultsController<StorageProduct> = {
@@ -327,10 +331,12 @@ private extension ProductsViewController {
     }
 
     func updateTopBannerView() {
-        ProductsTopBannerFactory.topBanner(expandedStateChangeHandler: { [weak self] in
+        let isExpanded = topBannerView?.isExpanded ?? false
+        ProductsTopBannerFactory.topBanner(isExpanded: isExpanded, expandedStateChangeHandler: { [weak self] in
             self?.tableView.updateHeaderHeight()
         }, onCompletion: { [weak self] topBannerView in
             self?.topBannerContainerView.updateSubview(topBannerView)
+            self?.topBannerView = topBannerView
             self?.tableView.updateHeaderHeight()
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -46,7 +46,7 @@ final class TopBannerView: UIView {
 
     private let isActionEnabled: Bool
 
-    private var isExpanded: Bool = true
+    private(set) var isExpanded: Bool
 
     private let onDismiss: (() -> Void)?
     private let onAction: (() -> Void)?

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -54,6 +54,7 @@ final class TopBannerView: UIView {
 
     init(viewModel: TopBannerViewModel) {
         isActionEnabled = viewModel.actionHandler != nil
+        isExpanded = viewModel.isExpanded
         onDismiss = viewModel.dismissHandler
         onAction = viewModel.actionHandler
         onExpandedStateChange = viewModel.expandedStateChangeHandler

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -7,6 +7,7 @@ struct TopBannerViewModel {
     let infoText: String?
     let icon: UIImage?
     let actionButtonTitle: String?
+    let isExpanded: Bool
     let actionHandler: (() -> Void)?
     let dismissHandler: (() -> Void)?
     let expandedStateChangeHandler: (() -> Void)?
@@ -16,10 +17,12 @@ struct TopBannerViewModel {
     init(title: String?,
          infoText: String?,
          icon: UIImage?,
+         isExpanded: Bool = true,
          expandedStateChangeHandler: (() -> Void)?) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
+        self.isExpanded = isExpanded
         self.actionButtonTitle = nil
         self.actionHandler = nil
         self.dismissHandler = nil
@@ -32,12 +35,14 @@ struct TopBannerViewModel {
          infoText: String?,
          icon: UIImage?,
          actionButtonTitle: String,
+         isExpanded: Bool = true,
          actionHandler: @escaping () -> Void,
          dismissHandler: @escaping () -> Void) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
         self.actionButtonTitle = actionButtonTitle
+        self.isExpanded = isExpanded
         self.actionHandler = actionHandler
         self.dismissHandler = dismissHandler
         self.expandedStateChangeHandler = nil


### PR DESCRIPTION
Fixes #2042 

## Changes

- Added `isExpanded` to `TopBannerViewModel` and `ProductsTopBannerFactory` so that the initial expanded state can be customized
- Opened up `isExpanded` in `TopBannerView` to be readonly
- In `ProductsViewController`, kept a reference of the top banner view and initialized its expanded state to `false` by default and then the current expanded state when updating the top banner

## Testing

- Launch the app
- Go to the Products tab --> the WIP banner should be collapsed by default
- Go to "My store" tab, and flip the Products switch under Settings > Experimental Features
- Go back to the Products tab --> the WIP banner should stay in the collapsed state with a different message
- Tap on the "🔽" button in the WIP banner to expand
- Go to "My store" tab, and flip the Products switch under Settings > Experimental Features
- Go back to the Products tab --> the WIP banner should stay in the expanded state with a different message

## Example screencast

![simulator](https://user-images.githubusercontent.com/1945542/82020510-cec09600-96bb-11ea-929c-2fa1c31caca1.gif)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
