### PR TITLE
Update top banner trailing edge spacing from 10px to 16px

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -157,7 +157,7 @@ private extension TopBannerView {
         let contentContainerView = UIView(frame: .zero)
         contentContainerView.translatesAutoresizingMaskIntoConstraints = false
         contentContainerView.addSubview(contentView)
-        contentContainerView.pinSubviewToAllEdges(contentView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 10))
+        contentContainerView.pinSubviewToAllEdges(contentView, insets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16))
         return contentContainerView
     }
 


### PR DESCRIPTION
Part of #2410 

## Changes

- Updated the top banner content stack view's trailing edge spacing from 10px to 16px

## Testing

- Launch the app with stats v4 disabled (if not, you can turn off stats v4 in Settings > Experimental Features) --> the top banner should look good, and the "X" button is tappable
- Go to the Products tab --> the top banner should look good, and the chevron up/down button is tappable

## Example screenshots

(Please note the CTA position on the right of the top banner!)

tab | before | after
-- | -- | --
Products top banner | ![Simulator Screen Shot - iPhone 11 - 2020-06-15 at 11 06 40](https://user-images.githubusercontent.com/1945542/84614884-0492ad80-aefa-11ea-9a1d-fc58a9eab4df.png) | ![Simulator Screen Shot - iPhone 11 - 2020-06-15 at 11 07 32](https://user-images.githubusercontent.com/1945542/84614897-0b212500-aefa-11ea-83f1-bda6bf573e4f.png)
Dashboard top banner | ![Simulator Screen Shot - iPhone 11 - 2020-06-15 at 11 06 55](https://user-images.githubusercontent.com/1945542/84614916-183e1400-aefa-11ea-95a0-7a038ddccb0f.png) | ![Simulator Screen Shot - iPhone 11 - 2020-06-15 at 11 07 34](https://user-images.githubusercontent.com/1945542/84614925-1c6a3180-aefa-11ea-8035-55a5e5f5b5cf.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
