### PR TITLE
Products: the Limited Editing Available banner now it's more easy to tap

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -96,7 +96,9 @@ private extension TopBannerView {
         } else {
             updateExpandCollapseState(isExpanded: isExpanded)
             expandCollapseButton.tintColor = .textSubtle
-            expandCollapseButton.addTarget(self, action: #selector(onExpandCollapseButtonTapped), for: .touchUpInside)
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onExpandCollapseButtonTapped))
+            tapGesture.cancelsTouchesInView = false
+            contentView.addGestureRecognizer(tapGesture)
         }
     }
 


### PR DESCRIPTION
Fixes #2340 

## Description
The banner " Limited Editing Available" (now called New editing options available) on top of Product List it's not easy to expand. A user needs to tap exactly the small arrow on the right side. In this PR, now the entire banner become tappable.

## Testing
- Navigate to the product list.
- Try to open and close the top banner tapping everywhere.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
