### PR TITLE
External products: external link & button text

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -467,6 +467,10 @@ public struct Product: Codable, GeneratedCopiable {
         try container.encode(slug, forKey: .slug)
         try container.encode(purchaseNote, forKey: .purchaseNote)
         try container.encode(menuOrder, forKey: .menuOrder)
+
+        // External link for external/affiliate products.
+        try container.encode(externalURL, forKey: .externalURL)
+        try container.encode(buttonText, forKey: .buttonText)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -13,6 +13,13 @@ final class ProductExternalLinkViewController: UIViewController {
     private var externalURL: String?
     private var buttonText: String
 
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
+            self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
+        }
+        return keyboardFrameObserver
+    }()
+
     typealias Completion = (_ externalURL: String?, _ buttonText: String) -> Void
     private let onCompletion: Completion
 
@@ -44,6 +51,7 @@ final class ProductExternalLinkViewController: UIViewController {
         configureNavigation()
         configureMainView()
         configureTableView()
+        startListeningToNotifications()
     }
 }
 
@@ -173,6 +181,22 @@ private extension ProductExternalLinkViewController {
 
     func registerTableViewCells() {
         tableView.register(TitleAndTextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TitleAndTextFieldTableViewCell.reuseIdentifier)
+    }
+}
+
+// MARK: - Keyboard management
+//
+private extension ProductExternalLinkViewController {
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        keyboardFrameObserver.startObservingKeyboardFrame()
+    }
+}
+
+extension ProductExternalLinkViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return tableView
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -125,8 +125,9 @@ private extension ProductExternalLinkViewController {
     }
 
     func configureExternalURL(cell: TitleAndTextFieldTableViewCell) {
-        let title = NSLocalizedString("Product URL", comment: "")
-        let placeholder = NSLocalizedString("Enter URL", comment: "")
+        let title = NSLocalizedString("Product URL", comment: "Title of the text field for editing the external URL for an external/affiliate product")
+        let placeholder = NSLocalizedString("Enter URL",
+                                            comment: "Placeholder of the text field for editing the external URL for an external/affiliate product")
         let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
                                                                  text: externalURL,
                                                                  placeholder: placeholder,
@@ -139,8 +140,9 @@ private extension ProductExternalLinkViewController {
     }
 
     func configureButtonText(cell: TitleAndTextFieldTableViewCell) {
-        let title = NSLocalizedString("Button Text", comment: "")
-        let placeholder = NSLocalizedString("Enter button text", comment: "")
+        let title = NSLocalizedString("Button Text", comment: "Title of the text field for editing the button text for an external/affiliate product")
+        let placeholder = NSLocalizedString("Buy product",
+                                            comment: "Placeholder of the text field for editing the button text for an external/affiliate product")
         let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
                                                                  text: buttonText,
                                                                  placeholder: placeholder,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -13,12 +13,9 @@ final class ProductExternalLinkViewController: UIViewController {
     private var externalURL: String?
     private var buttonText: String
 
-    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
-        let keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
-            self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
-        }
-        return keyboardFrameObserver
-    }()
+    private lazy var keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
+        self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
+    }
 
     typealias Completion = (_ externalURL: String?, _ buttonText: String) -> Void
     private let onCompletion: Completion
@@ -51,7 +48,7 @@ final class ProductExternalLinkViewController: UIViewController {
         configureNavigation()
         configureMainView()
         configureTableView()
-        startListeningToNotifications()
+        startObservingKeyboardNotifications()
     }
 }
 
