### PR TITLE
Add Tests for Proving and Documenting Possible Concurrency Issues

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		45739F372437680F00480C95 /* ProductSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45739F362437680F00480C95 /* ProductSettings.swift */; };
 		45E18632237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */; };
 		45ED4F16239E939A004F1BE3 /* TaxClassStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */; };
+		572F2B8D247312E4005A5F74 /* StorageManagerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
 		57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
@@ -311,6 +312,7 @@
 		45739F362437680F00480C95 /* ProductSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductSettings.swift; sourceTree = "<group>"; };
 		45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStoreTests.swift; sourceTree = "<group>"; };
+		572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManagerConcurrencyTests.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
 		57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -629,6 +631,14 @@
 			path = Products;
 			sourceTree = "<group>";
 		};
+		572F2B8B247312D3005A5F74 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */,
+			);
+			path = Storage;
+			sourceTree = "<group>";
+		};
 		57FDD6B9246B580700B8344B /* Testing */ = {
 			isa = PBXGroup;
 			children = (
@@ -869,6 +879,7 @@
 		B5C9DE022087FEC0006B910A /* YosemiteTests */ = {
 			isa = PBXGroup;
 			children = (
+				572F2B8B247312D3005A5F74 /* Storage */,
 				57FDD6B9246B580700B8344B /* Testing */,
 				B5BC71DA21139CF2005CF5AA /* Responses */,
 				B5BC736C20D1AB3500B5B6FA /* Settings */,
@@ -1334,6 +1345,7 @@
 				B53A56A0211245E0000776C9 /* MockupStorage+Sample.swift in Sources */,
 				453305FB245AEDCB00264E50 /* SitePostStoreTests.swift in Sources */,
 				020220E42396969E00290165 /* MockProduct.swift in Sources */,
+				572F2B8D247312E4005A5F74 /* StorageManagerConcurrencyTests.swift in Sources */,
 				744914F7224AD2AF00546DE4 /* ProductStoreTests.swift in Sources */,
 				0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */,
 				B5A01CA120D19C4700E3207E /* MockupStorage.swift in Sources */,

--- a/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
+++ b/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
@@ -26,7 +26,7 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         super.tearDown()
     }
 
-    func testGivenSequentialSavingTheArchitectureCanAllowSavingOfDuplicates() {
+    func testWhenSequentiallySavingItCanAllowSavingOfDuplicates() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
         let secondDerivedStorage = storageManager.newDerivedStorage()
@@ -56,7 +56,7 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 2)
     }
 
-    func testGivenConcurrentSavingTheArchitectureCanAllowSavingOfDuplicates() {
+    func testWhenConcurrentlySavingItCanAllowSavingOfDuplicates() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
         let secondDerivedStorage = storageManager.newDerivedStorage()
@@ -89,7 +89,7 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 2)
     }
 
-    func testGivenConcurrentSavingInASinglePerformBlockTheArchitectureCanAllowSavingOfDuplicates() {
+    func testWhenConcurrentlySavingUsingASinglePerformBlockItCanAllowSavingOfDuplicates() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
         let secondDerivedStorage = storageManager.newDerivedStorage()

--- a/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
+++ b/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
@@ -1,0 +1,61 @@
+
+import XCTest
+import Storage
+import Networking
+
+@testable import Yosemite
+
+final class StorageManagerConcurrencyTests: XCTestCase {
+
+    private var storageManager: StorageManagerType!
+
+    private var viewStorage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        // Using the real Sqlite-based StorageManagerType to be closer to the production operations
+        storageManager = CoreDataManager(name: "WooCommerce")
+        storageManager.reset()
+    }
+
+    override func tearDown() {
+        storageManager.reset()
+        storageManager = nil
+        super.tearDown()
+    }
+
+    func testTheConcurrencyArchitectureCanAllowSavingOfDuplicates() {
+        // Given
+        let firstDerivedStorage = storageManager.newDerivedStorage()
+        let secondDerivedStorage = storageManager.newDerivedStorage()
+
+        let orderStatus = Networking.OrderStatus(name: "In Space", siteID: 1_998, slug: "in-space", total: 9)
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 0)
+
+        // When
+        [firstDerivedStorage, secondDerivedStorage].forEach { derivedContext in
+            derivedContext.perform {
+                if let existing = derivedContext.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) {
+                    existing.update(with: orderStatus)
+                } else {
+                    let newStorageOrderStatus = derivedContext.insertNewObject(ofType: Storage.OrderStatus.self)
+                    newStorageOrderStatus.update(with: orderStatus)
+                }
+            }
+        }
+
+        [firstDerivedStorage, secondDerivedStorage].forEach { derivedContext in
+            waitForExpectation { exp in
+                storageManager.saveDerivedType(derivedStorage: derivedContext) {
+                    exp.fulfill()
+                }
+            }
+        }
+
+        // Then
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 2)
+    }
+}

