### PR TITLE
Add Additional Tests for ResultsController

### DIFF
--- a/WooCommerce/WooCommerceTests/Mockups/MockupTableView.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupTableView.swift
@@ -39,30 +39,37 @@ class MockupTableView: UITableView {
     // MARK: - Overridden Methods
 
     override func beginUpdates() {
+        super.beginUpdates()
         onBeginUpdates?()
     }
 
     override func endUpdates() {
+        super.endUpdates()
         onEndUpdates?()
     }
 
     override func insertRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
+        super.insertRows(at: indexPaths, with: animation)
         onInsertedRows?(indexPaths)
     }
 
     override func deleteRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
+        super.deleteRows(at: indexPaths, with: animation)
         onDeletedRows?(indexPaths)
     }
 
     override func reloadRows(at indexPaths: [IndexPath], with animation: UITableView.RowAnimation) {
+        super.reloadRows(at: indexPaths, with: animation)
         onReloadRows?(indexPaths)
     }
 
     override func deleteSections(_ sections: IndexSet, with animation: UITableView.RowAnimation) {
+        super.deleteSections(sections, with: animation)
         onDeletedSections?(sections)
     }
 
     override func insertSections(_ sections: IndexSet, with animation: UITableView.RowAnimation) {
+        super.insertSections(sections, with: animation)
         onInsertedSections?(sections)
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -23,8 +23,8 @@ final class ResultsControllerUIKitTests: XCTestCase {
     // MARK: - Overridden Methods
 
     override func setUp() {
+        super.setUp()
         storageManager = MockupStorageManager()
-        tableView = MockupTableView()
 
         resultsController = {
             let viewStorage = storageManager.viewStorage
@@ -38,13 +38,17 @@ final class ResultsControllerUIKitTests: XCTestCase {
             )
         }()
 
+        tableView = MockupTableView()
+        tableView.dataSource = self
+
         resultsController.startForwardingEvents(to: tableView)
         try? resultsController.performFetch()
     }
 
     override func tearDown() {
-        resultsController = nil
+        tableView.dataSource = nil
         tableView = nil
+        resultsController = nil
         storageManager = nil
         super.tearDown()
     }

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -210,14 +210,6 @@ final class ResultsControllerUIKitTests: XCTestCase {
     func testItCanHandleSimultaneousSectionAndRowDeletionAndInsertion() {
         // Given
 
-        // Add the tableview to a window to avoid a logged warning
-        let window = makeWindow(containing: tableView)
-        window.makeKeyAndVisible()
-
-        defer {
-            window.resignKey()
-        }
-
         // Set up initial rows and sections.
         let expectOnEndUpdates = self.expectation(description: "wait for onEndUpdates")
         tableView.onEndUpdates = {
@@ -304,17 +296,5 @@ private extension ResultsControllerUIKitTests {
         account.username = username
         account.userID = userID
         return account
-    }
-
-    /// Create a `UIWindow` with the `tableView` as the child.
-    ///
-    func makeWindow(containing tableView: UITableView) -> UIWindow {
-        let viewController = UIViewController()
-        viewController.view.addSubview(tableView)
-
-        let window = UIWindow(frame: .zero)
-        window.rootViewController = viewController
-
-        return window
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -42,7 +42,7 @@ final class ResultsControllerUIKitTests: XCTestCase {
         tableView.dataSource = self
 
         resultsController.startForwardingEvents(to: tableView)
-        try? resultsController.performFetch()
+        try! resultsController.performFetch()
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 /// StoresManager Unit Tests
 ///
-class ResultsControllerUIKitTests: XCTestCase {
+final class ResultsControllerUIKitTests: XCTestCase {
 
     /// Mockup StorageManager
     ///

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import Yosemite
+
+import protocol Storage.StorageType
+
 @testable import WooCommerce
 
 
@@ -19,6 +22,9 @@ final class ResultsControllerUIKitTests: XCTestCase {
     ///
     private var resultsController: ResultsController<StorageAccount>!
 
+    private var viewStorage: StorageType {
+        storageManager.viewStorage
+    }
 
     // MARK: - Overridden Methods
 
@@ -208,4 +214,21 @@ extension ResultsControllerUIKitTests: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         UITableViewCell()
     }
+}
+
+// MARK: - Utils
+
+private extension ResultsControllerUIKitTests {
+    /// Create an account belonging to a section.
+    ///
+    /// The `section` is really just the `username`. This is just how we configured it in `setUp()`.
+    ///
+    @discardableResult
+    func insertAccount(section username: String, userID: Int64) -> StorageAccount {
+        let account = storageManager.insertSampleAccount()
+        account.username = username
+        account.userID = userID
+        return account
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -190,4 +190,18 @@ final class ResultsControllerUIKitTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
+// MARK: - UITableViewDataSource
+
+extension ResultsControllerUIKitTests: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        resultsController.sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        resultsController.sections[section].numberOfObjects
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        UITableViewCell()
+    }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -200,6 +200,81 @@ final class ResultsControllerUIKitTests: XCTestCase {
         storageManager.viewStorage.saveIfNeeded()
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
+
+    /// Tests that `ResultsController` can handle a simultataneous section deletion, row deletion,
+    /// and row insertion.
+    ///
+    /// This scenario is based on the Ordering of Operations and Index Paths section in
+    /// [this Apple Doc](https://tinyurl.com/yc3379jb)
+    ///
+    func testItCanHandleSimultaneousSectionAndRowDeletionAndInsertion() {
+        // Given
+
+        // Add the tableview to a window to avoid a logged warning
+        let window = makeWindow(containing: tableView)
+        window.makeKeyAndVisible()
+
+        defer {
+            window.resignKey()
+        }
+
+        // Set up initial rows and sections.
+        let expectOnEndUpdates = self.expectation(description: "wait for onEndUpdates")
+        tableView.onEndUpdates = {
+            expectOnEndUpdates.fulfill()
+        }
+
+        let firstSection = [
+            insertAccount(section: "Alpha", userID: 9_900),
+            insertAccount(section: "Alpha", userID: 9_800),
+            insertAccount(section: "Alpha", userID: 9_700)
+        ]
+
+        let secondSection = [
+            insertAccount(section: "Beta", userID: 8_900),
+            insertAccount(section: "Beta", userID: 8_800),
+            insertAccount(section: "Beta", userID: 8_700)
+        ]
+
+        let _ = [
+            insertAccount(section: "Charlie", userID: 7_900),
+            insertAccount(section: "Charlie", userID: 7_800),
+            insertAccount(section: "Charlie", userID: 7_700)
+        ]
+
+        viewStorage.saveIfNeeded()
+
+        wait(for: [expectOnEndUpdates], timeout: Constants.expectationTimeout)
+
+        XCTAssertEqual(tableView.numberOfSections, 3)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 0), 3)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 1), 3)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 2), 3)
+
+        // When
+        let expectSecondOnEndUpdates = self.expectation(description: "second wait for onEndUpdates")
+        tableView.onEndUpdates = {
+            expectSecondOnEndUpdates.fulfill()
+        }
+
+        // Delete row at index 1 of section at index 0.
+        viewStorage.deleteObject(firstSection[1])
+        // Delete section at index 1
+        secondSection.forEach(viewStorage.deleteObject)
+        // Insert row at index 1 of section at index 1.
+        insertAccount(section: "Charlie", userID: 7_801)
+
+        viewStorage.saveIfNeeded()
+
+        wait(for: [expectSecondOnEndUpdates], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(tableView.numberOfSections, 2)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 0), 2)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 1), 4)
+    }
+}
+
 // MARK: - UITableViewDataSource
 
 extension ResultsControllerUIKitTests: UITableViewDataSource {
@@ -231,4 +306,15 @@ private extension ResultsControllerUIKitTests {
         return account
     }
 
+    /// Create a `UIWindow` with the `tableView` as the child.
+    ///
+    func makeWindow(containing tableView: UITableView) -> UIWindow {
+        let viewController = UIViewController()
+        viewController.view.addSubview(tableView)
+
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = viewController
+
+        return window
+    }
 }


### PR DESCRIPTION
This just adds an additional test in `ResultsControllerUIKitTests`. I was using this to find the cause of #1543. I thought it would be a good permanent addition.  

## MockupTableView

I changed the `MockupTableView` so that it will always call `super` instead of just absorbing everything. This makes it closer to production behavior.

## DataSource

I also updated the `ResultsControllerUIKitTests` so it is a `UITableViewDataSource`. Again, this is to simulate how things work in production. 

## Testing

The build passing should be good enough. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

