### PR TITLE
Move 4.4 release notes to 4.3

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,3 @@
-4.4
------
-- In Order Details, the Payment card is now shown right after the Products and Refunded Products cards.
-
 4.3
 -----
 - Products: now the Product details can be edited and saved outside Products tab (e.g. from Order details or Top Performers).
@@ -11,6 +7,7 @@
 - In Settings > Experimental Features, a Products switch is now available for turning Products M2 features on and off for simple products (default off for beta testing). Products M2 features: update product images, product settings, viewing and sharing a product.
 - The WIP banner on the Products tab is now collapsed by default for more vertical space.
 - Dropped iOS 11 support. From now we support iOS 12 and later.
+- In Order Details, the Payment card is now shown right after the Products and Refunded Products cards.
 
 
 4.2


### PR DESCRIPTION
This fixes the incorrectly placed release notes in https://github.com/woocommerce/woocommerce-ios/pull/2306. 

I merged that PR in `develop` today without checking if `release/4.3` has been cut. 🤦 I meant that PR to be in 4.4 but since `release/4.3` branch hasn't been cut yet, it's fine if #2306 is included in 4.3. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 