--- a/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
+++ b/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
@@ -5,6 +5,50 @@ import Networking
 
 @testable import Yosemite
 
+/// Proofs and documentation for **possible** concurrency issues that we may run into in the future.
+///
+/// Currently, every Yosemite `Store` creates their own `StorageType` for background saving.
+/// For example, in `OrderStore` and `ProductStore`, we declare them like this:
+///
+/// ```
+/// private lazy var sharedDerivedStorage: StorageType = {
+///     return storageManager.newDerivedStorage()
+/// }()
+/// ```
+///
+/// The `newDerivedStorage()` method typically creates a child `StorageType`
+/// (`NSManagedObjectContext`). These children:
+///
+/// - Have no idea they have siblings (derived `StorageType` in other `Stores`)
+/// - Do not see a siblings' data until a `saveIfNeeded()` is executed on that sibling.
+///
+/// This can mean that if two or more derived `StorageTypes` do similar things, it may be
+/// possible to upsert the same records, leading to duplicate data. For example, in `OrderStore`, we
+/// upsert records like this:
+///
+/// ```
+/// // Fetch an existing record. If it doesn't exist, create a new one.
+/// let storageOrder = storage.loadOrder(orderID: readOnlyOrder.orderID)
+///             ?? storage.insertNewObject(ofType: Storage.Order.self)
+///
+/// // Update the new or existing record with the newly fetched data from the API
+/// storageOrder.update(with: readOnlyOrder)
+/// ```
+///
+/// If by coincidence, the same operation happens **at the same time** with the same order on a
+/// **different** derived `StorageType`, we could be inserting the same order twice. And because we
+/// currently don't have unique key constraints, two records would be saved in Core Data.
+///
+/// ## Is it a Problem?
+///
+/// This is probably not a problem at the moment. We are careful with using a single `StorageType`
+/// for every `Store`. It would be a problem if:
+///
+/// - We have `Store` instances that are not deallocated, still running and doing something
+///   in the background while another newly created `Store` is doing the same thing.
+/// - The app grows and we need to do complex cross-feature operations. For example, saving
+///   Products and Product Categories simultaneously as a single transaction.
+///
 final class StorageManagerConcurrencyTests: XCTestCase {
 
     private var storageManager: StorageManagerType!
@@ -26,6 +70,9 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         super.tearDown()
     }
 
+    /// Simulate what will happen if `perform()` happens at the same time but the `saveDerivedType`
+    /// happens in sequence. We end up with the same record inserted twice.
+    ///
     func testWhenSequentiallySavingItCanAllowSavingOfDuplicates() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
@@ -54,6 +101,9 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 2)
     }
 
+    /// Simulate what will happen if both the `perform()` and `saveDerivedType` happens at the
+    /// same time. We end up with the same record inserted twice.
+    ///
     func testWhenConcurrentlySavingItCanAllowSavingOfDuplicates() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
