### PR TITLE
Edit Product: extract view data logic from view controller to view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -44,7 +44,10 @@ final class ProductFormViewController: UIViewController {
     private var navigationRightBarButtonItems: Observable<[UIBarButtonItem]> {
         navigationRightBarButtonItemsSubject
     }
-    private var cancellable: ObservationToken?
+    private var cancellableProduct: ObservationToken?
+    private var cancellableProductName: ObservationToken?
+    private var cancellableUpdateEnabled: ObservationToken?
+    private var cancellableNavigationRightBarButtonItems: ObservationToken?
 
     init(product: Product,
          currency: String = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode),
@@ -84,7 +87,10 @@ final class ProductFormViewController: UIViewController {
     }
 
     deinit {
-        cancellable?.cancel()
+        cancellableProduct?.cancel()
+        cancellableProductName?.cancel()
+        cancellableUpdateEnabled?.cancel()
+        cancellableNavigationRightBarButtonItems?.cancel()
     }
 
     override func viewDidLoad() {
@@ -193,7 +199,7 @@ private extension ProductFormViewController {
     }
 
     func observeNavigationRightBarButtonItems(viewControllerWithNavigationItem: UIViewController) {
-        cancellable = navigationRightBarButtonItems.subscribe { [weak viewControllerWithNavigationItem] rightBarButtonItems in
+        cancellableNavigationRightBarButtonItems = navigationRightBarButtonItems.subscribe { [weak viewControllerWithNavigationItem] rightBarButtonItems in
             viewControllerWithNavigationItem?.navigationItem.rightBarButtonItems = rightBarButtonItems
         }
     }
@@ -218,19 +224,19 @@ private extension ProductFormViewController {
 
 private extension ProductFormViewController {
     func observeProduct() {
-        cancellable = viewModel.observableProduct.subscribe { [weak self] product in
+        cancellableProduct = viewModel.observableProduct.subscribe { [weak self] product in
             self?.onProductUpdated(product: product)
         }
     }
 
     func observeProductName() {
-        cancellable = viewModel.productName.subscribe { [weak self] name in
+        cancellableProductName = viewModel.productName.subscribe { [weak self] name in
             self?.updateNavigationBarTitle(productName: name)
         }
     }
 
     func observeUpdateCTAVisibility() {
-        cancellable = viewModel.isUpdateEnabled.subscribe { [weak self] isUpdateEnabled in
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { [weak self] isUpdateEnabled in
             self?.updateNavigationBar(isUpdateEnabled: isUpdateEnabled)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -102,6 +102,7 @@ final class ProductFormViewController: UIViewController {
         configurePresentationStyle()
 
         observeProduct()
+        observeProductName()
         observeUpdateCTAVisibility()
 
         productImageActionHandler.addUpdateObserver(self) { [weak self] (productImageStatuses, error) in
@@ -129,7 +130,7 @@ final class ProductFormViewController: UIViewController {
 private extension ProductFormViewController {
     func configureNavigationBar() {
         updateNavigationBar(isUpdateEnabled: false)
-        updateNavigationBarTitle(product: product)
+        updateNavigationBarTitle(productName: product.name)
         removeNavigationBackBarButtonText()
     }
 
@@ -218,6 +219,12 @@ private extension ProductFormViewController {
         }
     }
 
+    func observeProductName() {
+        cancellable = viewModel.productName.subscribe { [weak self] name in
+            self?.updateNavigationBarTitle(productName: name)
+        }
+    }
+
     func observeUpdateCTAVisibility() {
         cancellable = viewModel.isUpdateEnabled.subscribe { [weak self] isUpdateEnabled in
             self?.updateNavigationBar(isUpdateEnabled: isUpdateEnabled)
@@ -226,7 +233,6 @@ private extension ProductFormViewController {
 
     func onProductUpdated(product: Product) {
         updateMoreDetailsButtonVisibility()
-        updateNavigationBarTitle(product: product)
 
         tableViewModel = DefaultProductFormTableViewModel(product: product,
                                                           currency: currency,
@@ -249,8 +255,8 @@ private extension ProductFormViewController {
 // MARK: UI updates from product changes
 //
 private extension ProductFormViewController {
-    func updateNavigationBarTitle(product: Product) {
-        navigationItem.title = product.name
+    func updateNavigationBarTitle(productName: String) {
+        navigationItem.title = productName
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -116,6 +116,10 @@ final class ProductFormViewController: UIViewController {
                 self.displayErrorAlert(title: title, message: message)
             }
 
+            if productImageStatuses.hasPendingUpload {
+                self.onImageStatusesUpdated(statuses: productImageStatuses)
+            }
+
             self.viewModel.updateImages(productImageStatuses.images)
         }
     }
@@ -240,6 +244,20 @@ private extension ProductFormViewController {
                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
         tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
                                                              productImageStatuses: productImageActionHandler.productImageStatuses,
+                                                             productUIImageLoader: productUIImageLoader,
+                                                             canEditImages: isEditProductsRelease2Enabled)
+        tableViewDataSource.configureActions(onNameChange: { [weak self] name in
+            self?.onEditProductNameCompletion(newName: name ?? "")
+        }, onAddImage: { [weak self] in
+            self?.showProductImages()
+        })
+        tableView.dataSource = tableViewDataSource
+        tableView.reloadData()
+    }
+
+    func onImageStatusesUpdated(statuses: [ProductImageStatus]) {
+        tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
+                                                             productImageStatuses: statuses,
                                                              productUIImageLoader: productUIImageLoader,
                                                              canEditImages: isEditProductsRelease2Enabled)
         tableViewDataSource.configureActions(onNameChange: { [weak self] name in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -34,11 +34,11 @@ final class ProductFormViewController: UIViewController {
 
             updateMoreDetailsButtonVisibility(product: product)
 
-            viewModel = DefaultProductFormTableViewModel(product: product,
+            tableViewModel = DefaultProductFormTableViewModel(product: product,
                                                          currency: currency,
                                                          isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
                                                          isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
-            tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel,
+            tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
                                                                  productImageStatuses: productImageActionHandler.productImageStatuses,
                                                                  productUIImageLoader: productUIImageLoader,
                                                                  canEditImages: isEditProductsRelease2Enabled)
@@ -69,7 +69,7 @@ final class ProductFormViewController: UIViewController {
         return product
     }
 
-    private var viewModel: ProductFormTableViewModel
+    private var tableViewModel: ProductFormTableViewModel
     private var tableViewDataSource: ProductFormTableViewDataSource
 
     private let productImageActionHandler: ProductImageActionHandler
@@ -101,15 +101,15 @@ final class ProductFormViewController: UIViewController {
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         self.originalProduct = product
         self.product = product
-        self.viewModel = DefaultProductFormTableViewModel(product: product,
-                                                          currency: currency,
-                                                          isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                                          isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        self.tableViewModel = DefaultProductFormTableViewModel(product: product,
+                                                               currency: currency,
+                                                               isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                               isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
         self.productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
                                                                    product: product)
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
-        self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: viewModel,
+        self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
                                                                   productImageStatuses: productImageActionHandler.productImageStatuses,
                                                                   productUIImageLoader: productUIImageLoader,
                                                                   canEditImages: isEditProductsRelease2Enabled)
@@ -192,7 +192,7 @@ private extension ProductFormViewController {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
-        viewModel.sections.forEach { section in
+        tableViewModel.sections.forEach { section in
             switch section {
             case .primaryFields(let rows):
                 rows.forEach { row in
@@ -486,7 +486,7 @@ extension ProductFormViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        let section = viewModel.sections[indexPath.section]
+        let section = tableViewModel.sections[indexPath.section]
         switch section {
         case .primaryFields(let rows):
             let row = rows[indexPath.row]
@@ -520,7 +520,7 @@ extension ProductFormViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let section = viewModel.sections[section]
+        let section = tableViewModel.sections[section]
         switch section {
         case .settings:
             return Constants.settingsHeaderHeight
@@ -530,7 +530,7 @@ extension ProductFormViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let section = viewModel.sections[section]
+        let section = tableViewModel.sections[section]
         switch section {
         case .settings:
             let clearView = UIView(frame: .zero)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -222,6 +222,8 @@ private extension ProductFormViewController {
     }
 }
 
+// MARK: - Observations & responding to changes
+//
 private extension ProductFormViewController {
     func observeProduct() {
         cancellableProduct = viewModel.observableProduct.subscribe { [weak self] product in
@@ -273,14 +275,6 @@ private extension ProductFormViewController {
         })
         tableView.dataSource = tableViewDataSource
         tableView.reloadData()
-    }
-}
-
-// MARK: UI updates from product changes
-//
-private extension ProductFormViewController {
-    func updateNavigationBarTitle(productName: String) {
-        navigationItem.title = productName
     }
 }
 
@@ -474,6 +468,10 @@ private extension ProductFormViewController {
 // MARK: Navigation Bar Items
 //
 private extension ProductFormViewController {
+    func updateNavigationBarTitle(productName: String) {
+        navigationItem.title = productName
+    }
+
     func updateNavigationBar(isUpdateEnabled: Bool) {
         var rightBarButtonItems = [UIBarButtonItem]()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -64,9 +64,7 @@ final class ProductFormViewController: UIViewController {
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
         self.viewModel = ProductFormViewModel(product: product,
-                                              currency: currency,
                                               productImageActionHandler: productImageActionHandler,
-                                              productUIImageLoader: productUIImageLoader,
                                               isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
                                               isEditProductsRelease3Enabled: isEditProductsRelease2Enabled)
         self.tableViewDataSource = ProductFormTableViewDataSource(viewModel: tableViewModel,
@@ -440,7 +438,6 @@ private extension ProductFormViewController {
                 return
             }
             self.viewModel.updateProductSettings(productSettings)
-            self.viewModel.updatePassword(productSettings.password)
         }, onPasswordRetrieved: { [weak self] (originalPassword) in
             self?.viewModel.resetPassword(originalPassword)
         })

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -90,6 +90,9 @@ final class ProductFormViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // Presentation style is configured before navigation bar updates below because the subscriber for the navigation bar updates is different.
+        configurePresentationStyle()
+
         configureNavigationBar()
         configureMainView()
         configureTableView()
@@ -97,7 +100,6 @@ final class ProductFormViewController: UIViewController {
 
         startListeningToNotifications()
         handleSwipeBackGesture()
-        configurePresentationStyle()
 
         observeProduct()
         observeProductName()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -183,6 +183,7 @@ extension ProductFormViewModel {
 
     func resetPassword(_ password: String?) {
         originalPassword = password
+        isUpdateEnabledSubject.send(hasUnsavedChanges())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -22,6 +22,7 @@ final class ProductFormViewModel {
 
     private let productSubject: PublishSubject<Product> = PublishSubject<Product>()
     private let productNameSubject: PublishSubject<String> = PublishSubject<String>()
+    private let isUpdateEnabledSubject: PublishSubject<Bool>
 
     /// The product model before any potential edits; reset after a remote update.
     private var originalProduct: Product {
@@ -71,8 +72,6 @@ final class ProductFormViewModel {
     private var productUpdater: ProductUpdater {
         return product
     }
-
-    private let isUpdateEnabledSubject: PublishSubject<Bool>
 
     private let productImageActionHandler: ProductImageActionHandler
     private let isEditProductsRelease2Enabled: Bool

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -78,6 +78,8 @@ final class ProductFormViewModel {
     private let isEditProductsRelease2Enabled: Bool
     private let isEditProductsRelease3Enabled: Bool
 
+    private var cancellable: ObservationToken?
+
     init(product: Product,
          productImageActionHandler: ProductImageActionHandler,
          isEditProductsRelease2Enabled: Bool,
@@ -91,6 +93,16 @@ final class ProductFormViewModel {
                                                                               isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
                                                                               isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
         self.isUpdateEnabledSubject = PublishSubject<Bool>()
+
+        self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
+            if allStatuses.productImageStatuses.hasPendingUpload {
+                self?.isUpdateEnabledSubject.send(true)
+            }
+        }
+    }
+
+    deinit {
+        cancellable?.cancel()
     }
 
     func hasUnsavedChanges() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -1,0 +1,167 @@
+import Yosemite
+
+final class ProductFormViewModel {
+    var observableProduct: Observable<Product> {
+        productSubject
+    }
+
+    var isUpdateEnabled: Observable<Bool> {
+        isUpdateEnabledSubject
+    }
+
+    private(set) var bottomSheetActionsFactory: ProductFormBottomSheetActionsFactory
+
+    private let productSubject: PublishSubject<Product>
+
+    /// The product model before any potential edits; reset after a remote update.
+    private var originalProduct: Product
+
+    /// The product model with potential edits; reset after a remote update.
+    private(set) var product: Product {
+        didSet {
+            defer {
+                isUpdateEnabledSubject.send(hasUnsavedChanges())
+                productSubject.send(product)
+            }
+
+            if isNameTheOnlyChange(oldProduct: oldValue, newProduct: product) {
+                return
+            }
+            bottomSheetActionsFactory = ProductFormBottomSheetActionsFactory(product: product,
+                                                                             isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                             isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        }
+    }
+
+    /// The product password, fetched in Product Settings
+    private var originalPassword: String? {
+        didSet {
+            password = originalPassword
+        }
+    }
+
+    private(set) var password: String?
+
+    private var productUpdater: ProductUpdater {
+        return product
+    }
+
+    private let isUpdateEnabledSubject: PublishSubject<Bool>
+
+    private let currency: String
+    private let productImageActionHandler: ProductImageActionHandler
+    private let productUIImageLoader: ProductUIImageLoader
+    private let isEditProductsRelease2Enabled: Bool
+    private let isEditProductsRelease3Enabled: Bool
+
+    init(product: Product,
+         currency: String,
+         productImageActionHandler: ProductImageActionHandler,
+         productUIImageLoader: ProductUIImageLoader,
+         isEditProductsRelease2Enabled: Bool,
+         isEditProductsRelease3Enabled: Bool) {
+        self.currency = currency
+        self.productImageActionHandler = productImageActionHandler
+        self.productUIImageLoader = productUIImageLoader
+        self.isEditProductsRelease2Enabled = isEditProductsRelease2Enabled
+        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+        self.originalProduct = product
+        self.product = product
+        self.productSubject = PublishSubject<Product>()
+        self.bottomSheetActionsFactory = ProductFormBottomSheetActionsFactory(product: product,
+                                                                              isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        self.isUpdateEnabledSubject = PublishSubject<Bool>()
+    }
+
+    func hasUnsavedChanges() -> Bool {
+        return product != originalProduct || productImageActionHandler.productImageStatuses.hasPendingUpload || password != originalPassword
+    }
+
+    func hasProductChanged() -> Bool {
+        return product != originalProduct
+    }
+
+    func hasPasswordChanged() -> Bool {
+        return password != nil && password != originalPassword
+    }
+}
+
+// MARK: Action handling
+//
+extension ProductFormViewModel {
+    func updateName(_ name: String) {
+        product = productUpdater.nameUpdated(name: name)
+    }
+
+    func updatePassword(_ password: String?) {
+        originalPassword = password
+        isUpdateEnabledSubject.send(hasUnsavedChanges())
+    }
+
+    func updateImages(_ images: [ProductImage]) {
+        product = productUpdater.imagesUpdated(images: images)
+    }
+
+    func updateDescription(_ newDescription: String) {
+        product = productUpdater.descriptionUpdated(description: newDescription)
+    }
+
+    func updatePriceSettings(regularPrice: String?,
+                             salePrice: String?,
+                             dateOnSaleStart: Date?,
+                             dateOnSaleEnd: Date?,
+                             taxStatus: ProductTaxStatus,
+                             taxClass: TaxClass?) {
+        product = productUpdater.priceSettingsUpdated(regularPrice: regularPrice,
+                                                      salePrice: salePrice,
+                                                      dateOnSaleStart: dateOnSaleStart,
+                                                      dateOnSaleEnd: dateOnSaleEnd,
+                                                      taxStatus: taxStatus,
+                                                      taxClass: taxClass)
+    }
+
+    func updateInventorySettings(sku: String?,
+                                 manageStock: Bool,
+                                 soldIndividually: Bool,
+                                 stockQuantity: Int?,
+                                 backordersSetting: ProductBackordersSetting?,
+                                 stockStatus: ProductStockStatus?) {
+        product = productUpdater.inventorySettingsUpdated(sku: sku,
+                                                          manageStock: manageStock,
+                                                          soldIndividually: soldIndividually,
+                                                          stockQuantity: stockQuantity,
+                                                          backordersSetting: backordersSetting,
+                                                          stockStatus: stockStatus)
+    }
+
+    func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: ProductShippingClass?) {
+        product = productUpdater.shippingSettingsUpdated(weight: weight, dimensions: dimensions, shippingClass: shippingClass)
+    }
+
+    func updateBriefDescription(_ briefDescription: String) {
+        product = productUpdater.briefDescriptionUpdated(briefDescription: briefDescription)
+    }
+
+    func updateProductSettings(_ settings: ProductSettings) {
+        product = productUpdater.productSettingsUpdated(settings: settings)
+    }
+}
+
+extension ProductFormViewModel {
+    func resetProduct(_ product: Product) {
+        originalProduct = product
+        self.product = product
+    }
+
+    func resetPassword(_ password: String?) {
+        originalPassword = password
+    }
+}
+
+private extension ProductFormViewModel {
+    func isNameTheOnlyChange(oldProduct: Product, newProduct: Product) -> Bool {
+        let oldProductWithNewName = oldProduct.nameUpdated(name: newProduct.name)
+        return oldProductWithNewName == newProduct && newProduct.name != oldProduct.name
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
 		0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */; };
+		0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */; };
 		02279586237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */; };
 		02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02279584237A50C900787C63 /* AztecHeaderFormatBarCommand.swift */; };
 		0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0227958C237A51F300787C63 /* OptionsTableViewController+Styles.swift */; };
@@ -926,6 +927,7 @@
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
 		0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelProductListFilterTests.swift; sourceTree = "<group>"; };
+		0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModel.swift; sourceTree = "<group>"; };
 		02279583237A50C900787C63 /* AztecUnorderedListFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecUnorderedListFormatBarCommand.swift; sourceTree = "<group>"; };
 		02279584237A50C900787C63 /* AztecHeaderFormatBarCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecHeaderFormatBarCommand.swift; sourceTree = "<group>"; };
 		0227958C237A51F300787C63 /* OptionsTableViewController+Styles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OptionsTableViewController+Styles.swift"; sourceTree = "<group>"; };
@@ -1801,6 +1803,7 @@
 				025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */,
 				025B1749237AA49D00C780B4 /* Product+ProductForm.swift */,
 				4580BA7123F192A300B5F764 /* Product Settings */,
+				0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -4713,6 +4716,7 @@
 				B57C5C9221B80E3C00FF82B2 /* APNSDevice+Woo.swift in Sources */,
 				02A652FF246A908D00755A01 /* BottomSheetListSelectorPresenter.swift in Sources */,
 				D8CD710F237A49DB007148B9 /* UIColor+SemanticColors.swift in Sources */,
+				0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */,
 				020F41E523163C0100776C4D /* TopBannerViewModel.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -134,6 +134,8 @@
 		0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */; };
 		0259EF77246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259EF76246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift */; };
 		0259EF79246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259EF78246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift */; };
+		025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A1245247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift */; };
+		025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */; };
 		025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */; };
 		025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1749237AA49D00C780B4 /* Product+ProductForm.swift */; };
 		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
@@ -987,6 +989,8 @@
 		0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsV4ChartAxisHelperTests.swift; sourceTree = "<group>"; };
 		0259EF76246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsFactoryTests.swift; sourceTree = "<group>"; };
 		0259EF78246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductsAppSettingsStoresManager.swift; sourceTree = "<group>"; };
+		025A1245247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+ChangesTests.swift"; sourceTree = "<group>"; };
+		025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+ObservablesTests.swift"; sourceTree = "<group>"; };
 		025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormSection+ReusableTableRow.swift"; sourceTree = "<group>"; };
 		025B1749237AA49D00C780B4 /* Product+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductForm.swift"; sourceTree = "<group>"; };
 		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
@@ -1754,6 +1758,8 @@
 				453770CF2431FEC400AC718D /* Settings */,
 				02BA128A24616B48008D8325 /* ProductFormSectionSettingsRow+VisibilityTests.swift */,
 				02BA128C2461711D008D8325 /* ProductFormBottomSheetAction+VisibilityTests.swift */,
+				025A1245247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift */,
+				025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -5092,6 +5098,7 @@
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */,
+				025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */,
 				453770D12431FF4700AC718D /* ProductSettingsViewModelTests.swift in Sources */,
 				020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */,
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,
@@ -5124,6 +5131,7 @@
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
+				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
 				6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */,
 			);

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -23,8 +23,18 @@ final class ProductFormViewModelTests_Changes: XCTestCase {
         viewModel.updateDescription(product.fullDescription ?? "")
         viewModel.updateBriefDescription(product.briefDescription ?? "")
         viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
-        viewModel.updatePriceSettings(regularPrice: product.regularPrice, salePrice: product.salePrice, dateOnSaleStart: product.dateOnSaleStart, dateOnSaleEnd: product.dateOnSaleEnd, taxStatus: product.productTaxStatus, taxClass: taxClass)
-        viewModel.updateInventorySettings(sku: product.sku, manageStock: product.manageStock, soldIndividually: product.soldIndividually, stockQuantity: product.stockQuantity, backordersSetting: product.backordersSetting, stockStatus: product.productStockStatus)
+        viewModel.updatePriceSettings(regularPrice: product.regularPrice,
+                                      salePrice: product.salePrice,
+                                      dateOnSaleStart: product.dateOnSaleStart,
+                                      dateOnSaleEnd: product.dateOnSaleEnd,
+                                      taxStatus: product.productTaxStatus,
+                                      taxClass: taxClass)
+        viewModel.updateInventorySettings(sku: product.sku,
+                                          manageStock: product.manageStock,
+                                          soldIndividually: product.soldIndividually,
+                                          stockQuantity: product.stockQuantity,
+                                          backordersSetting: product.backordersSetting,
+                                          stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -1,0 +1,211 @@
+import Photos
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+/// MARK: tests for unsaved changes (`hasUnsavedChanges`, `hasProductChanged`, `hasPasswordChanged`)
+final class ProductFormViewModelTests_Changes: XCTestCase {
+    private let defaultSiteID: Int64 = 134
+
+    func testProductHasNoChangesFromEditActionsOfTheSameData() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+        let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
+
+        // Action
+        viewModel.updateName(product.name)
+        viewModel.updateDescription(product.fullDescription ?? "")
+        viewModel.updateBriefDescription(product.briefDescription ?? "")
+        viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
+        viewModel.updatePriceSettings(regularPrice: product.regularPrice, salePrice: product.salePrice, dateOnSaleStart: product.dateOnSaleStart, dateOnSaleEnd: product.dateOnSaleEnd, taxStatus: product.productTaxStatus, taxClass: taxClass)
+        viewModel.updateInventorySettings(sku: product.sku, manageStock: product.manageStock, soldIndividually: product.soldIndividually, stockQuantity: product.stockQuantity, backordersSetting: product.backordersSetting, stockStatus: product.productStockStatus)
+        viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
+
+        // Assert
+        XCTAssertFalse(viewModel.hasUnsavedChanges())
+        XCTAssertFalse(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingProductName() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        viewModel.updateName("this new product name")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingPassword() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        let settings = ProductSettings(from: product, password: "secret secret")
+        viewModel.updateProductSettings(settings)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertFalse(viewModel.hasProductChanged())
+        XCTAssertTrue(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromUploadingAnImage() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+        let expectation = self.expectation(description: "Wait for image upload")
+        productImageActionHandler.addUpdateObserver(self) { statuses in
+            if statuses.productImageStatuses.isNotEmpty {
+                expectation.fulfill()
+            }
+        }
+
+        // Action
+        productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+
+        // Assert
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertFalse(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingImages() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        let productImage = ProductImage(imageID: 6,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: "",
+                                        name: "woo",
+                                        alt: nil)
+        viewModel.updateImages([productImage])
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingProductDescription() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        viewModel.updateDescription("Another way to describe the product?")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingProductBriefDescription() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        viewModel.updateBriefDescription("A short one")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingPriceSettings() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        viewModel.updatePriceSettings(regularPrice: "999999", salePrice: "888888", dateOnSaleStart: nil, dateOnSaleEnd: nil, taxStatus: .none, taxClass: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingInventorySettings() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        viewModel.updateInventorySettings(sku: "", manageStock: false, soldIndividually: true, stockQuantity: 888888, backordersSetting: nil, stockStatus: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingShippingSettings() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        viewModel.updateShippingSettings(weight: "88888", dimensions: product.dimensions, shippingClass: product.productShippingClass)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -5,7 +5,7 @@ import XCTest
 import Yosemite
 
 /// Unit tests for unsaved changes (`hasUnsavedChanges`, `hasProductChanged`, `hasPasswordChanged`)
-final class ProductFormViewModelTests_Changes: XCTestCase {
+final class ProductFormViewModel_ChangesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
 
     func testProductHasNoChangesFromEditActionsOfTheSameData() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 
-/// MARK: tests for unsaved changes (`hasUnsavedChanges`, `hasProductChanged`, `hasPasswordChanged`)
+/// Unit tests for unsaved changes (`hasUnsavedChanges`, `hasProductChanged`, `hasPasswordChanged`)
 final class ProductFormViewModelTests_Changes: XCTestCase {
     private let defaultSiteID: Int64 = 134
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 
-/// MARK: tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
+/// Unit tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
 final class ProductFormViewModel_ObservablesTests: XCTestCase {
     private let defaultSiteID: Int64 = 134
     private var cancellableProduct: ObservationToken?

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -48,8 +48,18 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.updateDescription(product.fullDescription ?? "")
         viewModel.updateBriefDescription(product.briefDescription ?? "")
         viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
-        viewModel.updatePriceSettings(regularPrice: product.regularPrice, salePrice: product.salePrice, dateOnSaleStart: product.dateOnSaleStart, dateOnSaleEnd: product.dateOnSaleEnd, taxStatus: product.productTaxStatus, taxClass: taxClass)
-        viewModel.updateInventorySettings(sku: product.sku, manageStock: product.manageStock, soldIndividually: product.soldIndividually, stockQuantity: product.stockQuantity, backordersSetting: product.backordersSetting, stockStatus: product.productStockStatus)
+        viewModel.updatePriceSettings(regularPrice: product.regularPrice,
+                                      salePrice: product.salePrice,
+                                      dateOnSaleStart: product.dateOnSaleStart,
+                                      dateOnSaleEnd: product.dateOnSaleEnd,
+                                      taxStatus: product.productTaxStatus,
+                                      taxClass: taxClass)
+        viewModel.updateInventorySettings(sku: product.sku,
+                                          manageStock: product.manageStock,
+                                          soldIndividually: product.soldIndividually,
+                                          stockQuantity: product.stockQuantity,
+                                          backordersSetting: product.backordersSetting,
+                                          stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+/// MARK: tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
+final class ProductFormViewModel_ObservablesTests: XCTestCase {
+    private let defaultSiteID: Int64 = 134
+    private var cancellableProduct: ObservationToken?
+    private var cancellableProductName: ObservationToken?
+    private var cancellableUpdateEnabled: ObservationToken?
+
+    override func tearDown() {
+        [cancellableProduct, cancellableProductName, cancellableUpdateEnabled].forEach { cancellable in
+            cancellable?.cancel()
+        }
+        cancellableProduct = nil
+        cancellableProductName = nil
+        cancellableUpdateEnabled = nil
+
+        super.tearDown()
+    }
+
+    func testObservablesFromEditActionsOfTheSameData() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+        let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
+        cancellableProduct = viewModel.observableProduct.subscribe { _ in
+            // Assert
+            XCTFail("Should not be triggered from edit actions of the same data")
+        }
+        cancellableProductName = viewModel.productName.subscribe { _ in
+            // Assert
+            XCTFail("Should not be triggered from edit actions of the same data")
+        }
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { _ in
+            // Assert
+            XCTFail("Should not be triggered from edit actions of the same data")
+        }
+
+        // Action
+        viewModel.updateName(product.name)
+        viewModel.updateDescription(product.fullDescription ?? "")
+        viewModel.updateBriefDescription(product.briefDescription ?? "")
+        viewModel.updateProductSettings(ProductSettings(from: product, password: nil))
+        viewModel.updatePriceSettings(regularPrice: product.regularPrice, salePrice: product.salePrice, dateOnSaleStart: product.dateOnSaleStart, dateOnSaleEnd: product.dateOnSaleEnd, taxStatus: product.productTaxStatus, taxClass: taxClass)
+        viewModel.updateInventorySettings(sku: product.sku, manageStock: product.manageStock, soldIndividually: product.soldIndividually, stockQuantity: product.stockQuantity, backordersSetting: product.backordersSetting, stockStatus: product.productStockStatus)
+        viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
+    }
+
+    /// When only product name is updated, the product name observable should be triggered but no the product observable.
+    func testObservablesFromEditingProductName() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+        var isProductUpdated: Bool?
+        cancellableProduct = viewModel.observableProduct.subscribe { product in
+            isProductUpdated = true
+        }
+
+        var updatedProductName: String?
+        let expectationForProductName = self.expectation(description: "Product name updates")
+        expectationForProductName.expectedFulfillmentCount = 1
+        cancellableProductName = viewModel.productName.subscribe { productName in
+            updatedProductName = productName
+            expectationForProductName.fulfill()
+        }
+
+        var updatedUpdateEnabled: Bool?
+        let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
+        expectationForUpdateEnabled.expectedFulfillmentCount = 1
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+            updatedUpdateEnabled = isUpdateEnabled
+            expectationForUpdateEnabled.fulfill()
+        }
+
+        // Action
+        let newProductName = "this new product name"
+        viewModel.updateName(newProductName)
+
+        // Assert
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        XCTAssertNil(isProductUpdated)
+        XCTAssertEqual(updatedProductName, newProductName)
+        XCTAssertEqual(updatedUpdateEnabled, true)
+    }
+
+    /// When only product password is updated, only the update enabled boolean should be triggered.
+    func testObservablesFromEditingProductPassword() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+        var isProductUpdated: Bool?
+        cancellableProduct = viewModel.observableProduct.subscribe { product in
+            isProductUpdated = true
+        }
+
+        var updatedProductName: String?
+        cancellableProductName = viewModel.productName.subscribe { productName in
+            updatedProductName = productName
+        }
+
+        var updatedUpdateEnabled: Bool?
+        let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
+        expectationForUpdateEnabled.expectedFulfillmentCount = 1
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+            updatedUpdateEnabled = isUpdateEnabled
+            expectationForUpdateEnabled.fulfill()
+        }
+
+        // Action
+        let settings = ProductSettings(from: product, password: "secret secret")
+        viewModel.updateProductSettings(settings)
+
+        // Assert
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        XCTAssertNil(isProductUpdated)
+        XCTAssertNil(updatedProductName)
+        XCTAssertEqual(updatedUpdateEnabled, true)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -1,3 +1,4 @@
+import Photos
 import XCTest
 
 @testable import WooCommerce
@@ -134,6 +135,42 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         // Action
         let settings = ProductSettings(from: product, password: "secret secret")
         viewModel.updateProductSettings(settings)
+
+        // Assert
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        XCTAssertNil(isProductUpdated)
+        XCTAssertNil(updatedProductName)
+        XCTAssertEqual(updatedUpdateEnabled, true)
+    }
+
+    func testObservablesFromUploadingAnImage() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+        var isProductUpdated: Bool?
+        cancellableProduct = viewModel.observableProduct.subscribe { product in
+            isProductUpdated = true
+        }
+
+        var updatedProductName: String?
+        cancellableProductName = viewModel.productName.subscribe { productName in
+            updatedProductName = productName
+        }
+
+        var updatedUpdateEnabled: Bool?
+        let expectationForUpdateEnabled = self.expectation(description: "Update enabled updates")
+        expectationForUpdateEnabled.expectedFulfillmentCount = 1
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+            updatedUpdateEnabled = isUpdateEnabled
+            expectationForUpdateEnabled.fulfill()
+        }
+
+        // Action
+        productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
 
         // Assert
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)

--- a/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
+++ b/Yosemite/Yosemite/Model/Updaters/ProductUpdater.swift
@@ -190,7 +190,7 @@ extension Product: ProductUpdater {
                        dimensions: dimensions,
                        shippingRequired: shippingRequired,
                        shippingTaxable: shippingTaxable,
-                       shippingClass: shippingClass?.slug,
+                       shippingClass: shippingClass?.slug ?? "",
                        shippingClassID: shippingClass?.shippingClassID ?? 0,
                        productShippingClass: shippingClass,
                        reviewsAllowed: reviewsAllowed,


### PR DESCRIPTION
Fixes #1985

Apology for the bigger PR than I expected! ~340 diffs are on the unit tests that have some boilerplates. `ProductFormViewController` didn't get significantly shorter from this PR (there are a bunch of unsaved changes logic that we can extract from the VC to a different class separately), but now the product/password states can be tested. Please feel free to suggest anything!

## Changes

As we add more functionalities to Edit Products, the states in `ProductFormViewController` have got complicated (e.g. the two `password` properties that it manages from product settings). This PR extracted the editable data from `ProductFormViewController` to 
a new class `ProductFormViewModel` that provides UI data for `ProductFormViewController`.

- In `ProductFormViewController`, moved `originalProduct`, `originalPassword`, and `productUpdater` to `ProductFormViewModel`. `product` and `password` are now just getting from `ProductFormViewModel` 
- `ProductFormViewModel` now has 3 observables: `observableProduct: Observable<Product>` (let me know if renaming to `product` would be better; right now the private `product` property is used to keep the latest product with potential edits), `productName: Observable<String>`, and `isUpdateEnabled: Observable<Bool>`. `ProductFormViewController` subscribes to changes on these 3 observables, and updates the corresponding UI.
- `ProductFormViewModel` has functions for edit actions, and `ProductFormViewController` calls these edit functions when it's ready to update the product
- Added unit tests for unsaved changes functions and observables in `ProductFormViewModel`

## Testing

No behavior changes are expected from this PR, please watch out for regression! Some areas that we can sanity check:

### Edit Product name
- Go to the Products tab
- Tap on a simple product --> the product name should be shown in the navigation bar
- Edit the product name --> the navigation bar title should change as you type that matches the product name text field, and "Update" CTA is visible only when the new product name is different
- Tap "Update" to save the new product name --> the product name should be saved remotely

### Edit Product images
- Go to the Products tab
- Tap on a simple product --> the product name should be shown in the navigation bar
- Tap on the "+" cell in the images header
- Tap "Add Photos"
- Choose a photo or take one with camera --> the photo with a spinner is shown on the product form, and the "Update" CTA should be visible
- Tap "Update" to save the new product image --> the product images should be saved remotely

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
