### PR TITLE
Disable product categories row/action in release 4.5

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -64,7 +64,7 @@ final class ProductFormViewController: UIViewController {
         self.viewModel = ProductFormViewModel(product: product,
                                               productImageActionHandler: productImageActionHandler,
                                               isEditProductsRelease2Enabled: isEditProductsRelease2Enabled,
-                                              isEditProductsRelease3Enabled: isEditProductsRelease2Enabled)
+                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
         self.tableViewModel = DefaultProductFormTableViewModel(product: product,
                                                                actionsFactory: viewModel.actionsFactory,
                                                                currency: currency)


### PR DESCRIPTION
Fixes #2438 

## Changes

- Passed the correct M3 flag to `ProductFormViewModel` - my bad! 🤦🏻‍♀️ 🙇🏻‍♀️

## Testing

- Build the app with release configuration
- Go to the Products tab
- Tap on a simple product --> the product categories should not be visible on the product form, nor in the "Add more details" bottom sheet

## Example screenshots

debug build | release build
-- | --
![Simulator Screen Shot - iPhone Xs - 2020-06-17 at 17 05 09](https://user-images.githubusercontent.com/1945542/84878701-c4c7f380-b0bc-11ea-8fdc-f1e94f3323b6.png) | ![Simulator Screen Shot - iPhone Xs - 2020-06-17 at 17 03 55](https://user-images.githubusercontent.com/1945542/84878683-c0033f80-b0bc-11ea-8830-112189763bae.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
