### PR TITLE
Update PList storage implementation

### DIFF
--- a/Storage/Storage/Protocols/FileStorage.swift
+++ b/Storage/Storage/Protocols/FileStorage.swift
@@ -7,13 +7,13 @@ import Foundation
 /// Reads and writes are not expected to be thread safe.
 ///
 public protocol FileStorage {
-    /// Reads a file at a given URL and returns is representation as `Data`
+    /// Reads a file at a given URL and returns the expected type if possible
     ///
-    func data(for fileURL: URL) throws -> Data
+    func data<T: Decodable>(for fileURL: URL) throws -> T
 
-    /// Reads a `Data` blob to a file at `fileURL`
+    /// Writes data of a given type to a file at `fileURL`
     ///
-    func write(_ data: Data, to fileURL: URL) throws
+    func write<T: Encodable>(_ data: T, to fileURL: URL) throws
 
     /// Deletes a file at `fileURL`
     func deleteFile(at fileURL: URL) throws

--- a/Storage/Storage/Tools/PListFileStorage.swift
+++ b/Storage/Storage/Tools/PListFileStorage.swift
@@ -6,19 +6,22 @@ import Foundation
 public final class PListFileStorage: FileStorage {
     public init() { }
 
-    public func data(for fileURL: URL) throws -> Data {
+    public func data<T: Decodable>(for fileURL: URL) throws -> T {
         do {
             let data = try Data(contentsOf: fileURL)
-            return data
+            let decoder = PropertyListDecoder()
+            return try decoder.decode(T.self, from: data)
         } catch {
-            let error = PListFileStorageErrors.fileReadFailed
-            throw error
+            throw PListFileStorageErrors.fileReadFailed
         }
     }
 
-    public func write(_ data: Data, to fileURL: URL) throws {
+    public func write<T: Encodable>(_ data: T, to fileURL: URL) throws {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
         do {
-            try data.write(to: fileURL)
+            let encodedData = try encoder.encode(data)
+            try encodedData.write(to: fileURL)
         } catch {
             let error = PListFileStorageErrors.fileWriteFailed
             throw error

--- a/Storage/StorageTests/Tools/FileStorageTests.swift
+++ b/Storage/StorageTests/Tools/FileStorageTests.swift
@@ -19,13 +19,17 @@ final class FileStorageTests: XCTestCase {
     }
 
     func testFileIsLoaded() {
-        XCTAssertNoThrow(try subject?.data(for: fileURL!))
+        var data: [PreselectedProvider]?
+        XCTAssertNoThrow(data = try subject?.data(for: fileURL!))
+        XCTAssertNotNil(data)
     }
 
     func testErrorIsTriggeredWhenFileFailsToLoad() {
         let url = URL(string: "http://somewhere.on.the.internet")
 
-        XCTAssertThrowsError(try subject?.data(for: url!))
+        var data: Data?
+        XCTAssertThrowsError(data = try subject?.data(for: url!))
+        XCTAssertNil(data)
     }
 
     func testErrorIsTriggeredWhenWritingFails() {

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -153,36 +153,24 @@ private extension AppSettingsStore {
                      providerURL: String? = nil,
                      fileURL: URL,
                      onCompletion: (Error?) -> Void) {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        guard let settings: [PreselectedProvider] = try? fileStorage.data(for: fileURL) else {
             insertNewProvider(siteID: siteID,
                               providerName: providerName,
                               providerURL: providerURL,
                               toFileURL: fileURL,
                               onCompletion: onCompletion)
-            onCompletion(nil)
             return
         }
-
-        do {
-            let data = try fileStorage.data(for: fileURL)
-            let decoder = PropertyListDecoder()
-            let settings = try decoder.decode([PreselectedProvider].self, from: data)
-            upsertTrackingProvider(siteID: siteID,
-                                   providerName: providerName,
-                                   preselectedData: settings,
-                                   toFileURL: fileURL,
-                                   onCompletion: onCompletion)
-        } catch {
-            let error = AppSettingsStoreErrors.parsePreselectedProvider
-            onCompletion(error)
-
-            DDLogError("⛔️ Saving a tracking provider locally failed: siteID \(siteID). Error: \(error)")
-        }
+        upsertTrackingProvider(siteID: siteID,
+                               providerName: providerName,
+                               preselectedData: settings,
+                               toFileURL: fileURL,
+                               onCompletion: onCompletion)
     }
 
     func loadTrackingProvider(siteID: Int64,
                               onCompletion: (ShipmentTrackingProvider?, ShipmentTrackingProviderGroup?, Error?) -> Void) {
-        guard let allSavedProviders = read(from: selectedProvidersURL) as [PreselectedProvider]? else {
+        guard let allSavedProviders: [PreselectedProvider] = try? fileStorage.data(for: selectedProvidersURL) else {
             let error = AppSettingsStoreErrors.readPreselectedProvider
             onCompletion(nil, nil, error)
             return
@@ -208,7 +196,7 @@ private extension AppSettingsStore {
 
     func loadCustomTrackingProvider(siteID: Int64,
                               onCompletion: (ShipmentTrackingProvider?, Error?) -> Void) {
-        guard let allSavedProviders = read(from: customSelectedProvidersURL) as [PreselectedProvider]? else {
+        guard let allSavedProviders: [PreselectedProvider] = try? fileStorage.data(for: customSelectedProvidersURL) else {
             let error = AppSettingsStoreErrors.readPreselectedProvider
             onCompletion(nil, error)
             return
@@ -253,7 +241,12 @@ private extension AppSettingsStore {
             dataToSave.append(newPreselectedProvider)
         }
 
-        write(dataToSave, to: toFileURL, onCompletion: onCompletion)
+        do {
+            try fileStorage.write(dataToSave, to: toFileURL)
+            onCompletion(nil)
+        } catch {
+            onCompletion(error)
+        }
     }
 
     func insertNewProvider(siteID: Int64,
@@ -265,7 +258,12 @@ private extension AppSettingsStore {
                                                       providerName: providerName,
                                                       providerURL: providerURL)
 
-        write([preselectedProvider], to: toFileURL, onCompletion: onCompletion)
+        do {
+            try fileStorage.write([preselectedProvider], to: toFileURL)
+            onCompletion(nil)
+        } catch {
+            onCompletion(error)
+        }
     }
 
     func resetStoredProviders(onCompletion: ((Error?) -> Void)? = nil) {
@@ -302,7 +300,7 @@ private extension AppSettingsStore {
     }
 
     func loadInitialStatsVersionToShow(siteID: Int64, onCompletion: (StatsVersion?) -> Void) {
-        guard let existingData: StatsVersionBySite = read(from: statsVersionLastShownURL),
+        guard let existingData: StatsVersionBySite = try? fileStorage.data(for: statsVersionLastShownURL),
             let statsVersion = existingData.statsVersionBySite[siteID] else {
             onCompletion(nil)
             return
@@ -311,7 +309,7 @@ private extension AppSettingsStore {
     }
 
     func loadStatsVersionEligible(siteID: Int64, onCompletion: (StatsVersion?) -> Void) {
-        guard let existingData: StatsVersionBySite = read(from: statsVersionEligibleURL),
+        guard let existingData: StatsVersionBySite = try? fileStorage.data(for: statsVersionEligibleURL),
             let statsVersion = existingData.statsVersionBySite[siteID] else {
                 onCompletion(nil)
                 return
@@ -320,21 +318,30 @@ private extension AppSettingsStore {
     }
 
     func set(statsVersion: StatsVersion, for siteID: Int64, to fileURL: URL, onCompletion: (Error?) -> Void) {
-        guard let existingData: StatsVersionBySite = read(from: fileURL) else {
+        guard let existingData: StatsVersionBySite = try? fileStorage.data(for: fileURL) else {
             let statsVersionBySite: StatsVersionBySite = StatsVersionBySite(statsVersionBySite: [siteID: statsVersion])
-            write(statsVersionBySite, to: fileURL, onCompletion: onCompletion)
-            onCompletion(nil)
+            do {
+                try fileStorage.write(statsVersionBySite, to: fileURL)
+                onCompletion(nil)
+            } catch {
+                onCompletion(error)
+            }
             return
         }
 
         var statsVersionBySite = existingData.statsVersionBySite
         statsVersionBySite[siteID] = statsVersion
-        write(StatsVersionBySite(statsVersionBySite: statsVersionBySite), to: fileURL, onCompletion: onCompletion)
+        do {
+            try fileStorage.write(StatsVersionBySite(statsVersionBySite: statsVersionBySite), to: fileURL)
+            onCompletion(nil)
+        } catch {
+            onCompletion(error)
+        }
     }
 
     func loadStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner,
                                          onCompletion: (Bool) -> Void) {
-        guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL),
+        guard let existingData: StatsVersionBannerVisibility = try? fileStorage.data(for: statsVersionBannerVisibilityURL),
             let shouldShowBanner = existingData.visibilityByBanner[banner] else {
                 onCompletion(true)
                 return
@@ -345,19 +352,19 @@ private extension AppSettingsStore {
     func setStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner,
                                          shouldShowBanner: Bool) {
         let fileURL = statsVersionBannerVisibilityURL
-        guard let existingData: StatsVersionBannerVisibility = read(from: statsVersionBannerVisibilityURL) else {
+        guard let existingData: StatsVersionBannerVisibility = try? fileStorage.data(for: statsVersionBannerVisibilityURL) else {
             let statsVersionBySite: StatsVersionBannerVisibility = StatsVersionBannerVisibility(visibilityByBanner: [banner: shouldShowBanner])
-            write(statsVersionBySite, to: fileURL, onCompletion: { _ in })
+            try? fileStorage.write(statsVersionBySite, to: fileURL)
             return
         }
 
         var visibilityByBanner = existingData.visibilityByBanner
         visibilityByBanner[banner] = shouldShowBanner
-        write(StatsVersionBannerVisibility(visibilityByBanner: visibilityByBanner), to: fileURL, onCompletion: { _ in })
+        try? fileStorage.write(StatsVersionBannerVisibility(visibilityByBanner: visibilityByBanner), to: fileURL)
     }
 
     func loadProductsFeatureSwitch(onCompletion: (Bool) -> Void) {
-        guard let existingData: ProductsFeatureSwitchPListWrapper = read(from: productsFeatureSwitchURL) else {
+        guard let existingData: ProductsFeatureSwitchPListWrapper = try? fileStorage.data(for: productsFeatureSwitchURL) else {
             onCompletion(false)
             return
         }
@@ -367,10 +374,11 @@ private extension AppSettingsStore {
     func setProductsFeatureSwitch(isEnabled: Bool, onCompletion: () -> Void) {
         let fileURL = productsFeatureSwitchURL
         let wrapper = ProductsFeatureSwitchPListWrapper(isEnabled: isEnabled)
-        write(wrapper, to: fileURL) { error in
-            if let error = error {
-                DDLogError("⛔️ Saving the Products visibility to \(isEnabled) failed: \(error)")
-            }
+        do {
+            try fileStorage.write(wrapper, to: fileURL)
+            onCompletion()
+        } catch {
+            DDLogError("⛔️ Saving the Products visibility to \(isEnabled) failed: \(error)")
             onCompletion()
         }
     }
@@ -383,32 +391,6 @@ private extension AppSettingsStore {
         } catch {
             let error = AppSettingsStoreErrors.deleteStatsVersionStates
             DDLogError("⛔️ Deleting the stats version files failed. Error: \(error)")
-        }
-    }
-}
-
-// MARK: - PList decoding/encoding from and to file storage
-//
-private extension AppSettingsStore {
-    func read<T: Decodable>(from url: URL) -> T? {
-        do {
-            let data = try fileStorage.data(for: url)
-            let decoder = PropertyListDecoder()
-            return try decoder.decode(T.self, from: data)
-        } catch {
-            return nil
-        }
-    }
-
-    func write<T: Encodable>(_ data: T, to fileURL: URL, onCompletion: (Error?) -> Void) {
-        let encoder = PropertyListEncoder()
-        encoder.outputFormat = .xml
-        do {
-            let encodedData = try encoder.encode(data)
-            try fileStorage.write(encodedData, to: fileURL)
-            onCompletion(nil)
-        } catch {
-            onCompletion(error)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Mockups/MockInMemoryStorage.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockInMemoryStorage.swift
@@ -22,7 +22,7 @@ final class MockInMemoryStorage: FileStorage {
         return data
     }
 
-    func write<T>(_ data: T, to fileURL: URL) throws where T : Encodable {
+    func write<T>(_ data: T, to fileURL: URL) throws where T: Encodable {
         self.data = data as? Codable
         dataWriteIsHit = true
     }

--- a/Yosemite/YosemiteTests/Mockups/MockInMemoryStorage.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockInMemoryStorage.swift
@@ -5,8 +5,6 @@
 /// It reads and writes the data from and to an object in memory.
 ///
 final class MockInMemoryStorage: FileStorage {
-    private let loader = PListFileStorage()
-
     /// A boolean value to test if a write to disk is requested
     ///
     var dataWriteIsHit: Bool = false
@@ -15,21 +13,28 @@ final class MockInMemoryStorage: FileStorage {
     ///
     var deleteIsHit: Bool = false
 
-    private var data: Data?
+    private(set) var data: Codable?
 
-    func data(for fileURL: URL) throws -> Data {
-        guard let data = data else {
-            throw AppSettingsStoreErrors.deletePreselectedProvider
+    func data<T>(for fileURL: URL) throws -> T where T: Decodable {
+        guard let data = data as? T else {
+            throw Error.readFailed
         }
         return data
     }
 
-    func write(_ data: Data, to fileURL: URL) throws {
-        self.data = data
+    func write<T>(_ data: T, to fileURL: URL) throws where T : Encodable {
+        self.data = data as? Codable
+        dataWriteIsHit = true
     }
 
     func deleteFile(at fileURL: URL) throws {
         data = nil
         deleteIsHit = true
+    }
+}
+
+extension MockInMemoryStorage {
+    enum Error: Swift.Error {
+        case readFailed
     }
 }


### PR DESCRIPTION
Prerequisite for #1388 

## Background

Currently, we have a `FileStorage` protocol for reading/writing data from/to local storage usually for some lightweight data (similar to the usage of `UserDefaults`). So far, our `AppSettingsStore`/`AppSettingsAction` uses a `FileStorage` implementation to read/write app settings - custom shipment provider under Order Details, and the switches under Settings > Experimental Features. We use a PList implementation `PListFileStorage` to persist the app settings, and a mock in unit tests. However, before this PR, `PListFileStorage` didn't actually have any PList logic - all it used to do was to read/write data from/to a file at a URL locally without the knowledge of PList file type. Instead, the PList logic used to be in `AppSettingsStore`. This PR moves the PList logic (encode/decode) to `PListFileStorage` so that we can use this `FileStorage` implementation for persisting push notification count in #1388 as well.

## Changes

- Updated `FileStorage` protocol so that the data in read/write interface conform to `Decodable`/`Encodable`, respectively
- Moved the PList encode/decode logic from `AppSettingsStore` (private `read`/`write` functions) to `PListFileStorage`, and updated the read/write calls in `AppSettingsStore`
- Unit tests:
  - Updated `MockInMemoryStorage` from `FileStorage` protocol changes
  - Updated `AppSettingsStoreTests` to reuse `MockInMemoryStorage` instead of a very similar implementation `MockFileLoader`
  - Updated `FileStorageTests`

## Testing

The app should behave as before. The affected parts are custom carrier in shipment tracking (an extension), and feature switches under Settings > Experimental Features (stats v3/4 and Products). These are pretty well unit tested, and I'd suggest just sanity checking the following:

### Feature switches

Prerequisite: the site has WC 4+ (so that stats v4 is supported)

- Tap on the settings icon ⚙️ then "Experimental Features" row
- Toggle both switches
- Relaunch the app
- Tap on the settings icon ⚙️ then "Experimental Features" row --> the switches should have the toggled values set right before the relaunch

### Custom shipping provider

Prerequisite: the site has the shipment tracking extension

- Go to the Orders tab
- Tap on an order
- Tap "Add Tracking" row under "OPTIONAL TRACKING INFORMATION" section
- Tap the shipping carrier row
- Tap "Custom Carrier" row under "CUSTOM" section
- Type in any name and tracking number, then save by tapping "Add" to go back to the order details
- Tap "Add Tracking" row under "OPTIONAL TRACKING INFORMATION" section
- Tap the shipping carrier row
- Tap "Custom Carrier" row under "CUSTOM" section --> the custom carrier name should be the default name


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
