### PR TITLE
Update release tooling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: e426345db3afc839ee463ec1ce8432f584880957
-  tag: 0.9.2
+  revision: f04b19fddf1f3a9485a48a7ba4a93d32c0af62d5
+  tag: 0.9.7
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.2)
+    fastlane-plugin-wpmreleasetoolkit (0.9.7)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
       nokogiri (>= 1.10.4)
-      octokit (~> 4.13)
+      octokit (~> 4.18)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
       rake (~> 12.3)
@@ -146,7 +146,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.6.0)
+    git (1.7.0)
       rchardet (~> 1.8)
     google-api-client (0.36.4)
       addressable (~> 2.5, >= 2.5.1)
@@ -206,7 +206,7 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.10.6)
-    optimist (3.0.0)
+    optimist (3.0.1)
     options (2.3.2)
     os (1.0.1)
     parallel (1.19.1)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,10 +68,27 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     ios_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
-
-    ios_localize_project()
-    
     get_prs_list(repository:GHHELPER_REPO, start_tag:"#{old_version}", report_path:"#{File.expand_path('~')}/wcios_prs_list_#{old_version}_#{new_version}.txt")
+    ios_check_beta_deps(podfile:"#{ENV["PROJECT_ROOT_FOLDER"]}Podfile")
+  end
+
+  #####################################################################################
+  # complete_code_freeze
+  # -----------------------------------------------------------------------------------
+  # This lane executes the initial steps planned on code freeze
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane complete_code_freeze [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane complete_code_freeze
+  # bundle exec fastlane complete_code_freeze skip_confirm:true
+  #####################################################################################
+  desc "Creates a new release branch from the current develop"
+  lane :complete_code_freeze do | options |
+    ios_completecodefreeze_prechecks(options)
+    ios_localize_project()
+    ios_tag_build()
   end
 
   #####################################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.7'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.6.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
This PR updates the `code_freeze` lane to align it with the new flow we've been using lately where the beta pods are updated in the release branch. 

The changes reflects what we've done on WPiOS here: https://github.com/wordpress-mobile/WordPress-iOS/pull/14107.

To test: 
The hard way is described in the PR above, but since the only new action is `ios_check_beta_deps`, a good enough test would be to verify that it's correctly configured. 
In order to do this: 
- comment out all the stuff in `code_freeze` other than the last line.
- run `bundle exec fastlane code_freeze` and verify that it succeeds and that the list of the beta pods is printed out. 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
