### PR TITLE
Fix crash when uploading product images after logging in

### DIFF
--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -19,6 +19,9 @@ public class AlamofireNetwork: Network {
     ///
     public required init(credentials: Credentials) {
         self.credentials = credentials
+
+        // A unique ID is included in the background session identifier so that the session does not get invalidated when the initializer is called multiple
+        // times (e.g. when logging in).
         let uniqueID = UUID().uuidString
         let configuration = URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession.\(uniqueID)")
         self.backgroundSessionManager = Alamofire.SessionManager(configuration: configuration)

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -19,7 +19,8 @@ public class AlamofireNetwork: Network {
     ///
     public required init(credentials: Credentials) {
         self.credentials = credentials
-        let configuration = URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession")
+        let uniqueID = UUID().uuidString
+        let configuration = URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession.\(uniqueID)")
         self.backgroundSessionManager = Alamofire.SessionManager(configuration: configuration)
     }
 


### PR DESCRIPTION
Fixes #2337 

## Reason for crash

From the stack trace and crash reason (`Task created in a session that has been invalidated`), it seems related to the background session `backgroundSessionManager: Alamofire.SessionManager` in `AlamofireNetwork`. Since we initialize a background session manager on every login, and each login request [triggers the `AuthenticatedState` init](https://github.com/woocommerce/woocommerce-ios/blob/84b1a8cfd99043c410e7c24fc345637328fe130d/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift#L90) twice, and we are assigning the same identifier to the session, the session gets invalidated and results in a crash when it's trying to make a network request on the invalidated background session.

I'm not super sure why each login action triggers `AuthenticatedState` init twice, there are probably some reasons behind it. Since this is a hotfix, I kept the changes only to address the crash.

## Changes

This PR added a UUID to the background session identifier, so that a new session manager of a different identifier is created when `AuthenticatedState`/`AlamofireNetwork` is reinitialized (e.g. when the user logs in) and the original background session isn't invalidated.

## Testing

### The app is logged out on launch

- Log out of the app if the app is not already logged out
- Relaunch the app
- Log in to a store
- In Settings > Experimental Features, turn on the Products switch if it was off before
- Go to the Products tab
- Tap on a simple product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera --> the app used to crash before this PR, and now it should not crash and go back to the product details screen when the image is being uploaded
- Tap "Update" on the product details --> after the update completes, make sure the image is uploaded on web

### The app is logged in on launch

- Launch the app in logged in state
- In Settings > Experimental Features, turn on the Products switch if it was off before
- Go to the Products tab
- Tap on a simple product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera
- Tap "Update" on the product details --> after the update completes, make sure the image is uploaded on web


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
