### PR TITLE
Dashboard: removed bottom separator from last Top Performer product

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UITableView {
+
+    /// Return the last Index Path (the last row of the last section)
+    func lastIndexPath() -> IndexPath {
+        let section = max(numberOfSections - 1, 0)
+        let row = max(numberOfRows(inSection: section) - 1, 0)
+        return IndexPath(row: row, section: section)
+    }
+}

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -8,12 +8,12 @@ extension UITableView {
             return nil
         }
         let section = numberOfSections - 1
-        
+
         guard numberOfRows(inSection: section) > 0 else {
             return nil
         }
         let row = numberOfRows(inSection: section) - 1
-        
+
         return IndexPath(row: row, section: section)
     }
 }

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -2,10 +2,18 @@ import UIKit
 
 extension UITableView {
 
-    /// Return the last Index Path (the last row of the last section)
-    func lastIndexPath() -> IndexPath {
+    /// Return the last Index Path (the last row of the last section) if available
+    func lastIndexPath() -> IndexPath? {
+        guard numberOfSections > 0 else {
+            return nil
+        }
         let section = max(numberOfSections - 1, 0)
+        
+        guard numberOfRows(inSection: section) > 0 else {
+            return nil
+        }
         let row = max(numberOfRows(inSection: section) - 1, 0)
+        
         return IndexPath(row: row, section: section)
     }
 }

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -3,7 +3,7 @@ import UIKit
 extension UITableView {
 
     /// Return the last Index Path (the last row of the last section) if available
-    func lastIndexPath() -> IndexPath? {
+    func lastIndexPathOfTheLastSection() -> IndexPath? {
         guard numberOfSections > 0 else {
             return nil
         }

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -7,12 +7,12 @@ extension UITableView {
         guard numberOfSections > 0 else {
             return nil
         }
-        let section = max(numberOfSections - 1, 0)
+        let section = numberOfSections - 1
         
         guard numberOfRows(inSection: section) > 0 else {
             return nil
         }
-        let row = max(numberOfRows(inSection: section) - 1, 0)
+        let row = numberOfRows(inSection: section) - 1
         
         return IndexPath(row: row, section: section)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -41,6 +41,12 @@ class ProductTableViewCell: UITableViewCell {
             priceLabel.text = newValue
         }
     }
+    
+    var hideBottomBorder: Bool = false {
+        didSet {
+            bottomBorderView.isHidden = hideBottomBorder
+        }
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -41,7 +41,7 @@ class ProductTableViewCell: UITableViewCell {
             priceLabel.text = newValue
         }
     }
-    
+
     var hideBottomBorder: Bool = false {
         didSet {
             bottomBorderView.isHidden = hideBottomBorder

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -42,9 +42,9 @@ class ProductTableViewCell: UITableViewCell {
         }
     }
 
-    var hideBottomBorder: Bool = false {
+    var hidesBottomBorder: Bool = false {
         didSet {
-            bottomBorderView.isHidden = hideBottomBorder
+            bottomBorderView.isHidden = hidesBottomBorder
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -244,7 +244,7 @@ extension TopPerformerDataViewController: UITableViewDataSource {
         }
 
         cell.configure(statsItem, imageService: imageService)
-        cell.hideBottomBorder = tableView.lastIndexPath() == indexPath ? true : false
+        cell.hidesBottomBorder = tableView.lastIndexPath() == indexPath ? true : false
         return cell
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -244,6 +244,7 @@ extension TopPerformerDataViewController: UITableViewDataSource {
         }
 
         cell.configure(statsItem, imageService: imageService)
+        cell.hideBottomBorder = tableView.lastIndexPath() == indexPath ? true : false
         return cell
     }
 }
@@ -266,11 +267,6 @@ extension TopPerformerDataViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
-    }
-
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        // iOS 11 table bug. Must return a tiny value to collapse `nil` or `empty` section headers.
-        return .leastNonzeroMagnitude
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -244,7 +244,7 @@ extension TopPerformerDataViewController: UITableViewDataSource {
         }
 
         cell.configure(statsItem, imageService: imageService)
-        cell.hidesBottomBorder = tableView.lastIndexPath() == indexPath ? true : false
+        cell.hidesBottomBorder = tableView.lastIndexPathOfTheLastSection() == indexPath ? true : false
         return cell
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
 		455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */; };
+		456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F3247D5434001203F6 /* UITableView+Helpers.swift */; };
 		456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */; };
 		456CB50E2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */; };
 		457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */; };
