### PR TITLE
Products: the "View product in store" action will be shown only if the product is published

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] The product name is now shown in the product details navigation bar so that the name is always visible.
 - [*] The images pending upload should be visible after editing product images from product details.
 - [*] The discard changes prompt does not appear when navigating from product settings detail screens with a text field (slug, purchase note, and menu order) anymore.
+- [*] The "View product in store" action will be shown only if the product is published.
 
 
 4.3

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -813,9 +813,12 @@ private extension ProductFormViewController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.view.tintColor = .text
 
-        actionSheet.addDefaultActionWithTitle(ActionSheetStrings.viewProduct) { [weak self] _ in
-            ServiceLocator.analytics.track(.productDetailViewProductButtonTapped)
-            self?.displayWebViewForProductInStore()
+        /// The "View product in store" action will be shown only if the product is published.
+        if originalProduct.productStatus == .publish {
+            actionSheet.addDefaultActionWithTitle(ActionSheetStrings.viewProduct) { [weak self] _ in
+                ServiceLocator.analytics.track(.productDetailViewProductButtonTapped)
+                self?.displayWebViewForProductInStore()
+            }
         }
 
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.share) { [weak self] _ in


### PR DESCRIPTION
Fixes #2332 

## Description
When I edit a draft product on my store, I have the option "View product in store" but it leads to a 404 error. (This also happens with any product that isn't publicly published, e.g. pending review and private products.)
From now, the "View product in Store" action will be shown only if the product is published.

## Testing
1. Enable Product editing under Settings > Experimental features.
2. Go to the Products tab.
3. Select a draft product to edit it. (If you don't have a draft product, select a product and go to the ellipsis menu > Product settings and change the Status to Draft. Update the product to save the draft status.)
4. Go to the ellipsis menu > "View product in store" action should NOT be visible.
5. Repeat the steps with a published product > "View product in store" action should be visible.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
