### PR TITLE
Add slack notification to release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,19 @@ jobs:
             curl -sL https://sentry.io/get-cli/ | bash
       - run:
           name: Build
-          command: "bundle exec fastlane build_and_upload_release skip_confirm:true"
+          command: |
+            APP_VERSION=$(cat ../config/Version.Public.xcconfig | grep "^VERSION_LONG" | cut -d "=" -f2)
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WooCommerce iOS $APP_VERSION failed!'" >> $BASH_ENV
+            echo "export SLACK_SUCCESS_MESSAGE=':tada: WooCommerce iOS $APP_VERSION has been deployed!'" >> $BASH_ENV 
+            bundle exec fastlane build_and_upload_release skip_confirm:true
           no_output_timeout: 60m
+      - slack/status:
+          include_job_number_field: false
+          include_project_field: false
+          include_visit_job_action: false
+          webhook: '${SLACK_BUILD_WEBHOOK}'
+          failure_message: '${SLACK_FAILURE_MESSAGE}'
+          success_message: '${SLACK_SUCCESS_MESSAGE}'
 
 workflows:
   woocommerce_ios:


### PR DESCRIPTION
This PR adds a Slack notification that posts the results of the release build. 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
