### PR TITLE
Products: fix navigation bar not showing product name and ellipsis menu from outside of Products tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.5
 -----
 - [*] In Order Details, the item subtotal is now shown on the right side instead of the quantity. The quantity can still be viewed underneath the product name.
+- [*] When opening a simple product from outside of the Products tab (e.g. from Top Performers section or an order), the product name and ellipsis menu (if the Products feature switch is enabled) should be visible in the navigation bar.
  
 4.4
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -211,16 +211,14 @@ extension OrderDetailsViewModel {
         case .orderItem:
             let item = items[indexPath.row]
             let loaderViewController = ProductLoaderViewController(productID: item.productOrVariationID,
-                                                                   siteID: order.siteID,
-                                                                   currency: order.currency)
+                                                                   siteID: order.siteID)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .aggregateOrderItem:
             let item = dataSource.aggregateOrderItems[indexPath.row]
             let productID = item.variationID == 0 ? item.productID : item.variationID
             let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: order.siteID,
-                                                                   currency: order.currency)
+                                                                   siteID: order.siteID)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .billingDetail:

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
@@ -141,8 +141,7 @@ extension RefundDetailsViewModel {
             let item = refund.items[indexPath.row]
             let productID = item.variationID == 0 ? item.productID : item.variationID
             let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: refund.siteID,
-                                                                   currency: order.currency)
+                                                                   siteID: refund.siteID)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -278,11 +278,8 @@ private extension TopPerformerDataViewController {
     /// Presents the ProductDetailsViewController or the ProductFormViewController, as a childViewController, for a given Product.
     ///
     func presentProductDetails(for productID: Int64, siteID: Int64) {
-        let currencyCode = CurrencySettings.shared.currencyCode
-        let currency = CurrencySettings.shared.symbol(from: currencyCode)
         let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                               siteID: siteID,
-                                                               currency: currency)
+                                                               siteID: siteID)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -266,8 +266,7 @@ private extension FulfillViewController {
     ///
     func productWasPressed(for productID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                               siteID: order.siteID,
-                                                               currency: order.currency)
+                                                               siteID: order.siteID)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -126,8 +126,7 @@ private extension ProductListViewController {
     ///
     func productWasPressed(for productID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                               siteID: viewModel.order.siteID,
-                                                               currency: viewModel.order.currency)
+                                                               siteID: viewModel.order.siteID)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -468,6 +468,12 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func updateNavigationBarTitle(productName: String) {
         navigationItem.title = productName
+        switch presentationStyle {
+        case .contained(let containerViewController):
+            containerViewController.navigationItem.title = productName
+        default:
+            break
+        }
     }
 
     func updateNavigationBar(isUpdateEnabled: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -47,7 +47,6 @@ final class ProductFormViewController: UIViewController {
     private var cancellableProduct: ObservationToken?
     private var cancellableProductName: ObservationToken?
     private var cancellableUpdateEnabled: ObservationToken?
-    private var cancellableNavigationRightBarButtonItems: ObservationToken?
 
     init(product: Product,
          currency: String = CurrencySettings.shared.symbol(from: CurrencySettings.shared.currencyCode),
@@ -89,15 +88,12 @@ final class ProductFormViewController: UIViewController {
         cancellableProduct?.cancel()
         cancellableProductName?.cancel()
         cancellableUpdateEnabled?.cancel()
-        cancellableNavigationRightBarButtonItems?.cancel()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Presentation style is configured before navigation bar updates below because the subscriber for the navigation bar updates is different.
         configurePresentationStyle()
-
         configureNavigationBar()
         configureMainView()
         configureTableView()
@@ -183,9 +179,8 @@ private extension ProductFormViewController {
         switch presentationStyle {
         case .contained(let containerViewController):
             containerViewController.addCloseNavigationBarButton(target: self, action: #selector(closeNavigationBarButtonTapped))
-            observeNavigationRightBarButtonItems(viewControllerWithNavigationItem: containerViewController)
         case .navigationStack:
-            observeNavigationRightBarButtonItems(viewControllerWithNavigationItem: self)
+            break
         }
     }
 
@@ -195,12 +190,6 @@ private extension ProductFormViewController {
             return
         }
         exitForm()
-    }
-
-    func observeNavigationRightBarButtonItems(viewControllerWithNavigationItem: UIViewController) {
-        cancellableNavigationRightBarButtonItems = navigationRightBarButtonItems.subscribe { [weak viewControllerWithNavigationItem] rightBarButtonItems in
-            viewControllerWithNavigationItem?.navigationItem.rightBarButtonItems = rightBarButtonItems
-        }
     }
 
     func configureMoreDetailsContainerView() {
@@ -487,7 +476,13 @@ private extension ProductFormViewController {
             rightBarButtonItems.insert(createMoreOptionsBarButtonItem(), at: 0)
         }
 
-        navigationRightBarButtonItemsSubject.send(rightBarButtonItems)
+        navigationItem.rightBarButtonItems = rightBarButtonItems
+        switch presentationStyle {
+        case .contained(let containerViewController):
+            containerViewController.navigationItem.rightBarButtonItems = rightBarButtonItems
+        default:
+            break
+        }
     }
 
     func createUpdateBarButtonItem() -> UIBarButtonItem {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -20,10 +20,6 @@ final class ProductLoaderViewController: UIViewController {
     ///
     private let siteID: Int64
 
-    /// The Target Product's Currency
-    ///
-    private let currency: String
-
     /// UI Active State
     ///
     private var state: State = .loading {
@@ -35,10 +31,9 @@ final class ProductLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(productID: Int64, siteID: Int64, currency: String) {
+    init(productID: Int64, siteID: Int64) {
         self.productID = productID
         self.siteID = siteID
-        self.currency = currency
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -169,7 +169,7 @@ private extension ProductLoaderViewController {
         viewController.didMove(toParent: self)
 
         // And, of course, borrow the Child's Title + right nav bar items
-        title = viewController.title
+        title = viewController.navigationItem.title
         navigationItem.rightBarButtonItems = viewController.navigationItem.rightBarButtonItems
     }
 


### PR DESCRIPTION
Fixes #2388 

## Cause of the bug

When a product form is contained in `ProductLoaderViewController` (e.g. when opening a simple product from outside of the Products tab), the container VC's [navigation bar right items are set up to update to the latest value correctly in `viewDidLoad`](https://github.com/woocommerce/woocommerce-ios/blob/09741efe783fb6aacabba6036fe6fcdcfd5e0d54/WooCommerce/Classes/ViewRelated/Products/Edit%20Product/ProductFormViewController.swift#L99). However, after we add `ProductFormViewController` as a child VC in `ProductLoaderViewController`, it also assigns its title and right bar button items immediately after:

https://github.com/woocommerce/woocommerce-ios/blob/09741efe783fb6aacabba6036fe6fcdcfd5e0d54/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift#L177-L178

Since `ProductFormViewController`'s **self** navigation item isn't set up for the title nor the right bar button items, the right bar button items are cleared. As for the product name, `ProductFormViewController` is set up to only update self navigation item and not the container's, and `ProductLoaderViewController` is setting the initial value with the child VC's `title` instead of `navigationItem.title`.

## Changes

I didn't want to alter the behavior of `ProductLoaderViewController` too much since it also has to work with `ProductDetailsViewController`, so I made most of the changes in `ProductFormViewController` to update its own `navigationItem` in addition to its container.

I'd recommend reviewing by commit:

- (cleanup from touching `ProductLoaderViewController`) Removed the unused parameter/property `currency` from `ProductLoaderViewController`, and updated its usage https://github.com/woocommerce/woocommerce-ios/commit/10edde1b2850a578b53b9583a1739359c18b2e23
- Fixed the product name not appearing on the navigation bar if the product form is contained in `ProductLoaderViewController` by setting its own navigation item title and its container's  https://github.com/woocommerce/woocommerce-ios/commit/b9a6181c930025e32966494bcc26f0461bb41ed9
- Fixed the ellipsis menu not appearing on the navigation bar initially if the product form is contained in `ProductLoaderViewController` by setting its own navigation item and its container's https://github.com/woocommerce/woocommerce-ios/commit/6f449b8a1fcd87875a1cdb4ffea7596202fafa38
  - Also removed the observable since the right bar button items can be updated directly in the same class

## Testing

Prerequisites:
1. the store has an order with a simple product
2. please test on a non-iOS 13.4 simulator/device so that the discard changes behavior can be tested

- Go to Settings > Experimental Features and make sure the Products feature switch is on
- Open the Orders tab
- Tap on the order with a simple product
- Tap on the simple product in order details --> the product name should be in the navbar title, and the ellipsis menu is visible on the right
- Update the product name --> the product name should reflect the latest product name, and "Update" CTA should be visible in the navbar
- Tap the "X" in the navbar --> a discard changes prompt should be shown
- Close the product form
- Open the Products tab
- Select the same simple product from the products list --> the product name should be in the navbar title, and the ellipsis menu is visible on the right
- Update the product name --> the product name should reflect the latest product name, and "Update" CTA should be visible in the navbar
- Tap the "X" in the navbar --> a discard changes prompt should be shown

## Example screenshots

Notice the ellipsis menu and product name in the navigation bar!

before | after
-- | --
![Simulator Screen Shot - iPhone Xs - 2020-06-05 at 11 12 20](https://user-images.githubusercontent.com/1945542/83832998-79f1c780-a71d-11ea-8d3c-8fb05211f685.png) | ![Simulator Screen Shot - iPhone Xs - 2020-06-05 at 10 51 09](https://user-images.githubusercontent.com/1945542/83832991-75c5aa00-a71d-11ea-896c-04aa88f2750c.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
