### PR TITLE
Fix certain M1 settings aren't accessible if the data are empty when M2 feature switch is off

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetActionsFactory.swift
@@ -1,0 +1,17 @@
+import Yosemite
+
+struct ProductFormBottomSheetActionsFactory {
+    /// Retruns an array of actions that are visible in the product form bottom sheet.
+    static func actions(product: Product, isEditProductsRelease2Enabled: Bool, isEditProductsRelease3Enabled: Bool) -> [ProductFormBottomSheetAction] {
+        let shouldShowShippingSettingsRow = product.isShippingEnabled
+        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
+        let shouldShowShortDescriptionRow = isEditProductsRelease2Enabled
+        let actions: [ProductFormBottomSheetAction?] = [
+            .editInventorySettings,
+            shouldShowShippingSettingsRow ? .editShippingSettings: nil,
+            shouldShowCategoriesRow ? .editCategories: nil,
+            shouldShowShortDescriptionRow ? .editBriefDescription: nil
+        ]
+        return actions.compactMap({ $0 }).filter({ $0.isVisible(product: product) })
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetActionsFactory.swift
@@ -1,5 +1,6 @@
 import Yosemite
 
+/// Creates actions for product form bottom sheet.
 struct ProductFormBottomSheetActionsFactory {
     /// Retruns an array of actions that are visible in the product form bottom sheet.
     static func actions(product: Product, isEditProductsRelease2Enabled: Bool, isEditProductsRelease3Enabled: Bool) -> [ProductFormBottomSheetAction] {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetActionsFactory.swift
@@ -2,8 +2,18 @@ import Yosemite
 
 /// Creates actions for product form bottom sheet.
 struct ProductFormBottomSheetActionsFactory {
+    private let product: Product
+    private let isEditProductsRelease2Enabled: Bool
+    private let isEditProductsRelease3Enabled: Bool
+
+    init(product: Product, isEditProductsRelease2Enabled: Bool, isEditProductsRelease3Enabled: Bool) {
+        self.product = product
+        self.isEditProductsRelease2Enabled = isEditProductsRelease2Enabled
+        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+    }
+
     /// Retruns an array of actions that are visible in the product form bottom sheet.
-    static func actions(product: Product, isEditProductsRelease2Enabled: Bool, isEditProductsRelease3Enabled: Bool) -> [ProductFormBottomSheetAction] {
+    func actions() -> [ProductFormBottomSheetAction] {
         let shouldShowShippingSettingsRow = product.isShippingEnabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowShortDescriptionRow = isEditProductsRelease2Enabled

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetListSelectorCommand.swift
@@ -12,20 +12,10 @@ final class ProductFormBottomSheetListSelectorCommand: BottomSheetListSelectorCo
 
     private let onSelection: (ProductFormBottomSheetAction) -> Void
 
-    init(product: Product,
-         isEditProductsRelease3Enabled: Bool,
+    init(actions: [ProductFormBottomSheetAction],
          onSelection: @escaping (ProductFormBottomSheetAction) -> Void) {
         self.onSelection = onSelection
-
-        let shouldShowShippingSettingsRow = product.isShippingEnabled
-        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
-        let actions: [ProductFormBottomSheetAction?] = [
-            .editInventorySettings,
-            shouldShowShippingSettingsRow ? .editShippingSettings: nil,
-            shouldShowCategoriesRow ? .editCategories: nil,
-            .editBriefDescription
-        ]
-        self.data = actions.compactMap({ $0 }).filter({ $0.isVisible(product: product) })
+        self.data = actions
     }
 
     func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: ProductFormBottomSheetAction) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -253,9 +253,7 @@ private extension ProductFormViewController {
         let title = NSLocalizedString("Add more details",
                                       comment: "Title of the bottom sheet from the product form to add more product details.")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = createBottomSheetActions()
         let dataSource = ProductFormBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
                                                                     self?.dismiss(animated: true) { [weak self] in
                                                                         switch action {
@@ -279,9 +277,7 @@ private extension ProductFormViewController {
     }
 
     func updateMoreDetailsButtonVisibility(product: Product) {
-        let moreDetailsActions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                              isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let moreDetailsActions = createBottomSheetActions()
         moreDetailsContainerView.isHidden = moreDetailsActions.isEmpty
     }
 }
@@ -467,6 +463,12 @@ private extension ProductFormViewController {
         moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "Accessibility label for the Edit Product More Options action sheet")
         moreButton.accessibilityIdentifier = "edit-product-more-options-button"
         return moreButton
+    }
+
+    private func createBottomSheetActions() -> [ProductFormBottomSheetAction] {
+        ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                     isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                     isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -229,11 +229,6 @@ private extension ProductFormViewController {
     }
 
     func configureMoreDetailsContainerView() {
-        guard isEditProductsRelease2Enabled else {
-            moreDetailsContainerView.isHidden = true
-            return
-        }
-
         let title = NSLocalizedString("Add more details", comment: "Title of the button at the bottom of the product form to add more product details.")
         let viewModel = BottomButtonContainerView.ViewModel(style: .link,
                                                             title: title,
@@ -258,8 +253,10 @@ private extension ProductFormViewController {
         let title = NSLocalizedString("Add more details",
                                       comment: "Title of the bottom sheet from the product form to add more product details.")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
-        let dataSource = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { [weak self] action in
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let dataSource = ProductFormBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
                                                                     self?.dismiss(animated: true) { [weak self] in
                                                                         switch action {
                                                                         case .editInventorySettings:
@@ -282,16 +279,10 @@ private extension ProductFormViewController {
     }
 
     func updateMoreDetailsButtonVisibility(product: Product) {
-        guard isEditProductsRelease2Enabled else {
-            moreDetailsContainerView.isHidden = true
-            return
-        }
-
-        let moreDetailsActions: [ProductFormBottomSheetAction] = isEditProductsRelease3Enabled ?
-            [.editInventorySettings, .editShippingSettings, .editCategories, .editBriefDescription]:
-            [.editInventorySettings, .editShippingSettings, .editBriefDescription]
-        let hasVisibleActions = moreDetailsActions.map({ $0.isVisible(product: product) }).contains(true)
-        moreDetailsContainerView.isHidden = hasVisibleActions == false
+        let moreDetailsActions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                              isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        moreDetailsContainerView.isHidden = moreDetailsActions.isEmpty
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -466,9 +466,9 @@ private extension ProductFormViewController {
     }
 
     private func createBottomSheetActions() -> [ProductFormBottomSheetAction] {
-        ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                     isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                     isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        ProductFormBottomSheetActionsFactory(product: product,
+                                             isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                             isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		0235595B24496E88004BE2B8 /* BottomSheetListSelectorViewController+DrawerPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235595A24496E88004BE2B8 /* BottomSheetListSelectorViewController+DrawerPresentable.swift */; };
 		02357B2A23CDB3E300147C2B /* ProductImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02357B2823CDB3E300147C2B /* ProductImageViewController.swift */; };
 		02357B2B23CDB3E300147C2B /* ProductImageViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02357B2923CDB3E300147C2B /* ProductImageViewController.xib */; };
+		0235BFD9246E959500778909 /* ProductFormBottomSheetActionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235BFD8246E959500778909 /* ProductFormBottomSheetActionsFactory.swift */; };
+		0235BFDB246E99A700778909 /* ProductFormBottomSheetActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0235BFDA246E99A700778909 /* ProductFormBottomSheetActionsFactoryTests.swift */; };
 		02396251239948470096F34C /* UIImage+TintColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02396250239948470096F34C /* UIImage+TintColor.swift */; };
 		023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A059824135F2600E3FC99 /* ReviewsViewController.swift */; };
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
@@ -938,6 +940,8 @@
 		0235595A24496E88004BE2B8 /* BottomSheetListSelectorViewController+DrawerPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BottomSheetListSelectorViewController+DrawerPresentable.swift"; sourceTree = "<group>"; };
 		02357B2823CDB3E300147C2B /* ProductImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageViewController.swift; sourceTree = "<group>"; };
 		02357B2923CDB3E300147C2B /* ProductImageViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImageViewController.xib; sourceTree = "<group>"; };
+		0235BFD8246E959500778909 /* ProductFormBottomSheetActionsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetActionsFactory.swift; sourceTree = "<group>"; };
+		0235BFDA246E99A700778909 /* ProductFormBottomSheetActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetActionsFactoryTests.swift; sourceTree = "<group>"; };
 		02396250239948470096F34C /* UIImage+TintColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+TintColor.swift"; sourceTree = "<group>"; };
 		023A059824135F2600E3FC99 /* ReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsViewController.swift; sourceTree = "<group>"; };
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
@@ -1764,6 +1768,7 @@
 			children = (
 				0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */,
 				0212276224498CDC0042161F /* ProductFormBottomSheetAction.swift */,
+				0235BFD8246E959500778909 /* ProductFormBottomSheetActionsFactory.swift */,
 			);
 			path = BottomSheetListSelector;
 			sourceTree = "<group>";
@@ -2199,6 +2204,7 @@
 			children = (
 				02A9A495244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift */,
 				02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */,
+				0235BFDA246E99A700778909 /* ProductFormBottomSheetActionsFactoryTests.swift */,
 			);
 			path = BottomSheetListSelector;
 			sourceTree = "<group>";
@@ -4727,6 +4733,7 @@
 				D8C251DB230D288A00F49782 /* PushNotesManager.swift in Sources */,
 				748D34E12148291E00E21A2F /* TopPerformerDataViewController.swift in Sources */,
 				02C887712450285100E4470F /* BottomButtonContainerView.swift in Sources */,
+				0235BFD9246E959500778909 /* ProductFormBottomSheetActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
 				5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
@@ -4950,6 +4957,7 @@
 				02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */,
 				B555531121B57E6F00449E71 /* MockupApplicationAdapter.swift in Sources */,
 				021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */,
+				0235BFDB246E99A700778909 /* ProductFormBottomSheetActionsFactoryTests.swift in Sources */,
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetActionsFactoryTests.swift
@@ -4,9 +4,54 @@ import XCTest
 
 final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
 
-    // M3 feature flag off & M2 feature flag is on
+    // M3 feature flag off & M2 feature flag off
 
-    func testDataHasNoEditProductsRelease3ActionsForAPhysicalProductWhenFeatureFlagIsOff() {
+    func testDataHasNoEditProductsRelease2And3ActionsForAPhysicalProductWhenBothFeatureFlagsAreOff() {
+        let product = Fixtures.physicalProduct
+        let isEditProductsRelease2Enabled = false
+        let isEditProductsRelease3Enabled = false
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editShippingSettings
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    func testDataHasNoEditProductsRelease2And3AndShippingActionsForAVirtualProductWhenBothFeatureFlagsAreOff() {
+        let product = Fixtures.virtualProduct
+        let isEditProductsRelease2Enabled = false
+        let isEditProductsRelease3Enabled = false
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    func testDataHasNoEditProductsRelease2And3AndShippingActionsForADownloadableProductWhenBothFeatureFlagsAreOff() {
+        let product = Fixtures.downloadableProduct
+        let isEditProductsRelease2Enabled = false
+        let isEditProductsRelease3Enabled = false
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    // M3 feature flag off & M2 feature flag on
+
+    func testDataHasNoEditProductsRelease3ActionsForAPhysicalProductWhenM3FeatureFlagIsOff() {
         let product = Fixtures.physicalProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = false
@@ -22,7 +67,7 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         XCTAssertEqual(actions, expectedActions)
     }
 
-    func testDataHasNoEditProductsRelease3AndShippingActionsForAVirtualProductWhenFeatureFlagIsOff() {
+    func testDataHasNoEditProductsRelease3AndShippingActionsForAVirtualProductWhenM3FeatureFlagIsOff() {
         let product = Fixtures.virtualProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = false
@@ -37,7 +82,7 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         XCTAssertEqual(actions, expectedActions)
     }
 
-    func testDataHasNoEditProductsRelease3AndShippingActionsForADownloadableProductWhenFeatureFlagIsOff() {
+    func testDataHasNoEditProductsRelease3AndShippingActionsForADownloadableProductWhenM3FeatureFlagIsOff() {
         let product = Fixtures.downloadableProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = false
@@ -54,7 +99,7 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
 
     // M3 feature flag on & M2 feature flag is on
 
-    func testDataHasEditProductsRelease3ActionsForAPhysicalProductWhenFeatureFlagIsOn() {
+    func testDataHasEditProductsRelease3ActionsForAPhysicalProductWhenBothFeatureFlagsAreOn() {
         let product = Fixtures.physicalProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = true
@@ -71,7 +116,7 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         XCTAssertEqual(actions, expectedActions)
     }
 
-    func testDataHasEditProductsRelease3ButNoShippingActionsForAVirtualProductWhenFeatureFlagIsOn() {
+    func testDataHasEditProductsRelease3ButNoShippingActionsForAVirtualProductWhenBothFeatureFlagsAreOn() {
         let product = Fixtures.virtualProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = true
@@ -87,7 +132,7 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         XCTAssertEqual(actions, expectedActions)
     }
 
-    func testDataHasEditProductsRelease3ButNoShippingActionsForADownloadableProductWhenFeatureFlagIsOn() {
+    func testDataHasEditProductsRelease3ButNoShippingActionsForADownloadableProductWhenBothFeatureFlagsAreOn() {
         let product = Fixtures.downloadableProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetActionsFactoryTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
+
+    // M3 feature flag off & M2 feature flag is on
+
+    func testDataHasNoEditProductsRelease3ActionsForAPhysicalProductWhenFeatureFlagIsOff() {
+        let product = Fixtures.physicalProduct
+        let isEditProductsRelease2Enabled = true
+        let isEditProductsRelease3Enabled = false
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editShippingSettings,
+            .editBriefDescription
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    func testDataHasNoEditProductsRelease3AndShippingActionsForAVirtualProductWhenFeatureFlagIsOff() {
+        let product = Fixtures.virtualProduct
+        let isEditProductsRelease2Enabled = true
+        let isEditProductsRelease3Enabled = false
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editBriefDescription
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    func testDataHasNoEditProductsRelease3AndShippingActionsForADownloadableProductWhenFeatureFlagIsOff() {
+        let product = Fixtures.downloadableProduct
+        let isEditProductsRelease2Enabled = true
+        let isEditProductsRelease3Enabled = false
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editBriefDescription
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    // M3 feature flag on & M2 feature flag is on
+
+    func testDataHasEditProductsRelease3ActionsForAPhysicalProductWhenFeatureFlagIsOn() {
+        let product = Fixtures.physicalProduct
+        let isEditProductsRelease2Enabled = true
+        let isEditProductsRelease3Enabled = true
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editShippingSettings,
+            .editCategories,
+            .editBriefDescription
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    func testDataHasEditProductsRelease3ButNoShippingActionsForAVirtualProductWhenFeatureFlagIsOn() {
+        let product = Fixtures.virtualProduct
+        let isEditProductsRelease2Enabled = true
+        let isEditProductsRelease3Enabled = true
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editCategories,
+            .editBriefDescription
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+    func testDataHasEditProductsRelease3ButNoShippingActionsForADownloadableProductWhenFeatureFlagIsOn() {
+        let product = Fixtures.downloadableProduct
+        let isEditProductsRelease2Enabled = true
+        let isEditProductsRelease3Enabled = true
+        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
+                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+
+        let expectedActions: [ProductFormBottomSheetAction] = [
+            .editInventorySettings,
+            .editCategories,
+            .editBriefDescription
+        ]
+        XCTAssertEqual(actions, expectedActions)
+    }
+
+}
+
+private extension ProductFormBottomSheetActionsFactoryTests {
+    enum Fixtures {
+        // downloadable: false, virtual: false, missing inventory/shipping/categories/brief description
+        static let physicalProduct = MockProduct().product(downloadable: false, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
+                                                           dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
+                                                           virtual: false,
+                                                           categories: [])
+        // downloadable: false, virtual: true, missing inventory/shipping/categories/brief description
+        static let virtualProduct = MockProduct().product(downloadable: false, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
+                                                          dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
+                                                          virtual: true,
+                                                          categories: [])
+        // downloadable: true, virtual: true, missing inventory/shipping/categories/brief description
+        static let downloadableProduct = MockProduct().product(downloadable: true, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
+                                                               dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
+                                                               virtual: true,
+                                                               categories: [])
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetActionsFactoryTests.swift
@@ -10,9 +10,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.physicalProduct
         let isEditProductsRelease2Enabled = false
         let isEditProductsRelease3Enabled = false
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,
@@ -25,9 +25,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.virtualProduct
         let isEditProductsRelease2Enabled = false
         let isEditProductsRelease3Enabled = false
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings
@@ -39,9 +39,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.downloadableProduct
         let isEditProductsRelease2Enabled = false
         let isEditProductsRelease3Enabled = false
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings
@@ -55,9 +55,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.physicalProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = false
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,
@@ -71,9 +71,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.virtualProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = false
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,
@@ -86,9 +86,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.downloadableProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = false
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,
@@ -103,9 +103,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.physicalProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = true
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,
@@ -120,9 +120,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.virtualProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = true
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,
@@ -136,9 +136,9 @@ final class ProductFormBottomSheetActionsFactoryTests: XCTestCase {
         let product = Fixtures.downloadableProduct
         let isEditProductsRelease2Enabled = true
         let isEditProductsRelease3Enabled = true
-        let actions = ProductFormBottomSheetActionsFactory.actions(product: product,
-                                                                   isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                                   isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        let actions = ProductFormBottomSheetActionsFactory(product: product,
+                                                           isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled).actions()
 
         let expectedActions: [ProductFormBottomSheetAction] = [
             .editInventorySettings,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormBottomSheetListSelectorCommandTests.swift
@@ -3,103 +3,13 @@ import XCTest
 @testable import Yosemite
 
 final class ProductFormBottomSheetListSelectorCommandTests: XCTestCase {
-    // MARK: - `data`
-
-    // M3 feature flag off
-
-    func testDataHasNoEditProductsRelease3ActionsForAPhysicalProductWhenFeatureFlagIsOff() {
-        let product = Fixtures.physicalProduct
-        let isEditProductsRelease3Enabled = false
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { _ in }
-
-        let expectedActions: [ProductFormBottomSheetAction] = [
-            .editInventorySettings,
-            .editShippingSettings,
-            .editBriefDescription
-        ]
-        XCTAssertEqual(command.data, expectedActions)
-    }
-
-    func testDataHasNoEditProductsRelease3AndShippingActionsForAVirtualProductWhenFeatureFlagIsOff() {
-        let product = Fixtures.virtualProduct
-        let isEditProductsRelease3Enabled = false
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { _ in }
-
-        let expectedActions: [ProductFormBottomSheetAction] = [
-            .editInventorySettings,
-            .editBriefDescription
-        ]
-        XCTAssertEqual(command.data, expectedActions)
-    }
-
-    func testDataHasNoEditProductsRelease3AndShippingActionsForADownloadableProductWhenFeatureFlagIsOff() {
-        let product = Fixtures.downloadableProduct
-        let isEditProductsRelease3Enabled = false
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { _ in }
-
-        let expectedActions: [ProductFormBottomSheetAction] = [
-            .editInventorySettings,
-            .editBriefDescription
-        ]
-        XCTAssertEqual(command.data, expectedActions)
-    }
-
-    // M3 feature flag on
-
-    func testDataHasEditProductsRelease3ActionsForAPhysicalProductWhenFeatureFlagIsOn() {
-        let product = Fixtures.physicalProduct
-        let isEditProductsRelease3Enabled = true
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { _ in }
-
-        let expectedActions: [ProductFormBottomSheetAction] = [
-            .editInventorySettings,
-            .editShippingSettings,
-            .editCategories,
-            .editBriefDescription
-        ]
-        XCTAssertEqual(command.data, expectedActions)
-    }
-
-    func testDataHasEditProductsRelease3ButNoShippingActionsForAVirtualProductWhenFeatureFlagIsOn() {
-        let product = Fixtures.virtualProduct
-        let isEditProductsRelease3Enabled = true
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { _ in }
-
-        let expectedActions: [ProductFormBottomSheetAction] = [
-            .editInventorySettings,
-            .editCategories,
-            .editBriefDescription
-        ]
-        XCTAssertEqual(command.data, expectedActions)
-    }
-
-    func testDataHasEditProductsRelease3ButNoShippingActionsForADownloadableProductWhenFeatureFlagIsOn() {
-        let product = Fixtures.downloadableProduct
-        let isEditProductsRelease3Enabled = true
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: isEditProductsRelease3Enabled) { _ in }
-
-        let expectedActions: [ProductFormBottomSheetAction] = [
-            .editInventorySettings,
-            .editCategories,
-            .editBriefDescription
-        ]
-        XCTAssertEqual(command.data, expectedActions)
-    }
-
     // MARK: - `handleSelectedChange`
 
     func testCallbackIsCalledOnSelection() {
         // Arrange
-        let product = Fixtures.physicalProduct
+        let actions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editShippingSettings, .editCategories, .editBriefDescription]
         var selectedActions = [ProductFormBottomSheetAction]()
-        let command = ProductFormBottomSheetListSelectorCommand(product: product,
-                                                                isEditProductsRelease3Enabled: true) { selected in
+        let command = ProductFormBottomSheetListSelectorCommand(actions: actions) { selected in
                                                                     selectedActions.append(selected)
         }
 
@@ -117,25 +27,5 @@ final class ProductFormBottomSheetListSelectorCommandTests: XCTestCase {
             .editCategories
         ]
         XCTAssertEqual(selectedActions, expectedActions)
-    }
-}
-
-private extension ProductFormBottomSheetListSelectorCommandTests {
-    enum Fixtures {
-        // downloadable: false, virtual: false, missing inventory/shipping/categories/brief description
-        static let physicalProduct = MockProduct().product(downloadable: false, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
-                                                           dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
-                                                           virtual: false,
-                                                           categories: [])
-        // downloadable: false, virtual: true, missing inventory/shipping/categories/brief description
-        static let virtualProduct = MockProduct().product(downloadable: false, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
-                                                          dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
-                                                          virtual: true,
-                                                          categories: [])
-        // downloadable: true, virtual: true, missing inventory/shipping/categories/brief description
-        static let downloadableProduct = MockProduct().product(downloadable: true, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
-                                                               dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
-                                                               virtual: true,
-                                                               categories: [])
     }
 }


### PR DESCRIPTION
Fixes #2302

## Changes

- Since there 2 places that require the knowledge of the visible actions on the product form bottom sheet (the CTA visibility + bottom sheet list selector data), the duplicated actions logic from `ProductFormViewController` and `ProductFormBottomSheetListSelectorCommand` were now shared in `ProductFormBottomSheetActionsFactory`
- Updated `ProductFormViewController` to get the bottom sheet actions from `ProductFormBottomSheetActionsFactory` and passing them to `ProductFormBottomSheetListSelectorCommand`
- Updated unit tests

## Testing

Prerequisite: prepare a simple product that is not virtual/downloadable (so that it has shipping settings) and its shipping data are all empty

- Go to Settings > Experimental Features, and turn off the Products feature switch
- Go to the Products tab
- Tap on the simple Product in the prerequisite --> "Add more details" CTA should be visible at the bottom

## Example screenshots

before (no way to edit shipping settings) | after
-- | --
![Simulator Screen Shot - iPhone 8 Plus - 2020-05-15 at 16 58 44](https://user-images.githubusercontent.com/1945542/82037723-20c1e580-96d5-11ea-9a58-370d1e947d0f.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2020-05-15 at 17 52 36](https://user-images.githubusercontent.com/1945542/82037793-38996980-96d5-11ea-809d-8364691b69ff.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
