### PR TITLE
Enabled Products Milestone 2 by default

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 4.5
 -----
+- [**] Products: now you can update product images, product settings, viewing and sharing a product.
+- The WIP banner on the Products tab is now collapsed by default for more vertical space.
 - [*] In Order Details, the item subtotal is now shown on the right side instead of the quantity. The quantity can still be viewed underneath the product name.
 - [*] In Order Details, SKU was removed from the Products List. It is still shown when fulfilling the order or viewing the product details.
 - [*] Polish the loading state on the product variations screen.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 4.5
 -----
 - [**] Products: now you can update product images, product settings, viewing and sharing a product.
-- The WIP banner on the Products tab is now collapsed by default for more vertical space.
 - [*] In Order Details, the item subtotal is now shown on the right side instead of the quantity. The quantity can still be viewed underneath the product name.
 - [*] In Order Details, SKU was removed from the Products List. It is still shown when fulfilling the order or viewing the product details.
 - [*] Polish the loading state on the product variations screen.

--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -4,7 +4,7 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         case .editProducts:
             return true
         case .editProductsRelease2:
-            return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
+            return true
         case .editProductsRelease3:
             return BuildConfiguration.current == .localDeveloper || BuildConfiguration.current == .alpha
         case .readonlyProductVariants:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -88,14 +88,12 @@ private extension BetaFeaturesViewController {
             }
             guard eligibleStatsVersion == .v4 else {
                 self.sections = [
-                    self.productsSection()
                 ]
 
                 return
             }
             self.sections = [
-                self.statsSection(),
-                self.productsSection()
+                self.statsSection()
             ]
         }
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -16,16 +16,13 @@ struct ProductDetailsFactory {
                                onCompletion: @escaping (UIViewController) -> Void) {
         let isEditProductsEnabled = featureFlagService.isFeatureFlagEnabled(.editProducts)
         if product.productType == .simple && isEditProductsEnabled {
-            let action = AppSettingsAction.loadProductsFeatureSwitch { isEditProductsRelease2Enabled in
                 let vc = productDetails(product: product,
                                         presentationStyle: presentationStyle,
                                         currencySettings: currencySettings,
                                         isEditProductsEnabled: isEditProductsEnabled,
-                                        isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
+                                        isEditProductsRelease2Enabled: featureFlagService.isFeatureFlagEnabled(.editProductsRelease2),
                                         isEditProductsRelease3Enabled: featureFlagService.isFeatureFlagEnabled(.editProductsRelease3))
                 onCompletion(vc)
-            }
-            ServiceLocator.stores.dispatch(action)
         } else {
             let vc = productDetails(product: product,
                                     presentationStyle: presentationStyle,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -10,9 +10,8 @@ struct ProductsTopBannerFactory {
     static func topBanner(isExpanded: Bool,
                           expandedStateChangeHandler: @escaping () -> Void,
                           onCompletion: @escaping (TopBannerView) -> Void) {
-        let action = AppSettingsAction.loadProductsFeatureSwitch { isEditProductsRelease2Enabled in
-            let title = isEditProductsRelease2Enabled ? Strings.titleWhenEditProductsRelease2IsEnabled: Strings.titleWhenEditProductsRelease2IsDisabled
-            let infoText = isEditProductsRelease2Enabled ? Strings.infoWhenEditProductsRelease2IsEnabled: Strings.infoWhenEditProductsRelease2IsDisabled
+            let title = Strings.title
+            let infoText = Strings.info
             let viewModel = TopBannerViewModel(title: title,
                                                infoText: infoText,
                                                icon: .workInProgressBanner,
@@ -21,25 +20,16 @@ struct ProductsTopBannerFactory {
             let topBannerView = TopBannerView(viewModel: viewModel)
             topBannerView.translatesAutoresizingMaskIntoConstraints = false
             onCompletion(topBannerView)
-        }
-        ServiceLocator.stores.dispatch(action)
     }
 }
 
 private extension ProductsTopBannerFactory {
     enum Strings {
-        static let titleWhenEditProductsRelease2IsEnabled =
-            NSLocalizedString("New editing options available",
-                              comment: "The title of the Work In Progress top banner on the Products tab when the Products release 2 feature switch is on.")
-        static let titleWhenEditProductsRelease2IsDisabled =
+        static let title =
             NSLocalizedString("Limited editing available",
-                              comment: "The title of the Work In Progress top banner on the Products tab when the Products release 2 feature switch is off.")
-        static let infoWhenEditProductsRelease2IsEnabled =
-            NSLocalizedString(
-                "We've added more editing functionalities to products. You can now update images, see previews and sort, filter & share products!",
-                              comment: "The info of the Work In Progress top banner on the Products tab when the Products release 2 feature switch is on.")
-        static let infoWhenEditProductsRelease2IsDisabled =
+                              comment: "The title of the Work In Progress top banner on the Products tab.")
+        static let info =
             NSLocalizedString("We've added editing functionality to simple products. Keep an eye out for more options soon!",
-                              comment: "The info of the Work In Progress top banner on the Products tab when the Products release 2 feature switch is off.")
+                              comment: "The info of the Work In Progress top banner on the Products tab.")
     }
 }


### PR DESCRIPTION
Resolves #2420 

We [decided](https://a8c.slack.com/archives/CGPNUU63E/p1591881834062300) to enable for everyone from the next release all the functionalities under the Products Milestone 2. I updated the banner message showed in the product list, and I did all the changes to enable these new functionalities of the products and for hiding the product switch in the Experimental Features screen.

## Testing
1. Run a build from `develop`, and enable the product switch under the "Experimental Features" screen.
2. Switch to this branch and run the app -> Make sure that you can update product images, product settings, viewing, and sharing a product.
3. Erase all contents and settings from your iOS simulator
4. Run the app from this branch
5. Make sure that the product switch under the "Experimental Features" screen disappeared
6. Make sure that the banner message in the product list is updated (Limited editing available).
7. Make sure you can update product images, product settings, viewing, and sharing a product.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
