### PR TITLE
Product Categories: updated Network/Yosemite layers with create new ProductCategory request

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4568E2212459ADC60007E478 /* SitePostsRemote.swift */; };
 		4568E2242459D3230007E478 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4568E2232459D3230007E478 /* Post.swift */; };
 		457FC68C2382B2FD00B41B02 /* product-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 457FC68B2382B2FD00B41B02 /* product-update.json */; };
+		45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B204B72489095100FE6526 /* ProductCategoryMapper.swift */; };
 		45CDAFAB2434CA9300F83C22 /* ProductCatalogVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CDAFAA2434CA9300F83C22 /* ProductCatalogVisibility.swift */; };
 		45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */; };
 		45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */; };
@@ -388,6 +389,7 @@
 		4568E2212459ADC60007E478 /* SitePostsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostsRemote.swift; sourceTree = "<group>"; };
 		4568E2232459D3230007E478 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		457FC68B2382B2FD00B41B02 /* product-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-update.json"; sourceTree = "<group>"; };
+		45B204B72489095100FE6526 /* ProductCategoryMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryMapper.swift; sourceTree = "<group>"; };
 		45CDAFAA2434CA9300F83C22 /* ProductCatalogVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCatalogVisibility.swift; sourceTree = "<group>"; };
 		45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatus.swift; sourceTree = "<group>"; };
 		45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSkuMapper.swift; sourceTree = "<group>"; };
@@ -1138,6 +1140,7 @@
 				D8FBFF1022D3B3FC006E3336 /* OrderStatsV4Mapper.swift */,
 				74749B96224134FF005C4CF2 /* ProductMapper.swift */,
 				CE0A0F18223987DF0075ED8D /* ProductListMapper.swift */,
+				45B204B72489095100FE6526 /* ProductCategoryMapper.swift */,
 				26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */,
 				D88D5A4A230BCF0A007B6E01 /* ProductReviewListMapper.swift */,
 				D8C251CF230BD72700F49782 /* ProductReviewMapper.swift */,
@@ -1620,6 +1623,7 @@
 				D8736B5E22F0849700A14A29 /* OrderCountItem.swift in Sources */,
 				B554FA8F2180BC7000C54DFF /* NoteHashListMapper.swift in Sources */,
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
+				45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */,
 				B557DA0D20975DB1005962F4 /* WordPressAPIVersion.swift in Sources */,
 				7412A8EC21B6E286005D182A /* ReportOrderTotalsMapper.swift in Sources */,
 				5726F72E2460A2820031CAAC /* Copiable.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		4568E2242459D3230007E478 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4568E2232459D3230007E478 /* Post.swift */; };
 		457FC68C2382B2FD00B41B02 /* product-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 457FC68B2382B2FD00B41B02 /* product-update.json */; };
 		45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B204B72489095100FE6526 /* ProductCategoryMapper.swift */; };
+		45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */; };
+		45B204BC24890B1200FE6526 /* category.json in Resources */ = {isa = PBXBuildFile; fileRef = 45B204BB24890B1200FE6526 /* category.json */; };
 		45CDAFAB2434CA9300F83C22 /* ProductCatalogVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CDAFAA2434CA9300F83C22 /* ProductCatalogVisibility.swift */; };
 		45D1CF4923BACA6500945A36 /* ProductTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */; };
 		45D685F823D0BC78005F87D0 /* ProductSkuMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */; };
@@ -390,6 +392,8 @@
 		4568E2232459D3230007E478 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		457FC68B2382B2FD00B41B02 /* product-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-update.json"; sourceTree = "<group>"; };
 		45B204B72489095100FE6526 /* ProductCategoryMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryMapper.swift; sourceTree = "<group>"; };
+		45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryMapperTests.swift; sourceTree = "<group>"; };
+		45B204BB24890B1200FE6526 /* category.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = category.json; sourceTree = "<group>"; };
 		45CDAFAA2434CA9300F83C22 /* ProductCatalogVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCatalogVisibility.swift; sourceTree = "<group>"; };
 		45D1CF4823BACA6500945A36 /* ProductTaxStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTaxStatus.swift; sourceTree = "<group>"; };
 		45D685F723D0BC78005F87D0 /* ProductSkuMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSkuMapper.swift; sourceTree = "<group>"; };
@@ -1033,6 +1037,7 @@
 				265BCA01243056E3004E53EE /* categories-all.json */,
 				2683D70F24456EE4002A1589 /* categories-extra.json */,
 				2683D70D24456DB7002A1589 /* categories-empty.json */,