@@ -191,7 +188,7 @@ private extension ProductExternalLinkViewController {
 private extension ProductExternalLinkViewController {
     /// Registers for all of the related Notifications
     ///
-    func startListeningToNotifications() {
+    func startObservingKeyboardNotifications() {
         keyboardFrameObserver.startObservingKeyboardFrame()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -1,0 +1,208 @@
+import UIKit
+import Yosemite
+
+/// Contains text fields for editing an external product's external URL and button text.
+final class ProductExternalLinkViewController: UIViewController {
+    private lazy var tableView: UITableView = {
+        return UITableView(frame: .zero, style: .grouped)
+    }()
+
+    private let product: Product
+    private let sections: [Section]
+
+    private var externalURL: String?
+    private var buttonText: String
+
+    typealias Completion = (_ externalURL: String?, _ buttonText: String) -> Void
+    private let onCompletion: Completion
+
+    init(product: Product, onCompletion: @escaping Completion) {
+        self.product = product
+        self.externalURL = product.externalURL
+        self.buttonText = product.buttonText
+        self.onCompletion = onCompletion
+
+        let externalURLFooter = NSLocalizedString("Enter the external URL to the product.",
+                                                  comment: "Footer text for editing product external URL")
+        let buttonTextFooter = NSLocalizedString("This text will be shown on the button linking to the external product.",
+                                                 comment: "Footer text for editing external product button text")
+        self.sections = [
+            Section(footer: externalURLFooter, rows: [.externalURL]),
+            Section(footer: buttonTextFooter, rows: [.buttonText])
+        ]
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavigation()
+        configureMainView()
+        configureTableView()
+    }
+}
+
+// MARK: - Navigation actions handling
+//
+extension ProductExternalLinkViewController {
+    override func shouldPopOnBackButton() -> Bool {
+        guard hasUnsavedChanges() else {
+            return true
+        }
+        presentBackNavigationActionSheet()
+        return false
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+
+    @objc private func completeEditing() {
+        onCompletion(externalURL, buttonText)
+    }
+
+    private func hasUnsavedChanges() -> Bool {
+        return externalURL != product.externalURL || buttonText != product.buttonText
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
+    }
+}
+
+extension ProductExternalLinkViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+}
+
+// MARK: - Support for UITableViewDataSource
+//
+private extension ProductExternalLinkViewController {
+    /// Configure cellForRowAtIndexPath:
+    ///
+   func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TitleAndTextFieldTableViewCell where row == .externalURL:
+            configureExternalURL(cell: cell)
+        case let cell as TitleAndTextFieldTableViewCell where row == .buttonText:
+            configureButtonText(cell: cell)
+        default:
+            fatalError("Unexpected row: \(row)")
+        }
+    }
+
+    func configureExternalURL(cell: TitleAndTextFieldTableViewCell) {
+        let title = NSLocalizedString("Product URL", comment: "")
+        let placeholder = NSLocalizedString("Enter URL", comment: "")
+        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
+                                                                 text: externalURL,
+                                                                 placeholder: placeholder,
+                                                                 keyboardType: .URL,
+                                                                 textFieldAlignment: .trailing,
+                                                                 onTextChange: { [weak self] text in
+                                                                    self?.externalURL = text
+        })
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureButtonText(cell: TitleAndTextFieldTableViewCell) {
+        let title = NSLocalizedString("Button Text", comment: "")
+        let placeholder = NSLocalizedString("Enter button text", comment: "")
+        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
+                                                                 text: buttonText,
+                                                                 placeholder: placeholder,
+                                                                 textFieldAlignment: .trailing,
+                                                                 onTextChange: { [weak self] text in
+                                                                    self?.buttonText = text ?? ""
+        })
+        cell.configure(viewModel: viewModel)
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ProductExternalLinkViewController {
+    func configureNavigation() {
+        title = NSLocalizedString("Product Link", comment: "Edit Product External Link navigation title")
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeEditing))
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.dataSource = self
+
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+        tableView.removeLastCellSeparator()
+
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(tableView)
+
+        registerTableViewCells()
+    }
+
+    func registerTableViewCells() {
+        tableView.register(TitleAndTextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TitleAndTextFieldTableViewCell.reuseIdentifier)
+    }
+}
+
+// MARK: - Constants
+//
+private extension ProductExternalLinkViewController {
+    /// Table Rows
+    ///
+    enum Row {
+        /// Listed in the order they appear on screen
+        case externalURL
+        case buttonText
+
+        var reuseIdentifier: String {
+            switch self {
+            case .externalURL, .buttonText:
+                return TitleAndTextFieldTableViewCell.reuseIdentifier
+            }
+        }
+    }
+
+    /// Table Sections
+    ///
+    struct Section: RowIterable {
+        let footer: String?
+        let rows: [Row]
+
+        init(footer: String? = nil, rows: [Row]) {
+            self.footer = footer
+            self.rows = rows
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Error Handling/TitleAndTextFieldTableViewCell.ViewModel+State.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Error Handling/TitleAndTextFieldTableViewCell.ViewModel+State.swift
@@ -8,6 +8,7 @@ extension TitleAndTextFieldTableViewCell.ViewModel {
                                                         text: text,
                                                         placeholder: placeholder,
                                                         state: state,
+                                                        textFieldAlignment: .leading,
                                                         onTextChange: onTextChange)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -8,6 +8,7 @@ extension Product {
         return TitleAndTextFieldTableViewCell.ViewModel(title: title,
                                                         text: sku,
                                                         placeholder: placeholder,
+                                                        textFieldAlignment: .leading,
                                                         onTextChange: onTextChange)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -539,7 +539,7 @@ extension ProductFormViewController: UITableViewDelegate {
                 editBriefDescription()
             case .externalURL:
                 // TODO-2000 Edit Product M3 analytics
-                // TODO-2200: implement external URL editing action
+                editExternalLink()
                 break
             case .sku:
                 // TODO-2000 Edit Product M3 analytics
@@ -832,6 +832,29 @@ private extension ProductFormViewController {
             return
         }
         viewModel.updateSKU(sku)
+    }
+}
+
+// MARK: Action - Edit Product External Link
+//
+private extension ProductFormViewController {
+    func editExternalLink() {
+        let viewController = ProductExternalLinkViewController(product: product) { [weak self] externalURL, buttonText in
+            self?.onEditExternalLinkCompletion(externalURL: externalURL, buttonText: buttonText)
+        }
+        show(viewController, sender: self)
+    }
+
+    func onEditExternalLinkCompletion(externalURL: String?, buttonText: String) {
+        defer {
+            navigationController?.popViewController(animated: true)
+        }
+        // TODO-2000: Edit Product M3 analytics
+        let hasChangedData = externalURL != product.externalURL || buttonText != product.buttonText
+        guard hasChangedData else {
+            return
+        }
+        viewModel.updateExternalLink(externalURL: externalURL, buttonText: buttonText)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -185,6 +185,10 @@ extension ProductFormViewModel {
                                menuOrder: settings.menuOrder)
         password = settings.password
     }
+
+    func updateExternalLink(externalURL: String?, buttonText: String) {
+        product = product.copy(buttonText: buttonText, externalURL: externalURL)
+    }
 }
 
 // MARK: Reset actions

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldContentAlignment.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldContentAlignment.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+/// Horizontal alignment for content (text or placeholder) in a text field.
+enum TextFieldContentAlignment {
+    case leading
+    case trailing
+    case center
+}
+
+extension TextFieldContentAlignment {
+    func toTextAlignment(layoutDirection: UIUserInterfaceLayoutDirection = UIApplication.shared.userInterfaceLayoutDirection) -> NSTextAlignment {
+        let isLeftToRight = layoutDirection == .leftToRight
+        switch self {
+        case .leading:
+            return isLeftToRight ? .left: .right
+        case .trailing:
+            return isLeftToRight ? .right: .left
+        case .center:
+            return .center
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTextAlignment.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTextAlignment.swift
@@ -1,13 +1,15 @@
 import UIKit
 
-/// Horizontal alignment for content (text or placeholder) in a text field.
-enum TextFieldContentAlignment {
+/// How the text content (text or placeholder) is aligned horizontally in a `UITextField`.
+/// Since `NSTextAlignment` does not have .leading and .trailing cases for .left and .right respectively, this enum is used as a wrapper for specifying
+/// `NSTextAlignment` for a `UITextField` with the layout direction in mind.
+enum TextFieldTextAlignment {
     case leading
     case trailing
     case center
 }
 
-extension TextFieldContentAlignment {
+extension TextFieldTextAlignment {
     func toTextAlignment(layoutDirection: UIUserInterfaceLayoutDirection = UIApplication.shared.userInterfaceLayoutDirection) -> NSTextAlignment {
         let isLeftToRight = layoutDirection == .leftToRight
         switch self {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -8,6 +8,8 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         let text: String?
         let placeholder: String?
         let state: State
+        let keyboardType: UIKeyboardType
+        let textFieldAlignment: TextFieldContentAlignment
         let onTextChange: ((_ text: String?) -> Void)?
 
         enum State {
@@ -19,11 +21,15 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
              text: String?,
              placeholder: String?,
              state: State = .normal,
+             keyboardType: UIKeyboardType = .default,
+             textFieldAlignment: TextFieldContentAlignment,
              onTextChange: ((_ text: String?) -> Void)?) {
             self.title = title
             self.text = text
             self.placeholder = placeholder
             self.state = state
+            self.keyboardType = keyboardType
+            self.textFieldAlignment = textFieldAlignment
             self.onTextChange = onTextChange
         }
     }
@@ -51,6 +57,8 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         textField.text = viewModel.text
         textField.placeholder = viewModel.placeholder
         textField.textColor = viewModel.state.textColor
+        textField.keyboardType = viewModel.keyboardType
+        textField.textAlignment = viewModel.textFieldAlignment.toTextAlignment()
         onTextChange = viewModel.onTextChange
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndTextFieldTableViewCell.swift
@@ -9,7 +9,7 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
         let placeholder: String?
         let state: State
         let keyboardType: UIKeyboardType
-        let textFieldAlignment: TextFieldContentAlignment
+        let textFieldAlignment: TextFieldTextAlignment
         let onTextChange: ((_ text: String?) -> Void)?
 
         enum State {
@@ -22,7 +22,7 @@ final class TitleAndTextFieldTableViewCell: UITableViewCell {
              placeholder: String?,
              state: State = .normal,
              keyboardType: UIKeyboardType = .default,
-             textFieldAlignment: TextFieldContentAlignment,
+             textFieldAlignment: TextFieldTextAlignment,
              onTextChange: ((_ text: String?) -> Void)?) {
             self.title = title
             self.text = text

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */; };
 		0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */; };
 		0206483A23FA4160008441BB /* OrdersRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0206483923FA4160008441BB /* OrdersRootViewController.swift */; };
+		020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020886562499E642001D784E /* ProductExternalLinkViewController.swift */; };
 		020B2F8F23BD9F1F00BD79AD /* IntegerInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */; };
 		020B2F9123BDD71500BD79AD /* IntegerInputFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */; };
 		020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */; };
@@ -151,6 +152,7 @@
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
 		0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */; };
 		02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */; };
+		026B3C57249A046E00F7823C /* TextFieldContentAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B3C56249A046E00F7823C /* TextFieldContentAlignment.swift */; };
 		026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */; };
 		026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
@@ -886,6 +888,7 @@
 		0202B6912387AB0C00F3EBE0 /* WooTab+Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooTab+Tag.swift"; sourceTree = "<group>"; };
 		0202B6942387AD1B00F3EBE0 /* UITabBar+Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBar+Order.swift"; sourceTree = "<group>"; };
 		0206483923FA4160008441BB /* OrdersRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRootViewController.swift; sourceTree = "<group>"; };
+		020886562499E642001D784E /* ProductExternalLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductExternalLinkViewController.swift; sourceTree = "<group>"; };
 		020B2F8E23BD9F1F00BD79AD /* IntegerInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatter.swift; sourceTree = "<group>"; };
 		020B2F9023BDD71500BD79AD /* IntegerInputFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerInputFormatterTests.swift; sourceTree = "<group>"; };
 		020B2F9323BDDBDC00BD79AD /* ProductUpdateError+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductUpdateError+UI.swift"; sourceTree = "<group>"; };
@@ -1012,6 +1015,7 @@
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
 		0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserverTests.swift; sourceTree = "<group>"; };
 		0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecTextViewAttachmentHandler.swift; sourceTree = "<group>"; };
+		026B3C56249A046E00F7823C /* TextFieldContentAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldContentAlignment.swift; sourceTree = "<group>"; };
 		026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewController.swift; sourceTree = "<group>"; };
 		026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVariationsViewController.xib; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
@@ -1751,6 +1755,14 @@
 			path = TabBar;
 			sourceTree = "<group>";
 		};
+		020886582499E64B001D784E /* Edit External Link */ = {
+			isa = PBXGroup;
+			children = (
+				020886562499E642001D784E /* ProductExternalLinkViewController.swift */,
+			);
+			path = "Edit External Link";
+			sourceTree = "<group>";
+		};
 		020B2F9223BDDBC300BD79AD /* Error Handling */ = {
 			isa = PBXGroup;
 			children = (
@@ -1805,6 +1817,7 @@
 		021627232379637E000208D2 /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
+				020886582499E64B001D784E /* Edit External Link */,
 				0212275F244989D20042161F /* BottomSheetListSelector */,
 				020B2F9223BDDBC300BD79AD /* Error Handling */,
 				02F4F50C237AFBB700E13A9C /* Cells */,
@@ -3859,6 +3872,7 @@
 				02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */,
 				02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */,
 				451750B124470CD5004FDA65 /* EnhancedTextView.swift */,
+				026B3C56249A046E00F7823C /* TextFieldContentAlignment.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -4867,6 +4881,7 @@
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,
 				CE1F51272064345B00C6C810 /* UIColor+Helpers.swift in Sources */,
 				934CB123224EAB150005CCB9 /* main.swift in Sources */,
+				020886572499E643001D784E /* ProductExternalLinkViewController.swift in Sources */,
 				02F4F50F237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.swift in Sources */,
 				021E2A1C23AA0DD100B1DE07 /* ProductBackordersSettingListSelectorCommand.swift in Sources */,
 				5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */,
@@ -4924,6 +4939,7 @@
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */,
+				026B3C57249A046E00F7823C /* TextFieldContentAlignment.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -152,7 +152,7 @@
 		0269576A23726304001BA0BF /* KeyboardFrameObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576923726304001BA0BF /* KeyboardFrameObserver.swift */; };
 		0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */; };
 		02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */; };
-		026B3C57249A046E00F7823C /* TextFieldContentAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B3C56249A046E00F7823C /* TextFieldContentAlignment.swift */; };
+		026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */; };
 		026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */; };
 		026CF63B237E9ABE009563D4 /* ProductVariationsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
@@ -211,6 +211,7 @@
 		02ADC7D02398C8EB008D4BED /* UIColor+SystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */; };
 		02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */; };
 		02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */; };
