### PR TITLE
Add Documentation for Copiable Code Generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,7 @@ store.dispatch(action)
 
 This is quite cumbersome, especially since `Product` has more than 50 properties. 
 
-To help with this, we create `copy()` methods for these objects. These `copy()` methods follow a specific pattern and will make use of the [`CopiableProp` and `NullableCopiableProp` typealiases](../Networking/Networking/Copiable/Copiable.swift).
+To help with this, we generate `copy()` methods for these objects. These `copy()` methods follow a specific pattern and will make use of the [`CopiableProp` and `NullableCopiableProp` typealiases](../Networking/Networking/Copiable/Copiable.swift).
 
 Here is an example implementation on a `Person` `struct`:
 
@@ -75,7 +75,10 @@ struct Person {
     let id: Int
     let name: String
     let address: String?
+}
 
+/// This will be automatically generated
+extension Person {
     func copy(
         id: CopiableProp<Int> = .copy,
         name: CopiableProp<String> = .copy,

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 - [Design Patterns](#design-patterns)
     - [Copiable](#copiable)
         - [Generating Copiable Methods](#generating-copiable-methods)
-        - [Modifying The Copiable Code Generation](modifying-the-copiable-code-generation)
+        - [Modifying The Copiable Code Generation](#modifying-the-copiable-code-generation)
 - [Testing](#testing)
 
 ## Architecture
@@ -152,7 +152,7 @@ The `copy()` methods are generated using [Sourcery](https://github.com/krzysztof
 
 To generate a `copy()` method for a `class` or `struct`:
 
-1. Make it conform to [`GeneratedCopiable`](../Networking/Networking/Copiable/GeneratedCopiable.swift). Consider importaing the `protocol` only.
+1. Make it conform to [`GeneratedCopiable`](../Networking/Networking/Copiable/GeneratedCopiable.swift). Consider importing the `protocol` only.
 
     ```swift
     import protocol Networking.GeneratedCopiable

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@
     - [Choosing Between Structures and Classes](#choosing-between-structures-and-classes)
 - [Design Patterns](#design-patterns)
     - [Copiable](#copiable)
+        - [Generating Copiable Methods](#generating-copiable-methods)
+        - [Modifying The Copiable Code Generation](modifying-the-copiable-code-generation)
 - [Testing](#testing)
 
 ## Architecture
@@ -144,9 +146,53 @@ let lukeWithNoAddress = luke.copy(address: nil)
 let lukeWithNoAddress = luke.copy(address: .some(nil))
 ```
 
-### Code Generation
+### Generating Copiable Methods
 
-These `copy()` methods will be automatically generated in the future.
+The `copy()` methods are generated using [Sourcery](https://github.com/krzysztofzablocki/Sourcery). For now, only the classes or structs in the WooCommerce, Yosemite, and Networking modules are supported.
+
+To generate a `copy()` method for a `class` or `struct`:
+
+1. Make it conform to [`GeneratedCopiable`](../Networking/Networking/Copiable/GeneratedCopiable.swift). Consider importaing the `protocol` only.
+
+    ```swift
+    import protocol Networking.GeneratedCopiable
+
+    struct ProductSettings: GeneratedCopiable {
+        ...
+    }
+    ```
+
+2. In terminal, navigate to the project's root folder and run `rake generate`.
+
+    ```
+    $ cd /path/to/root
+    $ rake generate
+    ```
+
+    This will generate separate files for every module. For example:
+
+    ```
+    WooCommerce/Classes/Copiable/Models+Copiable.generated.swift
+    Yosemite/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+    ```
+    
+3. Add the generated files to the appropriate project if they're not added yet.
+4. Compile the project.
+
+### Modifying The Copiable Code Generation
+
+The [`rake generate`](../Rakefile) command executes the Sourcery configuration files located in the [`CodeGeneration` folder](../CodeGeneration). There are different configuration files for every module:
+
+```
+Networking module → Networking-Copiable.sourcery.yaml
+WooCommerce module → WooCommerce-Copiable.sourcery.yaml
+Yosemite module → Yosemite-Copiable.sourcery.yaml
+```
+
+All of them use a single template, [`Models+Copiable.swifttemplate`](../CodeGeneration/Models+Copiable.swifttemplate), to generate the code. It's written using [Swift templates](https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/writing-templates.html).
+
+Please refer to the [Sourcery reference](https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/index.html) for more info about how to write templates.
+
 
 ## Testing
 


### PR DESCRIPTION
Continuation of #2405. Ref p91TBi-2TB-p2. 

## Testing

View the documentation [here](https://github.com/woocommerce/woocommerce-ios/tree/update/docs-for-copiable/docs)

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

