### PR TITLE
Fixed "pull request template" spaces

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 
-Update release notes:
 
+
+Update release notes:
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


### PR DESCRIPTION
This PR fixes some wrong spaces in the default Pull request template, adding extra space above, and removing the space between `Update release notes:` and the next line. Usually I make these changes in every PR, and having them by default would be ideal.

## Before:
```

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary
```

## After:
```


Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary
```