@@ -1146,6 +1147,7 @@
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibilityTests.swift; sourceTree = "<group>"; };
+		456417F3247D5434001203F6 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaseNoteViewController.swift; sourceTree = "<group>"; };
 		456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductPurchaseNoteViewController.xib; sourceTree = "<group>"; };
 		457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSlugViewController.swift; sourceTree = "<group>"; };
@@ -3473,6 +3475,7 @@
 				D8149F552251EE300006A245 /* UITextField+Helpers.swift */,
 				D82DFB49225F22D400EFE2CB /* UISearchBar+Appearance.swift */,
 				02820F3322C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift */,
+				456417F3247D5434001203F6 /* UITableView+Helpers.swift */,
 				02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */,
 				02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */,
 				020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */,
@@ -4608,6 +4611,7 @@
 				024DF31623742BB6006658FE /* AztecStrikethroughFormatBarCommand.swift in Sources */,
 				02817B39242B34560050AD8B /* ToolbarView.swift in Sources */,
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
+				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
 				0282DD94233C9465006A5FDB /* SearchUICommand.swift in Sources */,
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,
 				024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
 		455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */; };
 		456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F3247D5434001203F6 /* UITableView+Helpers.swift */; };
+		456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */; };
 		456CB50D2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */; };
 		456CB50E2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */; };
 		457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */; };
@@ -1148,6 +1149,7 @@
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibilityTests.swift; sourceTree = "<group>"; };
 		456417F3247D5434001203F6 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
+		456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HelpersTests.swift"; sourceTree = "<group>"; };
 		456CB50B2444BFAC00992A05 /* ProductPurchaseNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaseNoteViewController.swift; sourceTree = "<group>"; };
 		456CB50C2444BFAC00992A05 /* ProductPurchaseNoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductPurchaseNoteViewController.xib; sourceTree = "<group>"; };
 		457151A9243B6E8000EB2DFA /* ProductSlugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSlugViewController.swift; sourceTree = "<group>"; };
@@ -3036,6 +3038,7 @@
 				B55BC1F221A8790F0011A0C0 /* StringHTMLTests.swift */,
 				B5980A6421AC905C00EBF596 /* UIDeviceWooTests.swift */,
 				B57C745020F56EE900EEFC87 /* UITableViewCellHelpersTests.swift */,
+				456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */,
 				021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */,
 				F997174623DC070C00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift */,
 				0215320C2423309B003F2BBD /* UIStackView+SubviewsTests.swift */,