+				45B204BB24890B1200FE6526 /* category.json */,
 				74C9477F2193A6C60024CB60 /* comment-moderate-approved.json */,
 				74C9477E2193A6C60024CB60 /* comment-moderate-trash.json */,
 				74C947812193A6C70024CB60 /* comment-moderate-unapproved.json */,
@@ -1233,6 +1238,7 @@
 				CE0A0F1C22398D520075ED8D /* ProductListMapperTests.swift */,
 				74CF0A8B22414D7800DB993F /* ProductMapperTests.swift */,
 				D88D5A4E230BD276007B6E01 /* ProductReviewListMapperTests.swift */,
+				45B204B924890A8C00FE6526 /* ProductCategoryMapperTests.swift */,
 				26615478242DA54D00A31661 /* ProductCategoyListMapperTests.swift */,
 				45D685FB23D0C739005F87D0 /* ProductSkuMapperTests.swift */,
 				CEC4BF94234E7F34008D9195 /* RefundListMapperTests.swift */,
@@ -1444,6 +1450,7 @@
 				743FDB9C210FB36900AC737F /* order-stats-month.json in Resources */,
 				022902D622E2436400059692 /* no_stats_permission_error.json in Resources */,
 				743FDB9D210FB36900AC737F /* order-stats-year.json in Resources */,
+				45B204BC24890B1200FE6526 /* category.json in Resources */,
 				022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */,
 				B58D10C62114D1F200107ED4 /* order-stats.json in Resources */,
 				7412A51121702E9700994370 /* order-stats-alt.json in Resources */,
