### PR TITLE
Add More ResultsController+UIKit Tests

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 		57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */; };
 		5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */; };
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
+		578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578187B12481D9290063B46B /* XCTestCase+Assertions.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
@@ -1208,6 +1209,7 @@
 		57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlus.swift"; sourceTree = "<group>"; };
 		5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlusTests.swift"; sourceTree = "<group>"; };
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
+		578187B12481D9290063B46B /* XCTestCase+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Assertions.swift"; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
@@ -2588,6 +2590,7 @@
 			isa = PBXGroup;
 			children = (
 				6856D66A1963092C34D20674 /* Calendar+Extensions.swift */,
+				578187B12481D9290063B46B /* XCTestCase+Assertions.swift */,
 			);
 			path = Testing;
 			sourceTree = "<group>";
@@ -5087,6 +5090,7 @@
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,
+				578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
@@ -7,7 +7,7 @@ import XCTest
 extension XCTestCase {
     /// Asserts that an array is empty.
     ///
-    func assertEmpty<Element>(_ array: [Element]) {
-        XCTAssertTrue(array.isEmpty)
+    func assertEmpty<Element>(_ array: [Element], file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(array.isEmpty, "Expected array \(array) to be empty.", file: file, line: line)
     }
 }

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
@@ -1,0 +1,13 @@
+
+import Foundation
+import XCTest
+
+/// Additional assertions to help with readability in tests.
+///
+extension XCTestCase {
+    /// Asserts that an array is empty.
+    ///
+    func assertEmpty<Element>(_ array: [Element]) {
+        XCTAssertTrue(array.isEmpty)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -256,7 +256,8 @@ final class ResultsControllerUIKitTests: XCTestCase {
         XCTAssertEqual(tableView.numberOfRows(inSection: 1), 4)
     }
 
-    /// Test that `ResultsController` will emit a `move` `ChangeType` if a
+    /// Test that `ResultsController` will emit a `move` `ChangeType` if a row is moved to
+    /// a new section because of an update to a property used as the `sectionNameKeyPath`.
     ///
     /// This proves that the bug discussed in [here](https://forums.developer.apple.com/thread/61282)
     /// was already fixed by Apple. The bug was that a `move` was being emitted as an `update`.

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -209,6 +209,10 @@ final class ResultsControllerUIKitTests: XCTestCase {
     ///
     func testItCanHandleSimultaneousSectionAndRowDeletionAndInsertion() {
         // Given
+        // Add the table to a UIWindow so that it will crash in case an invalid number of rows
+        // is detected.
+        let window = makeWindow(containing: tableView)
+        window.isHidden = false
 
         // Set up initial rows and sections.
         let firstSection = [
@@ -259,6 +263,10 @@ final class ResultsControllerUIKitTests: XCTestCase {
     ///
     func testWhenARowIsMovedToANewSectionThenAMoveChangeTypeEventIsEmitted() {
         // Given
+        // Add the table to a UIWindow so that it will crash in case an invalid number of rows
+        // is detected.
+        let window = makeWindow(containing: tableView)
+        window.isHidden = false
 
         // Set up initial rows and sections.
         let _ = [
@@ -350,5 +358,17 @@ private extension ResultsControllerUIKitTests {
         viewStorage.saveIfNeeded()
 
         wait(for: [expectOnEndUpdates], timeout: Constants.expectationTimeout)
+    }
+
+    /// Create a UIWindow containing the given `tableView`.
+    ///
+    func makeWindow(containing tableView: UITableView) -> UIWindow {
+        let rootViewController = UIViewController()
+        rootViewController.view.addSubview(tableView)
+
+        let window = UIWindow(frame: .zero)
+        window.rootViewController = rootViewController
+
+        return window
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -211,11 +211,6 @@ final class ResultsControllerUIKitTests: XCTestCase {
         // Given
 
         // Set up initial rows and sections.
-        let expectOnEndUpdates = self.expectation(description: "wait for onEndUpdates")
-        tableView.onEndUpdates = {
-            expectOnEndUpdates.fulfill()
-        }
-
         let firstSection = [
             insertAccount(section: "Alpha", userID: 9_900),
             insertAccount(section: "Alpha", userID: 9_800),
@@ -234,9 +229,7 @@ final class ResultsControllerUIKitTests: XCTestCase {
             insertAccount(section: "Charlie", userID: 7_700)
         ]
 
-        viewStorage.saveIfNeeded()
-
-        wait(for: [expectOnEndUpdates], timeout: Constants.expectationTimeout)
+        saveAndWaitForTableViewOnEndUpdates()
 
         XCTAssertEqual(tableView.numberOfSections, 3)
         XCTAssertEqual(tableView.numberOfRows(inSection: 0), 3)
@@ -244,11 +237,6 @@ final class ResultsControllerUIKitTests: XCTestCase {
         XCTAssertEqual(tableView.numberOfRows(inSection: 2), 3)
 
         // When
-        let expectSecondOnEndUpdates = self.expectation(description: "second wait for onEndUpdates")
-        tableView.onEndUpdates = {
-            expectSecondOnEndUpdates.fulfill()
-        }
-
         // Delete row at index 1 of section at index 0.
         viewStorage.deleteObject(firstSection[1])
         // Delete section at index 1
@@ -256,9 +244,7 @@ final class ResultsControllerUIKitTests: XCTestCase {
         // Insert row at index 1 of section at index 1.
         insertAccount(section: "Charlie", userID: 7_801)
 
-        viewStorage.saveIfNeeded()
-
-        wait(for: [expectSecondOnEndUpdates], timeout: Constants.expectationTimeout)
+        saveAndWaitForTableViewOnEndUpdates()
 
         // Then
         XCTAssertEqual(tableView.numberOfSections, 2)
@@ -275,11 +261,6 @@ final class ResultsControllerUIKitTests: XCTestCase {
         // Given
 
         // Set up initial rows and sections.
-        let expectOnEndUpdates = self.expectation(description: "wait for onEndUpdates")
-        tableView.onEndUpdates = {
-            expectOnEndUpdates.fulfill()
-        }
-
         let _ = [
             insertAccount(section: "Alpha", userID: 9_900),
             insertAccount(section: "Alpha", userID: 9_800),
@@ -292,16 +273,9 @@ final class ResultsControllerUIKitTests: XCTestCase {
             insertAccount(section: "Beta", userID: 8_700)
         ]
 
-        viewStorage.saveIfNeeded()
-
-        wait(for: [expectOnEndUpdates], timeout: Constants.expectationTimeout)
+        saveAndWaitForTableViewOnEndUpdates()
 
         // When
-        let expectSecondOnEndUpdates = self.expectation(description: "second wait for onEndUpdates")
-        tableView.onEndUpdates = {
-            expectSecondOnEndUpdates.fulfill()
-        }
-
         var insertedRows = [IndexPath]()
         var deletedRows = [IndexPath]()
         var reloadedRows = [IndexPath]()
@@ -318,9 +292,7 @@ final class ResultsControllerUIKitTests: XCTestCase {
         // Move a row to a new section
         secondSection[1].username = "Foxtrot"
 
-        viewStorage.saveIfNeeded()
-
-        wait(for: [expectSecondOnEndUpdates], timeout: Constants.expectationTimeout)
+        saveAndWaitForTableViewOnEndUpdates()
 
         // Then
         // A `.move` change type is handled as both a delete and then an insert
@@ -364,5 +336,19 @@ private extension ResultsControllerUIKitTests {
         account.username = username
         account.userID = userID
         return account
+    }
+
+    /// Save the `viewStorage` and wait for `self.tableView`'s `onEndUpdates` (cell animations)
+    /// to be called.
+    ///
+    func saveAndWaitForTableViewOnEndUpdates() {
+        let expectOnEndUpdates = self.expectation(description: "wait for onEndUpdates")
+        tableView.onEndUpdates = {
+            expectOnEndUpdates.fulfill()
+        }
+
+        viewStorage.saveIfNeeded()
+
+        wait(for: [expectOnEndUpdates], timeout: Constants.expectationTimeout)
     }
 }


### PR DESCRIPTION
I added more test cases based on some of our assumptions.

## Test Cases

### Test That `ResultsController` Will Emit a `move` `ChangeType`

https://github.com/woocommerce/woocommerce-ios/blob/5dd0dc967c7e5042dfd442496325ff4f0dae0262/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift#L259-L264

### Test That the `fixedType` fix is Still Necessary

https://github.com/woocommerce/woocommerce-ios/blob/5dd0dc967c7e5042dfd442496325ff4f0dae0262/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift#L317-L333

## Other Changes

I added `UIWindow` creations in the test cases. Without it, the `UITableView` will not actually crash if it ends up with an inconsistent state. The `UITableView` checks whether it is visible before doing any cell change. 

https://github.com/woocommerce/woocommerce-ios/blob/5dd0dc967c7e5042dfd442496325ff4f0dae0262/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift#L337-L338

## Testing

The build passing should be good enough. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

