### PR TITLE
Use NSFetchedResultsSectionInfo.numberOfObjects Instead of objects.count

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] The discard changes prompt does not appear when navigating from product settings detail screens with a text field (slug, purchase note, and menu order) anymore.
 - [*] Fix the wrong cell appearance in the order status list.
 - [*] The "View product in store" action will be shown only if the product is published.
+- [internal] Modified the component used for fetching data from the database. Please watch out for crashes in lists.
 
 
 4.3

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -257,7 +257,7 @@ public extension ResultsController {
 
     // MARK: - ResultsController.SectionInfo
     //
-    class SectionInfo {
+    final class SectionInfo {
 
         /// Name of the section
         ///

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -259,6 +259,10 @@ public extension ResultsController {
     //
     final class SectionInfo {
 
+        /// The real SectionInfo that we're hiding.
+        ///
+        private let mutableSectionInfo: NSFetchedResultsSectionInfo
+
         /// Name of the section
         ///
         public let name: String
@@ -284,6 +288,8 @@ public extension ResultsController {
         /// Designated Initializer
         ///
         init(mutableSection: NSFetchedResultsSectionInfo) {
+            mutableSectionInfo = mutableSection
+
             name = mutableSection.name
             mutableObjects = mutableSection.objects as? [T] ?? []
         }

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -265,7 +265,9 @@ public extension ResultsController {
 
         /// Name of the section
         ///
-        public let name: String
+        public var name: String {
+            mutableSectionInfo.name
+        }
 
         /// Number of objects in the current section
         ///
@@ -290,7 +292,6 @@ public extension ResultsController {
         init(mutableSection: NSFetchedResultsSectionInfo) {
             mutableSectionInfo = mutableSection
 
-            name = mutableSection.name
             mutableObjects = mutableSection.objects as? [T] ?? []
         }
     }

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -280,21 +280,21 @@ public extension ResultsController {
         /// Returns the array of (ReadOnly) objects in the section.
         ///
         private(set) public lazy var objects: [T.ReadOnlyType] = {
-            return mutableObjects.map { $0.toReadOnly() }
+            guard let objects = mutableSectionInfo.objects else {
+                return []
+            }
+            guard let castedObjects = objects as? [T] else {
+                assertionFailure("Failed to cast objects into an array of \(T.self)")
+                return []
+            }
+
+            return castedObjects.map { $0.toReadOnly() }
         }()
-
-
-        /// Array of Mutable Objects!
-        ///
-        private let mutableObjects: [T]
-
 
         /// Designated Initializer
         ///
         init(mutableSection: NSFetchedResultsSectionInfo) {
             mutableSectionInfo = mutableSection
-
-            mutableObjects = mutableSection.objects as? [T] ?? []
         }
     }
 }

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -256,7 +256,9 @@ public extension ResultsController {
     typealias ChangeType = NSFetchedResultsChangeType
 
     // MARK: - ResultsController.SectionInfo
-    //
+
+    /// An interface to `NSFetchedResultsSectionInfo` which enforces readonly usage.
+    ///
     final class SectionInfo {
 
         /// The real SectionInfo that we're hiding.

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -274,7 +274,7 @@ public extension ResultsController {
         /// Number of objects in the current section
         ///
         public var numberOfObjects: Int {
-            return mutableObjects.count
+            mutableSectionInfo.numberOfObjects
         }
 
         /// Returns the array of (ReadOnly) objects in the section.

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -45,8 +45,10 @@ final class ResultsControllerTests: XCTestCase {
         XCTAssertEqual(resultsController.sections.count, 0)
 
         try? resultsController.performFetch()
+
         XCTAssertEqual(resultsController.sections.count, 1)
         XCTAssertEqual(resultsController.sections.first?.objects.count, 0)
+        XCTAssertEqual(resultsController.sections.first?.numberOfObjects, 0)
     }
 
 
@@ -61,6 +63,7 @@ final class ResultsControllerTests: XCTestCase {
 
         XCTAssertEqual(resultsController.sections.count, 1)
         XCTAssertEqual(resultsController.sections.first?.objects.count, 1)
+        XCTAssertEqual(resultsController.sections.first?.numberOfObjects, 1)
     }
 
 
@@ -75,6 +78,7 @@ final class ResultsControllerTests: XCTestCase {
 
         XCTAssertEqual(resultsController.sections.count, 1)
         XCTAssertEqual(resultsController.sections.first?.objects.count, 1)
+        XCTAssertEqual(resultsController.sections.first?.numberOfObjects, 1)
     }
 
 

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -7,7 +7,7 @@ import CoreData
 
 // MARK: - ResultsController Unit Tests
 //
-class ResultsControllerTests: XCTestCase {
+final class ResultsControllerTests: XCTestCase {
 
     /// InMemory Storage!
     ///


### PR DESCRIPTION
This is just an attempt in fixing #1543. 

## Findings

We currently use `objects.count` when determining the number of rows in the section. 

https://github.com/woocommerce/woocommerce-ios/blob/9420a214faa675cd5eb5d36de1a4f6ac509f8cfa/Yosemite/Yosemite/Tools/ResultsController.swift#L266-L270

I found from these resources that `objects.count` can sometimes have a different value compared to [`numberOfObjects`](https://developer.apple.com/documentation/coredata/nsfetchedresultssectioninfo/1622289-numberofobjects):

- http://mikeabdullah.net/nsfetchedresultscontroller.html
- https://stackoverflow.com/a/39232007
- https://stackoverflow.com/q/3967895

Sadly, I have not been able to prove that this is the cause of the crash. 😞 

The [official Apple doc](https://developer.apple.com/documentation/coredata/nsfetchedresultscontroller) also shows that `numberOfObjects` should be used.

## Changes

This changes `SectionInfo` to use `numberOfObjects` instead of `objects.count`. I also made it store the `NSFetchedResultsSectionInfo` internally so `SectionInfo` would act more like just a wrapper. 

While we can't really prove if this fixes #1543, this change at least eliminates some _possible_ causes that we should look into. We can now ignore this part and move on.

## Testing

Please do a regression test that this does not affect the table view loading. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

