### PR TITLE
Improvement to FileStorageTests: managed URLs that never exists

### DIFF
--- a/Storage/StorageTests/Tools/FileStorageTests.swift
+++ b/Storage/StorageTests/Tools/FileStorageTests.swift
@@ -25,23 +25,23 @@ final class FileStorageTests: XCTestCase {
     }
 
     func testErrorIsTriggeredWhenFileFailsToLoad() {
-        let url = URL(string: "http://somewhere.on.the.internet")
+        let url = URL(fileURLWithPath: "/non-existing-file")
 
         var data: Data?
-        XCTAssertThrowsError(data = try subject?.data(for: url!))
+        XCTAssertThrowsError(data = try subject?.data(for: url))
         XCTAssertNil(data)
     }
 
     func testErrorIsTriggeredWhenWritingFails() {
-        let url = URL(string: "http://somewhere.on.the.internet")
+        let url = URL(fileURLWithPath: "/non-existing-file")
         let data = Data(count: 0)
 
-        XCTAssertThrowsError(try subject?.write(data, to: url!))
+        XCTAssertThrowsError(try subject?.write(data, to: url))
     }
 
     func testErrorIsTriggeredWhenFileFailsToDelete() {
-        let url = URL(string: "http://somewhere.on.the.internet")
+        let url = URL(fileURLWithPath: "/non-existing-file")
 
-        XCTAssertThrowsError(try subject?.deleteFile(at: url!))
+        XCTAssertThrowsError(try subject?.deleteFile(at: url))
     }
 }

--- a/Storage/StorageTests/Tools/FileStorageTests.swift
+++ b/Storage/StorageTests/Tools/FileStorageTests.swift
@@ -5,6 +5,8 @@ final class FileStorageTests: XCTestCase {
     private var fileURL: URL?
     private var subject: PListFileStorage?
 
+    private let nonExistingFileURL = URL(fileURLWithPath: "/non-existing-file")
+    
     override func setUp() {
         super.setUp()
         subject = PListFileStorage()
@@ -25,23 +27,18 @@ final class FileStorageTests: XCTestCase {
     }
 
     func testErrorIsTriggeredWhenFileFailsToLoad() {
-        let url = URL(fileURLWithPath: "/non-existing-file")
-
         var data: Data?
-        XCTAssertThrowsError(data = try subject?.data(for: url))
+        XCTAssertThrowsError(data = try subject?.data(for: nonExistingFileURL))
         XCTAssertNil(data)
     }
 
     func testErrorIsTriggeredWhenWritingFails() {
-        let url = URL(fileURLWithPath: "/non-existing-file")
         let data = Data(count: 0)
 
-        XCTAssertThrowsError(try subject?.write(data, to: url))
+        XCTAssertThrowsError(try subject?.write(data, to: nonExistingFileURL))
     }
 
     func testErrorIsTriggeredWhenFileFailsToDelete() {
-        let url = URL(fileURLWithPath: "/non-existing-file")
-
-        XCTAssertThrowsError(try subject?.deleteFile(at: url))
+        XCTAssertThrowsError(try subject?.deleteFile(at: nonExistingFileURL))
     }
 }

--- a/Storage/StorageTests/Tools/FileStorageTests.swift
+++ b/Storage/StorageTests/Tools/FileStorageTests.swift
@@ -6,7 +6,7 @@ final class FileStorageTests: XCTestCase {
     private var subject: PListFileStorage?
 
     private let nonExistingFileURL = URL(fileURLWithPath: "/non-existing-file")
-    
+
     override func setUp() {
         super.setUp()
         subject = PListFileStorage()


### PR DESCRIPTION
Part of #1687. Discussions started here https://github.com/woocommerce/woocommerce-ios/pull/1672#issuecomment-569953807 and here https://github.com/woocommerce/woocommerce-ios/pull/2318#discussion_r427922592

Since URLs are the preferred way to refer to local files, but also to external resources, I modified how `FileStorageTests` manage non-existing URLs, pointing to a non-existing path.
Previously, a URL that points to a nonexisting website in some cases will be rendered because locally the router redirects us to the web page of the internet provider (after the redirect, the website exist and there is a file to download, so tests fail).

## Testing
- Just CI
- Look at the code

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
