### PR TITLE
Edit Product Images: "Discard changes" prompt now only appears when any images have been deleted

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - Order Detail: the HTML shipping method is now showed correctly
 - [internal] Logging in via 'Log in with Google' has changes that can cause regressions. See https://git.io/Jf2Fs for full testing details.
 - [**] Fix bugs related to push notifications: after receiving a new order push notification, the Reviews tab does not show a badge anymore. The application icon badge number is now cleared by navigating to the Orders tab and/or the Reviews tab, depending on the types of notifications received.
+- [*] The discard changes prompt now only appears when navigating from product images screen if any images have been deleted.
 - [*] Fix the issue where product details screen cannot be scrolled to the bottom in landscape after keyboard is dismissed (e.g. from editing product title).
 - [*] The product name is now shown in the product details navigation bar so that the name is always visible.
 - [*] The images pending upload should be visible after editing product images from product details.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -53,6 +53,8 @@ final class ProductImagesViewController: UIViewController {
         })
     }()
 
+    private var hasDeletedAnyImages: Bool = false
+
     private let onCompletion: Completion
 
     init(product: Product,
@@ -166,6 +168,7 @@ private extension ProductImagesViewController {
     }
 
     func onDeletion(productImage: ProductImage) {
+        hasDeletedAnyImages = true
         productImageActionHandler.deleteProductImage(productImage)
         navigationController?.popViewController(animated: true)
     }
@@ -179,7 +182,6 @@ extension ProductImagesViewController {
             presentDiscardChangesActionSheet()
             return false
         }
-        resetProductImages()
         return true
     }
 
@@ -199,8 +201,7 @@ extension ProductImagesViewController {
     }
 
     private func hasOutstandingChanges() -> Bool {
-        return originalProductImages != productImages
-            || productImageStatuses.hasPendingUpload
+        return hasDeletedAnyImages
     }
 }
 


### PR DESCRIPTION
Fixes #2354 

## Changes

Before this PR, we display the "Discard changes" prompt whenever there are any images pending upload or the product's images have changed. However, the user could still come back to the Edit Product Images screen after selecting a few photos for upload with the current UX. It doesn't make sense to show the "Discard changes" prompt in this case.

Since the only action that the user could change the product images on the Edit Product Images screen is the delete action (tapping on an image and then tapping the trash icon), this PR only shows the "Discard changes" prompt when the user has deleted any images.

## Testing

- Go to the Products tab
- Tap on a simple Product
- Tap on the "+" cell in the images header, then tap "Add Photos"
- Choose a photo or take one with camera --> it should go back to the product details screen with a spinner cell
- Tap on the "+" cell in the images header again
- Tap "<" in the navigation bar to go back to the product details screen --> it should go back to the product details screen without the discard changes prompt

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
