### PR TITLE
[WIP] Testing: Add UI tests for orders

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -316,6 +316,7 @@ private extension OrderDetailsDataSource {
             "Composes a new order note.",
             comment: "VoiceOver accessibility hint, informing the user that the button can be used to create a new order note."
         )
+        cell.accessibilityIdentifier = "add-order-note-button"
     }
 
     private func configureOrderNoteHeader(cell: OrderNoteHeaderTableViewCell, at indexPath: IndexPath) {
@@ -441,6 +442,7 @@ private extension OrderDetailsDataSource {
         cell.onFullfillTouchUp = { [weak self] in
             self?.onCellAction?(.fulfill, nil)
         }
+        cell.fulfillButton.accessibilityIdentifier = "begin-fulfillment-button"
     }
 
     private func configureTracking(cell: OrderTrackingTableViewCell, at indexPath: IndexPath) {
@@ -483,6 +485,7 @@ private extension OrderDetailsDataSource {
             "Adds tracking to an order.",
             comment: "VoiceOver accessibility hint, informing the user that the button can be used to add tracking to an order. Should end with a period."
         )
+        cell.accessibilityIdentifier = "order-details-add-tracking-button"
     }
 
     private func configureShippingAddress(cell: CustomerInfoTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -283,6 +283,7 @@ private extension NewNoteViewController {
                                              action: #selector(addButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
         navigationItem.rightBarButtonItem?.isEnabled = false
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "order-note-add-button"
     }
 
     func configureForCommittingNote() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -272,6 +272,7 @@ private extension NewNoteViewController {
                                             target: self,
                                             action: #selector(dismissButtonTapped))
         navigationItem.setLeftBarButton(leftBarButton, animated: false)
+        navigationItem.leftBarButtonItem?.accessibilityIdentifier = "order-note-dismiss-button"
     }
 
     func configureRightButtonItemAsAdd() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -144,6 +144,7 @@ private extension NewNoteViewController {
             self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
             self?.noteText = text
         }
+        cell.noteTextView.accessibilityIdentifier = "order-note-text-field"
     }
 
     private func setupEmailCustomerCell(_ cell: UITableViewCell) {
@@ -164,6 +165,7 @@ private extension NewNoteViewController {
             "Double tap to toggle setting.",
             comment: "VoiceOver accessibility hint, informing the user that double-tapping will toggle the switch off and on."
         )
+        cell.accessibilityIdentifier = "order-note-email-switch"
 
         cell.onChange = { [weak self] newValue in
             guard let `self` = self else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -155,6 +155,7 @@ private extension FulfillViewController {
         actionButton.setTitle(title, for: .normal)
         actionButton.applyPrimaryButtonStyle()
         actionButton.addTarget(self, action: #selector(fulfillWasPressed), for: .touchUpInside)
+        actionButton.accessibilityIdentifier = "mark-order-complete-button"
     }
 
     /// Registers all of the available TableViewCells
@@ -442,6 +443,7 @@ private extension FulfillViewController {
             "Adds tracking to an order.",
             comment: "VoiceOver accessibility hint, informing the user that the button can be used to add tracking to an order. Should end with a period."
         )
+        cell.accessibilityIdentifier = "fulfill-order-add-tracking-button"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -109,6 +109,7 @@ private extension ManualTrackingViewController {
                                              action: #selector(primaryButtonTapped))
         navigationItem.setRightBarButton(rightBarButton, animated: false)
         navigationItem.rightBarButtonItem?.isEnabled = false
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "add-tracking-add-button"
     }
 
     func configureForCommittingTracking() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -236,6 +236,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
 
         cell.value.isEnabled = false
         cell.accessoryType = viewModel.providerCellAccessoryType
+
+        cell.accessibilityIdentifier = "add-tracking-shipping-carrier-cell"
     }
 
     private func configureProviderName(cell: TitleAndEditableValueTableViewCell) {
@@ -259,6 +261,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
 
         cell.value.addTarget(self, action: #selector(didChangeTrackingNumber), for: .editingChanged)
         cell.accessoryType = .none
+
+        cell.value.accessibilityIdentifier = "add-tracking-enter-tracking-number-field"
     }
 
     private func configureTrackingLink(cell: TitleAndEditableValueTableViewCell) {
@@ -283,6 +287,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
         cell.accessoryType = .none
 
         cell.separatorInset = datePickerVisible ? Constants.cellSeparatorInset : .zero
+
+        cell.accessibilityIdentifier = "add-tracking-date-shipped-cell"
     }
 
     private func configureSecondaryAction(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -82,6 +82,7 @@ private extension ManualTrackingViewController {
                                             target: self,
                                             action: #selector(dismissButtonTapped))
         navigationItem.setLeftBarButton(leftBarButton, animated: false)
+        navigationItem.leftBarButtonItem?.accessibilityIdentifier = "add-tracking-dismiss-button"
     }
 
     func configureBackButton() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -119,6 +119,7 @@ private extension ShipmentProvidersViewController {
 
     func configureSearchController() {
         searchController.searchBar.textField?.backgroundColor = .listBackground
+        searchController.searchBar.accessibilityIdentifier = "shipping-carriers-search-field"
 
         guard table.tableHeaderView == nil else {
             return
@@ -136,6 +137,7 @@ private extension ShipmentProvidersViewController {
 
         table.dataSource = self
         table.delegate = self
+        table.accessibilityIdentifier = "shipping-carriers-table"
     }
 
     /// Registers all of the available TableViewCells

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -567,6 +567,18 @@
 		B5FD111221D3CE7700560344 /* NewNoteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5FD111121D3CE7700560344 /* NewNoteViewController.xib */; };
 		B5FD111621D3F13700560344 /* BordersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FD111521D3F13700560344 /* BordersView.swift */; };
 		B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */; };
+		CC52315E248FEDAF007B128F /* OrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC52315D248FEDAF007B128F /* OrderTests.swift */; };
+		CC523160248FEE81007B128F /* Flows.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC52315F248FEE81007B128F /* Flows.swift */; };
+		CC5231622490F7BC007B128F /* FulfillOrderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5231612490F7BC007B128F /* FulfillOrderScreen.swift */; };
+		CC52316424910476007B128F /* AddTrackingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC52316324910476007B128F /* AddTrackingScreen.swift */; };
+		CC5231662491082D007B128F /* ShippingCarriersScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5231652491082D007B128F /* ShippingCarriersScreen.swift */; };
+		CC523168249131B9007B128F /* orders_2201_shipment_trackings_providers.json in Resources */ = {isa = PBXBuildFile; fileRef = CC523167249131B9007B128F /* orders_2201_shipment_trackings_providers.json */; };
+		CC52316B249133F3007B128F /* rest_v11_sites.json in Resources */ = {isa = PBXBuildFile; fileRef = CC52316A249133F3007B128F /* rest_v11_sites.json */; };
+		CC52316D249135E6007B128F /* rest_v11_me_settings.json in Resources */ = {isa = PBXBuildFile; fileRef = CC52316C249135E6007B128F /* rest_v11_me_settings.json */; };
+		CC52316F24913CB4007B128F /* orders_2201_shipment_trackings_POST.json in Resources */ = {isa = PBXBuildFile; fileRef = CC52316E24913CB4007B128F /* orders_2201_shipment_trackings_POST.json */; };
+		CC52317124915068007B128F /* orders_2201_POST.json in Resources */ = {isa = PBXBuildFile; fileRef = CC52317024915068007B128F /* orders_2201_POST.json */; };
+		CC523175249268FA007B128F /* OrderNoteScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC523174249268FA007B128F /* OrderNoteScreen.swift */; };
+		CC523177249277D9007B128F /* orders_2201_notes_POST.json in Resources */ = {isa = PBXBuildFile; fileRef = CC523176249277D9007B128F /* orders_2201_notes_POST.json */; };
 		CC8413E423F5C48E00EFC277 /* stop.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011123E9E40B00157A78 /* stop.sh */; };
 		CC8413E523F5C49100EFC277 /* start.sh in Resources */ = {isa = PBXBuildFile; fileRef = CCFC011023E9E3F400157A78 /* start.sh */; };
 		CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDC49CC23FFFFF4003166BA /* LoginTests.swift */; };
