### PR TITLE
Order Details → Show Item Total on the Right Instead of Quantity

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.5
 -----
+- [*] In Order Details, the item subtotal is now shown on the right side instead of the quantity. The quantity can still be viewed underneath the product name.
  
 4.4
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -567,7 +567,7 @@ extension OrderDetailsDataSource {
                     rows.append(.details)
                 }
 
-                return Section(title: Title.product, rightTitle: Title.quantity, rows: rows)
+                return Section(title: Title.products, rightTitle: nil, rows: rows)
             }
 
             var rows = [Row]()
@@ -589,7 +589,7 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            return Section(title: Title.product, rightTitle: Title.quantity, rows: rows)
+            return Section(title: Title.products, rightTitle: nil, rows: rows)
         }()
 
         let refundedProducts: Section? = {
@@ -851,8 +851,7 @@ extension OrderDetailsDataSource {
     }
 
     enum Title {
-        static let product = NSLocalizedString("Product", comment: "Product section title")
-        static let quantity = NSLocalizedString("Qty", comment: "Quantity abbreviation for section title")
+        static let products = NSLocalizedString("Products", comment: "Product section title")
         static let refundedProducts = NSLocalizedString("Refunded Products", comment: "Section title")
         static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
         static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
@@ -25,11 +25,6 @@ final class RefundDetailsViewModel {
         self.refund = refund
     }
 
-    /// Section Titles
-    ///
-    let productLeftTitle = NSLocalizedString("PRODUCT", comment: "Product section title")
-    let productRightTitle = NSLocalizedString("QTY", comment: "Quantity abbreviation for section title")
-
     /// Products from a Refund
     ///
     var products: [Product] {

--- a/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsDataSource.swift
@@ -141,7 +141,7 @@ extension RefundedProductsDataSource {
         let refundedProductsSection: Section? = {
             let rows: [Row] = Array(repeating: .orderItemRefunded, count: refundedProducts.count)
 
-            return Section(title: SectionTitle.product, rightTitle: SectionTitle.quantity, rows: rows)
+            return Section(title: SectionTitle.product, rightTitle: nil, rows: rows)
         }()
 
         sections = [refundedProductsSection].compactMap { $0 }
@@ -156,7 +156,6 @@ extension RefundedProductsDataSource {
     ///
     enum SectionTitle {
         static let product = NSLocalizedString("Refunded Products", comment: "Refunded Products section title")
-        static let quantity = NSLocalizedString("Qty", comment: "Quantity abbreviation for section title")
     }
 
     /// Table Rows

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -50,6 +50,12 @@ struct ProductDetailsCellViewModel {
         return NumberFormatter.localizedString(from: positiveQuantity as NSDecimalNumber, number: .decimal)
     }
 
+    /// The localized total value of this line item. This is the quantity x price.
+    ///
+    var total: String {
+        currencyFormatter.formatAmount(positiveTotal, with: currency) ?? String()
+    }
+
     /// Returns the localized "quantity x price" to use for the subtitle.
     ///
     var subtitle: String {

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -50,22 +50,12 @@ struct ProductDetailsCellViewModel {
         return NumberFormatter.localizedString(from: positiveQuantity as NSDecimalNumber, number: .decimal)
     }
 
-    /// Refunded Product Price
-    /// Always return a string, even for zero amounts.
+    /// Returns the localized "quantity x price" to use for the subtitle.
     ///
-    var price: String {
-        guard positiveQuantity > 1 else {
-            return currencyFormatter.formatAmount(total, with: currency) ?? String()
-        }
+    var subtitle: String {
+        let itemPrice = currencyFormatter.formatAmount(positivePrice, with: currency) ?? String()
 
-        let itemTotal = currencyFormatter.formatAmount(total, with: currency) ?? String()
-        let itemSubtotal = currencyFormatter.formatAmount(positivePrice, with: currency) ?? String()
-
-        let priceTemplate = NSLocalizedString("%@ (%@ x %@)",
-                                              comment: "<item total> (<item individual price> multipled by <quantity>)")
-        let priceText = String.localizedStringWithFormat(priceTemplate, itemTotal, itemSubtotal, quantity)
-
-        return priceText
+        return Localization.subtitle(quantity: quantity, price: itemPrice)
     }
 
     /// Item SKU
@@ -139,5 +129,18 @@ struct ProductDetailsCellViewModel {
         self.total = currencyFormatter.convertToDecimal(from: refundedItem.total)?.abs() ?? NSDecimalNumber.zero
         self.positivePrice = refundedItem.price.abs()
         self.skuText = refundedItem.sku
+    }
+}
+
+// MARK: - Localization
+
+private extension ProductDetailsCellViewModel {
+    enum Localization {
+        static func subtitle(quantity: String, price: String) -> String {
+            let format = NSLocalizedString("%1$@ x %2$@", comment: "In Order Details,"
+                + " the pattern used to show the quantity multiplied by the price. For example, “23 x $400.00”."
+                + " The %1$@ is the quantity. The %2$@ is the formatted price with currency (e.g. $400.00).")
+            return String.localizedStringWithFormat(format, quantity, price)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -42,7 +42,7 @@ struct ProductDetailsCellViewModel {
 
     /// Item Name
     ///
-    var name: String
+    let name: String
 
     /// Item Quantity as a String
     ///

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -27,7 +27,7 @@ struct ProductDetailsCellViewModel {
     /// Item Total
     /// represented as a positive value
     ///
-    private let total: NSDecimalNumber
+    private let positiveTotal: NSDecimalNumber
 
     /// Item Price
     /// represented as a positive value
@@ -94,7 +94,7 @@ struct ProductDetailsCellViewModel {
         self.product = product
         self.name = item.name
         self.positiveQuantity = abs(item.quantity)
-        self.total = currencyFormatter.convertToDecimal(from: item.total)?.abs() ?? NSDecimalNumber.zero
+        self.positiveTotal = currencyFormatter.convertToDecimal(from: item.total)?.abs() ?? NSDecimalNumber.zero
         self.positivePrice = item.price.abs()
         self.skuText = item.sku
     }
@@ -110,7 +110,7 @@ struct ProductDetailsCellViewModel {
         self.product = product
         self.name = aggregateItem.name
         self.positiveQuantity = abs(aggregateItem.quantity)
-        self.total = aggregateItem.total.abs()
+        self.positiveTotal = aggregateItem.total.abs()
         self.positivePrice = aggregateItem.price.abs()
         self.skuText = aggregateItem.sku
     }
@@ -126,7 +126,7 @@ struct ProductDetailsCellViewModel {
         self.product = product
         self.name = refundedItem.name
         self.positiveQuantity = abs(refundedItem.quantity)
-        self.total = currencyFormatter.convertToDecimal(from: refundedItem.total)?.abs() ?? NSDecimalNumber.zero
+        self.positiveTotal = currencyFormatter.convertToDecimal(from: refundedItem.total)?.abs() ?? NSDecimalNumber.zero
         self.positivePrice = refundedItem.price.abs()
         self.skuText = refundedItem.sku
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -17,7 +17,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
 
     /// Label: Quantity
     ///
-    @IBOutlet private var quantityLabel: UILabel!
+    @IBOutlet private var priceLabel: UILabel!
 
     /// Label: Price
     ///
@@ -70,8 +70,8 @@ private extension ProductDetailsTableViewCell {
     }
 
     func configureQuantityLabel() {
-        quantityLabel.applyBodyStyle()
-        quantityLabel?.text = ""
+        priceLabel.applyBodyStyle()
+        priceLabel?.text = ""
     }
 
     func configurePriceLabel() {
@@ -103,7 +103,7 @@ extension ProductDetailsTableViewCell {
                                                        completion: nil)
 
         nameLabel.text = item.name
-        quantityLabel.text = item.quantity
+        priceLabel.text = item.quantity
         subtitleLabel.text = item.price
         skuLabel.text = item.sku
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -104,7 +104,7 @@ extension ProductDetailsTableViewCell {
 
         nameLabel.text = item.name
         priceLabel.text = item.quantity
-        subtitleLabel.text = item.price
+        subtitleLabel.text = item.subtitle
         skuLabel.text = item.sku
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -27,50 +27,6 @@ final class ProductDetailsTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var skuLabel: UILabel!
 
-    /// Product Name
-    ///
-    var name: String? {
-        get {
-            return nameLabel?.text
-        }
-        set {
-            nameLabel?.text = newValue
-        }
-    }
-
-    /// Number of Items
-    ///
-    var quantity: String? {
-        get {
-            return quantityLabel?.text
-        }
-        set {
-            quantityLabel?.text = newValue
-        }
-    }
-
-    /// Item's Price
-    ///
-    var price: String? {
-        get {
-            return priceLabel?.text
-        }
-        set {
-            priceLabel?.text = newValue
-        }
-    }
-
-    /// Item's SKU
-    ///
-    var sku: String? {
-        get {
-            return skuLabel?.text
-        }
-        set {
-            skuLabel?.text = newValue
-        }
-    }
-
     // MARK: - Overridden Methods
 
     required init?(coder aDecoder: NSCoder) {
@@ -146,9 +102,9 @@ extension ProductDetailsTableViewCell {
                                                        progressBlock: nil,
                                                        completion: nil)
 
-        name = item.name
-        quantity = item.quantity
-        price = item.price
-        sku = item.sku
+        nameLabel.text = item.name
+        quantityLabel.text = item.quantity
+        priceLabel.text = item.price
+        skuLabel.text = item.sku
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -7,23 +7,23 @@ import Yosemite
 ///
 final class ProductDetailsTableViewCell: UITableViewCell {
 
-    /// ImageView
+    /// Shows the product's image.
     ///
     @IBOutlet private var productImageView: UIImageView!
 
-    /// Label: Name
+    /// The label for the product's name.
     ///
     @IBOutlet private var nameLabel: UILabel!
 
-    /// Label: Quantity
+    /// The label for the subtotal (quantity x item price).
     ///
     @IBOutlet private var priceLabel: UILabel!
 
-    /// Label: Price
+    /// The label showing the pattern "{qty} x {item_price}".
     ///
     @IBOutlet private var subtitleLabel: UILabel!
 
-    /// Label: SKU
+    /// The label showing the SKU.
     ///
     @IBOutlet private var skuLabel: UILabel!
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -21,7 +21,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
 
     /// Label: Price
     ///
-    @IBOutlet private var priceLabel: UILabel!
+    @IBOutlet private var subtitleLabel: UILabel!
 
     /// Label: SKU
     ///
@@ -75,8 +75,8 @@ private extension ProductDetailsTableViewCell {
     }
 
     func configurePriceLabel() {
-        priceLabel.applySecondaryFootnoteStyle()
-        priceLabel?.text = ""
+        subtitleLabel.applySecondaryFootnoteStyle()
+        subtitleLabel?.text = ""
     }
 
     func configureSKULabel() {
@@ -104,7 +104,7 @@ extension ProductDetailsTableViewCell {
 
         nameLabel.text = item.name
         quantityLabel.text = item.quantity
-        priceLabel.text = item.price
+        subtitleLabel.text = item.price
         skuLabel.text = item.sku
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -103,7 +103,7 @@ extension ProductDetailsTableViewCell {
                                                        completion: nil)
 
         nameLabel.text = item.name
-        priceLabel.text = item.quantity
+        priceLabel.text = item.total
         subtitleLabel.text = item.subtitle
         skuLabel.text = item.sku
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -42,7 +42,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
         configureNameLabel()
         configureQuantityLabel()
         configureSKULabel()
-        configurePriceLabel()
+        configureSubtitleLabel()
         configureSelectionStyle()
     }
 }
@@ -74,7 +74,7 @@ private extension ProductDetailsTableViewCell {
         priceLabel?.text = ""
     }
 
-    func configurePriceLabel() {
+    func configureSubtitleLabel() {
         subtitleLabel.applySecondaryFootnoteStyle()
         subtitleLabel?.text = ""
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 /// Product Details: Renders a row that displays a single Product.
 ///
-class ProductDetailsTableViewCell: UITableViewCell {
+final class ProductDetailsTableViewCell: UITableViewCell {
 
     /// ImageView
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -40,7 +40,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
         configureBackground()
         configureProductImageView()
         configureNameLabel()
-        configureQuantityLabel()
+        configurePriceLabel()
         configureSKULabel()
         configureSubtitleLabel()
         configureSelectionStyle()
@@ -69,7 +69,7 @@ private extension ProductDetailsTableViewCell {
         nameLabel?.text = ""
     }
 
-    func configureQuantityLabel() {
+    func configurePriceLabel() {
         priceLabel.applyBodyStyle()
         priceLabel?.text = ""
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -81,10 +80,10 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="nameLabel" destination="14R-zK-tgC" id="LmK-XT-zbU"/>
-                <outlet property="priceLabel" destination="IBM-H2-zE2" id="acc-K8-vmg"/>
                 <outlet property="productImageView" destination="p6h-Fq-FjW" id="bIw-1F-5GW"/>
                 <outlet property="quantityLabel" destination="pPE-SE-pY7" id="ir4-Ou-SuU"/>
                 <outlet property="skuLabel" destination="7JH-rt-n9v" id="U07-2n-W3b"/>
+                <outlet property="subtitleLabel" destination="IBM-H2-zE2" id="acc-K8-vmg"/>
             </connections>
             <point key="canvasLocation" x="62" y="96.5"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
@@ -80,8 +80,8 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="nameLabel" destination="14R-zK-tgC" id="LmK-XT-zbU"/>
+                <outlet property="priceLabel" destination="pPE-SE-pY7" id="ir4-Ou-SuU"/>
                 <outlet property="productImageView" destination="p6h-Fq-FjW" id="bIw-1F-5GW"/>
-                <outlet property="quantityLabel" destination="pPE-SE-pY7" id="ir4-Ou-SuU"/>
                 <outlet property="skuLabel" destination="7JH-rt-n9v" id="U07-2n-W3b"/>
                 <outlet property="subtitleLabel" destination="IBM-H2-zE2" id="acc-K8-vmg"/>
             </connections>

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -46,7 +46,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let actualTitles = dataSource.sections.map(\.title)
         let expectedTitles = [
             nil,
-            Title.product,
+            Title.products,
             Title.refundedProducts,
             Title.payment,
             Title.information,


### PR DESCRIPTION
⚠️ Requires #2381 to be merged first.

Refs #2281. 

## Design

### Order Details

This swaps the quantity shown on the right side with the item total. The header also now just says “Products” instead of “Product” and “QTY” on the right. According to #2281, the header should be using a white background. I'll get to that in a follow-up PR. 

There are no changes in the layout. 

@Garance91540 Should the font sizes of the SKU and "Quantity x Price" be bigger? I couldn't find an existing style of that in the app so I wasn't sure. 

Before | After 
--------|-------
 ![image](https://user-images.githubusercontent.com/198826/83679753-25274300-a59d-11ea-87f5-c7a107ce4420.png)    |       ![image](https://user-images.githubusercontent.com/198826/83680771-a4694680-a59e-11ea-896b-5481d1e80c60.png)

After (Dark) | After (Large)
--------|-------
![Simulator Screen Shot - iPhone 11 Dark - 2020-06-03 at 13 18 50](https://user-images.githubusercontent.com/198826/83679801-3a03d680-a59d-11ea-93f4-48d14fcbc601.png)        |     ![image](https://user-images.githubusercontent.com/198826/83681008-ff02a280-a59e-11ea-951e-42eb2e088c7c.png)

### Refunded Products

Since the Refunded Products view is using the same components as the Order Details, it is also affected by the changes too. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/83682003-83095a00-a5a0-11ea-81ec-fb05355c1e02.png)        |     ![image](https://user-images.githubusercontent.com/198826/83682068-a16f5580-a5a0-11ea-9956-86856f272910.png)


@Garance91540 Please let me know if this is okay or not. 

## Testing

1. Navigate to a processing Order.
2. Confirm that the price is on the right side.
3. Tap on Begin Fulfillment. 
4. Confirm that the quantity is still on the right side. 
5. Navigate to an Order with a refund. 
6. Tap on the Refunded Products
7. Confirm that the price is shown on the right. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

