### PR TITLE
Update Auth to use Google login refactor.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,9 +32,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '1.17.0-beta.7'
+  pod 'WordPressAuthenticator', '1.17.0-beta.7'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/282-refactor_google_login_from_email'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.8.16'

--- a/Podfile
+++ b/Podfile
@@ -32,9 +32,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '1.17.0-beta.3'
+  # pod 'WordPressAuthenticator', '1.17.0-beta.7'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/282-refactor_google_login_from_email'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.8.16'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/282-refactor_google_login_from_email`)
+  - WordPressAuthenticator (= 1.17.0-beta.7)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.7.0)
   - Wormholy (~> 1.6.0)
@@ -138,6 +138,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -152,16 +153,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: feature/282-refactor_google_login_from_email
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: 3ca7495aac20f860e2ca24d3b083edc9b5289010
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -203,6 +194,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: c9d66195b05c78d8d0ab30f2ab1a2743dcc2592b
+PODFILE CHECKSUM: 29c9ebbbd6df655e0cc04fa307a0e761dbef5044
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,7 +53,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.17.0-beta.3):
+  - WordPressAuthenticator (1.17.0-beta.7):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -62,10 +62,10 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.8.0)
+    - WordPressKit (~> 4.9.0-beta.1)
     - WordPressShared (~> 1.8.16)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.8.0):
+  - WordPressKit (4.9.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (= 1.17.0-beta.3)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/282-refactor_google_login_from_email`)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.7.0)
   - Wormholy (~> 1.6.0)
@@ -138,7 +138,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -153,6 +152,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: feature/282-refactor_google_login_from_email
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 3ca7495aac20f860e2ca24d3b083edc9b5289010
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -178,8 +187,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: 9c95b0da802f047ec99349da51fccc150afdd0e4
-  WordPressKit: 84045e236949248632a2c644149e5657733011bb
+  WordPressAuthenticator: aa6c0a219c17cdfdb19fe6c2a1859b2577857cd5
+  WordPressKit: e8aab0ace717c9b9be307ccfdda08821f31b655c
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   Wormholy: f52cd3c384fb49ae3e8fdb2b1398b66746a65104
@@ -194,6 +203,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 682d871417754c95c57da69f0f247cad66f4ecdc
+PODFILE CHECKSUM: c9d66195b05c78d8d0ab30f2ab1a2743dcc2592b
 
 COCOAPODS: 1.9.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
  
 - Order Detail: the HTML shipping method is now showed correctly
+- [internal] Logging in via 'Log in with Google' has changes that can cause regressions. See https://git.io/Jf2Fs for full testing details.
 
 
 4.3


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/282
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/286

This uses the Auth branch to utilize the Google login refactor.  To note, there should be _no_ functional or visible changes. Testing is to verify nothing is broken.

To test:

---
**Test Case 1: Login with Google account**
1. Have an account that was created via the Google path (i.e so it is flagged as a social account).
2. Go to `Log In` > `Log in with Google`.
3. Walk through the Google account authentication.
4. Verify the Login Epilogue is displayed. (or whatever it looks like with a valid Woo account. 😄 )

![epilogue](https://user-images.githubusercontent.com/1816888/82708161-d68fb580-9c3a-11ea-893e-aa2d6262aedf.png)

---
**Test Case 2: Login with Google account that has 2FA enabled on the WP account**
1. Have the same kind of account as in Test Case 1, but with 2FA enabled on the WordPress account.
2. Go to `Log In` > `Log in with Google`.
3. Walk through the Google account authentication.
4. Verify the 2FA code prompt is displayed.

![2fa](https://user-images.githubusercontent.com/1816888/82708225-f3c48400-9c3a-11ea-8397-2fd4ce7ab40e.png)

---
**Test Case 3: Login with Google using an existing WP account**
1. Have an account that was created via the email signup path (i.e so it is flagged as a WP account).
2. Go to `Log In` > `Log in with Google`.
3. Walk through the Google account authentication.
4. Verify the WP email prompt is displayed.

![password](https://user-images.githubusercontent.com/1816888/82708250-03dc6380-9c3b-11ea-911f-a862d7788aa8.png)

---
**Test Case 4: Login with Google fails**
1. Have the same kind of account as in Test Case 2.
2. Go to `Log In` > `Log in with Google`.
3. Walk through the Google account authentication.
3. Immediately log out and attempt to login again via Google.
4. Verify the `Unable to Connect` view is displayed.

![fail](https://user-images.githubusercontent.com/1816888/82708269-10f95280-9c3b-11ea-87be-db56a59a3a48.png)

---
Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