@@ -72,10 +122,8 @@ final class StorageManagerConcurrencyTests: XCTestCase {
                 self.upsert(orderStatus: orderStatus, using: derivedStorage)
             }
 
-            derivedStorage.perform {
-                self.storageManager.saveDerivedType(derivedStorage: derivedStorage) {
-                    exp.fulfill()
-                }
+            self.storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+                exp.fulfill()
             }
         }
 
@@ -85,6 +133,10 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 2)
     }
 
+    /// Simulate what will happen if `perform()` and `saveDerivedType` called under a single
+    /// `perform()` block happens at the same time on two `StorageTypes`. We end up with the same
+    /// record inserted twice.
+    ///
     func testWhenConcurrentlySavingUsingASinglePerformBlockItCanAllowSavingOfDuplicates() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
@@ -114,6 +166,10 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 2)
     }
 
+    /// Simulate what will happen if we wait for the `perform()` and `saveDerivedType` to finish
+    /// before saving the same record on a sibling `StorageType`. The record is correctly
+    /// inserted only once.
+    ///
     func testWhenSequentiallySavingAndWaitingThenNoDuplicatesAreSaved() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
@@ -140,6 +196,9 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 1)
     }
 
+    /// Prove that siblings will not be able to access any upserted record from a modified
+    /// sibling (Sibling-X) if Sibling-X never calls `saveIfNeeded()`.
+    ///
     func testWhenNotSavingThenADerivedStorageWillNotShareDataToItsSiblings() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
@@ -159,12 +218,16 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         }
 
         // Then
+        // No records are accessible from siblings and the `viewStorage`
         XCTAssertEqual(secondDerivedStorage.countObjects(ofType: Storage.OrderStatus.self), 0)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 0)
 
         XCTAssertEqual(firstDerivedStorage.countObjects(ofType: Storage.OrderStatus.self), 1)
     }
 
+    /// Prove that siblings will be able to access the upserted record from a modified sibling
+    /// (Sibling-X) if Sibling-X calls `saveIfNeeded()`.
+    ///
     func testWhenSavedThenADerivedStorageWillShareDataToItsSiblings() {
         // Given
         let firstDerivedStorage = storageManager.newDerivedStorage()
@@ -186,6 +249,8 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         }
 
         // Then
+        // The record is accessible from siblings and `viewStorage` even if we never persisted
+        // the change by calling `saveIfNeeded` on the `viewStorage`.
         XCTAssertEqual(secondDerivedStorage.countObjects(ofType: Storage.OrderStatus.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 1)
 

--- a/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
+++ b/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
@@ -36,17 +36,17 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderStatus.self), 0)
 
         // When
-        [firstDerivedStorage, secondDerivedStorage].forEach { derivedContext in
-            derivedContext.perform {
-                let storageOrderStatus = derivedContext.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) ??
-                    derivedContext.insertNewObject(ofType: Storage.OrderStatus.self)
+        [firstDerivedStorage, secondDerivedStorage].forEach { derivedStorage in
+            derivedStorage.perform {
+                let storageOrderStatus = derivedStorage.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) ??
+                    derivedStorage.insertNewObject(ofType: Storage.OrderStatus.self)
                 storageOrderStatus.update(with: orderStatus)
             }
         }
 
