### PR TITLE
Fixed tracking events opened/closed called multiple times 

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -139,7 +139,8 @@ private extension WooAnalytics {
         guard userHasOptedIn == true else {
             return
         }
-
+        
+        stopObservingNotifications()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(trackApplicationOpened),
                                                name: UIApplication.didBecomeActiveNotification,

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -118,13 +118,11 @@ extension WooAnalytics {
         userHasOptedIn = !optedOut
 
         if optedOut {
-            stopObservingNotifications()
             analyticsProvider.clearEvents()
             analyticsProvider.clearUsers()
             DDLogInfo("🔴 Tracking opt-out complete.")
         } else {
             refreshUserData()
-            startObservingNotifications()
             DDLogInfo("🔵 Tracking started.")
         }
     }
@@ -140,7 +138,6 @@ private extension WooAnalytics {
             return
         }
 
-        stopObservingNotifications()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(trackApplicationOpened),
                                                name: UIApplication.didBecomeActiveNotification,
@@ -150,16 +147,6 @@ private extension WooAnalytics {
                                                selector: #selector(trackApplicationClosed),
                                                name: UIApplication.didEnterBackgroundNotification,
                                                object: nil)
-    }
-
-    func stopObservingNotifications() {
-        NotificationCenter.default.removeObserver(self,
-                                                  name: UIApplication.didBecomeActiveNotification,
-                                                  object: nil)
-
-        NotificationCenter.default.removeObserver(self,
-                                                  name: UIApplication.didEnterBackgroundNotification,
-                                                  object: nil)
     }
 
     @objc func trackApplicationOpened() {

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -139,7 +139,7 @@ private extension WooAnalytics {
         guard userHasOptedIn == true else {
             return
         }
-        
+
         stopObservingNotifications()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(trackApplicationOpened),


### PR DESCRIPTION
Fixes #2440 

Investigating the issue #2440 seems that the events `application_opened` and `application_closed` are called two times every time they are fired because we start to observe notifications two times if the user has opted in the analytics.
To make sure to not register the notifications two times, I remove all the observers before adding a new one.

## Testing
- Launch the app, and make sure that in the console you are able to see only one `application_opened` event. 
- Send the app in foreground, make sure that the event `application_closed` is fired only one time. (if you relaunch the app, you will notice another `application_opened` event)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
