### PR TITLE
Order Details → Remove SKU from Products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.5
 -----
 - [*] In Order Details, the item subtotal is now shown on the right side instead of the quantity. The quantity can still be viewed underneath the product name.
+- [*] In Order Details, SKU was removed from the Products List. It is still shown when fulfilling the order or viewing the product details.
 - [*] Polish the loading state on the product variations screen.
  
 4.4

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -23,10 +23,6 @@ final class ProductDetailsTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var subtitleLabel: UILabel!
 
-    /// The label showing the SKU.
-    ///
-    @IBOutlet private var skuLabel: UILabel!
-
     // MARK: - Overridden Methods
 
     required init?(coder aDecoder: NSCoder) {
@@ -41,7 +37,6 @@ final class ProductDetailsTableViewCell: UITableViewCell {
         configureProductImageView()
         configureNameLabel()
         configurePriceLabel()
-        configureSKULabel()
         configureSubtitleLabel()
         configureSelectionStyle()
     }
@@ -79,11 +74,6 @@ private extension ProductDetailsTableViewCell {
         subtitleLabel?.text = ""
     }
 
-    func configureSKULabel() {
-        skuLabel.applySecondaryFootnoteStyle()
-        skuLabel?.text = ""
-    }
-
     func configureSelectionStyle() {
         selectionStyle = .none
     }
@@ -105,6 +95,5 @@ extension ProductDetailsTableViewCell {
         nameLabel.text = item.name
         priceLabel.text = item.total
         subtitleLabel.text = item.subtitle
-        skuLabel.text = item.sku
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -27,16 +28,16 @@
                         <rect key="frame" x="75" y="19" width="230" height="85"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HX7-V5-bhX">
-                                <rect key="frame" x="0.0" y="0.0" width="230" height="45"/>
+                                <rect key="frame" x="0.0" y="0.0" width="230" height="50"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="The Title Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="14R-zK-tgC">
-                                        <rect key="frame" x="0.0" y="0.0" width="190.5" height="45"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="190.5" height="50"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="893" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pPE-SE-pY7">
-                                        <rect key="frame" x="198.5" y="0.0" width="31.5" height="45"/>
+                                        <rect key="frame" x="198.5" y="0.0" width="31.5" height="50"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -53,12 +54,6 @@
                                     <constraint firstItem="pPE-SE-pY7" firstAttribute="leading" secondItem="14R-zK-tgC" secondAttribute="trailing" constant="8" id="lJh-P7-t92"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SKU" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7JH-rt-n9v">
-                                <rect key="frame" x="0.0" y="49" width="230" height="16"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total price (item price x qty)" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBM-H2-zE2">
                                 <rect key="frame" x="0.0" y="69" width="230" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -82,7 +77,6 @@
                 <outlet property="nameLabel" destination="14R-zK-tgC" id="LmK-XT-zbU"/>
                 <outlet property="priceLabel" destination="pPE-SE-pY7" id="ir4-Ou-SuU"/>
                 <outlet property="productImageView" destination="p6h-Fq-FjW" id="bIw-1F-5GW"/>
-                <outlet property="skuLabel" destination="7JH-rt-n9v" id="U07-2n-W3b"/>
                 <outlet property="subtitleLabel" destination="IBM-H2-zE2" id="acc-K8-vmg"/>
             </connections>
             <point key="canvasLocation" x="62" y="96.5"/>


### PR DESCRIPTION
Part of #2281. 

## Design

This removes the SKU from the Products in the Order Details. The SKU is still shown when fulfilling the order or viewing the product details. 

Before | After  
--------|-------
![image](https://user-images.githubusercontent.com/198826/83895282-b6b6c200-a70f-11ea-8979-dbf5c4e93198.png) | ![image](https://user-images.githubusercontent.com/198826/83895307-c0402a00-a70f-11ea-88b8-51f0cc79cfa5.png)

![magic](https://www.reactiongifs.com/r/mgc.gif)

## Testing

1. Navigate to an order
2. Confirm that the SKU is no longer visible. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