-        [firstDerivedStorage, secondDerivedStorage].forEach { derivedContext in
+        [firstDerivedStorage, secondDerivedStorage].forEach { derivedStorage in
             waitForExpectation { exp in
-                storageManager.saveDerivedType(derivedStorage: derivedContext) {
+                storageManager.saveDerivedType(derivedStorage: derivedStorage) {
                     exp.fulfill()
                 }
             }
@@ -69,15 +69,15 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         let exp = expectation(description: "concurrent-saving")
         exp.expectedFulfillmentCount = 2
 
-        [firstDerivedStorage, secondDerivedStorage].forEach { derivedContext in
-            derivedContext.perform {
-                let storageOrderStatus = derivedContext.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) ??
-                    derivedContext.insertNewObject(ofType: Storage.OrderStatus.self)
+        [firstDerivedStorage, secondDerivedStorage].forEach { derivedStorage in
+            derivedStorage.perform {
+                let storageOrderStatus = derivedStorage.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) ??
+                    derivedStorage.insertNewObject(ofType: Storage.OrderStatus.self)
                 storageOrderStatus.update(with: orderStatus)
             }
 
-            derivedContext.perform {
-                self.storageManager.saveDerivedType(derivedStorage: derivedContext) {
+            derivedStorage.perform {
+                self.storageManager.saveDerivedType(derivedStorage: derivedStorage) {
                     exp.fulfill()
                 }
             }

--- a/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
+++ b/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
@@ -268,4 +268,3 @@ private extension StorageManagerConcurrencyTests {
         storageOrderStatus.update(with: orderStatus)
     }
 }
-

--- a/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
+++ b/Yosemite/YosemiteTests/Storage/StorageManagerConcurrencyTests.swift
@@ -38,12 +38,9 @@ final class StorageManagerConcurrencyTests: XCTestCase {
         // When
         [firstDerivedStorage, secondDerivedStorage].forEach { derivedContext in
             derivedContext.perform {
-                if let existing = derivedContext.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) {
-                    existing.update(with: orderStatus)
-                } else {
-                    let newStorageOrderStatus = derivedContext.insertNewObject(ofType: Storage.OrderStatus.self)
-                    newStorageOrderStatus.update(with: orderStatus)
-                }
+                let storageOrderStatus = derivedContext.loadOrderStatus(siteID: orderStatus.siteID, slug: orderStatus.slug) ??
+                    derivedContext.insertNewObject(ofType: Storage.OrderStatus.self)
+                storageOrderStatus.update(with: orderStatus)
             }
         }
 


### PR DESCRIPTION
This adds some tests that prove and document **possible** concurrency issues that we may run into in the future.

Currently, every Yosemite `Store` creates its own `StorageType` for background saving.
For example, in `OrderStore` and `ProductStore`, we declare them like this:

https://github.com/woocommerce/woocommerce-ios/blob/cd7ba8751a0f4e7ecd459fe5f683ba5cf55d333e/Yosemite/Yosemite/Stores/OrderStore.swift#L10-L14

The `newDerivedStorage()` method typically creates a child `StorageType`
(`NSManagedObjectContext`). These children:

- Have no idea they have siblings (i.e. derived `StorageType` in other `Stores`)
- Do not see a siblings' data until a `saveIfNeeded()` is executed on that sibling.

This can mean that if two or more derived `StorageTypes` do similar things, it may be
possible to upsert the same records, leading to **duplicate data**. For example, in `OrderStore`, we
upsert records like this:

```swift
// Fetch an existing record. If it doesn't exist, create a new one.
let storageOrder = storage.loadOrder(orderID: readOnlyOrder.orderID)
            ?? storage.insertNewObject(ofType: Storage.Order.self)

// Update the new or existing record with the newly fetched data from the API
storageOrder.update(with: readOnlyOrder)
```

If by coincidence, the same operation happens **at the same time** with the same order on a
**different** derived `StorageType`, we could be inserting the same order twice. And because we
currently don't have unique key constraints, two records would be inserted in Core Data.

## Is it a Problem?

This is probably not a problem at the moment. We are careful with using a single `StorageType`
for every `Store`. It would be a problem if:

- We have `Store` instances that are not deallocated, still running, and doing something in the background while another newly created `Store` is doing the same thing.
- The app grows and we need to do complex cross-feature operations. For example, saving
  Products and Product Categories simultaneously as a single transaction.

## Reviewing 

Please scrutinize the unit tests. Am I just missing something? Does this really happen?

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