@@ -5010,6 +5013,7 @@
 				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,
 				B53A569D21123EEB000776C9 /* MockupStorage.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
+				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
@@ -17,23 +17,24 @@ final class UITableView_HelpersTests: XCTestCase {
         tableView.reloadData()
     }
     
-    func testReturnLastIndexPathWorksLikeExpected() {
+    func testLastIndexPathWorksLikeExpected() {
         let lastIndexPath = tableView.lastIndexPath()
         XCTAssertEqual(lastIndexPath, IndexPath(row: 7, section: 1))
     }
     
-    func testReturnLastIndexPathWithNoSectionsAndRows() {
+    func testLastIndexPathWithNoSectionsAndRowsReturnNil() {
         let lastIndexPath = emptyTableView.lastIndexPath()
         XCTAssertNil(lastIndexPath)
     }
     
-    func testReturnLastIndexPathWithNoRows() {
+    func testLastIndexPathWithOnlyNoRowsReturnNil() {
         let lastIndexPath = tableViewWithoutRows.lastIndexPath()
         XCTAssertNil(lastIndexPath)
     }
 
     
 }
+
 
 extension UITableView_HelpersTests: UITableViewDataSource {
 

--- a/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
@@ -16,6 +16,8 @@ final class UITableView_HelpersTests: XCTestCase {
         emptyTableView.dataSource = self
         tableViewWithoutRows.dataSource = self
         tableView.reloadData()
+        emptyTableView.reloadData()
+        tableViewWithoutRows.reloadData()
     }
 
     func testLastIndexPathWorksLikeExpected() {

--- a/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
@@ -21,17 +21,17 @@ final class UITableView_HelpersTests: XCTestCase {
     }
 
     func testLastIndexPathWorksLikeExpected() {
-        let lastIndexPath = tableView.lastIndexPath()
+        let lastIndexPath = tableView.lastIndexPathOfTheLastSection()
         XCTAssertEqual(lastIndexPath, IndexPath(row: 7, section: 1))
     }
 
     func testLastIndexPathWithNoSectionsAndRowsReturnNil() {
-        let lastIndexPath = emptyTableView.lastIndexPath()
+        let lastIndexPath = emptyTableView.lastIndexPathOfTheLastSection()
         XCTAssertNil(lastIndexPath)
     }
 
     func testLastIndexPathWithOnlyNoRowsReturnNil() {
-        let lastIndexPath = tableViewWithoutRows.lastIndexPath()
+        let lastIndexPath = tableViewWithoutRows.lastIndexPathOfTheLastSection()
         XCTAssertNil(lastIndexPath)
     }
 }

--- a/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WooCommerce
+
+// UITableViewCell+Helpers: Unit Tests
+//
+final class UITableView_HelpersTests: XCTestCase {
+
+    let tableView = UITableView()
+    let emptyTableView = UITableView()
+    let tableViewWithoutRows = UITableView()
+    
+    override func setUp() {
+        super.setUp()
+        tableView.dataSource = self
+        emptyTableView.dataSource = self
+        tableViewWithoutRows.dataSource = self
+        tableView.reloadData()
+    }
+    
+    func testReturnLastIndexPathWorksLikeExpected() {
+        let lastIndexPath = tableView.lastIndexPath()
+        XCTAssertEqual(lastIndexPath, IndexPath(row: 7, section: 1))
+    }
+    
+    func testReturnLastIndexPathWithNoSectionsAndRows() {
+        let lastIndexPath = emptyTableView.lastIndexPath()
+        XCTAssertNil(lastIndexPath)
+    }
+    
+    func testReturnLastIndexPathWithNoRows() {
+        let lastIndexPath = tableViewWithoutRows.lastIndexPath()
+        XCTAssertNil(lastIndexPath)
+    }
+
+    
+}
+
+extension UITableView_HelpersTests: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        switch tableView {
+        case self.tableView:
+            return 2
+        case tableViewWithoutRows:
+            return 1
+        default:
+            return 0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch tableView {
+        case self.tableView:
+            return 8
+        default:
+            return 0
+        }
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
@@ -1,7 +1,8 @@
 import XCTest
 @testable import WooCommerce
 
-// UITableViewCell+Helpers: Unit Tests
+
+// UITableView+Helpers: Unit Tests
 //
 final class UITableView_HelpersTests: XCTestCase {
 
@@ -31,7 +32,6 @@ final class UITableView_HelpersTests: XCTestCase {
         let lastIndexPath = tableViewWithoutRows.lastIndexPath()
         XCTAssertNil(lastIndexPath)
     }
-
 }
 
 

--- a/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/UITableView+HelpersTests.swift
@@ -8,7 +8,7 @@ final class UITableView_HelpersTests: XCTestCase {
     let tableView = UITableView()
     let emptyTableView = UITableView()
     let tableViewWithoutRows = UITableView()
-    
+
     override func setUp() {
         super.setUp()
         tableView.dataSource = self
@@ -16,23 +16,22 @@ final class UITableView_HelpersTests: XCTestCase {
         tableViewWithoutRows.dataSource = self
         tableView.reloadData()
     }
-    
+
     func testLastIndexPathWorksLikeExpected() {
         let lastIndexPath = tableView.lastIndexPath()
         XCTAssertEqual(lastIndexPath, IndexPath(row: 7, section: 1))
     }
-    
+
     func testLastIndexPathWithNoSectionsAndRowsReturnNil() {
         let lastIndexPath = emptyTableView.lastIndexPath()
         XCTAssertNil(lastIndexPath)
     }
-    
+
     func testLastIndexPathWithOnlyNoRowsReturnNil() {
         let lastIndexPath = tableViewWithoutRows.lastIndexPath()
         XCTAssertNil(lastIndexPath)
     }
 
-    
 }
 
 


### PR DESCRIPTION
Fixes #2290

## Description
In the top performer section of the My Store tab, the bottom separator of the last top performer product overlaps with the bottom separator of the top performer box.
In this PR I removed the separator, some unused code, and I implemented a method in a new extension of `UITableView` to get the last `IndexPath` (+ tests).


## Screenshots
(zoom the images to see the difference)
| Before             |  After |
:-------------------------:|:-------------------------:
![separator at the end](https://user-images.githubusercontent.com/495617/82915419-ff80b500-9f70-11ea-91ff-84f7d02ac187.png) | ![without separator](https://user-images.githubusercontent.com/495617/82915423-014a7880-9f71-11ea-9f9f-46c69b210868.png)

## Testing
1. Go to the dashboard
2. Make sure that the last cell inside Top Performer Products doesn't show the cell separator.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
