### PR TITLE
Add unit tests for filter product list view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -146,7 +146,7 @@ final class FilterListViewController<ViewModel: FilterListViewModel>: UIViewCont
 
     // MARK: - Navigation
     //
-    @objc func filterActionButtonTapped() {
+    @objc private func filterActionButtonTapped() {
         dismiss(animated: true) { [weak self] in
             guard let self = self else {
                 return
@@ -156,7 +156,7 @@ final class FilterListViewController<ViewModel: FilterListViewModel>: UIViewCont
         }
     }
 
-    @objc func dismissButtonTapped() {
+    @objc private func dismissButtonTapped() {
         if hasFilterChanges() {
             UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
                 self?.dismiss(animated: true) {}
@@ -169,7 +169,7 @@ final class FilterListViewController<ViewModel: FilterListViewModel>: UIViewCont
         }
     }
 
-    @objc func clearAllButtonTapped() {
+    @objc private func clearAllButtonTapped() {
         viewModel.clearAll()
         listSelectorCommand.data = viewModel.filterTypeViewModels
         updateUI(numberOfActiveFilters: viewModel.filterTypeViewModels.numberOfActiveFilters)

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -6,7 +6,7 @@ final class FilterProductListViewModel: FilterListViewModel {
     typealias Criteria = Filters
 
     /// Aggregates the filter values that can be updated in the Filter Products UI.
-    struct Filters {
+    struct Filters: Equatable {
         let stockStatus: ProductStockStatus?
         let productStatus: ProductStatus?
         let productType: ProductType?
@@ -118,13 +118,5 @@ extension FilterProductListViewModel.ProductListFilter {
                                        listSelectorConfig: .staticOptions(options: options),
                                        selectedValue: filters.productType)
         }
-    }
-}
-
-extension FilterProductListViewModel.Filters: Equatable {
-    static func == (lhs: FilterProductListViewModel.Filters, rhs: FilterProductListViewModel.Filters) -> Bool {
-        return lhs.stockStatus == rhs.stockStatus &&
-            lhs.productStatus == rhs.productStatus &&
-            lhs.productType == rhs.productType
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */; };
 		021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */; };
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
+		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
 		02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */; };
 		02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279584237A50C900787C63 /* AztecHeaderFormatBarCommand.swift */; };
 		0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0227958C237A51F300787C63 /* OptionsTableViewController+Styles.swift */; };
@@ -920,6 +921,7 @@
 		021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxisTests.swift"; sourceTree = "<group>"; };
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
+		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
 		02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecUnorderedListFormatBarCommand.swift; sourceTree = "<group>"; };
 		02279584237A50C900787C63 /* AztecHeaderFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecHeaderFormatBarCommand.swift; sourceTree = "<group>"; };
 		0227958C237A51F300787C63 /* OptionsTableViewController+Styles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OptionsTableViewController+Styles.swift"; sourceTree = "<group>"; };
@@ -1922,6 +1924,7 @@
 			isa = PBXGroup;
 			children = (
 				02F5F80D246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift */,
+				0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -4985,6 +4988,7 @@
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
+				0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */,
 				D85136C9231E12B600DD0539 /* ReviewViewModelTests.swift in Sources */,
 				D83A6A782379097A00419D48 /* MurielColorTests.swift in Sources */,
 				020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */; };
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
+		0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */; };
 		02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */; };
 		02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279584237A50C900787C63 /* AztecHeaderFormatBarCommand.swift */; };
 		0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0227958C237A51F300787C63 /* OptionsTableViewController+Styles.swift */; };
@@ -922,6 +923,7 @@
 		021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxisTests.swift"; sourceTree = "<group>"; };
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
+		0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelProductListFilterTests.swift; sourceTree = "<group>"; };
 		02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecUnorderedListFormatBarCommand.swift; sourceTree = "<group>"; };
 		02279584237A50C900787C63 /* AztecHeaderFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecHeaderFormatBarCommand.swift; sourceTree = "<group>"; };
 		0227958C237A51F300787C63 /* OptionsTableViewController+Styles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OptionsTableViewController+Styles.swift"; sourceTree = "<group>"; };
@@ -1925,6 +1927,7 @@
 			children = (
 				02F5F80D246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift */,
 				0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */,
