### PR TITLE
Product Settings: fix "Discard changes" prompt erroneously shown when swiping back from slug, purchase note, and menu order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - Order Detail: the HTML shipping method is now showed correctly
 - [**] Fix bugs related to push notifications: after receiving a new order push notification, the Reviews tab does not show a badge anymore. The application icon badge number is now cleared by navigating to the Orders tab and/or the Reviews tab, depending on the types of notifications received.
+- [*] The discard changes prompt does not appear when navigating from product settings detail screens with a text field (slug, purchase note, and menu order) anymore.
 
 
 4.3

--- a/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UINavigationController+Woo.swift
@@ -95,7 +95,7 @@ extension UIViewController: NavigationSwipeBackHandler {
 extension UIViewController: UIGestureRecognizerDelegate {
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        if gestureRecognizer.isEqual(navigationController?.interactivePopGestureRecognizer) {
+        if gestureRecognizer.isEqual(navigationController?.interactivePopGestureRecognizer) && navigationController?.topViewController == self {
             return shouldPopOnSwipeBack()
         }
 


### PR DESCRIPTION
Fixes #2333 

## Changes

- When handling swipe back gesture in a view controller as a `UIGestureRecognizerDelegate`, this PR added a check on whether the view controller is the top view controller in the navigation back so that only the top view controller handles the swipe back gesture

## Testing

- Enable the Products M2 features in Settings > Experimental Features if the switch was off before
- Go to the Products tab
- Tap on a simple Product
- Go to the ellipsis menu > Product Settings
- Under "More Options" select Slug
- Edit the slug and swipe back to the main Product Settings screen --> it should go back to the Product Settings screen without the "Discard Changes" prompt
- Swipe back the Product Settings screen --> the "Discard Changes" prompt should now appear from the slug changes
- Repeat the above two steps with Purchase Note and Menu Order settings

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