@@ -1458,6 +1470,18 @@
 		B5FD111121D3CE7700560344 /* NewNoteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NewNoteViewController.xib; sourceTree = "<group>"; };
 		B5FD111521D3F13700560344 /* BordersView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BordersView.swift; sourceTree = "<group>"; };
 		BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC52315D248FEDAF007B128F /* OrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderTests.swift; sourceTree = "<group>"; };
+		CC52315F248FEE81007B128F /* Flows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flows.swift; sourceTree = "<group>"; };
+		CC5231612490F7BC007B128F /* FulfillOrderScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FulfillOrderScreen.swift; sourceTree = "<group>"; };
+		CC52316324910476007B128F /* AddTrackingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTrackingScreen.swift; sourceTree = "<group>"; };
+		CC5231652491082D007B128F /* ShippingCarriersScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingCarriersScreen.swift; sourceTree = "<group>"; };
+		CC523167249131B9007B128F /* orders_2201_shipment_trackings_providers.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_2201_shipment_trackings_providers.json; sourceTree = "<group>"; };
+		CC52316A249133F3007B128F /* rest_v11_sites.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = rest_v11_sites.json; sourceTree = "<group>"; };
+		CC52316C249135E6007B128F /* rest_v11_me_settings.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = rest_v11_me_settings.json; sourceTree = "<group>"; };
+		CC52316E24913CB4007B128F /* orders_2201_shipment_trackings_POST.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_2201_shipment_trackings_POST.json; sourceTree = "<group>"; };
+		CC52317024915068007B128F /* orders_2201_POST.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_2201_POST.json; sourceTree = "<group>"; };
+		CC523174249268FA007B128F /* OrderNoteScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteScreen.swift; sourceTree = "<group>"; };
+		CC523176249277D9007B128F /* orders_2201_notes_POST.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = orders_2201_notes_POST.json; sourceTree = "<group>"; };
 		CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCDC49CC23FFFFF4003166BA /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		CCDC49CE23FFFFF4003166BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -3235,6 +3259,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		CC523169249133B8007B128F /* sites */ = {
+			isa = PBXGroup;
+			children = (
+				CC52316A249133F3007B128F /* rest_v11_sites.json */,
+			);
+			path = sites;
+			sourceTree = "<group>";
+		};
 		CCDC49CB23FFFFF4003166BA /* WooCommerceUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -3253,6 +3285,7 @@
 			children = (
 				F997173223DBCF2800592D8E /* XCTest+Extensions.swift */,
 				CCDC49EC24000533003166BA /* TestCredentials.swift */,
+				CC52315F248FEE81007B128F /* Flows.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3261,6 +3294,7 @@
 			isa = PBXGroup;
 			children = (
 				CCDC49CC23FFFFF4003166BA /* LoginTests.swift */,
+				CC52315D248FEDAF007B128F /* OrderTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -3299,6 +3333,7 @@
 				CCFC00C023E9BD5500157A78 /* jetpack-blogs */,
 				CCFC00D623E9BD5500157A78 /* me */,
 				CCFC00D923E9BD5500157A78 /* notifications */,
+				CC523169249133B8007B128F /* sites */,
 				CCFC00DC23E9BD5500157A78 /* stats */,
 			);
 			path = mappings;
@@ -3364,9 +3399,13 @@
 			isa = PBXGroup;
 			children = (
 				CCFC00CB23E9BD5500157A78 /* orders_2201_shipment_trackings.json */,
+				CC52316E24913CB4007B128F /* orders_2201_shipment_trackings_POST.json */,
+				CC523167249131B9007B128F /* orders_2201_shipment_trackings_providers.json */,
 				CCFC00CC23E9BD5500157A78 /* orders_totals.json */,
 				CCFC00CD23E9BD5500157A78 /* orders.json */,
 				CCFC00CE23E9BD5500157A78 /* orders_2201_notes.json */,
+				CC523176249277D9007B128F /* orders_2201_notes_POST.json */,
+				CC52317024915068007B128F /* orders_2201_POST.json */,
 				CCFC00CF23E9BD5500157A78 /* orders_2201_refunds.json */,
 			);
 			path = orders;
@@ -3394,6 +3433,7 @@
 			children = (
 				CCFC00D723E9BD5500157A78 /* rest_v11_me.json */,
 				CCFC00D823E9BD5500157A78 /* rest_v11_me_sites.json */,
+				CC52316C249135E6007B128F /* rest_v11_me_settings.json */,
 			);
 			path = me;
 			sourceTree = "<group>";
