### PR TITLE
Add Mocks and Test Data

### DIFF
--- a/Networking/Networking/Model/MetaContainer.swift
+++ b/Networking/Networking/Model/MetaContainer.swift
@@ -38,7 +38,7 @@ extension MetaContainer {
 
     /// Known Meta Containers
     ///
-    enum Containers: String {
+    public enum Containers: String {
         case ids
         case links
         case titles

--- a/Networking/Networking/Remote/NotificationsRemote.swift
+++ b/Networking/Networking/Remote/NotificationsRemote.swift
@@ -10,7 +10,7 @@ public protocol NotificationsEndpointsProviding {
 
 /// Notifications: Remote Endpoints
 ///
-public class NotificationsRemote: Remote, NotificationsEndpointsProviding {
+public final class NotificationsRemote: Remote, NotificationsEndpointsProviding {
 
     /// Retrieves latest Notifications (OR collection of specified Notifications, whenever the NoteIds is present).
     ///

--- a/Networking/Networking/Remote/NotificationsRemote.swift
+++ b/Networking/Networking/Remote/NotificationsRemote.swift
@@ -1,9 +1,16 @@
 import Foundation
 
+/// Protocol for `NotificationsRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol NotificationsEndpointsProviding {
+    func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void)
+}
 
 /// Notifications: Remote Endpoints
 ///
-public class NotificationsRemote: Remote {
+public class NotificationsRemote: Remote, NotificationsEndpointsProviding {
 
     /// Retrieves latest Notifications (OR collection of specified Notifications, whenever the NoteIds is present).
     ///

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -1,8 +1,18 @@
 import Foundation
 
+/// Protocol for `ProductReviewsRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol ProductReviewsEndpointsProviding {
+    func loadProductReview(for siteID: Int64,
+                           reviewID: Int64,
+                           completion: @escaping (Result<ProductReview, Error>) -> Void)
+}
+
 /// Product reviews: Remote Endpoints
 ///
-public final class ProductReviewsRemote: Remote {
+public final class ProductReviewsRemote: Remote, ProductReviewsEndpointsProviding {
 
     // MARK: - Product Reviews
 

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Product: Remote Endpoints
 ///
-public class ProductsRemote: Remote {
+public final class ProductsRemote: Remote {
 
     // MARK: - Products
 

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+/// Protocol for `ProductsRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol ProductsEndpointsProviding {
+    func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
+}
+
 /// Product: Remote Endpoints
 ///
-public final class ProductsRemote: Remote {
+public final class ProductsRemote: Remote, ProductsEndpointsProviding {
 
     // MARK: - Products
 

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
 		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
 		578CE7922475EC9200492EBF /* MockProductsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7912475EC9200492EBF /* MockProductsRemote.swift */; };
+		578CE7942475F52F00492EBF /* MockNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7932475F52F00492EBF /* MockNote.swift */; };
 		57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
@@ -318,6 +319,7 @@
 		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
 		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
 		578CE7912475EC9200492EBF /* MockProductsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductsRemote.swift; sourceTree = "<group>"; };
+		578CE7932475F52F00492EBF /* MockNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNote.swift; sourceTree = "<group>"; };
 		57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
@@ -638,6 +640,7 @@
 		578CE7892475E78C00492EBF /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				578CE7952475FD6B00492EBF /* Model */,
 				578CE78A2475E79300492EBF /* Remote */,
 			);
 			path = Networking;
@@ -651,6 +654,14 @@
 				578CE7912475EC9200492EBF /* MockProductsRemote.swift */,
 			);
 			path = Remote;
+			sourceTree = "<group>";
+		};
+		578CE7952475FD6B00492EBF /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				578CE7932475F52F00492EBF /* MockNote.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		57FDD6B9246B580700B8344B /* Testing */ = {
@@ -1335,6 +1346,7 @@
 				7495C5292114979D00CDD33B /* StatsStoreTests.swift in Sources */,
 				7499A9ED2220527500D8FDFA /* ShipmentStoreTests.swift in Sources */,
 				0212AC64242C6FC300C51F6C /* ProductStore+ProductsSortOrderTests.swift in Sources */,
+				578CE7942475F52F00492EBF /* MockNote.swift in Sources */,
 				0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift in Sources */,
 				02FF055623D984310058E6E7 /* MockupFileManager.swift in Sources */,
 				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		45E18632237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */; };
 		45ED4F16239E939A004F1BE3 /* TaxClassStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
+		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
 		57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
@@ -312,6 +313,7 @@
 		45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStoreTests.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
+		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
 		57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
@@ -629,6 +631,22 @@
 			path = Products;
 			sourceTree = "<group>";
 		};
+		578CE7892475E78C00492EBF /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				578CE78A2475E79300492EBF /* Remote */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		578CE78A2475E79300492EBF /* Remote */ = {
+			isa = PBXGroup;
+			children = (
+				578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */,
+			);
+			path = Remote;
+			sourceTree = "<group>";
+		};
 		57FDD6B9246B580700B8344B /* Testing */ = {
 			isa = PBXGroup;
 			children = (
@@ -917,6 +935,7 @@
 		B5C9DE1D2087FF20006B910A /* Mockups */ = {
 			isa = PBXGroup;
 			children = (
+				578CE7892475E78C00492EBF /* Networking */,
 				D8BD6A4B229D07C8007CAD6C /* custom-shipment-provider.plist */,
 				D87F615F2265B2400031A13B /* shipment-provider.plist */,
 				B5C9DE1E2087FF20006B910A /* MockupProcessor.swift */,
@@ -1336,6 +1355,7 @@
 				020220E42396969E00290165 /* MockProduct.swift in Sources */,
 				744914F7224AD2AF00546DE4 /* ProductStoreTests.swift in Sources */,
 				0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */,
+				578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */,
 				B5A01CA120D19C4700E3207E /* MockupStorage.swift in Sources */,
 				7455263022305F88003F8932 /* OrderStatusStoreTests.swift in Sources */,
 				B5C9DE242087FF20006B910A /* StoreTests.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
 		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
 		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
+		578CE7922475EC9200492EBF /* MockProductsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7912475EC9200492EBF /* MockProductsRemote.swift */; };
 		57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
@@ -316,6 +317,7 @@
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
 		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
 		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
+		578CE7912475EC9200492EBF /* MockProductsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductsRemote.swift; sourceTree = "<group>"; };
 		57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
@@ -646,6 +648,7 @@
 			children = (
 				578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */,
 				578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */,
+				578CE7912475EC9200492EBF /* MockProductsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1360,6 +1363,7 @@
 				0218B4F2242E09E80083A847 /* MediaTypeTests.swift in Sources */,
 				578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */,
 				B5A01CA120D19C4700E3207E /* MockupStorage.swift in Sources */,
+				578CE7922475EC9200492EBF /* MockProductsRemote.swift in Sources */,
 				7455263022305F88003F8932 /* OrderStatusStoreTests.swift in Sources */,
 				B5C9DE242087FF20006B910A /* StoreTests.swift in Sources */,
 				02FF055C23D9846A0058E6E7 /* MediaFileManagerTests.swift in Sources */,
@@ -1392,6 +1396,7 @@
 				02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */,
 				748525AC218A45360036DF75 /* NotificationStoreTests.swift in Sources */,
 				7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */,
+				578CE7972475FD8200492EBF /* MockProductReview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		45ED4F16239E939A004F1BE3 /* TaxClassStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
 		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
+		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
 		57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
@@ -314,6 +315,7 @@
 		45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStoreTests.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
 		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
+		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
 		57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
@@ -643,6 +645,7 @@
 			isa = PBXGroup;
 			children = (
 				578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */,
+				578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1378,6 +1381,7 @@
 				B5C9DE282087FF20006B910A /* MockupSite.swift in Sources */,
 				B5BC736820D1AA8F00B5B6FA /* AccountStoreTests.swift in Sources */,
 				0212AC67242C799B00C51F6C /* ResultsController+StorageProductTests.swift in Sources */,
+				578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */,
 				D87F615E2265B1BC0031A13B /* AppSettingsStoreTests.swift in Sources */,
 				02FF056923DECD5B0058E6E7 /* MediaImageExporterTests.swift in Sources */,
 				02BA23C622EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
 		578CE7922475EC9200492EBF /* MockProductsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7912475EC9200492EBF /* MockProductsRemote.swift */; };
 		578CE7942475F52F00492EBF /* MockNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7932475F52F00492EBF /* MockNote.swift */; };
+		578CE7972475FD8200492EBF /* MockProductReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7962475FD8200492EBF /* MockProductReview.swift */; };
 		57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */; };
 		741F34802195EA62005F5BD9 /* CommentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F347F2195EA62005F5BD9 /* CommentAction.swift */; };
 		741F34822195EA71005F5BD9 /* CommentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741F34812195EA71005F5BD9 /* CommentStore.swift */; };
@@ -320,6 +321,7 @@
 		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
 		578CE7912475EC9200492EBF /* MockProductsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductsRemote.swift; sourceTree = "<group>"; };
 		578CE7932475F52F00492EBF /* MockNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNote.swift; sourceTree = "<group>"; };
+		578CE7962475FD8200492EBF /* MockProductReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReview.swift; sourceTree = "<group>"; };
 		57FDD6BA246B583200B8344B /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		741F347F2195EA62005F5BD9 /* CommentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAction.swift; sourceTree = "<group>"; };
@@ -660,6 +662,7 @@
 			isa = PBXGroup;
 			children = (
 				578CE7932475F52F00492EBF /* MockNote.swift */,
+				578CE7962475FD8200492EBF /* MockProductReview.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";

--- a/Yosemite/YosemiteTests/Mockups/Networking/Model/MockNote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Model/MockNote.swift
@@ -1,0 +1,51 @@
+
+import Foundation
+import XCTest
+
+import Networking
+
+/// Provides builders for `Note` to use as test data.
+///
+struct MockNote {
+    func make(noteID: Int64 = 0,
+              metaSiteID: Int64? = nil,
+              metaReviewID: Int64? = nil) -> Note {
+
+        let metaAsData: Data = {
+            var ids = [String: Int64]()
+            if let siteID = metaSiteID {
+                ids[MetaContainer.Keys.site.rawValue] = siteID
+            }
+            if let reviewID = metaReviewID {
+                ids[MetaContainer.Keys.comment.rawValue] = reviewID
+            }
+
+            if ids.isEmpty {
+                return Data()
+            } else {
+                var metaAsJSON = [String: [String: Int64]]()
+                metaAsJSON[MetaContainer.Containers.ids.rawValue] = ids
+                do {
+                    return try JSONEncoder().encode(metaAsJSON)
+                } catch {
+                    fatalError("Expected to convert MetaContainer JSON to Data. \(error)")
+                }
+            }
+        }()
+
+        return Note(noteID: noteID,
+                    hash: 0,
+                    read: false,
+                    icon: nil,
+                    noticon: nil,
+                    timestamp: "",
+                    type: "",
+                    subtype: nil,
+                    url: nil,
+                    title: nil,
+                    subject: Data(),
+                    header: Data(),
+                    body: Data(),
+                    meta: metaAsData)
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/Networking/Model/MockProductReview.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Model/MockProductReview.swift
@@ -1,0 +1,22 @@
+
+import Foundation
+
+import Networking
+
+/// Provides builders for `Note` to use as test data.
+///
+struct MockProductReview {
+    func make(siteID: Int64, reviewID: Int64, productID: Int64) -> ProductReview {
+        ProductReview(siteID: siteID,
+                      reviewID: reviewID,
+                      productID: productID,
+                      dateCreated: Date(),
+                      statusKey: "",
+                      reviewer: "",
+                      reviewerEmail: "",
+                      reviewerAvatarURL: nil,
+                      review: "",
+                      rating: 0,
+                      verified: false)
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
@@ -6,7 +6,7 @@ import XCTest
 
 /// Mock for `NotificationsRemote`.
 ///
-final class MockNotificationsRemote: NotificationsEndpointsProviding {
+final class MockNotificationsRemote {
     private typealias ResultKey = [Int64]
 
     /// The results to pass to the `completion` block if `loadNotes()` is called.
@@ -16,6 +16,11 @@ final class MockNotificationsRemote: NotificationsEndpointsProviding {
         let key: ResultKey = noteIDs
         notesLoadingResults[key] = result
     }
+}
+
+// MARK: NotificationsEndpointsProviding
+
+extension MockNotificationsRemote: NotificationsEndpointsProviding {
 
     func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void) {
         guard let noteIDs = noteIDs else {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
@@ -1,0 +1,38 @@
+
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `NotificationsRemote`.
+///
+final class MockNotificationsRemote: NotificationsEndpointsProviding {
+    private typealias ResultKey = [Int64]
+
+    /// The results to pass to the `completion` block if `loadNotes()` is called.
+    private var notesLoadingResults = [ResultKey: Result<[Note], Error>]()
+
+    func whenLoadingNotes(noteIDs: [Int64], thenReturn result: Result<[Note], Error>) {
+        let key: ResultKey = noteIDs
+        notesLoadingResults[key] = result
+    }
+
+    func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void) {
+        guard let noteIDs = noteIDs else {
+            return XCTFail("Expected noteIDs to not be nil.")
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key: ResultKey = noteIDs
+            if let result = self.notesLoadingResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
@@ -1,0 +1,41 @@
+
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `ProductReviewsRemote`.
+///
+final class MockProductReviewsRemote: ProductReviewsEndpointsProviding {
+    private struct ResultKey: Hashable {
+        let siteID: Int64
+        let reviewID: Int64
+    }
+
+    /// The results to return based on the given arguments in `loadProductReview`
+    private var productReviewLoadingResults = [ResultKey: Result<ProductReview, Error>]()
+
+    /// Set the value passed to the `completion` block if `loadProductReview()` is called.
+    ///
+    func whenLoadingProductReview(siteID: Int64, reviewID: Int64, thenReturn result: Result<ProductReview, Error>) {
+        let key = ResultKey(siteID: siteID, reviewID: reviewID)
+        productReviewLoadingResults[key] = result
+    }
+
+    func loadProductReview(for siteID: Int64,
+                           reviewID: Int64,
+                           completion: @escaping (Result<ProductReview, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key = ResultKey(siteID: siteID, reviewID: reviewID)
+            if let result = self.productReviewLoadingResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
@@ -6,7 +6,7 @@ import XCTest
 
 /// Mock for `ProductReviewsRemote`.
 ///
-final class MockProductReviewsRemote: ProductReviewsEndpointsProviding {
+final class MockProductReviewsRemote {
     private struct ResultKey: Hashable {
         let siteID: Int64
         let reviewID: Int64
@@ -21,7 +21,11 @@ final class MockProductReviewsRemote: ProductReviewsEndpointsProviding {
         let key = ResultKey(siteID: siteID, reviewID: reviewID)
         productReviewLoadingResults[key] = result
     }
+}
 
+// MARK: - ProductReviewsEndpointsProviding
+
+extension MockProductReviewsRemote: ProductReviewsEndpointsProviding {
     func loadProductReview(for siteID: Int64,
                            reviewID: Int64,
                            completion: @escaping (Result<ProductReview, Error>) -> Void) {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
@@ -1,0 +1,41 @@
+
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `ProductsRemote`.
+///
+final class MockProductsRemote: ProductsEndpointsProviding {
+    private struct ResultKey: Hashable {
+        let siteID: Int64
+        let productID: Int64
+    }
+
+    /// The results to return based on the given arguments in `loadProduct`
+    private var productLoadingResults = [ResultKey: Result<Product, Error>]()
+
+    /// Set the value passed to the `completion` block if `loadProduct()` is called.
+    ///
+    func whenLoadingProduct(siteID: Int64, productID: Int64, thenReturn result: Result<Product, Error>) {
+        let key = ResultKey(siteID: siteID, productID: productID)
+        productLoadingResults[key] = result
+    }
+
+    func loadProduct(for siteID: Int64,
+                     productID: Int64,
+                     completion: @escaping (Result<Product, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key = ResultKey(siteID: siteID, productID: productID)
+            if let result = self.productLoadingResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
@@ -6,7 +6,7 @@ import XCTest
 
 /// Mock for `ProductsRemote`.
 ///
-final class MockProductsRemote: ProductsEndpointsProviding {
+final class MockProductsRemote {
     private struct ResultKey: Hashable {
         let siteID: Int64
         let productID: Int64
@@ -21,6 +21,11 @@ final class MockProductsRemote: ProductsEndpointsProviding {
         let key = ResultKey(siteID: siteID, productID: productID)
         productLoadingResults[key] = result
     }
+}
+
+// MARK: - ProductsEndpointsProviding
+
+extension MockProductsRemote: ProductsEndpointsProviding {
 
     func loadProduct(for siteID: Int64,
                      productID: Int64,


### PR DESCRIPTION
Still chugging away at #2254. It seems that we could use a lot of testing utilities. 😅 

I wanted to send this as a separate PR to control the size. My solution for #2254 including the contents of this PR was already at 650 lines and I was not even done writing unit tests. 😱 

The problem is that these are all testing utilities and are useless on their own. Let me know if that's not okay! 

## Remote Mocks

I added mocks for some of the `Remote` classes that I needed to use in a test:

- [MockNotificationsRemote](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-add-remote-mocks/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift)
- [MockProductReviewsRemote](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-add-remote-mocks/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift)
- [MockProductsRemote](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-add-remote-mocks/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift)

These mocks allow us to provide models instead of JSON files. I believe we have enough tests for the JSON parsing so we don't really need to use JSON files for `Store` test cases. Also, JSON files are so hard to debug and maintain. 

Here is an example of how these can be used: 

https://github.com/woocommerce/woocommerce-ios/blob/7127fcb04d2d8622066f07634a4e8b3ac6a99dc0/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift#L50-L62

The API is based on Mockito which sort of inspires all other test frameworks. 

## Test Data

As helpers for test cases that need to use the mocks above, I also created test data factories:

- [MockNote](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-add-remote-mocks/Yosemite/YosemiteTests/Mockups/Networking/Model/MockNote.swift)
- [MockProductReview](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-add-remote-mocks/Yosemite/YosemiteTests/Mockups/Networking/Model/MockProductReview.swift)

## Testing

These files are currently unused. Making sure the build is green should be enough. 

If you'd like to though, you may `checkout` the `issue/2254-fix-review-push-navigation` branch instead and run the [`RetrieveProductReviewFromNoteUseCaseTests`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-fix-review-push-navigation/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift) test case. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

