### PR TITLE
Testing: Fix local UI test runs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -217,6 +217,7 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Help & Support", comment: "Contact Support Action")
+        cell.accessibilityIdentifier = "settings-help-button"
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -217,7 +217,6 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Help & Support", comment: "Contact Support Action")
-        cell.accessibilityIdentifier = "settings-help-button"
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BasicTableViewCell.swift
@@ -14,6 +14,7 @@ class BasicTableViewCell: UITableViewCell {
 
         textLabel?.applyBodyStyle()
         textLabel?.textAlignment = .natural
+        accessibilityIdentifier = nil
     }
 }
 

--- a/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Login/LoginPasswordScreen.swift
@@ -26,11 +26,8 @@ final class LoginPasswordScreen: BaseScreen {
     }
 
     func tryProceed(password: String) -> LoginPasswordScreen {
-
-        XCTAssert(passwordTextField.waitForExistence(timeout: 3))
         XCTAssert(passwordTextField.waitForHittability(timeout: 3))
 
-        passwordTextField.tap()
         passwordTextField.pasteText(text: password)
 
         XCTAssert(loginButton.waitForExistence(timeout: 3))


### PR DESCRIPTION
Fixes #2253 

## Changes

The UI tests were failing on local test runs, at least on some devices such as iPhone 6/8, due to two identified issues:

* cannot paste the password on the login screen (inconsistent failure)
* cannot log out (consistent failure due to multiple matches for the logout button)

The inconsistent nature of the password pasting issue makes it a little tricky to be confident about the fix, but I noticed that we had two unnecessary steps while entering the password:

1. We were checking for the existence of the password field twice. (Shouldn't affect the test results but it was making the test take longer than needed.)
2. We were tapping in the password field even though it already has focus. I removed this so we go immediately to a long tap to bring up the contextual menu with the paste option (to paste the password in the field).

I saw the failure locally before these changes, and so far in my local test runs it is working consistently now.

The logout issue is a little odd. It was due to the "Help & Support" cell being assigned the same accessibility identifier as the logout button cell on some devices, which caused the test to fail because the identifier wasn't unique. I couldn't find a clear cause for that issue, but I did find that assigning that cell its own accessibility identifier resolves the issue. This addition shouldn't affect anything except the UI tests.

## Testing

* Confirm the tests pass on CI (see passing checks below).
* Run the UI tests locally on various devices (such as iPhone 6/8) and confirm they pass. A quick way to run the UI tests locally:
  * Run `rake mocks` to start the mocks server.
  * Select the `UITests` test plan in Xcode (in the test navigator or under Product > Test Plan).
  * Run the tests (in the test navigator or under Product > Test).

## Review

Only 1 reviewer is needed. @jaclync I'm requesting your review because you reported the issue [originally](https://github.com/woocommerce/woocommerce-ios/pull/2214#pullrequestreview-404718675) and I'm curious if this resolves the failures you were seeing, but other reviews are welcome.

## Submitter Checklist

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