+		02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */; };
 		02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */; };
 		02BA12852461674B008D8325 /* Optional+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA12842461674B008D8325 /* Optional+String.swift */; };
 		02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */; };
@@ -1015,7 +1016,7 @@
 		0269576923726304001BA0BF /* KeyboardFrameObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserver.swift; sourceTree = "<group>"; };
 		0269576C23726401001BA0BF /* KeyboardFrameObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardFrameObserverTests.swift; sourceTree = "<group>"; };
 		0269576F237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecTextViewAttachmentHandler.swift; sourceTree = "<group>"; };
-		026B3C56249A046E00F7823C /* TextFieldContentAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldContentAlignment.swift; sourceTree = "<group>"; };
+		026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignment.swift; sourceTree = "<group>"; };
 		026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsViewController.swift; sourceTree = "<group>"; };
 		026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVariationsViewController.xib; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
@@ -1074,6 +1075,7 @@
 		02ADC7CF2398C8EB008D4BED /* UIColor+SystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+SystemColors.swift"; sourceTree = "<group>"; };
 		02B296A622FA6DB500FD7A4C /* Date+StartAndEnd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+StartAndEnd.swift"; sourceTree = "<group>"; };
 		02B296A822FA6E0000FD7A4C /* DateStartAndEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateStartAndEndTests.swift; sourceTree = "<group>"; };
+		02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignmentTests.swift; sourceTree = "<group>"; };
 		02B653AB2429F7BF00A9C839 /* MockTaxClassStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTaxClassStoresManager.swift; sourceTree = "<group>"; };
 		02BA12842461674B008D8325 /* Optional+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+String.swift"; sourceTree = "<group>"; };
 		02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+VisibilityTests.swift"; sourceTree = "<group>"; };
@@ -2576,6 +2578,7 @@
 			isa = PBXGroup;
 			children = (
 				57B374B4245B32FE00D58BE0 /* EmptyStateViewController */,
