### PR TITLE
Add more logging for Core Data migration for crash investigation

### DIFF
--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -18,28 +18,28 @@ public struct CoreDataIterativeMigrator {
     ///
     /// - Throws: A whole bunch of crap is possible to be thrown between Core Data and FileManager.
     ///
-    static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String]) throws -> Bool {
+    static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String]) throws -> (success: Bool, debugMessages: [String]) {
         // If the persistent store does not exist at the given URL,
         // assume that it hasn't yet been created and return success immediately.
         guard FileManager.default.fileExists(atPath: sourceStore.path) == true else {
-            return true
+            return (true, [])
         }
 
         // Get the persistent store's metadata.  The metadata is used to
         // get information about the store's managed object model.
         guard let sourceMetadata = try metadataForPersistentStore(storeType: storeType, at: sourceStore) else {
-            return false
+            return (false, [])
         }
 
         // Check whether the final model is already compatible with the store.
         // If it is, no migration is necessary.
         guard targetModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: sourceMetadata) == false else {
-            return true
+            return (true, [])
         }
 
         // Find the current model used by the store.
         guard let sourceModel = try model(for: sourceMetadata) else {
-            return false
+            return (false, [])
         }
 
         // Get NSManagedObjectModels for each of the model names given.
@@ -76,6 +76,8 @@ public struct CoreDataIterativeMigrator {
             modelsToMigrate = modelsToMigrate.reversed()
         }
 
+        var debugMessages = [String]()
+
         // Migrate between each model. Count - 2 because of zero-based index and we want
         // to stop at the last pair (you can't migrate the last model to nothingness).
         let upperBound = modelsToMigrate.count - 2
@@ -86,18 +88,20 @@ public struct CoreDataIterativeMigrator {
             // Check whether a custom mapping model exists.
             guard let migrateWithModel = NSMappingModel(from: nil, forSourceModel: modelFrom, destinationModel: modelTo) ??
                 (try? NSMappingModel.inferredMappingModel(forSourceModel: modelFrom, destinationModel: modelTo)) else {
-                    return false
+                    return (false, debugMessages)
             }
 
             // Migrate the model to the next step
-            DDLogWarn("⚠️ Attempting migration from \(modelNames[index]) to \(modelNames[index + 1])")
+            let migrationAttemptMessage = "⚠️ Attempting migration from \(modelNames[index]) to \(modelNames[index + 1])"
+            debugMessages.append(migrationAttemptMessage)
+            DDLogWarn(migrationAttemptMessage)
 
             guard migrateStore(at: sourceStore, storeType: storeType, fromModel: modelFrom, toModel: modelTo, with: migrateWithModel) == true else {
-                return false
+                return (false, debugMessages)
             }
         }
 
-        return true
+        return (true, debugMessages)
     }
 }
 

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -18,7 +18,8 @@ public struct CoreDataIterativeMigrator {
     ///
     /// - Throws: A whole bunch of crap is possible to be thrown between Core Data and FileManager.
     ///
-    static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String]) throws -> (success: Bool, debugMessages: [String]) {
+    static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String])
+        throws -> (success: Bool, debugMessages: [String]) {
         // If the persistent store does not exist at the given URL,
         // assume that it hasn't yet been created and return success immediately.
         guard FileManager.default.fileExists(atPath: sourceStore.path) == true else {

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -58,7 +58,7 @@ public class CoreDataManager: StorageManagerType {
                                                    properties: ["persistentStoreLoadingError": persistentStoreLoadingError,
                                                                 "backupError": error,
                                                                 "appState": UIApplication.shared.applicationState.rawValue,
-                                                                "migrationMessages": "\(migrationDebugMessages)"],
+                                                                "migrationMessages": migrationDebugMessages],
                                                    level: .fatal)
                 fatalError(message)
             }
@@ -73,7 +73,7 @@ public class CoreDataManager: StorageManagerType {
                                                    properties: ["persistentStoreLoadingError": persistentStoreLoadingError,
                                                                 "removeStoreError": error,
                                                                 "appState": UIApplication.shared.applicationState.rawValue,
-                                                                "migrationMessages": "\(migrationDebugMessages)"],
+                                                                "migrationMessages": migrationDebugMessages],
                                                    level: .fatal)
                 fatalError(message)
             }
@@ -90,7 +90,7 @@ public class CoreDataManager: StorageManagerType {
                                                     properties: ["persistentStoreLoadingError": persistentStoreLoadingError,
                                                                  "retryError": error,
                                                                  "appState": UIApplication.shared.applicationState.rawValue,
-                                                                 "migrationMessages": "\(migrationDebugMessages)"],
+                                                                 "migrationMessages": migrationDebugMessages],
                                                     level: .fatal)
                 fatalError(message)
             }
@@ -98,7 +98,7 @@ public class CoreDataManager: StorageManagerType {
             self.crashLogger.logMessage("[CoreDataManager] Recovered from persistent store loading error",
                                         properties: ["persistentStoreLoadingError": persistentStoreLoadingError,
                                                      "appState": UIApplication.shared.applicationState.rawValue,
-                                                     "migrationMessages": "\(migrationDebugMessages)"],
+                                                     "migrationMessages": migrationDebugMessages],
                                         level: .info)
         }
 

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -57,7 +57,7 @@ class CoreDataIterativeMigratorTests: XCTestCase {
 
         do {
             let modelNames = ["Model", "Model 2", "Model 3", "Model 4", "Model 5", "Model 6", "Model 7", "Model 8", "Model 9", "Model 10"]
-            let result = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL, storeType: NSSQLiteStoreType, to: model!, using: modelNames)
+            let (result, _) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL, storeType: NSSQLiteStoreType, to: model!, using: modelNames)
             XCTAssertTrue(result)
         } catch {
             XCTFail("Error when attempting to migrate: \(error)")


### PR DESCRIPTION
Logging for crash investigation for #2371 

## Background

The current logging for the Core Data init crash doesn't get us very far to understand how it went during the migration process before we call `loadPersistentStores` on a `NSPersistentContainer`. This PR aims to add more logging to the Core Data init crash logging for us to know more about the migration before the crash.

## Changes

- In `CoreDataIterativeMigrator`, returns a tuple with an array of debug messages in addition to the success boolean
- In `CoreDataManager`, gathered debug messages from `migrateDataModelIfNecessary` including the call to `CoreDataIterativeMigrator` and included these debug messages under `"migrationMessages"` key in the "Additional data" logging ([example Sentry event](https://sentry.io/organizations/a8c/issues/1720861484/events/84dca9b5e32a4fe9a88f6a39986fa13a/))

## Testing

Feel free to manually log a message after the line of `let migrationDebugMessages = migrateDataModelIfNecessary()` in `CoreDataManager` like:

```swift
crashLogger.logMessage("[CoreDataManager] Testing only!", properties: ["migrationMessages": migrationDebugMessages], level: .info)
```

build with "Release-Alpha" configuration, and then check Sentry after launching the app (potentially with migration from a different model version).

at some point I wasn't able to see the events on Sentry, and noticed there were processing issues on the symbols. I wasn't able to figure out after running their script so I switched to a different simulator.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
