### PR TITLE
Move testing documentation to the docs directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
     - [Choosing Between Structures and Classes](#choosing-between-structures-and-classes)
 - [Design Patterns](#design-patterns)
     - [Copiable](#copiable)
+- [Testing](#testing)
 
 ## Architecture
 
@@ -143,3 +144,8 @@ let lukeWithNoAddress = luke.copy(address: .some(nil))
 ### Code Generation
 
 These `copy()` methods will be automatically generated in the future.
+
+## Testing
+
+- [UI Tests](UI-TESTS.md)
+- [Beta Testing](https://woocommercehalo.wordpress.com/setup/join-ios-beta/)

--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -6,7 +6,8 @@ WooCommerce for iOS has UI acceptance tests for critical user flows through the 
 
 The following user flows are covered with UI tests:
 
-* [Log in with email/password and log out](WooCommerceUITests/Tests/LoginTests.swift)
+* [Login](../WooCommerce/WooCommerceUITests/Tests/LoginTests.swift):
+	* Log in with email/password and log out
 
 ## Running tests
 
@@ -16,8 +17,8 @@ You can run the tests locally with these steps:
 
 1. Follow the [build instructions](../README.md#build-instructions) to clone the project, install the dependencies, and open the project in Xcode.
 2. Run `rake mocks` to start a local mock server.
-3. With the `WooCommerce` scheme selected in Xcode, open the Test Navigator and select the `UITests` test plan.
-4. Run the tests on a simulator.
+3. With the `WooCommerce` scheme selected in Xcode, navigate to Product > Test Plan and select `UITests`, or open the Test Navigator and select the `UITests` test plan.
+4. Navigate to Product > Test to run all the tests, or use the Test Navigator to run specific tests or test suites.
 
 We also run the UI tests on CircleCI on every commit to the `develop` or `release/*` branches. (See the [CircleCI config](../.circleci/config.yml) for device and workflow details.)
 
@@ -26,9 +27,9 @@ We also run the UI tests on CircleCI on every commit to the `develop` or `releas
 When adding a new UI test, consider:
 
 * Whether you need to test a user flow (to accomplish a task or goal) or a specific feature (e.g. boundary testing).
-* What screens are being tested (defined as screen objects in the [Screens](WooCommerceUITests/Screens) directory).
-* Whether there are actions or flows that could be shared across tests (defined in the [Utils](WooCommerceUITests/Utils) directory).
-* What network requests are made during the test (defined in the [Mocks](WooCommerceUITests/Mocks) directory).
+* What screens are being tested (defined as screen objects in the [Screens](../WooCommerce/WooCommerceUITests/Screens) directory).
+* Whether there are actions or flows that could be shared across tests (defined in the [Utils](../WooCommerce/WooCommerceUITests/Utils) directory).
+* What network requests are made during the test (defined in the [Mocks](../WooCommerce/WooCommerceUITests/Mocks) directory).
 
 It's preferred to focus UI tests on entire user flows, and group tests with related flows or goals in the same test suite.
 


### PR DESCRIPTION
## Changes

Based on @shiki's [feedback](https://github.com/woocommerce/woocommerce-ios/pull/2266#issuecomment-627561110) this moves the UI testing documentation into `docs/`. I made some small updates to that documentation and added links in the README to that doc and our instructions for joining the iOS beta program for beta testing.

This also sets us up to add the unit testing documentation described in https://github.com/woocommerce/woocommerce-ios/issues/2224.

## Testing

Please confirm that the documentation is clear and all links still work.

## Review

Only 1 review is needed. @shiki I've added you as a reviewer since you had the original feedback about the location of the docs. I'm also open to any other suggested improvements!

## Submitter Checklist

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
