### PR TITLE
Update pods for release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '1.17.0-beta.7'
+  pod 'WordPressAuthenticator', '1.17.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - 1PasswordExtension (1.8.6)
   - Alamofire (4.8.0)
-  - AppAuth (1.3.0):
-    - AppAuth/Core (= 1.3.0)
-    - AppAuth/ExternalUserAgent (= 1.3.0)
-  - AppAuth/Core (1.3.0)
-  - AppAuth/ExternalUserAgent (1.3.0)
+  - AppAuth (1.3.1):
+    - AppAuth/Core (= 1.3.1)
+    - AppAuth/ExternalUserAgent (= 1.3.1)
+  - AppAuth/Core (1.3.1)
+  - AppAuth/ExternalUserAgent (1.3.1)
   - Automattic-Tracks-iOS (0.4.4):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
@@ -53,7 +53,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.17.0-beta.7):
+  - WordPressAuthenticator (1.17.0):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -62,10 +62,10 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.9.0-beta.1)
+    - WordPressKit (~> 4.9.0)
     - WordPressShared (~> 1.8.16)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.9.0-beta.1):
+  - WordPressKit (4.9.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - KeychainAccess (~> 3.2)
   - Kingfisher (~> 5.11.0)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (= 1.17.0-beta.7)
+  - WordPressAuthenticator (= 1.17.0)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.7.0)
   - Wormholy (~> 1.6.0)
@@ -157,7 +157,7 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
-  AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
+  AppAuth: 8803ba1aec6d00d9afd30093f82e600307eaa6ea
   Automattic-Tracks-iOS: dbe6301bebdc1e444972475bae19299491702cef
   Charts: e0dd4cd8f257bccf98407b58183ddca8e8d5b578
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
@@ -178,8 +178,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: aa6c0a219c17cdfdb19fe6c2a1859b2577857cd5
-  WordPressKit: e8aab0ace717c9b9be307ccfdda08821f31b655c
+  WordPressAuthenticator: 4b133a708d585c0e7ce374985051c5f40bcc157c
+  WordPressKit: 2e707edd1b28e8dd0f74a40469ca6e7be7b20a70
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
   Wormholy: f52cd3c384fb49ae3e8fdb2b1398b66746a65104
@@ -194,6 +194,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 29c9ebbbd6df655e0cc04fa307a0e761dbef5044
+PODFILE CHECKSUM: 41411a660d9001775e42d2a8861853f682217eb8
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
This PR updates the Pods from the `beta` release to the stable version in order to prepare for `4.4` code freeze.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