+				02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -3872,7 +3875,7 @@
 				02EEB5C22424AFAA00B8A701 /* TextFieldTableViewCell.swift */,
 				02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */,
 				451750B124470CD5004FDA65 /* EnhancedTextView.swift */,
-				026B3C56249A046E00F7823C /* TextFieldContentAlignment.swift */,
+				026B3C56249A046E00F7823C /* TextFieldTextAlignment.swift */,
 			);
 			path = ReusableViews;
 			sourceTree = "<group>";
@@ -4939,7 +4942,7 @@
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */,
-				026B3C57249A046E00F7823C /* TextFieldContentAlignment.swift in Sources */,
+				026B3C57249A046E00F7823C /* TextFieldTextAlignment.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				CECC758C23D2227000486676 /* ProductDetailsCellViewModel.swift in Sources */,
 				453227B723C4D6EC00D816B3 /* TimeZone+Woo.swift in Sources */,
@@ -5187,6 +5190,7 @@
 				D816DDBC22265DA300903E59 /* OrderTrackingTableViewCellTests.swift in Sources */,
 				573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */,
 				D85136DD231E613900DD0539 /* ReviewsViewModelTests.swift in Sources */,
+				02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -225,6 +225,25 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         // Assert
         XCTAssertEqual(viewModel.product.sku, sku)
     }
