### PR TITLE
Made private the textField property inside TextFieldTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
@@ -83,7 +83,7 @@ private extension ProductMenuOrderViewController {
     func configureFirstTextFieldAsFirstResponder() {
         if let indexPath = sections.indexPathForRow(.menuOrder) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
-            cell?.textField.becomeFirstResponder()
+            cell?.becomeFirstResponder()
         }
     }
 }
@@ -146,10 +146,9 @@ private extension ProductMenuOrderViewController {
             }
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
-        }, inputFormatter: IntegerInputFormatter(defaultValue: ""))
+        }, inputFormatter: IntegerInputFormatter(defaultValue: ""), keyboardType: .numbersAndPunctuation)
         cell.configure(viewModel: viewModel)
-        cell.textField.applyBodyStyle()
-        cell.textField.keyboardType = .numbersAndPunctuation
+        cell.applyStyle(style: .body)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -76,7 +76,7 @@ private extension ProductSlugViewController {
     func configureTextFieldFirstResponder() {
         if let indexPath = sections.indexPathForRow(.slug) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
-            cell?.textField.becomeFirstResponder()
+            cell?.becomeFirstResponder()
         }
     }
 }
@@ -148,9 +148,9 @@ private extension ProductSlugViewController {
             }
             }, onTextDidBeginEditing: {
                 //TODO: Add analytics track
-        }, inputFormatter: nil)
+        }, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
-        cell.textField.applyBodyStyle()
+        cell.applyStyle(style: .body)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -129,7 +129,7 @@ private extension ProductFormTableViewDataSource {
             self?.onNameChange?(newName)
             }, onTextDidBeginEditing: {
                 ServiceLocator.analytics.track(.productDetailViewProductNameTapped)
-        }, inputFormatter: nil)
+        }, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -39,7 +39,7 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
     }
-    
+
     @discardableResult
     override func becomeFirstResponder() -> Bool {
         textField.becomeFirstResponder()
@@ -55,12 +55,12 @@ private extension TextFieldTableViewCell {
 
 // Styles
 extension TextFieldTableViewCell {
-    
+
     enum Style {
         case body
         case headline
     }
-    
+
     func applyStyle(style: Style) {
         switch style {
         case .headline:

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -9,9 +9,10 @@ final class TextFieldTableViewCell: UITableViewCell {
         let onTextChange: ((_ text: String?) -> Void)?
         let onTextDidBeginEditing: (() -> Void)?
         let inputFormatter: UnitInputFormatter?
+        let keyboardType: UIKeyboardType
     }
 
-    @IBOutlet weak var textField: UITextField!
+    @IBOutlet private weak var textField: UITextField!
 
     private var viewModel: ViewModel?
     private var onTextChange: ((_ text: String?) -> Void)?
@@ -22,6 +23,7 @@ final class TextFieldTableViewCell: UITableViewCell {
 
         configureTextField()
         applyDefaultBackgroundStyle()
+        applyStyle(style: .headline)
         selectionStyle = .none
     }
 
@@ -33,16 +35,39 @@ final class TextFieldTableViewCell: UITableViewCell {
         textField.text = viewModel.text
         textField.placeholder = viewModel.placeholder
         textField.borderStyle = .none
+        textField.keyboardType = viewModel.keyboardType
         textField.addTarget(self, action: #selector(textFieldDidChange(textField:)), for: .editingChanged)
         textField.addTarget(self, action: #selector(textFieldDidBegin(textField:)), for: .editingDidBegin)
+    }
+    
+    @discardableResult
+    override func becomeFirstResponder() -> Bool {
+        textField.becomeFirstResponder()
     }
 }
 
 private extension TextFieldTableViewCell {
     func configureTextField() {
         textField.clearButtonMode = .whileEditing
-        textField.applyHeadlineStyle()
         textField.delegate = self
+    }
+}
+
+// Styles
+extension TextFieldTableViewCell {
+    
+    enum Style {
+        case body
+        case headline
+    }
+    
+    func applyStyle(style: Style) {
+        switch style {
+        case .headline:
+            textField.applyHeadlineStyle()
+        case .body:
+            textField.applyBodyStyle()
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2196 

In this PR I made all the changes needed to transform the `textField` property inside  `TextFieldTableViewCell` as `private`.
Now the view model of the `TextFieldTableViewCell` accepts also the keyboard type.

## Testing
Make sure that the `TextFieldTableViewCells` in Product Inventory Settings, Product Detail, Product Slug, and Product Menu Order works like before.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
