### PR TITLE
Fix `develop` from merge conflicts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -830,7 +830,7 @@ private extension ProductFormViewController {
         actionSheet.view.tintColor = .text
 
         /// The "View product in store" action will be shown only if the product is published.
-        if originalProduct.productStatus == .publish {
+        if viewModel.canViewProductInStore() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.viewProduct) { [weak self] _ in
                 ServiceLocator.analytics.track(.productDetailViewProductButtonTapped)
                 self?.displayWebViewForProductInStore()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -115,6 +115,10 @@ final class ProductFormViewModel {
     func hasPasswordChanged() -> Bool {
         return password != nil && password != originalPassword
     }
+
+    func canViewProductInStore() -> Bool {
+        return originalProduct.productStatus == .publish
+    }
 }
 
 // MARK: Action handling


### PR DESCRIPTION
Fixes `develop` 🙇🏻‍♀️

There was a merge conflict in `ProductFormViewController` that I reminded myself when I code reviewed yesterday, but I forgot to make this change [in the PR](https://github.com/woocommerce/woocommerce-ios/pull/2348) before I merged it today. Next time I will add a checkmark in the PR that needs changes!

## Changes

Since `originalProduct` state was moved from `ProductFormViewController` to `ProductFormViewModel` in https://github.com/woocommerce/woocommerce-ios/pull/2348, this PR added a function for this visibility check in `ProductFormViewModel`.

## Testing

Just CI is good, but feel free to also test the visibility of "View product in store" action in the ellipsis menu in product details.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
