### PR TITLE
Rename `ProductImagesViewModel` to `ProductImagesHeaderViewModel` to match `ProductImagesHeaderTableViewCell`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesCollectionViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesCollectionViewDataSource.swift
@@ -4,10 +4,10 @@ import Kingfisher
 import Yosemite
 
 final class ProductImagesCollectionViewDataSource: NSObject {
-    private let viewModel: ProductImagesViewModel
+    private let viewModel: ProductImagesHeaderViewModel
     private let productUIImageLoader: ProductUIImageLoader
 
-    init(viewModel: ProductImagesViewModel,
+    init(viewModel: ProductImagesHeaderViewModel,
          productUIImageLoader: ProductUIImageLoader) {
         self.viewModel = viewModel
         self.productUIImageLoader = productUIImageLoader

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -7,7 +7,7 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
 
     /// View Model
     ///
-    private var viewModel: ProductImagesViewModel?
+    private var viewModel: ProductImagesHeaderViewModel?
 
     /// Collection View Datasource
     ///
@@ -37,7 +37,7 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
     func configure(with productImageStatuses: [ProductImageStatus],
                    config: ProductImagesCellConfig,
                    productUIImageLoader: ProductUIImageLoader) {
-        let viewModel = ProductImagesViewModel(productImageStatuses: productImageStatuses,
+        let viewModel = ProductImagesHeaderViewModel(productImageStatuses: productImageStatuses,
                                                config: config)
         self.viewModel = viewModel
         dataSource = ProductImagesCollectionViewDataSource(viewModel: viewModel,
@@ -90,7 +90,7 @@ extension ProductImagesHeaderTableViewCell: UICollectionViewDelegateFlowLayout {
         case .extendedAddImage:
             return frame.size
         default:
-            return ProductImagesViewModel.defaultCollectionViewCellSize
+            return ProductImagesHeaderViewModel.defaultCollectionViewCellSize
         }
     }
 }
@@ -135,7 +135,7 @@ private extension ProductImagesHeaderTableViewCell {
         case .extendedAddImages:
             collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: frame.size, config: config)
         default:
-            collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: ProductImagesViewModel.defaultCollectionViewCellSize, config: config)
+            collectionView.collectionViewLayout = ProductImagesFlowLayout(itemSize: ProductImagesHeaderViewModel.defaultCollectionViewCellSize, config: config)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Yosemite
 
-final class ProductImagesViewModel {
+final class ProductImagesHeaderViewModel {
 
     let productImageStatuses: [ProductImageStatus]
 
@@ -42,7 +42,7 @@ final class ProductImagesViewModel {
 
 // MARK: - Register collection view cells
 //
-extension ProductImagesViewModel {
+extension ProductImagesHeaderViewModel {
     /// Registers all of the available CollectionViewCells
     ///
     func registerCollectionViewCells(_ collectionView: UICollectionView) {

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Yosemite
 
+/// View model for displaying a collection of product images in the header.
 final class ProductImagesHeaderViewModel {
 
     let productImageStatuses: [ProductImageStatus]

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -269,7 +269,7 @@
 		451750B224470CD5004FDA65 /* EnhancedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451750B124470CD5004FDA65 /* EnhancedTextView.swift */; };
 		451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */; };
 		451A04E72386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */; };
-		451A04EA2386D28300E368C9 /* ProductImagesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */; };
+		451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04E92386D28300E368C9 /* ProductImagesHeaderViewModel.swift */; };
 		451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04EB2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift */; };
 		451A04F02386F7B500E368C9 /* ProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A04EE2386F7B500E368C9 /* ProductImageCollectionViewCell.swift */; };
 		451A04F12386F7B500E368C9 /* ProductImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 451A04EF2386F7B500E368C9 /* ProductImageCollectionViewCell.xib */; };
@@ -1120,7 +1120,7 @@
 		451750B124470CD5004FDA65 /* EnhancedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedTextView.swift; sourceTree = "<group>"; };
 		451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImagesHeaderTableViewCell.xib; sourceTree = "<group>"; };
-		451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesViewModel.swift; sourceTree = "<group>"; };
+		451A04E92386D28300E368C9 /* ProductImagesHeaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesHeaderViewModel.swift; sourceTree = "<group>"; };
 		451A04EB2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		451A04EE2386F7B500E368C9 /* ProductImageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		451A04EF2386F7B500E368C9 /* ProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
@@ -2334,7 +2334,7 @@
 				451A04E42386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift */,
 				451A04E52386CE8700E368C9 /* ProductImagesHeaderTableViewCell.xib */,
 				451A04EB2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift */,
-				451A04E92386D28300E368C9 /* ProductImagesViewModel.swift */,
+				451A04E92386D28300E368C9 /* ProductImagesHeaderViewModel.swift */,
 				453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */,
 				451A04ED2386F79600E368C9 /* Collection View Cells */,
 			);
@@ -4627,7 +4627,7 @@
 				4512055224655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift in Sources */,
 				57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */,
 				CE21B3D720FE669A00A259D5 /* BasicTableViewCell.swift in Sources */,
-				451A04EA2386D28300E368C9 /* ProductImagesViewModel.swift in Sources */,
+				451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */,
 				D843D5D92248EE91001BFA55 /* ManualTrackingViewModel.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				0235595524496B6D004BE2B8 /* BottomSheetListSelectorCommand.swift in Sources */,


### PR DESCRIPTION
Fixes #1905 

## Changes

- Per the description #1905, `ProductImagesViewModel` sounds quite generic and this PR renamed it to `ProductImagesHeaderViewModel` to match its usage in the header

## Testing

The code changes were from a pass of straightforward renaming, just CI!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
