### PR TITLE
Avoid Calling performFetch Twice

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -58,10 +58,7 @@ final class OrdersViewModel {
         let descriptor = NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false)
 
         let sectionNameKeyPath = #selector(StorageOrder.normalizedAgeAsString)
-        let resultsController = ResultsController<StorageOrder>(storageManager: storageManager,
-                                                                sectionNameKeyPath: "\(sectionNameKeyPath)",
-                                                                sortedBy: [descriptor])
-        resultsController.predicate = {
+        let predicate: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
             let excludeNonMatchingStatus = statusFilter.map { NSPredicate(format: "statusKey = %@", $0.slug) }
 
@@ -75,7 +72,10 @@ final class OrdersViewModel {
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
 
-        return resultsController
+        return ResultsController<StorageOrder>(storageManager: storageManager,
+                                               sectionNameKeyPath: "\(sectionNameKeyPath)",
+                                               matching: predicate,
+                                               sortedBy: [descriptor])
     }()
 
     /// Indicates if there are no results.


### PR DESCRIPTION
This is just to eliminate possible causes for #1543 and #2241. 

## Findings

I found that I was setting the `predicate` value right after the `ResultsController` initialization here: 

https://github.com/woocommerce/woocommerce-ios/blob/9420a214faa675cd5eb5d36de1a4f6ac509f8cfa/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L61-L66

Setting the `ResultsController.predicate` property causes a `performFetch`:

https://github.com/woocommerce/woocommerce-ios/blob/9420a214faa675cd5eb5d36de1a4f6ac509f8cfa/Yosemite/Yosemite/Tools/ResultsController.swift#L26-L29

https://github.com/woocommerce/woocommerce-ios/blob/9420a214faa675cd5eb5d36de1a4f6ac509f8cfa/Yosemite/Yosemite/Tools/ResultsController.swift#L184-L187

This causes two `performFetch` calls even though only one is necessary. Also, the first `performFetch` is unexpected because I really only wanted `performFetch` to be _controlled_ and happening during `activate*`:

https://github.com/woocommerce/woocommerce-ios/blob/9420a214faa675cd5eb5d36de1a4f6ac509f8cfa/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L108-L110

## Changes

This changes the `resultsController` initialization to pass the `predicate` on `init`, thereby avoiding the unexpected `performFetch`. 

## Testing

This shouldn't affect the behavior but please do a quick test that the orders are still loaded in the Orders tab. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

