### PR TITLE
Order Details: HTML in the shipping method is now decoded

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+4.4
+-----
+- Order Detail: the HTML shipping method is now showed correctly
+
+
 4.3
 -----
 - Products: now the Product details can be edited and saved outside Products tab (e.g. from Order details or Top Performers).

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -492,7 +492,7 @@ private extension OrderDetailsDataSource {
     private func configureShippingMethod(cell: CustomerNoteTableViewCell) {
         cell.headline = NSLocalizedString("Shipping Method",
                                           comment: "Shipping method title for customer info cell")
-        cell.body = shippingMethod
+        cell.body = shippingMethod.strippedHTML
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -390,7 +390,7 @@ private extension FulfillViewController {
 
         cell.headline = NSLocalizedString("Shipping Method",
                                           comment: "Shipping method title for customer info cell")
-        cell.body = shippingMethod
+        cell.body = shippingMethod.strippedHTML
         cell.selectionStyle = .none
     }
 


### PR DESCRIPTION
Fixes #1873

## Description
When a shipping method In Order Detail and Order Fulfillment contains something commonly escaped in HTML (like an ampersand &) it's showing up as an HTML entity.

## Testing
- Open an Order Detail, with a shipping method which contains HTML -> Now should show the correct string.
- Open an Order Fulfillment, with a shipping method which contains HTML -> Now should show the correct string.

<img src="https://user-images.githubusercontent.com/495617/82548939-70ccfc00-9b5c-11ea-9e11-600012c9a5c5.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