+
+    func testUpdatingExternalLink() {
+        // Arrange
+        let product = MockProduct().product(sku: "")
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: false)
+
+        // Action
+        let externalURL = "woo.com"
+        let buttonText = "Try!"
+        viewModel.updateExternalLink(externalURL: externalURL, buttonText: buttonText)
+
+        // Assert
+        XCTAssertEqual(viewModel.product.externalURL, externalURL)
+        XCTAssertEqual(viewModel.product.buttonText, buttonText)
+    }
 }
 
 private extension ProductFormViewModel_UpdatesTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -228,7 +228,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
 
     func testUpdatingExternalLink() {
         // Arrange
-        let product = MockProduct().product(sku: "")
+        let product = MockProduct().product()
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: product)
         let viewModel = ProductFormViewModel(product: product,
                                              productImageActionHandler: productImageActionHandler,

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TextFieldTextAlignmentTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TextFieldTextAlignmentTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import WooCommerce
+
+final class TextFieldTextAlignmentTests: XCTestCase {
+
+    // MARK: .leading
+
+    func testTextFieldTextLeadingAlignmentMapsToLeftForLTR() {
+        // Arrange
+        let textAlignment = TextFieldTextAlignment.leading
+
+        // Action
+        let nsTextAlignment = textAlignment.toTextAlignment(layoutDirection: .leftToRight)
+
+        // Assert
+        XCTAssertEqual(nsTextAlignment, .left)
+    }
+
+    func testTextFieldTextLeadingAlignmentMapsToRightForRTL() {
+        // Arrange
+        let textAlignment = TextFieldTextAlignment.leading
+
+        // Action
+        let nsTextAlignment = textAlignment.toTextAlignment(layoutDirection: .rightToLeft)
+
+        // Assert
+        XCTAssertEqual(nsTextAlignment, .right)
+    }
+
+    // MARK: .trailing
+
+    func testTextFieldTextTrailingAlignmentMapsToRightForLTR() {
+        // Arrange
+        let textAlignment = TextFieldTextAlignment.trailing
+
+        // Action
+        let nsTextAlignment = textAlignment.toTextAlignment(layoutDirection: .leftToRight)
+
+        // Assert
+        XCTAssertEqual(nsTextAlignment, .right)
+    }
+
+    func testTextFieldTextTrailingAlignmentMapsToLeftForRTL() {
+        // Arrange
+        let textAlignment = TextFieldTextAlignment.trailing
+
+        // Action
+        let nsTextAlignment = textAlignment.toTextAlignment(layoutDirection: .rightToLeft)
+
+        // Assert
+        XCTAssertEqual(nsTextAlignment, .left)
+    }
+
+    // MARK: .center
+
+    func testTextFieldTextCenterAlignmentMapsToCenterForLTR() {
+        // Arrange
+        let textAlignment = TextFieldTextAlignment.center
+
+        // Action
+        let nsTextAlignment = textAlignment.toTextAlignment(layoutDirection: .leftToRight)
+
+        // Assert
+        XCTAssertEqual(nsTextAlignment, .center)
+    }
+
+    func testTextFieldTextCenterAlignmentMapsToCenterForRTL() {
+        // Arrange
+        let textAlignment = TextFieldTextAlignment.center
+
+        // Action
+        let nsTextAlignment = textAlignment.toTextAlignment(layoutDirection: .rightToLeft)
+
+        // Assert
+        XCTAssertEqual(nsTextAlignment, .center)
+    }
+}


### PR DESCRIPTION
"editable product link" for #2200 

## Changes

- Encoded `externalURL` and `buttonText` for updating an external product
- Added a function to update `externalURL` and `buttonText` in `ProductFormViewModel` + test case
- Created `ProductExternalLinkViewController` that enabled editing the external URL and button text fields for an external product
- Created an enum `TextFieldContentAlignment` for different ways of text field content alignment for the text and placeholder (I was debating between this name and `TextFieldTextAlignment`, lemme know if you think another name would sound more clear!)
  - Because `NSTextAlignment` only has `left`/`right` instead of `leading`/`trailing` that takes LTR/RTL layout into account, this enum is mapped to `NSTextAlignment` based on the app layout
- Added `keyboardType` and `textFieldAlignment` parameters to `TitleAndTextFieldTableViewCell` for customizations in the external link screen
- Enabled editing external link in `ProductFormViewController`

## Testing

- Go to the Products tab
- Tap on an external product
- Tap on the Product link row --> should see the screen with two text fields for external URL and button text as in the screenshots
- Edit the external URL and button text
- (If not on iOS 13.4 simulator/device) Tap "<" in the navigation bar --> a discard changes prompt should be shown
- Tap "Cancel" to keep editing
- Tap "Done" to save changes
- Tap "Update" --> the external URL and button text should be updated remotely

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/84986133-973c8200-b170-11ea-8162-27d3d0751681.gif)


empty state | filled state
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 10 34 25](https://user-images.githubusercontent.com/1945542/84972500-8e888380-b151-11ea-84b0-b2e687b50d1c.png) | ![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 10 34 48](https://user-images.githubusercontent.com/1945542/84972506-91837400-b151-11ea-9700-ae38a2317e04.png)
![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 10 35 33](https://user-images.githubusercontent.com/1945542/84972509-934d3780-b151-11ea-820f-e92116cdec95.png) | ![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 10 35 28](https://user-images.githubusercontent.com/1945542/84972508-92b4a100-b151-11ea-8428-97a1c37b9b4d.png)


![Simulator Screen Shot - iPhone 11 - 2020-06-18 at 10 33 48](https://user-images.githubusercontent.com/1945542/84972519-97795500-b151-11ea-98a1-c95dc28a968d.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
