### PR TITLE
Products > shipping settings: fix unexpected discard changes prompt from shipping class retrieved later

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -36,12 +36,14 @@ final class ProductShippingSettingsViewController: UIViewController {
     private let onCompletion: Completion
 
     private let product: Product
+    private var originalShippingClass: ProductShippingClass?
     private let shippingSettingsService: ShippingSettingsService
 
     init(product: Product,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          completion: @escaping Completion) {
         self.product = product
+        self.originalShippingClass = product.productShippingClass
         self.shippingSettingsService = shippingSettingsService
         self.onCompletion = completion
 
@@ -111,6 +113,7 @@ private extension ProductShippingSettingsViewController {
             .retrieveProductShippingClass(siteID: product.siteID,
                                           remoteID: product.shippingClassID) { [weak self] (shippingClass, error) in
                                             self?.shippingClass = shippingClass
+                                            self?.originalShippingClass = shippingClass
                                             self?.hasRetrievedShippingClassIfNeeded = true
                                             self?.tableView.reloadData()
         }
@@ -124,7 +127,7 @@ extension ProductShippingSettingsViewController {
 
     override func shouldPopOnBackButton() -> Bool {
         if weight != product.weight || length != product.dimensions.length || width != product.dimensions.width || height != product.dimensions.height ||
-            shippingClass != product.productShippingClass {
+            shippingClass != originalShippingClass {
             presentBackNavigationActionSheet()
             return false
         }


### PR DESCRIPTION
Fixes #2263 

## Changes

In `ProductShippingSettingsViewController`, kept track of the product's original shipping class which could be retrieved asynchronously later on. When the user navigates away from the shipping settings, compared the latest shipping class against the original shipping class instead of the product's shipping class, which could be `nil` if the relationship wasn't linked beforehand

## Testing

Prerequisite: prepare a simple product with a shipping class

- Launch the app in a simulator/device that is not iOS 13.4 (due to an Apple bug https://github.com/woocommerce/woocommerce-ios/issues/2089 🤦🏻‍♀️)
- Log out and in to a store if you have loaded the shipping classes before
- Go to the Products tab
- Tap on the Product in the prerequisite
- Tap on the shipping settings row --> note the shipping class row is original blank and then filled later
- Tap "<" in the navigation bar --> the discard changes prompt should not appear

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
