### PR TITLE
Setup crash logging on Sentry before main window is setup

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -44,7 +44,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // As first thing, setup the crash logging
         setupCrashLogging()
-        
+
         // Setup the Interface!
         setupMainWindow()
         setupComponentsAppearance()

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -42,12 +42,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
+        // As first thing, setup the crash logging
+        setupCrashLogging()
+        
         // Setup the Interface!
         setupMainWindow()
         setupComponentsAppearance()
 
         // Setup Components
-        setupCrashLogging()
         setupAnalytics()
         setupAuthenticationManager()
         setupCocoaLumberjack()


### PR DESCRIPTION
After the discussion here p91TBi-2PM it turned out that that our crashes triggered by setupMainWindow() aren't logged on Sentry because `setupCrashLogging()` is called after 
`setupMainWindow()` and `setupComponentsAppearance()`.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