@@ -4003,6 +4043,10 @@
 				F997173423DBEB1900592D8E /* OrdersScreen.swift */,
 				F997173623DBF02400592D8E /* SingleOrderScreen.swift */,
 				F997173C23DBFBBF00592D8E /* OrderSearchScreen.swift */,
+				CC5231612490F7BC007B128F /* FulfillOrderScreen.swift */,
+				CC52316324910476007B128F /* AddTrackingScreen.swift */,
+				CC5231652491082D007B128F /* ShippingCarriersScreen.swift */,
+				CC523174249268FA007B128F /* OrderNoteScreen.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -4345,6 +4389,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC52316F24913CB4007B128F /* orders_2201_shipment_trackings_POST.json in Resources */,
+				CC52316B249133F3007B128F /* rest_v11_sites.json in Resources */,
+				CC52316D249135E6007B128F /* rest_v11_me_settings.json in Resources */,
+				CC523177249277D9007B128F /* orders_2201_notes_POST.json in Resources */,
+				CC52317124915068007B128F /* orders_2201_POST.json in Resources */,
+				CC523168249131B9007B128F /* orders_2201_shipment_trackings_providers.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5181,11 +5231,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC52315E248FEDAF007B128F /* OrderTests.swift in Sources */,
 				CCDC49DA2400011F003166BA /* MyStoreScreen.swift in Sources */,
 				CCDC49DB2400011F003166BA /* OrdersScreen.swift in Sources */,
 				F93E8E5C24087FE10057FF21 /* SingleProductScreen.swift in Sources */,
 				F93E8E5A24087FE10057FF21 /* ProductsScreen.swift in Sources */,
 				CCDC49DC2400011F003166BA /* SingleOrderScreen.swift in Sources */,
+				CC52316424910476007B128F /* AddTrackingScreen.swift in Sources */,
 				F93E8E5424087FDA0057FF21 /* BetaFeaturesScreen.swift in Sources */,
 				F93E8E5624087FDA0057FF21 /* SettingsScreen.swift in Sources */,
 				CCDC49DD2400011F003166BA /* OrderSearchScreen.swift in Sources */,
@@ -5194,14 +5246,18 @@
 				CCDC49E02400011F003166BA /* LinkOrPasswordScreen.swift in Sources */,
 				CCDC49E12400011F003166BA /* LoginCheckMagicLinkScreen.swift in Sources */,
 				CCDC49E22400011F003166BA /* LoginEmailScreen.swift in Sources */,
+				CC5231622490F7BC007B128F /* FulfillOrderScreen.swift in Sources */,
 				CCDC49E32400011F003166BA /* LoginEpilogueScreen.swift in Sources */,
 				CCDC49E42400011F003166BA /* LoginPasswordScreen.swift in Sources */,
 				CCDC49E52400011F003166BA /* LoginSiteAddressScreen.swift in Sources */,
 				CCDC49E62400011F003166BA /* LoginUsernamePasswordScreen.swift in Sources */,
+				CC523175249268FA007B128F /* OrderNoteScreen.swift in Sources */,
 				CCDC49E72400011F003166BA /* WelcomeScreen.swift in Sources */,
 				CCDC49E92400011F003166BA /* BaseScreen.swift in Sources */,
 				CCDC49EA2400011F003166BA /* PeriodStatsTable.swift in Sources */,
+				CC523160248FEE81007B128F /* Flows.swift in Sources */,
 				CCDC49EB2400011F003166BA /* TabNavComponent.swift in Sources */,
