### PR TITLE
Fix Crash When Running on iOS 12

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */; };
 		57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57448D27242E775000A56A74 /* EmptyStateViewController.swift */; };
 		57448D2A242E777700A56A74 /* EmptyStateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57448D29242E777700A56A74 /* EmptyStateViewController.xib */; };
+		5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		5754727B2451F14600A94C3C /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727A2451F14600A94C3C /* Observable.swift */; };
 		5754727D2451F1D800A94C3C /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727C2451F1D800A94C3C /* PublishSubject.swift */; };
 		5754727F24520B2A00A94C3C /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727E24520B2A00A94C3C /* Observer.swift */; };
@@ -1206,6 +1207,7 @@
 		573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
 		57448D27242E775000A56A74 /* EmptyStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewController.swift; sourceTree = "<group>"; };
 		57448D29242E777700A56A74 /* EmptyStateViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyStateViewController.xib; sourceTree = "<group>"; };
+		5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		5754727A2451F14600A94C3C /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		5754727C2451F1D800A94C3C /* PublishSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSubject.swift; sourceTree = "<group>"; };
 		5754727E24520B2A00A94C3C /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
@@ -1705,6 +1707,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
 				B5C3B5E320D189E60072CB9D /* Networking.framework in Frameworks */,
@@ -2755,6 +2758,7 @@
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */,
 				B5C3B5E620D189ED0072CB9D /* Yosemite.framework */,
 				B5C3B5E420D189EA0072CB9D /* Storage.framework */,
 				B5C3B5E220D189E60072CB9D /* Networking.framework */,


### PR DESCRIPTION
## Findings

The crash was caused by #2389. The PR added this optional `SwiftUI` import which apparently still doesn't work for iOS 12. 

https://github.com/woocommerce/woocommerce-ios/blob/5627c70af2219f62e89ebd936f6a7e460cc154c4/WooCommerce/Classes/ViewRelated/ReusableViews/Section%20Headers/PrimarySectionHeaderView.swift#L58-L62 

Thanks to @jaclync for finding it.

## Solution

I followed @pmusolino's suggestion to add SwiftUI as an optional linked library in Build Phases.

![image](https://user-images.githubusercontent.com/198826/84169804-4d4bf180-aa36-11ea-9628-59f8796ccf7a.png)

## Testing

1. Run the project on iOS 12. It should not crash right away anymore. 
2. Navigate to an Order.
3. Confirm that the “Products” header is still visible. 
4. Run the project on iOS 13 and repeat steps 2 to 3. 

### Optional: Xcode Preview

Contrary to [some tutorials](https://www.avanderlee.com/xcode/xcode-previews/), I can get the Xcode Preview working **without changing** the target version to iOS 13.0. If you can't, please change it temporarily. 🙂 

1. Open `PrimarySectionHeaderView.swift` in Xcode.
2. Show the Canvas on the right by clicking on Editor → Canvas.
3. Tap on the Resume button if it's shown. 

    ![image](https://user-images.githubusercontent.com/198826/84170540-15917980-aa37-11ea-9ecb-cf962fdb8d4f.png)

4. Xcode should build the app and show the previews when it's done. 
5. Change the `title` on this line:            

    https://github.com/woocommerce/woocommerce-ios/blob/5627c70af2219f62e89ebd936f6a7e460cc154c4/WooCommerce/Classes/ViewRelated/ReusableViews/Section%20Headers/PrimarySectionHeaderView.swift#L79
6. The Preview should be automatically updated.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
