### PR TITLE
Edit Products: scroll to the beginning of product images if any are pending upload

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Order Detail: the HTML shipping method is now showed correctly
 - [**] Fix bugs related to push notifications: after receiving a new order push notification, the Reviews tab does not show a badge anymore. The application icon badge number is now cleared by navigating to the Orders tab and/or the Reviews tab, depending on the types of notifications received.
+- [*] The images pending upload should be visible after editing product images from product details.
 
 
 4.3

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderTableViewCell.swift
@@ -46,6 +46,10 @@ final class ProductImagesHeaderTableViewCell: UITableViewCell {
         configureCollectionView(config: config)
 
         viewModel.registerCollectionViewCells(collectionView)
+
+        if viewModel.shouldScrollToStart {
+            collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .centeredHorizontally, animated: false)
+        }
     }
 
     /// Rotation management

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesHeaderViewModel.swift
@@ -8,6 +8,9 @@ final class ProductImagesHeaderViewModel {
 
     let config: ProductImagesCellConfig
 
+    /// Whether we should scroll to the beginning of the collection view.
+    let shouldScrollToStart: Bool
+
     // Fixed width/height of collection view cell
     static let defaultCollectionViewCellSize = CGSize(width: 128.0, height: 128.0)
 
@@ -16,6 +19,7 @@ final class ProductImagesHeaderViewModel {
     init(productImageStatuses: [ProductImageStatus], config: ProductImagesCellConfig) {
         self.productImageStatuses = productImageStatuses
         self.config = config
+        self.shouldScrollToStart = productImageStatuses.hasPendingUpload
 
         configureItems()
     }


### PR DESCRIPTION
Fixes #2338 

## Changes

On image status updates, the images collection view is scrolled to the beginning if there are any images that are still pending upload so that they are visible to the user

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera --> it should go back to the product form and the selected photo should be visible with a spinner overlay

## Example screencast

before | after
-- | --
<img src="https://user-images.githubusercontent.com/495617/82672364-903d5500-9c40-11ea-84ac-e0f27d7343c1.gif" width=300 /> | ![simulator](https://user-images.githubusercontent.com/1945542/82790407-94ff4480-9e9e-11ea-8fae-19525ed9afe3.gif)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