+				0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -5062,6 +5065,7 @@
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,
+				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class FilterProductListViewModelProductListFilterTests: XCTestCase {
+    func testCreatingStockStatusFilterTypeViewModel() {
+        let filterType = FilterProductListViewModel.ProductListFilter.stockStatus
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let viewModel = filterType.createViewModel(filters: filters)
+        XCTAssertEqual(viewModel.selectedValue as? ProductStockStatus, .inStock)
+    }
+
+    func testCreatingProductStatusFilterTypeViewModel() {
+        let filterType = FilterProductListViewModel.ProductListFilter.productStatus
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let viewModel = filterType.createViewModel(filters: filters)
+        XCTAssertEqual(viewModel.selectedValue as? ProductStatus, .draft)
+    }
+
+    func testCreatingProductTypeFilterTypeViewModel() {
+        let filterType = FilterProductListViewModel.ProductListFilter.productType
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let viewModel = filterType.createViewModel(filters: filters)
+        XCTAssertEqual(viewModel.selectedValue as? ProductType, .grouped)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -3,23 +3,38 @@ import XCTest
 
 final class FilterProductListViewModelTests: XCTestCase {
     func testCriteriaWithDefaultFilters() {
+        // Given
         let filters = FilterProductListViewModel.Filters()
+
+        // When
         let viewModel = FilterProductListViewModel(filters: filters)
+
+        // Then
         let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: nil, productType: nil, numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
     func testCriteriaWithNonNilFilters() {
+        // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+
+        // When
         let viewModel = FilterProductListViewModel(filters: filters)
+
+        // Then
         let expectedCriteria = filters
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }
 
     func testCriteriaAfterClearingAllNonNilFilters() {
+        // Given
         let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+
+        // When
         let viewModel = FilterProductListViewModel(filters: filters)
         viewModel.clearAll()
+
+        // Then
         let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: nil, productType: nil, numberOfActiveFilters: 0)
         XCTAssertEqual(viewModel.criteria, expectedCriteria)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import WooCommerce
+
+final class FilterProductListViewModelTests: XCTestCase {
+    func testCriteriaWithDefaultFilters() {
+        let filters = FilterProductListViewModel.Filters()
+        let viewModel = FilterProductListViewModel(filters: filters)
+        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: nil, productType: nil, numberOfActiveFilters: 0)
+        XCTAssertEqual(viewModel.criteria, expectedCriteria)
+    }
+
+    func testCriteriaWithNonNilFilters() {
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let viewModel = FilterProductListViewModel(filters: filters)
+        let expectedCriteria = filters
+        XCTAssertEqual(viewModel.criteria, expectedCriteria)
+    }
+
+    func testCriteriaAfterClearingAllNonNilFilters() {
+        let filters = FilterProductListViewModel.Filters(stockStatus: .inStock, productStatus: .draft, productType: .grouped, numberOfActiveFilters: 3)
+        let viewModel = FilterProductListViewModel(filters: filters)
+        viewModel.clearAll()
+        let expectedCriteria = FilterProductListViewModel.Filters(stockStatus: nil, productStatus: nil, productType: nil, numberOfActiveFilters: 0)
+        XCTAssertEqual(viewModel.criteria, expectedCriteria)
+    }
+}


### PR DESCRIPTION
Fixes #2037 

## Changes

Most of the logic and nested structs are private in `FilterListViewController`, please lemme know if you think of any ways to test the view controller interactions!

- Added unit tests for `FilterTypeViewModel` creation from `FilterProductListViewModel.ProductListFilter` in `FilterProductListViewModelProductListFilterTests`
- Added unit tests for `FilterProductListViewModel`'s criteria calculation in `FilterProductListViewModelTests`

## Testing

no user-facing changes, just CI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