@@ -1724,6 +1731,7 @@
 			files = (
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
+				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,
 				74749B9522413119005C4CF2 /* ProductsRemoteTests.swift in Sources */,
 				B524194321AC622500D6FC0A /* DotcomDeviceMapperTests.swift in Sources */,
 				74D5BECE217E0F98007B0348 /* SiteSettingsRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductCategoryMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryMapper.swift
@@ -1,0 +1,13 @@
+//
+//  ProductCategoryMapper.swift
+//  Networking
+//
+//  Created by Paolo Musolino on 04/06/2020.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import UIKit
+
+class ProductCategoryMapper: NSObject {
+
+}

--- a/Networking/Networking/Mapper/ProductCategoryMapper.swift
+++ b/Networking/Networking/Mapper/ProductCategoryMapper.swift
@@ -1,13 +1,38 @@
-//
-//  ProductCategoryMapper.swift
-//  Networking
-//
-//  Created by Paolo Musolino on 04/06/2020.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
+import Foundation
 
-import UIKit
 
-class ProductCategoryMapper: NSObject {
+/// Mapper: ProductCategory
+///
+struct ProductCategoryMapper: Mapper {
 
+    /// Site Identifier associated to the `ProductCategory`s that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the ProductCategory Endpoints.
+    ///
+    let siteID: Int64
+
+
+    /// (Attempts) to convert a dictionary into ProductCategory.
+    ///
+    func map(response: Data) throws -> ProductCategory {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        return try decoder.decode(ProductCategoryEnvelope.self, from: response).productCategory
+    }
+}
+
+
+/// ProductCategoryEnvelope Disposable Entity:
+/// `Load Product Category` endpoint returns the updated products document in the `data` key.
+/// This entity allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductCategoryEnvelope: Decodable {
+    let productCategory: ProductCategory
+
+    private enum CodingKeys: String, CodingKey {
+        case productCategory = "data"
+    }
 }

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -30,6 +30,33 @@ public final class ProductCategoriesRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Create a new `ProducCategory`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll add a new product categories.
+    ///     - pageNumber: Number of page that should be retrieved.
+    ///     - pageSize: Number of categories to be retrieved per page.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func createProductCategory(for siteID: Int64,
+                                      name: String,
+                                      parentID: Int64?,
+                                      completion: @escaping ([ProductCategory]?, Error?) -> Void) {
+        var parameters = [
+            ParameterKey.name: name
+        ]
+
+        if let parentID = parentID {
+            parameters[ParameterKey.parent] = String(parentID)
+        }
+
+        let path = Path.categories
+        let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+        let mapper = ProductCategoryListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 
@@ -48,5 +75,7 @@ public extension ProductCategoriesRemote {
     private enum ParameterKey {
         static let page: String = "page"
         static let perPage: String = "per_page"
+        static let name: String = "name"
+        static let parent: String = "parent"
     }
 }

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -42,7 +42,7 @@ public final class ProductCategoriesRemote: Remote {
     public func createProductCategory(for siteID: Int64,
                                       name: String,
                                       parentID: Int64?,
-                                      completion: @escaping ([ProductCategory]?, Error?) -> Void) {
+                                      completion: @escaping (ProductCategory?, Error?) -> Void) {
         var parameters = [
             ParameterKey.name: name
         ]
@@ -53,7 +53,7 @@ public final class ProductCategoriesRemote: Remote {
 
         let path = Path.categories
         let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
-        let mapper = ProductCategoryListMapper(siteID: siteID)
+        let mapper = ProductCategoryMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -31,12 +31,12 @@ public final class ProductCategoriesRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Create a new `ProducCategory`.
+    /// Create a new `ProductCategory`.
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll add a new product categories.
-    ///     - pageNumber: Number of page that should be retrieved.
-    ///     - pageSize: Number of categories to be retrieved per page.
+    ///     - name: Category name.
+    ///     - parentID: The ID for the parent of the category.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func createProductCategory(for siteID: Int64,

--- a/Networking/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Networking/Networking/Remote/ProductCategoriesRemote.swift
@@ -42,7 +42,7 @@ public final class ProductCategoriesRemote: Remote {
     public func createProductCategory(for siteID: Int64,
                                       name: String,
                                       parentID: Int64?,
-                                      completion: @escaping (ProductCategory?, Error?) -> Void) {
+                                      completion: @escaping (Result<ProductCategory, Error>) -> Void) {
         var parameters = [
             ParameterKey.name: name
         ]

--- a/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
@@ -13,14 +13,13 @@ final class ProductCategoryMapperTests: XCTestCase {
     /// Verifies that all of the ProductCategory Fields are parsed correctly.
     ///
     func testProductCategoryFieldsAreProperlyParsed() throws {
-        let productCategory = try mapProductCategoryResponse()
-        XCTAssertNotNil(productCategory)
+        let productCategory = try XCTUnwrap(mapProductCategoryResponse())
 
-        XCTAssertEqual(productCategory?.categoryID, 104)
-        XCTAssertEqual(productCategory?.parentID, 0)
-        XCTAssertEqual(productCategory?.siteID, dummySiteID)
-        XCTAssertEqual(productCategory?.name, "Dress")
-        XCTAssertEqual(productCategory?.slug, "Shirt")
+        XCTAssertEqual(productCategory.categoryID, 104)
+        XCTAssertEqual(productCategory.parentID, 0)
+        XCTAssertEqual(productCategory.siteID, dummySiteID)
+        XCTAssertEqual(productCategory.name, "Dress")
+        XCTAssertEqual(productCategory.slug, "Shirt")
     }
 
 }

--- a/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductCategoryMapper Unit Tests
+///
+final class ProductCategoryMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Verifies that all of the ProductCategory Fields are parsed correctly.
+    ///
+    func testProductCategoryFieldsAreProperlyParsed() throws {
+        let productCategory = try mapProductCategoryResponse()
+        XCTAssertNotNil(productCategory)
+
+        XCTAssertEqual(productCategory?.categoryID, 104)
+        XCTAssertEqual(productCategory?.parentID, 0)
+        XCTAssertEqual(productCategory?.siteID, dummySiteID)
+        XCTAssertEqual(productCategory?.name, "Dress")
+        XCTAssertEqual(productCategory?.slug, "Shirt")
+    }
+    
+}
+
+
+/// Private Methods.
+///
+private extension ProductCategoryMapperTests {
+
+    /// Returns the ProducCategoryMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductCategory(from filename: String) throws -> ProductCategory? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try ProductCategoryMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the ProductCategoryMapper output upon receiving `category`
+    ///
+    func mapProductCategoryResponse() throws -> ProductCategory? {
+        return try mapProductCategory(from: "category")
+    }
+}
+

--- a/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductCategoryMapperTests.swift
@@ -22,7 +22,7 @@ final class ProductCategoryMapperTests: XCTestCase {
         XCTAssertEqual(productCategory?.name, "Dress")
         XCTAssertEqual(productCategory?.slug, "Shirt")
     }
-    
+
 }
 
 
@@ -46,4 +46,3 @@ private extension ProductCategoryMapperTests {
         return try mapProductCategory(from: "category")
     }
 }
-

--- a/Networking/NetworkingTests/Remote/ProductCategoriesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductCategoriesRemoteTests.swift
@@ -69,4 +69,52 @@ final class ProductCategoriesRemoteTests: XCTestCase {
         XCTAssertNil(result.categories)
         XCTAssertNotNil(result.error)
     }
+
+    // MARK: - Create a product category tests
+
+    /// Verifies that createProductCategory properly parses the `category` sample response.
+    ///
+    func testCreateProductCategoryProperlyReturnsParsedProductCategory() {
+        // Given
+        let remote = ProductCategoriesRemote(network: network)
+        let expectation = self.expectation(description: "Create a new Product Category")
+
+        network.simulateResponse(requestUrlSuffix: "products/categories", filename: "category")
+
+        // When
+        var result: (category: ProductCategory?, error: Error?)
+        remote.createProductCategory(for: sampleSiteID, name: "Dress", parentID: 0) { category, error in
+            result = (category, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.category)
+        XCTAssertEqual(result.category?.name, "Dress")
+    }
+
+    /// Verifies that createProductCategory properly relays Networking Layer errors.
+    ///
+    func testCreateProductCategoryProperlyRelaysNetwokingErrors() {
+        // Given
+        let remote = ProductCategoriesRemote(network: network)
+        let expectation = self.expectation(description: "Create Product Category returns error")
+
+        // When
+        var result: (category: ProductCategory?, error: Error?)
+        remote.createProductCategory(for: sampleSiteID, name: "Dress", parentID: 0) { category, error in
+            result = (category, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.category)
+        XCTAssertNotNil(result.error)
+    }
+
 }

--- a/Networking/NetworkingTests/Remote/ProductCategoriesRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductCategoriesRemoteTests.swift
@@ -77,23 +77,22 @@ final class ProductCategoriesRemoteTests: XCTestCase {
     func testCreateProductCategoryProperlyReturnsParsedProductCategory() {
         // Given
         let remote = ProductCategoriesRemote(network: network)
-        let expectation = self.expectation(description: "Create a new Product Category")
 
         network.simulateResponse(requestUrlSuffix: "products/categories", filename: "category")
 
         // When
-        var result: (category: ProductCategory?, error: Error?)
-        remote.createProductCategory(for: sampleSiteID, name: "Dress", parentID: 0) { category, error in
-            result = (category, error)
-            expectation.fulfill()
+        var result: Result<ProductCategory, Error>?
+        waitForExpectation { exp in
+            remote.createProductCategory(for: sampleSiteID, name: "Dress", parentID: 0) { aResult in
+                result = aResult
+                exp.fulfill()
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        XCTAssertNil(result.error)
-        XCTAssertNotNil(result.category)
-        XCTAssertEqual(result.category?.name, "Dress")
+        XCTAssertNil(result?.failure)
+        XCTAssertNotNil(try result?.get())
+        XCTAssertEqual(try result?.get().name, "Dress")
     }
 
     /// Verifies that createProductCategory properly relays Networking Layer errors.
@@ -104,17 +103,17 @@ final class ProductCategoriesRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Create Product Category returns error")
 
         // When
-        var result: (category: ProductCategory?, error: Error?)
-        remote.createProductCategory(for: sampleSiteID, name: "Dress", parentID: 0) { category, error in
-            result = (category, error)
+        var result: Result<ProductCategory, Error>?
+        remote.createProductCategory(for: sampleSiteID, name: "Dress", parentID: 0) { aResult in
+            result = aResult
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertNil(result.category)
-        XCTAssertNotNil(result.error)
+        XCTAssertNil(try? result?.get())
+        XCTAssertNotNil(result?.failure)
     }
 
 }

--- a/Networking/NetworkingTests/Responses/category.json
+++ b/Networking/NetworkingTests/Responses/category.json
@@ -1,0 +1,35 @@
+{
+    "data":
+    {
+        "id": 104,
+        "name": "Dress",
+        "slug": "Shirt",
+        "parent": 0,
+        "description": "",
+        "display": "default",
+        "image": {
+            "id": 1310,
+            "date_created": "2018-08-28T13:09:22",
+            "date_created_gmt": "2018-08-28T17:09:22",
+            "date_modified": "2018-08-28T13:09:22",
+            "date_modified_gmt": "2018-08-28T17:09:22",
+            "src": "https://some-website.com/2018.jpg",
+            "name": "2018",
+            "alt": ""
+        },
+        "menu_order": 0,
+        "count": 1,
+        "_links": {
+            "self": [
+                {
+                    "href": "https://some-website.com/products/categories/104"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://some-website.com/products/categories"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
@@ -103,6 +103,8 @@ private final class MockProductCategoryStoresManager: DefaultStoresManager {
         case let .synchronizeProductCategories(_, _, onCompletion):
             numberOfResponsesConsumed = numberOfResponsesConsumed + 1
             onCompletion(productCategoryResponse)
+        default:
+            return
         }
     }
 }

--- a/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
@@ -9,6 +9,12 @@ public enum ProductCategoryAction: Action {
     /// `onCompletion` will be invoked when the sync operation finishes. `error` will be nill if the operation succeed.
     ///
     case synchronizeProductCategories(siteID: Int64, fromPageNumber: Int, onCompletion: (ProductCategoryActionError?) -> Void)
+
+    /// Create a new product category associated with a given Site ID.
+    /// `onCompletion` will be invoked when the add operation finishes. `error` will be nill if the operation succeed.
+    ///
+    case addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: (ProductCategory?, Error?) -> Void)
+
 }
 
 /// Defines all errors that a `ProductCategoryAction` can return

--- a/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
@@ -13,7 +13,7 @@ public enum ProductCategoryAction: Action {
     /// Create a new product category associated with a given Site ID.
     /// `onCompletion` will be invoked when the add operation finishes. `error` will be nill if the operation succeed.
     ///
-    case addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: (ProductCategory?, Error?) -> Void)
+    case addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: (Result<ProductCategory, Error>) -> Void)
 
 }
 

--- a/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
@@ -93,17 +93,17 @@ private extension ProductCategoryStore {
 
     /// Create a new product category associated with a given Site ID.
     ///
-    func addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: @escaping (ProductCategory?, Error?) -> Void) {
+    func addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: @escaping (Result<ProductCategory, Error>) -> Void) {
         let remote = ProductCategoriesRemote(network: network)
 
-        remote.createProductCategory(for: siteID, name: name, parentID: parentID) { [weak self] (productCategory, error) in
-            guard let productCategory = productCategory else {
-                onCompletion(nil, error)
-                return
-            }
-
-            self?.upsertStoredProductCategoriesInBackground([productCategory], siteID: siteID) {
-                onCompletion(productCategory, nil)
+        remote.createProductCategory(for: siteID, name: name, parentID: parentID) { [weak self] result in
+            switch result {
+            case .success(let productCategory):
+                self?.upsertStoredProductCategoriesInBackground([productCategory], siteID: siteID) {
+                    onCompletion(.success(productCategory))
+                }
+            case .failure(let error):
+                onCompletion(.failure(error))
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductCategoryStore.swift
@@ -27,6 +27,8 @@ public final class ProductCategoryStore: Store {
         switch action {
         case let .synchronizeProductCategories(siteID, fromPageNumber, onCompletion):
             synchronizeAllProductCategories(siteID: siteID, fromPageNumber: fromPageNumber, onCompletion: onCompletion)
+        case .addProductCategory(siteID: let siteID, name: let name, parentID: let parentID, onCompletion: let onCompletion):
+            addProductCategory(siteID: siteID, name: name, parentID: parentID, onCompletion: onCompletion)
         }
     }
 }
@@ -85,6 +87,23 @@ private extension ProductCategoryStore {
 
             self?.upsertStoredProductCategoriesInBackground(productCategories, siteID: siteID) {
                 onCompletion(productCategories, nil)
+            }
+        }
+    }
+
+    /// Create a new product category associated with a given Site ID.
+    ///
+    func addProductCategory(siteID: Int64, name: String, parentID: Int64?, onCompletion: @escaping (ProductCategory?, Error?) -> Void) {
+        let remote = ProductCategoriesRemote(network: network)
+
+        remote.createProductCategory(for: siteID, name: name, parentID: parentID) { [weak self] (productCategory, error) in
+            guard let productCategory = productCategory else {
+                onCompletion(nil, error)
+                return
+            }
+
+            self?.upsertStoredProductCategoriesInBackground([productCategory], siteID: siteID) {
+                onCompletion(productCategory, nil)
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -194,6 +194,70 @@ final class ProductCategoryStoreTests: XCTestCase {
         XCTAssertNotNil(errorResponse)
     }
 
+    func testAddProductCategoryAddsStoredCategorySuccessfulResponse() {
+        // Given a stubed product category network response
+        let expectation = self.expectation(description: #function)
+        network.simulateResponse(requestUrlSuffix: "products/categories", filename: "category")
+
+        // When dispatching a `addProductCategory` action
+        var errorResponse: Error?
+        let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { (productCategory, error) in
+            errorResponse = error
+            expectation.fulfill()
+        }
+        store.onAction(action)
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
+        // Then the category should be added
+        let addedCategory = viewStorage.loadProductCategory(siteID: sampleSiteID, categoryID: 104)
+        XCTAssertNotNil(addedCategory)
+        XCTAssertEqual(addedCategory?.categoryID, 104)
+        XCTAssertEqual(addedCategory?.parentID, 0)
+        XCTAssertEqual(addedCategory?.siteID, sampleSiteID)
+        XCTAssertEqual(addedCategory?.name, "Dress")
+        XCTAssertEqual(addedCategory?.slug, "Shirt")
+        XCTAssertNil(errorResponse)
+    }
+
+    func testAddProductCategoryReturnsErrorUponReponseError() {
+        // Given a stubed generic-error network response
+        let expectation = self.expectation(description: #function)
+        network.simulateResponse(requestUrlSuffix: "products/categories", filename: "generic_error")
+        XCTAssertEqual(storedProductCategoriesCount, 0)
+
+        // When dispatching a `addProductCategory` action
+        var errorResponse: Error?
+        let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { (productCategory, error) in
+            errorResponse = error
+            expectation.fulfill()
+        }
+        store.onAction(action)
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
+        // Then no categories should be stored
+        XCTAssertEqual(storedProductCategoriesCount, 0)
+        XCTAssertNotNil(errorResponse)
+    }
+
+    func testAddProductCategoryReturnsErrorUponEmptyResponse() {
+        // Given a an empty network response
+        let expectation = self.expectation(description: #function)
+        XCTAssertEqual(storedProductCategoriesCount, 0)
+
+        // When dispatching a `addProductCategory` action
+        var errorResponse: Error?
+        let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { (productCategory, error) in
+            errorResponse = error
+            expectation.fulfill()
+        }
+        store.onAction(action)
+        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
+        // Then no categories should be stored
+        XCTAssertEqual(storedProductCategoriesCount, 0)
+        XCTAssertNotNil(errorResponse)
+    }
+
     func testSynchronizeProductCategoriesDeletesUnusedCategories() {
         // Given some stored product categories without product relationships
         let expectation = self.expectation(description: #function)

--- a/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -152,7 +152,6 @@ final class ProductCategoryStoreTests: XCTestCase {
         case .none:
             XCTFail("errorResponse should not be nil")
         }
-
     }
 
     func testSynchronizeProductCategoriesReturnsErrorUponReponseError() {

--- a/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -195,17 +195,18 @@ final class ProductCategoryStoreTests: XCTestCase {
 
     func testAddProductCategoryAddsStoredCategorySuccessfulResponse() {
         // Given a stubed product category network response
-        let expectation = self.expectation(description: #function)
         network.simulateResponse(requestUrlSuffix: "products/categories", filename: "category")
 
         // When dispatching a `addProductCategory` action
-        var errorResponse: Error?
-        let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { (productCategory, error) in
-            errorResponse = error
-            expectation.fulfill()
+        var result: Result<Networking.ProductCategory, Error>?
+        waitForExpectation { (exp) in
+            let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { aResult in
+                result = aResult
+                exp.fulfill()
+            }
+            store.onAction(action)
         }
-        store.onAction(action)
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
 
         // Then the category should be added
         let addedCategory = viewStorage.loadProductCategory(siteID: sampleSiteID, categoryID: 104)
@@ -215,46 +216,47 @@ final class ProductCategoryStoreTests: XCTestCase {
         XCTAssertEqual(addedCategory?.siteID, sampleSiteID)
         XCTAssertEqual(addedCategory?.name, "Dress")
         XCTAssertEqual(addedCategory?.slug, "Shirt")
-        XCTAssertNil(errorResponse)
+        XCTAssertNil(result?.failure)
     }
 
     func testAddProductCategoryReturnsErrorUponReponseError() {
         // Given a stubed generic-error network response
-        let expectation = self.expectation(description: #function)
         network.simulateResponse(requestUrlSuffix: "products/categories", filename: "generic_error")
         XCTAssertEqual(storedProductCategoriesCount, 0)
 
         // When dispatching a `addProductCategory` action
-        var errorResponse: Error?
-        let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { (productCategory, error) in
-            errorResponse = error
-            expectation.fulfill()
+        var result: Result<Networking.ProductCategory, Error>?
+        waitForExpectation { (exp) in
+            let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { aResult in
+                result = aResult
+                exp.fulfill()
+            }
+            store.onAction(action)
         }
-        store.onAction(action)
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+
 
         // Then no categories should be stored
         XCTAssertEqual(storedProductCategoriesCount, 0)
-        XCTAssertNotNil(errorResponse)
+        XCTAssertNotNil(result?.failure)
     }
 
     func testAddProductCategoryReturnsErrorUponEmptyResponse() {
         // Given a an empty network response
-        let expectation = self.expectation(description: #function)
         XCTAssertEqual(storedProductCategoriesCount, 0)
 
         // When dispatching a `addProductCategory` action
-        var errorResponse: Error?
-        let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { (productCategory, error) in
-            errorResponse = error
-            expectation.fulfill()
+        var result: Result<Networking.ProductCategory, Error>?
+        waitForExpectation { (exp) in
+            let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { aResult in
+                result = aResult
+                exp.fulfill()
+            }
+            store.onAction(action)
         }
-        store.onAction(action)
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
 
         // Then no categories should be stored
         XCTAssertEqual(storedProductCategoriesCount, 0)
-        XCTAssertNotNil(errorResponse)
+        XCTAssertNotNil(result?.failure)
     }
 
     func testSynchronizeProductCategoriesDeletesUnusedCategories() {


### PR DESCRIPTION
Part of #2000

In order to build the add product category screen, I need to do some groundwork first adding the network request for adding a new product category.

## Changes
- Added the new `ProductCategoryMapper` + tests
- Added the new method “createProductCategory` in `ProductCategoriesRemote` + tests
- Added a new mock json `category.json`
- Added `addProductCategory` action in `ProductCategoryAction` and `ProductCategoryStore` + tests

## Testing
- Look at the code
- CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
