### PR TITLE
Order Detail: fixed Order Status Cell wrong cell appearance

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] The product name is now shown in the product details navigation bar so that the name is always visible.
 - [*] The images pending upload should be visible after editing product images from product details.
 - [*] The discard changes prompt does not appear when navigating from product settings detail screens with a text field (slug, purchase note, and menu order) anymore.
+- [*] Fix the wrong cell appearance in the order status list.
 
 
 4.3

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -233,6 +233,7 @@ extension OrderStatusListViewController: UITableViewDataSource {
 
         let status = statusResultsController.object(at: indexPath)
         cell.textLabel?.text = status.name
+        cell.selectionStyle = .none
 
         return cell
     }


### PR DESCRIPTION
Fixes #2256 

## Description
Navigating to an Order Detail -> Order Status, and selecting the last cell, the end separator is not shown, so it seems that the cell it's part of the background.
The fix suggested by @Garance91540, is to not change the background color of the cell when it's selected, like in other sections of the app.

## Testing
- Navigate to an order detail
- Go to the order status screen
- Select one of the cells
- Make sure the background is still white.

## Screenshots
| Before           |  After |  After (Dark) |
:-------------------------:|:-------------------------:|:-------------------------:
![81335878-9a8c1a80-90a8-11ea-9b8b-269a8f9bcfce](https://user-images.githubusercontent.com/495617/82889148-9a19cd80-9f4a-11ea-88d6-689dc0e1b5ad.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-26 at 12 10 25](https://user-images.githubusercontent.com/495617/82889153-9be39100-9f4a-11ea-80a8-f33937305705.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-05-26 at 12 18 07](https://user-images.githubusercontent.com/495617/82889414-fe3c9180-9f4a-11ea-9afb-942e0b9f9c4d.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
