### PR TITLE
Adds a link to the California Privacy Policy for CCPA compliance.

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -42,7 +42,7 @@ enum WooConstants {
     static var privacyURL: URL {
         trustedURL("https://automattic.com/privacy/")
     }
-    
+
     /// Privacy policy for California users URL
     ///
     static var californiaPrivacyURL: URL {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -42,6 +42,12 @@ enum WooConstants {
     static var privacyURL: URL {
         trustedURL("https://automattic.com/privacy/")
     }
+    
+    /// Privacy policy for California users URL
+    ///
+    static var californiaPrivacyURL: URL {
+        trustedURL("https://automattic.com/privacy/#california-consumer-privacy-act-ccpa")
+    }
 
     /// Help Center URL
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -124,7 +124,7 @@ private extension AboutViewController {
     /// Setup the sections in this table view
     ///
     func configureSections() {
-        sections = [Section(title: nil, rows: [.terms, .privacy])]
+        sections = [Section(title: nil, rows: [.terms, .privacy, .californiaPrivacy])]
     }
 
     /// Register table cells.
@@ -139,6 +139,8 @@ private extension AboutViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
+        case let cell as BasicTableViewCell where row == .californiaPrivacy:
+            configureCaliforniaPrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .terms:
             configureTerms(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
@@ -155,13 +157,21 @@ private extension AboutViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Terms of Service", comment: "Opens the Terms of Service web page")
     }
-
-    /// Privacy polocy cell.
+    
+    /// Privacy policy cell.
     ///
     func configurePrivacy(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Privacy Policy", comment: "Opens the Privacy Policy web page")
+    }
+    
+    /// California Privacy policy cell.
+    ///
+    func configureCaliforniaPrivacy(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString("Privacy Notice for California Users", comment: "Opens the California Privacy Policy web page")
     }
 }
 
@@ -185,13 +195,20 @@ private extension AboutViewController {
 //
 private extension AboutViewController {
 
-    /// Terms of Service action
+    
+    /// California Privacy Policy action
+    ///
+    func californiaPrivacyWasPressed() {
+        displayWebView(url: WooConstants.californiaPrivacyURL)
+    }
+    
+    /// Privacy Policy action
     ///
     func privacyWasPressed() {
         displayWebView(url: WooConstants.privacyURL)
     }
 
-    /// Privacy Policy action
+    /// Terms of Service action
     ///
     func termsWasPressed() {
         displayWebView(url: WooConstants.termsOfServiceUrl)
@@ -241,6 +258,8 @@ extension AboutViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
 
         switch rowAtIndexPath(indexPath) {
+        case .californiaPrivacy:
+            californiaPrivacyWasPressed()
         case .privacy:
             privacyWasPressed()
         case .terms:
@@ -267,9 +286,12 @@ private struct Section {
 private enum Row: CaseIterable {
     case terms
     case privacy
+    case californiaPrivacy
 
     var type: UITableViewCell.Type {
         switch self {
+        case .californiaPrivacy:
+            return BasicTableViewCell.self
         case .terms:
             return BasicTableViewCell.self
         case .privacy:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -157,7 +157,7 @@ private extension AboutViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Terms of Service", comment: "Opens the Terms of Service web page")
     }
-    
+
     /// Privacy policy cell.
     ///
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -165,7 +165,7 @@ private extension AboutViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Privacy Policy", comment: "Opens the Privacy Policy web page")
     }
-    
+
     /// California Privacy policy cell.
     ///
     func configureCaliforniaPrivacy(cell: BasicTableViewCell) {
@@ -195,13 +195,12 @@ private extension AboutViewController {
 //
 private extension AboutViewController {
 
-    
     /// California Privacy Policy action
     ///
     func californiaPrivacyWasPressed() {
         displayWebView(url: WooConstants.californiaPrivacyURL)
     }
-    
+
     /// Privacy Policy action
     ///
     func privacyWasPressed() {

--- a/fastlane/appstoreres/metadata/source/description.txt
+++ b/fastlane/appstoreres/metadata/source/description.txt
@@ -10,3 +10,5 @@ Get notifications about store activity – including new orders and product revi
 WooCommerce is the most customizable eCommerce platform for building your online business. Built on WordPress, it is integrated with the world’s best content management tools. From coffee subscriptions to Spanish lessons to gym memberships to complex enterprise-level eCommerce – visit WooCommerce.com/start to launch a new store and ship your idea.
 
 Requirements: WooCommerce v3.5+, the Jetpack plugin.
+
+View the Privacy Notice for California Users at https://automattic.com/privacy/#california-consumer-privacy-act-ccpa.


### PR DESCRIPTION
Closes #2411 

Adds a simple link to the Automattic Privacy Policy section specific to CCPA for California users. I also added a link to the policy with some copy in the App Store description. I wish we could exclude this from all regions except the US, but it is what it is. Technically it's not for California residents but for people existing in California.

@loremattei and/or @jkmassel can you make sure I'm not doing something terrible here with the descriptions that'll break our translations?

## Screenshot

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-06-10 at 11 30 39](https://user-images.githubusercontent.com/373903/84295369-1ba75900-ab10-11ea-9658-002a50ff1eab.png)
## Testing Steps

1. Launch the app.
2. Log into the app.
3. Tap on Settings in My Store.
4. Tap on WooCommerce under ABOUT THE APP.
5. Verify each of the three links function as expected.

Known Issue: Safari on iOS isn't scrolling to the proper location on the page for the anchor.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