+				CC5231662491082D007B128F /* ShippingCarriersScreen.swift in Sources */,
 				CCDC49ED24000533003166BA /* TestCredentials.swift in Sources */,
 				CCDC49D724000095003166BA /* XCTest+Extensions.swift in Sources */,
 				CCDC49CD23FFFFF4003166BA /* LoginTests.swift in Sources */,

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_POST.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_POST.json
@@ -1,0 +1,96 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [ {
+            "matches": "(.*&|^)body=%7B%22status%22%3A%22completed%22%7D($|&.*)",
+            "matches": "(.*&|^)path=/wc/v3/orders/2201%26_method%3Dpost($|&.*)"
+        } ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 2201,
+                "parent_id": 0,
+                "number": "2201",
+                "status": "completed",
+                "currency": "USD",
+                "date_created_gmt": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "total": "1310.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "customer_note": "",
+                "billing": {
+                    "first_name": "Mira",
+                    "last_name": "Workman",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "FR",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "Mira",
+                    "last_name": "Workman",
+                    "company": "",
+                    "address_1": "123 Main Street",
+                    "address_2": "",
+                    "city": "San Francisco",
+                    "state": "CA",
+                    "postcode": "94119",
+                    "country": "US"
+                },
+                "payment_method_title": "",
+                "date_paid_gmt": "{{now format=customformat}}",
+                "line_items": [{
+                    "id": 34,
+                    "name": "Black Coral shades",
+                    "product_id": 2130,
+                    "variation_id": 0,
+                    "quantity": 5,
+                    "tax_class": "",
+                    "subtotal": "750.00",
+                    "subtotal_tax": "0.00",
+                    "total": "750.00",
+                    "total_tax": "0.00",
+                    "taxes": [],
+                    "meta_data": [],
+                    "sku": "",
+                    "price": 150
+                }, {
+                    "id": 35,
+                    "name": "Malaya shades",
+                    "product_id": 2123,
+                    "variation_id": 0,
+                    "quantity": 4,
+                    "tax_class": "",
+                    "subtotal": "560.00",
+                    "subtotal_tax": "0.00",
+                    "total": "560.00",
+                    "total_tax": "0.00",
+                    "taxes": [],
+                    "meta_data": [],
+                    "sku": "",
+                    "price": 140
+                }],
+                "shipping_lines": [],
+                "coupon_lines": [],
+                "refunds": []
+            },
+            "headers": {
+                "Content-Type": "application/json",
+                "Connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_notes_POST.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_notes_POST.json
@@ -1,0 +1,37 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [ {
+            "matches": "(.*&|^)path=/wc/v3/orders/2201/notes%26_method%3Dpost($|&.*)"
+        } ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+                "data": {
+                    "id": 5600,
+                    "author": "WooCommerce Store Owner",
+                    "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                    "date_created_gmt": "{{now format=customformat}}",
+                    "note": "This is an order note.",
+                    "customer_note": true,
+                    "_links": {
+                        "self": [{
+                            "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/orders\/2201\/notes\/5600"
+                        }],
+                        "collection": [{
+                            "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/orders\/2201\/notes"
+                        }],
+                        "up": [{
+                            "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v3\/orders\/2201"
+                        }]
+                    }
+                }
+            },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_shipment_trackings_POST.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_shipment_trackings_POST.json
@@ -1,0 +1,36 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [ {
+            "matches": "(.*&|^)path=/wc/v2/orders/2201/shipment-trackings/%26_method%3Dpost($|&.*)"
+        } ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "tracking_id": "8a1f3816dc96003ca61bdbc3d0bde63e",
+                "tracking_provider": "USPS",
+                "tracking_link": "https:\/\/tools.usps.com\/go\/TrackConfirmAction_input?qtc_tLabels1=tracking123",
+                "tracking_number": "tracking123",
+                "date_shipped": "{{now format='yyyy-MM-dd'}}",
+                "_links": {
+                    "self": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v2\/orders\/2201\/shipment-trackings\/8a1f3816dc96003ca61bdbc3d0bde63e"
+                    }],
+                    "collection": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v2\/orders\/2201\/shipment-trackings"
+                    }],
+                    "up": [{
+                        "href": "https:\/\/automatticwidgets.com\/wp-json\/wc\/v2\/orders\/2201"
+                    }]
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_shipment_trackings_providers.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_2201_shipment_trackings_providers.json
@@ -1,0 +1,123 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "queryParameters": {
+            "json": {
+                "equalTo": "true"
+            },
+            "path": {
+                "equalTo": "/wc/v2/orders/2201/shipment-trackings/providers&_method=get"
+            }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "Australia": {
+                    "Australia Post": "http:\/\/auspost.com.au\/track\/track.html?id=%1$s",
+                    "Fastway Couriers": "http:\/\/www.fastway.com.au\/courier-services\/track-your-parcel?l=%1$s"
+                },
+                "Austria": {
+                    "post.at": "http:\/\/www.post.at\/sendungsverfolgung.php?pnum1=%1$s",
+                    "dhl.at": "http:\/\/www.dhl.at\/content\/at\/de\/express\/sendungsverfolgung.html?brand=DHL&AWB=%1$s",
+                    "DPD.at": "https:\/\/tracking.dpd.de\/parcelstatus?locale=de_AT&query=%1$s"
+                },
+                "Brazil": {
+                    "Correios": "http:\/\/websro.correios.com.br\/sro_bin\/txect01$.QueryList?P_LINGUA=001&P_TIPO=001&P_COD_UNI=%1$s"
+                },
+                "Belgium": {
+                    "bpost": "https:\/\/track.bpost.be\/btr\/web\/#\/search?itemCode=%1$s"
+                },
+                "Canada": {
+                    "Canada Post": "http:\/\/www.canadapost.ca\/cpotools\/apps\/track\/personal\/findByTrackNumber?trackingNumber=%1$s"
+                },
+                "Czech Republic": {
+                    "PPL.cz": "http:\/\/www.ppl.cz\/main2.aspx?cls=Package&idSearch=%1$s",
+                    "\u010cesk\u00e1 po\u0161ta": "https:\/\/www.postaonline.cz\/trackandtrace\/-\/zasilka\/cislo?parcelNumbers=%1$s",
+                    "DHL.cz": "http:\/\/www.dhl.cz\/cs\/express\/sledovani_zasilek.html?AWB=%1$s",
+                    "DPD.cz": "https:\/\/tracking.dpd.de\/parcelstatus?locale=cs_CZ&query=%1$s"
+                },
+                "Finland": {
+                    "Itella": "http:\/\/www.posti.fi\/itemtracking\/posti\/search_by_shipment_id?lang=en&ShipmentId=%1$s"
+                },
+                "France": {
+                    "Colissimo": "http:\/\/www.colissimo.fr\/portail_colissimo\/suivre.do?language=fr_FR&colispart=%1$s"
+                },
+                "Germany": {
+                    "DHL Intraship (DE)": "http:\/\/nolp.dhl.de\/nextt-online-public\/set_identcodes.do?lang=de&idc=%1$s&rfn=&extendedSearch=true",
+                    "Hermes": "https:\/\/tracking.hermesworld.com\/?TrackID=%1$s",
+                    "Deutsche Post DHL": "http:\/\/nolp.dhl.de\/nextt-online-public\/set_identcodes.do?lang=de&idc=%1$s",
+                    "UPS Germany": "http:\/\/wwwapps.ups.com\/WebTracking\/processInputRequest?sort_by=status&tracknums_displayed=1&TypeOfInquiryNumber=T&loc=de_DE&InquiryNumber1=%1$s",
+                    "DPD.de": "https:\/\/tracking.dpd.de\/parcelstatus?query=%1$s&locale=en_DE"
+                },
+                "Ireland": {
+                    "DPD.ie": "http:\/\/www2.dpd.ie\/Services\/QuickTrack\/tabid\/222\/ConsignmentID\/%1$s\/Default.aspx",
+                    "An Post": "https:\/\/track.anpost.ie\/TrackingResults.aspx?rtt=1&items=%1$s"
+                },
+                "Italy": {
+                    "BRT (Bartolini)": "http:\/\/as777.brt.it\/vas\/sped_det_show.hsm?referer=sped_numspe_par.htm&Nspediz=%1$s",
+                    "DHL Express": "http:\/\/www.dhl.it\/it\/express\/ricerca.html?AWB=%1$s&brand=DHL"
+                },
+                "India": {
+                    "DTDC": "http:\/\/www.dtdc.in\/tracking\/tracking_results.asp?Ttype=awb_no&strCnno=%1$s&TrkType2=awb_no"
+                },
+                "Netherlands": {
+                    "PostNL": "https:\/\/postnl.nl\/tracktrace\/?B=%1$s&P=%2$s&D=%3$s&T=C",
+                    "DPD.NL": "http:\/\/track.dpdnl.nl\/?parcelnumber=%1$s",
+                    "UPS Netherlands": "http:\/\/wwwapps.ups.com\/WebTracking\/processInputRequest?sort_by=status&tracknums_displayed=1&TypeOfInquiryNumber=T&loc=nl_NL&InquiryNumber1=%1$s"
+                },
+                "New Zealand": {
+                    "Courier Post": "http:\/\/trackandtrace.courierpost.co.nz\/Search\/%1$s",
+                    "NZ Post": "http:\/\/www.nzpost.co.nz\/tools\/tracking?trackid=%1$s",
+                    "Fastways": "http:\/\/www.fastway.co.nz\/courier-services\/track-your-parcel?l=%1$s",
+                    "PBT Couriers": "http:\/\/www.pbt.com\/nick\/results.cfm?ticketNo=%1$s"
+                },
+                "Poland": {
+                    "InPost": "https:\/\/inpost.pl\/sledzenie-przesylek?number=%1$s",
+                    "DPD.PL": "https:\/\/tracktrace.dpd.com.pl\/parcelDetails?p1=%1$s",
+                    "Poczta Polska": "https:\/\/emonitoring.poczta-polska.pl\/?numer=%1$s"
+                },
+                "Romania": {
+                    "Fan Courier": "https:\/\/www.fancourier.ro\/awb-tracking\/?xawb=%1$s",
+                    "DPD Romania": "https:\/\/tracking.dpd.de\/parcelstatus?query=%1$s&locale=ro_RO",
+                    "Urgent Cargus": "https:\/\/app.urgentcargus.ro\/Private\/Tracking.aspx?CodBara=%1$s"
+                },
+                "South African": {
+                    "SAPO": "http:\/\/sms.postoffice.co.za\/TrackingParcels\/Parcel.aspx?id=%1$s",
+                    "Fastway": "http:\/\/www.fastway.co.za\/our-services\/track-your-parcel?l=%1$s"
+                },
+                "Sweden": {
+                    "PostNord Sverige AB": "http:\/\/www.postnord.se\/sv\/verktyg\/sok\/Sidor\/spara-brev-paket-och-pall.aspx?search=%1$s",
+                    "DHL.se": "http:\/\/www.dhl.se\/content\/se\/sv\/express\/godssoekning.shtml?brand=DHL&AWB=%1$s",
+                    "Bring.se": "http:\/\/tracking.bring.se\/tracking.html?q=%1$s",
+                    "UPS.se": "http:\/\/wwwapps.ups.com\/WebTracking\/track?track=yes&loc=sv_SE&trackNums=%1$s",
+                    "DB Schenker": "http:\/\/privpakportal.schenker.nu\/TrackAndTrace\/packagesearch.aspx?packageId=%1$s"
+                },
+                "United Kingdom": {
+                    "DHL": "http:\/\/www.dhl.com\/content\/g0\/en\/express\/tracking.shtml?brand=DHL&AWB=%1$s",
+                    "DPD.co.uk": "http:\/\/www.dpd.co.uk\/tracking\/trackingSearch.do?search.searchType=0&search.parcelNumber=%1$s",
+                    "InterLink": "http:\/\/www.interlinkexpress.com\/apps\/tracking\/?reference=%1$s&postcode=%2$s#results",
+                    "ParcelForce": "http:\/\/www.parcelforce.com\/portal\/pw\/track?trackNumber=%1$s",
+                    "Royal Mail": "https:\/\/www.royalmail.com\/track-your-item\/?trackNumber=%1$s",
+                    "TNT Express (consignment)": "http:\/\/www.tnt.com\/webtracker\/tracking.do?requestType=GEN&searchType=CON&respLang=en&respCountry=GENERIC&sourceID=1&sourceCountry=ww&cons=%1$s&navigation=1&g\nenericSiteIdent=",
+                    "TNT Express (reference)": "http:\/\/www.tnt.com\/webtracker\/tracking.do?requestType=GEN&searchType=REF&respLang=en&respCountry=GENERIC&sourceID=1&sourceCountry=ww&cons=%1$s&navigation=1&genericSiteIdent=",
+                    "DHL Parcel UK": "https:\/\/track.dhlparcel.co.uk\/?con=%1$s"
+                },
+                "United States": {
+                    "Fedex": "http:\/\/www.fedex.com\/Tracking?action=track&tracknumbers=%1$s",
+                    "FedEx Sameday": "https:\/\/www.fedexsameday.com\/fdx_dotracking_ua.aspx?tracknum=%1$s",
+                    "OnTrac": "http:\/\/www.ontrac.com\/trackingdetail.asp?tracking=%1$s",
+                    "UPS": "http:\/\/wwwapps.ups.com\/WebTracking\/track?track=yes&trackNums=%1$s",
+                    "USPS": "https:\/\/tools.usps.com\/go\/TrackConfirmAction_input?qtc_tLabels1=%1$s",
+                    "DHL US": "https:\/\/www.logistics.dhl\/us-en\/home\/tracking\/tracking-ecommerce.html?tracking-id=%1$s"
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_settings.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/me/rest_v11_me_settings.json
@@ -1,0 +1,22 @@
+{
+    "request": {
+        "urlPath": "/rest/v1.1/me/settings",
+        "method": "GET",
+        "queryParameters": {
+          "fields": {
+            "equalTo": "tracks_opt_out"
+          }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "tracks_opt_out": true
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Cache-Control": "no-cache, must-revalidate, max-age=0"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/sites/rest_v11_sites.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/sites/rest_v11_sites.json
@@ -1,0 +1,51 @@
+{
+    "request": {
+        "urlPath": "/rest/v1.1/sites/161477129",
+        "method": "GET",
+        "queryParameters": {
+          "fields": {
+            "equalTo": "ID,plan"
+          }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "ID": 161477129,
+            "plan": {
+                "product_id": 1008,
+                "product_slug": "business-bundle",
+                "product_name": "WordPress.com Business",
+                "product_name_short": "Business",
+                "expired": false,
+                "user_is_owner": false,
+                "is_free": false,
+                "features": {
+                    "active": ["free-blog", "custom-domain", "space", "no-adverts\/no-adverts.php", "custom-design", "videopress", "unlimited_themes", "live_support", "private_whois", "premium-themes", "google-analytics", "simple-payments", "calendly", "opentable", "support", "wordads-jetpack"],
+                    "available": {
+                        "free-blog": ["free_plan", "personal-bundle", "value_bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+                        "space": ["free_plan", "personal-bundle", "value_bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+                        "support": ["free_plan", "personal-bundle", "value_bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+                        "custom-domain": ["personal-bundle", "value_bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+                        "no-adverts\/no-adverts.php": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "custom-design": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "videopress": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "unlimited_themes": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "live_support": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "private_whois": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "simple-payments": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "calendly": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "opentable": ["value_bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "premium-themes": ["ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+                        "google-analytics": ["ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"]
+                    }
+                }
+            }
+        },
+        "headers": {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "Cache-Control": "no-cache, must-revalidate, max-age=0"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/AddTrackingScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/AddTrackingScreen.swift
@@ -4,6 +4,7 @@ import XCTest
 final class AddTrackingScreen: BaseScreen {
 
     struct ElementStringIDs {
+        static let addButton = "add-tracking-add-button"
         static let shippingCarrierField = "add-tracking-shipping-carrier-cell"
         static let trackingNumberField = "add-tracking-enter-tracking-number-field"
         static let shippingDateField = "add-tracking-date-shipped-cell"
@@ -20,7 +21,7 @@ final class AddTrackingScreen: BaseScreen {
     }
 
     init() {
-        addButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 1)
+        addButton = XCUIApplication().navigationBars.buttons[ElementStringIDs.addButton]
         shippingCarrierField = XCUIApplication().cells[ElementStringIDs.shippingCarrierField]
         trackingNumberField = XCUIApplication().textFields[ElementStringIDs.trackingNumberField]
         shippingDateField = XCUIApplication().cells[ElementStringIDs.shippingDateField]

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/AddTrackingScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/AddTrackingScreen.swift
@@ -1,0 +1,59 @@
+import Foundation
+import XCTest
+
+final class AddTrackingScreen: BaseScreen {
+
+    struct ElementStringIDs {
+        static let shippingCarrierField = "add-tracking-shipping-carrier-cell"
+        static let trackingNumberField = "add-tracking-enter-tracking-number-field"
+        static let shippingDateField = "add-tracking-date-shipped-cell"
+    }
+
+    private let addButton: XCUIElement
+    private let shippingCarrierField: XCUIElement
+    private let trackingNumberField: XCUIElement
+    private let shippingDateField: XCUIElement
+
+    static var isVisible: Bool {
+        let shippingCarrierField = XCUIApplication().buttons[ElementStringIDs.shippingCarrierField]
+        return shippingCarrierField.exists && shippingCarrierField.isHittable
+    }
+
+    init() {
+        addButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 1)
+        shippingCarrierField = XCUIApplication().cells[ElementStringIDs.shippingCarrierField]
+        trackingNumberField = XCUIApplication().textFields[ElementStringIDs.trackingNumberField]
+        shippingDateField = XCUIApplication().cells[ElementStringIDs.shippingDateField]
+        super.init(element: shippingDateField)
+    }
+
+    // This method doesn't return another screen object because you return to where you started.
+    // This screen can be accessed from the SingleOrderScreen and the FulfillOrderScreen.
+    func addTrackingInfo(carrier: String, trackingNumber: String) {
+        XCTAssert(!addButton.isEnabled, "Add button should not be enabled before adding tracking info")
+        selectCarrier().selectShippingCarrier(withName: carrier)
+        XCTAssert(!addButton.isEnabled, "Add button should not be enabled without complete tracking info")
+        addTrackingNumber(number: trackingNumber)
+        XCTAssert(addButton.isEnabled, "Add button should be enabled after adding tracking info")
+        canSetDateShipped()
+        addButton.tap()
+    }
+
+    @discardableResult
+    private func selectCarrier() -> ShippingCarriersScreen {
+        shippingCarrierField.tap()
+        return ShippingCarriersScreen()
+    }
+
+    private func addTrackingNumber(number: String) {
+        trackingNumberField.tap()
+        trackingNumberField.typeText(number)
+    }
+
+    private func canSetDateShipped() {
+        shippingDateField.tap()
+        XCTAssert(XCUIApplication().pickerWheels.element(boundBy: 0).isHittable)
+        XCTAssert(XCUIApplication().pickerWheels.element(boundBy: 1).isHittable)
+        XCTAssert(XCUIApplication().pickerWheels.element(boundBy: 2).isHittable)
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/AddTrackingScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/AddTrackingScreen.swift
@@ -5,12 +5,14 @@ final class AddTrackingScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let addButton = "add-tracking-add-button"
+        static let dismissButton = "add-tracking-dismiss-button"
         static let shippingCarrierField = "add-tracking-shipping-carrier-cell"
         static let trackingNumberField = "add-tracking-enter-tracking-number-field"
         static let shippingDateField = "add-tracking-date-shipped-cell"
     }
 
     private let addButton: XCUIElement
+    private let dismissButton: XCUIElement
     private let shippingCarrierField: XCUIElement
     private let trackingNumberField: XCUIElement
     private let shippingDateField: XCUIElement
@@ -22,6 +24,7 @@ final class AddTrackingScreen: BaseScreen {
 
     init() {
         addButton = XCUIApplication().navigationBars.buttons[ElementStringIDs.addButton]
+        dismissButton = XCUIApplication().navigationBars.buttons[ElementStringIDs.dismissButton]
         shippingCarrierField = XCUIApplication().cells[ElementStringIDs.shippingCarrierField]
         trackingNumberField = XCUIApplication().textFields[ElementStringIDs.trackingNumberField]
         shippingDateField = XCUIApplication().cells[ElementStringIDs.shippingDateField]
@@ -38,6 +41,10 @@ final class AddTrackingScreen: BaseScreen {
         XCTAssert(addButton.isEnabled, "Add button should be enabled after adding tracking info")
         canSetDateShipped()
         addButton.tap()
+    }
+
+    override func pop() {
+        dismissButton.tap()
     }
 
     @discardableResult

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/FulfillOrderScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/FulfillOrderScreen.swift
@@ -1,0 +1,47 @@
+import Foundation
+import XCTest
+
+final class FulfillOrderScreen: BaseScreen {
+
+    struct ElementStringIDs {
+        static let markOrderCompleteButton = "mark-order-complete-button"
+        static let addTrackingButton = "fulfill-order-add-tracking-button"
+    }
+
+    private let markOrderCompleteButton: XCUIElement
+    private let addTrackingButton: XCUIElement
+
+    static var isVisible: Bool {
+        let markOrderCompleteButton = XCUIApplication().buttons[ElementStringIDs.markOrderCompleteButton]
+        return markOrderCompleteButton.exists && markOrderCompleteButton.isHittable
+    }
+
+    init() {
+        markOrderCompleteButton = XCUIApplication().buttons[ElementStringIDs.markOrderCompleteButton]
+        addTrackingButton = XCUIApplication().cells[ElementStringIDs.addTrackingButton]
+        super.init(element: markOrderCompleteButton)
+    }
+
+    func canAddTracking() -> FulfillOrderScreen {
+        selectTracking().pop()
+        return self
+    }
+
+    func completeFulfillment() -> SingleOrderScreen {
+        markOrderCompleteButton.tap()
+        XCTAssert(XCUIApplication().staticTexts["Order marked as fulfilled"].waitForExistence(timeout: 3))
+        return SingleOrderScreen()
+    }
+
+    @discardableResult
+    func goBackToSingleOrderScreen() -> SingleOrderScreen {
+        pop()
+        return SingleOrderScreen()
+    }
+
+    private func selectTracking() -> AddTrackingScreen {
+           XCTAssert(addTrackingButton.waitForExistence(timeout: 2))
+           addTrackingButton.tap()
+           return AddTrackingScreen()
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/OrderNoteScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/OrderNoteScreen.swift
@@ -5,6 +5,7 @@ final class OrderNoteScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let addButton = "order-note-add-button"
+        static let dismissButton = "order-note-dismiss-button"
         static let noteField = "order-note-text-field"
         static let emailNoteToggle = "order-note-email-switch"
     }
@@ -14,6 +15,7 @@ final class OrderNoteScreen: BaseScreen {
     }
 
     private let addButton: XCUIElement
+    private let dismissButton: XCUIElement
     private let noteField: XCUIElement
     private let emailNoteToggle: XCUIElement
 
@@ -24,6 +26,7 @@ final class OrderNoteScreen: BaseScreen {
 
     init() {
         addButton = XCUIApplication().navigationBars.buttons[ElementStringIDs.addButton]
+        dismissButton = XCUIApplication().navigationBars.buttons[ElementStringIDs.dismissButton]
         noteField = XCUIApplication().textViews[ElementStringIDs.noteField]
         emailNoteToggle = XCUIApplication().cells[ElementStringIDs.emailNoteToggle]
         super.init(element: noteField)
@@ -37,6 +40,10 @@ final class OrderNoteScreen: BaseScreen {
         toggleEmailOption(to: state)
         addButton.tap()
         return SingleOrderScreen()
+    }
+
+    override func pop() {
+        dismissButton.tap()
     }
 
     private func writeNote(withText text: String) {

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/OrderNoteScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/OrderNoteScreen.swift
@@ -4,6 +4,7 @@ import XCTest
 final class OrderNoteScreen: BaseScreen {
 
     struct ElementStringIDs {
+        static let addButton = "order-note-add-button"
         static let noteField = "order-note-text-field"
         static let emailNoteToggle = "order-note-email-switch"
     }
@@ -22,7 +23,7 @@ final class OrderNoteScreen: BaseScreen {
     }
 
     init() {
-        addButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 1)
+        addButton = XCUIApplication().navigationBars.buttons[ElementStringIDs.addButton]
         noteField = XCUIApplication().textViews[ElementStringIDs.noteField]
         emailNoteToggle = XCUIApplication().cells[ElementStringIDs.emailNoteToggle]
         super.init(element: noteField)

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/OrderNoteScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/OrderNoteScreen.swift
@@ -1,0 +1,64 @@
+import Foundation
+import XCTest
+
+final class OrderNoteScreen: BaseScreen {
+
+    struct ElementStringIDs {
+        static let noteField = "order-note-text-field"
+        static let emailNoteToggle = "order-note-email-switch"
+    }
+    enum Toggle {
+        case on
+        case off
+    }
+
+    private let addButton: XCUIElement
+    private let noteField: XCUIElement
+    private let emailNoteToggle: XCUIElement
+
+    static var isVisible: Bool {
+        let noteField = XCUIApplication().buttons[ElementStringIDs.noteField]
+        return noteField.exists && noteField.isHittable
+    }
+
+    init() {
+        addButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 1)
+        noteField = XCUIApplication().textViews[ElementStringIDs.noteField]
+        emailNoteToggle = XCUIApplication().cells[ElementStringIDs.emailNoteToggle]
+        super.init(element: noteField)
+    }
+
+    func addNote(withText text: String, sendEmail state: Toggle) -> SingleOrderScreen {
+        XCTAssert(!addButton.isEnabled, "Add button should not be enabled before writing note")
+        writeNote(withText: text)
+        XCTAssert(addButton.isEnabled, "Add button should be enabled after writing note")
+        XCTAssert(!isEmailNoteEnabled(), "Email note option should be off by default")
+        toggleEmailOption(to: state)
+        addButton.tap()
+        return SingleOrderScreen()
+    }
+
+    private func writeNote(withText text: String) {
+        // Note field already has focus, so we can type into it immediately
+        noteField.typeText(text)
+    }
+
+    private func toggleEmailOption(to state: Toggle) {
+        switch state {
+        case .on:
+            if !isEmailNoteEnabled() {
+                emailNoteToggle.tap()
+                XCTAssert(isEmailNoteEnabled())
+            }
+        case .off:
+            if isEmailNoteEnabled() {
+                emailNoteToggle.tap()
+                XCTAssert(!isEmailNoteEnabled())
+            }
+        }
+    }
+
+    private func isEmailNoteEnabled() -> Bool {
+        return emailNoteToggle.value as! String == "1"
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/ShippingCarriersScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/ShippingCarriersScreen.swift
@@ -1,0 +1,27 @@
+import Foundation
+import XCTest
+
+final class ShippingCarriersScreen: BaseScreen {
+
+    struct ElementStringIDs {
+        static let shippingCarriersTable = "shipping-carriers-table"
+    }
+
+    private let shippingCarriersTable: XCUIElement
+
+    static var isVisible: Bool {
+        let shippingCarriersTable = XCUIApplication().buttons[ElementStringIDs.shippingCarriersTable]
+        return shippingCarriersTable.exists && shippingCarriersTable.isHittable
+    }
+
+    init() {
+        shippingCarriersTable = XCUIApplication().tables[ElementStringIDs.shippingCarriersTable]
+        super.init(element: shippingCarriersTable)
+    }
+
+    @discardableResult
+    func selectShippingCarrier(withName name: String) -> AddTrackingScreen {
+        shippingCarriersTable.cells.staticTexts[name].tap()
+        return AddTrackingScreen()
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Screens/Orders/SingleOrderScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Orders/SingleOrderScreen.swift
@@ -5,10 +5,16 @@ final class SingleOrderScreen: BaseScreen {
 
     struct ElementStringIDs {
         static let summaryTitleLabel = "summary-table-view-cell-title-label"
+        static let fulfillmentButton = "begin-fulfillment-button"
+        static let addTrackingButton = "order-details-add-tracking-button"
+        static let addNoteButton = "add-order-note-button"
     }
 
     let tabBar = TabNavComponent()
     private let summaryTitleLabel: XCUIElement
+    private let fulfillmentButton: XCUIElement
+    private let addTrackingButton: XCUIElement
+    private let addNoteButton: XCUIElement
 
     static var isVisible: Bool {
         let summaryTitleLabel = XCUIApplication().staticTexts[ElementStringIDs.summaryTitleLabel]
@@ -17,12 +23,35 @@ final class SingleOrderScreen: BaseScreen {
 
     init() {
         summaryTitleLabel = XCUIApplication().staticTexts[ElementStringIDs.summaryTitleLabel]
+        fulfillmentButton = XCUIApplication().buttons[ElementStringIDs.fulfillmentButton]
+        addTrackingButton = XCUIApplication().cells[ElementStringIDs.addTrackingButton]
+        addNoteButton = XCUIApplication().cells[ElementStringIDs.addNoteButton]
         super.init(element: summaryTitleLabel)
+    }
+
+    func beginFulfillment() -> FulfillOrderScreen {
+        fulfillmentButton.tap()
+        return FulfillOrderScreen()
+    }
+
+    func addTracking(withCarrier carrier: String, andTrackingNumber trackingNumber: String) -> SingleOrderScreen {
+        selectAddTracking().addTrackingInfo(carrier: carrier, trackingNumber: trackingNumber)
+        return self
+    }
+
+    func selectAddNote() -> OrderNoteScreen {
+        addNoteButton.tap()
+        return OrderNoteScreen()
     }
 
     @discardableResult
     func goBackToOrdersScreen() -> OrdersScreen {
         pop()
         return OrdersScreen()
+    }
+
+    private func selectAddTracking() -> AddTrackingScreen {
+        addTrackingButton.tap()
+        return AddTrackingScreen()
     }
 }

--- a/WooCommerce/WooCommerceUITests/Tests/OrderTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrderTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+class OrderTests: XCTestCase {
+
+    override func setUp() {
+        continueAfterFailure = false
+
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launchArguments = ["disable-animations", "mocked-wpcom-api"]
+        app.launch()
+
+        Flows.loginIfNeeded(email: TestCredentials.emailAddress, password: TestCredentials.password)
+            .tabBar.gotoOrdersScreen()
+    }
+
+    func testFulfillOrder() {
+        OrdersScreen()
+            .selectOrder(atIndex: 0)
+            .beginFulfillment()
+            .canAddTracking()
+            .completeFulfillment()
+            .goBackToOrdersScreen()
+    }
+
+    func testAddOrderNote() {
+        let noteText = "This is an order note."
+        OrdersScreen()
+            .selectOrder(atIndex: 0)
+            .selectAddNote()
+            .addNote(withText: noteText, sendEmail: .on)
+            .goBackToOrdersScreen()
+    }
+
+    func testAddOrderTracking() {
+        OrdersScreen()
+            .selectOrder(atIndex: 0)
+            .addTracking(withCarrier: "USPS", andTrackingNumber: "tracking123")
+            .goBackToOrdersScreen()
+    }
+
+    override func tearDown() {
+        while !OrdersScreen.isVisible {
+            navBackButton.tap()
+        }
+    }
+}

--- a/WooCommerce/WooCommerceUITests/Utils/Flows.swift
+++ b/WooCommerce/WooCommerceUITests/Utils/Flows.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+class Flows {
+    @discardableResult
+    static func loginIfNeeded(email: String, password: String) -> MyStoreScreen {
+        if WelcomeScreen.isLoaded() {
+            return WelcomeScreen()
+                .selectLogin()
+                .proceedWith(email: email)
+                .proceedWithPassword()
+                .proceedWith(password: password)
+                .continueWithSelectedSite()
+        }
+        return MyStoreScreen()
+    }
+}

--- a/docs/UI-TESTS.md
+++ b/docs/UI-TESTS.md
@@ -8,6 +8,10 @@ The following user flows are covered with UI tests:
 
 * [Login](../WooCommerce/WooCommerceUITests/Tests/LoginTests.swift):
 	* Log in with email/password and log out
+* [Orders](../WooCommerce/WooCommerceUITests/Tests/OrderTests.swift):
+	* Fulfill an order
+	* Add an order note
+	* Add order tracking
 
 ## Running tests
 


### PR DESCRIPTION
## Changes

This PR adds three UI tests for orders:

* Fulfill an order
* Add an order note
* Add order tracking

This automates most of the Orders smoke test cases we use for beta testing, ensuring that user interactions (text input, button taps) work as expected and that the overall user flows work.

Note that this does **not** automate the smoke test cases for order push notifications (I'm still exploring how feasible this is to automate right now). Also, the focus here is on user flows/interactions and not verifying the order data on each screen.

_In Progress: Investigating CI failure on iPad._

## Testing

* Confirm the tests pass on CI (trigger the optional UI tests on this PR).
* Optionally, run the UI tests locally and confirm they pass. A quick way to run the UI tests locally:
  * In the simulator, disable the "Connect Hardware Keyboard" setting (this can interfere with text input in the test).
  * Run `rake mocks` to start the mocks server.
  * Select the `UITests` test plan in Xcode (in the test navigator or under Product > Test Plan).
  * Run the tests (in the test navigator or under Product > Test).

## Review

Only one reviewer is needed, although input from the whole team about test coverage/confidence is welcome. When reviewing, please confirm:

* The changes to the app itself (new accessibility identifiers) look ok.
* The new tests pass.
* The new tests give confidence about these user flows (the assertions look good and you feel confident that they are testing the right things).

Apologies for the number of lines of code changed in this PR. A lot of this comes from the new mocks (added under `WooCommerce/WooCommerceUITests/Mocks/`) — these don't need a detailed review as long as the UI tests pass without WireMock warnings.

## Submitter checklist

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
