### PR TITLE
Edit Products: show product name in the navigation bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Order Detail: the HTML shipping method is now showed correctly
 - [**] Fix bugs related to push notifications: after receiving a new order push notification, the Reviews tab does not show a badge anymore. The application icon badge number is now cleared by navigating to the Orders tab and/or the Reviews tab, depending on the types of notifications received.
+- [*] The product name is now shown in the product details navigation bar so that the name is always visible.
 
 
 4.3

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -25,6 +25,7 @@ final class ProductFormViewController: UIViewController {
             defer {
                 let isUpdateEnabled = hasUnsavedChanges(product: product, password: password)
                 updateNavigationBar(isUpdateEnabled: isUpdateEnabled)
+                updateNavigationBarTitle(product: product)
             }
 
             if isNameTheOnlyChange(oldProduct: oldValue, newProduct: product) {
@@ -165,6 +166,7 @@ final class ProductFormViewController: UIViewController {
 private extension ProductFormViewController {
     func configureNavigationBar() {
         updateNavigationBar(isUpdateEnabled: originalProduct != product)
+        updateNavigationBarTitle(product: product)
         removeNavigationBackBarButtonText()
     }
 
@@ -243,6 +245,14 @@ private extension ProductFormViewController {
         moreDetailsContainerView.setContentHuggingPriority(.required, for: .vertical)
 
         updateMoreDetailsButtonVisibility(product: product)
+    }
+}
+
+// MARK: UI updates from product changes
+//
+private extension ProductFormViewController {
+    func updateNavigationBarTitle(product: Product) {
+        navigationItem.title = product.name
     }
 }
 


### PR DESCRIPTION
Fixes #2339 

## Changes

- Set the product name to the navigation bar title on initialization and product updates

## Testing

- Go to the Products tab
- Tap on a simple product --> the product name should be shown in the navigation bar
- Edit the product name --> the navigation bar title should change as you type that matches the product name text field

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/82786927-0be50f00-9e98-11ea-883c-2c979f7ab580.gif)

before | after
-- | --
![Simulator Screen Shot - iPhone SE - 2020-05-25 at 14 37 02](https://user-images.githubusercontent.com/1945542/82786918-0982b500-9e98-11ea-85a3-308683a1add7.png) | ![Simulator Screen Shot - iPhone SE - 2020-05-25 at 14 40 55](https://user-images.githubusercontent.com/1945542/82786925-0b4c7880-9e98-11ea-805d-3613bee227b1.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
