### PR TITLE
Fix product details screen cannot be scrolled to the bottom in landscape after keyboard is dismissed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Order Detail: the HTML shipping method is now showed correctly
 - [**] Fix bugs related to push notifications: after receiving a new order push notification, the Reviews tab does not show a badge anymore. The application icon badge number is now cleared by navigating to the Orders tab and/or the Reviews tab, depending on the types of notifications received.
+- [*] Fix the issue where product details screen cannot be scrolled to the bottom in landscape after keyboard is dismissed (e.g. from editing product title).
 
 
 4.3

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardScrollable.swift
@@ -11,19 +11,27 @@ extension KeyboardScrollable where Self: UIViewController {
     func handleKeyboardFrameUpdate(keyboardFrame: CGRect) {
         let keyboardHeight = keyboardFrame.height
 
-        let bottomInset: CGFloat = {
+        let bottomInsetFromSafeArea: CGFloat
+
+        switch scrollable.contentInsetAdjustmentBehavior {
+        case .never where keyboardHeight == 0:
+            // If the `contentInset` is not meant to be adjusted, there should be zero inset from the safe area when the keyboard height is zero.
+            bottomInsetFromSafeArea = 0
+        default:
             // iPhone X+ adds a bottom inset for the Home Indicator. This inset is made irrelevant
             // if the keyboard is present. That's why we should deduct it from the final `bottomInset`
             // value. If we don't, the `scrollable` (i.e. TableView) will be shown with a space above
             // the keyboard.
-            var inset = keyboardHeight - view.safeAreaInsets.bottom
+            var inset = -view.safeAreaInsets.bottom
 
             if let provider = self as? KeyboardFrameAdjustmentProvider {
                 inset += provider.additionalKeyboardFrameHeight
             }
 
-            return inset
-        }()
+            bottomInsetFromSafeArea = inset
+        }
+
+        let bottomInset = keyboardHeight + bottomInsetFromSafeArea
 
         scrollable.contentInset.bottom = bottomInset
         scrollable.scrollIndicatorInsets.bottom = bottomInset


### PR DESCRIPTION
Fixes #2334

## Changes

- In product form (product details), the table view has `contentInsetAdjustmentBehavior` manually set to `never` because it's in a vertical stack view and the safe area adjustment should be handled by the constraint on the stack view (pinning the stack view bottom anchor to the safe area's bottom anchor). However, in the default implementation of `KeyboardScrollable` where we adjust the bottom inset for a scroll view from keyboard height changes, we used to always account for the safe area's bottom inset while there should be no adjustment when the keyboard is dismissed (keyboard height `0`). This PR made a special case for this specific scenario when the bottom inset should not include the safe area. When the keyboard is up, we still want to account for the safe area bottom inset because the keyboard height includes the safe area bottom inset.

## Testing

- Launch the app on a device/simulator with a notch (e.g. iPhone X series) (I also tested on a simulator without a notch but it's optional)
- Go to the Products tab
- Tap on a simple product
- Turn your device to landscape
- Scroll down and notice you can view all of the sections on the screen
- Edit a product detail that brings up the keyboard on screen (e.g. edit the product title)
- Dismiss the keyboard (e.g. by tapping "Return" on the keyboard) and scroll down on the main product details screen --> before this PR, you can't see all of the last section on the screen. now you should be able to see the end of the last section

## Example screencast


![simulator](https://user-images.githubusercontent.com/1945542/82785181-a3e0f980-9e94-11ea-98d8-6498c84e1d65.gif)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
