### PR TITLE
Order Details → Use singular or plural "Products" section title

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -577,7 +577,7 @@ extension OrderDetailsDataSource {
                     rows.append(.details)
                 }
 
-                return Section(title: Title.products, rightTitle: nil, rows: rows, headerStyle: .primary)
+                return Section(title: Localization.pluralizedProducts(count: items.count), rightTitle: nil, rows: rows, headerStyle: .primary)
             }
 
             var rows = [Row]()
@@ -599,7 +599,7 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            return Section(title: Title.products, rightTitle: nil, rows: rows, headerStyle: .primary)
+            return Section(title: Localization.pluralizedProducts(count: items.count), rightTitle: nil, rows: rows, headerStyle: .primary)
         }()
 
         let refundedProducts: Section? = {
@@ -861,7 +861,8 @@ extension OrderDetailsDataSource {
     }
 
     enum Title {
-        static let products = NSLocalizedString("Products", comment: "Product section title")
+        static let products = NSLocalizedString("Products", comment: "Product section title if there is more than one product.")
+        static let product = NSLocalizedString("Product", comment: "Product section title if there is only one product.")
         static let refundedProducts = NSLocalizedString("Refunded Products", comment: "Section title")
         static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
         static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")
@@ -1015,5 +1016,15 @@ extension OrderDetailsDataSource {
         static let addOrderCell = 1
         static let paymentCell = 1
         static let paidByCustomerCell = 1
+    }
+}
+
+// MARK: - Private Utils
+
+private extension OrderDetailsDataSource {
+    enum Localization {
+        static func pluralizedProducts(count: Int) -> String {
+            count > 1 ? Title.products : Title.product
+        }
     }
 }


### PR DESCRIPTION
Requires #2389 to be merged first. Closes #2281. 

## Design

This changes the products section header title to use the plural term only if there is more than one product. 

More Than One | One Product Only
--------|-------
![image](https://user-images.githubusercontent.com/198826/83901786-89badd00-a718-11ea-8a01-31bc3dea32cb.png)        |    ![image](https://user-images.githubusercontent.com/198826/83901928-be2e9900-a718-11ea-89a9-ba32064f9dc5.png)

## Testing

1. Navigate to an order containing one product. 
2. Confirm that the header shows “Product”. 
1. Navigate to an order containing more than one product. 
2. Confirm that the header shows “Products”. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

