### PR TITLE
Edit Products: update price row when price details are empty

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.6
 -----
 - [*] Fix an issue in the y-axis values on the dashboard charts where a negative value could show two minus signs.
+- [*] When a simple product doesn't have a price set, the price row on the product details screen now shows "Add Price" placeholder instead of an empty regular price.
 
 4.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -70,7 +70,6 @@ private extension DefaultProductFormTableViewModel {
 private extension DefaultProductFormTableViewModel {
     func priceSettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.priceImage
-        let title = Constants.priceSettingsTitle
 
         var priceDetails = [String]()
 
@@ -102,11 +101,9 @@ private extension DefaultProductFormTableViewModel {
                 let formattedDate = dateFormatter.string(from: dateOnSaleEnd)
                 priceDetails.append(String.localizedStringWithFormat(Constants.saleDateFormatTo, formattedDate))
             }
-        } else if product.price.isEmpty == false {
-            let formattedPrice = currencyFormatter.formatAmount(product.regularPrice ?? product.price, with: currency) ?? ""
-            priceDetails.append(String.localizedStringWithFormat(Constants.regularPriceFormat, formattedPrice))
         }
 
+        let title = priceDetails.isEmpty ? Constants.addPriceSettingsTitle: Constants.priceSettingsTitle
         let details = priceDetails.isEmpty ? nil: priceDetails.joined(separator: "\n")
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
@@ -228,8 +225,10 @@ private extension DefaultProductFormTableViewModel {
 
 private extension DefaultProductFormTableViewModel {
     enum Constants {
+        static let addPriceSettingsTitle = NSLocalizedString("Add Price",
+                                                             comment: "Title for adding the price settings row on Product main screen")
         static let priceSettingsTitle = NSLocalizedString("Price",
-                                                          comment: "Title of the Price Settings row on Product main screen")
+                                                          comment: "Title for editing the price settings row on Product main screen")
         static let inventorySettingsTitle = NSLocalizedString("Inventory",
                                                               comment: "Title of the Inventory Settings row on Product main screen")
         static let shippingSettingsTitle = NSLocalizedString("Shipping",


### PR DESCRIPTION
Fixes #2434 
Fixes #2443 

## Changes

- In `DefaultProductFormTableViewModel`, removed the check on `product.price` where we still show the price details if the `price` is non-empty. Since `product.price` is readonly and only set by the server (the current price that could be either the regular or sale price), its value could be outdated when the product has unsaved changes in the app (issue #2443)
- When the price details are empty, "Add Price" title is shown instead

## Testing

- Go to the Products tab
- Tap on a simple product with a price --> should see the price row with the regular price
- Tap on the price row
- Remove regular and sale price, and tap "Done" --> the price row now should show "Add Price"

## Example screenshots

product has a price | product has no price
-- | --
![Simulator Screen Shot - iPhone Xs - 2020-06-18 at 15 02 01](https://user-images.githubusercontent.com/1945542/84988608-dff63a00-b174-11ea-9297-72aaa6208130.png) | ![Simulator Screen Shot - iPhone Xs - 2020-06-18 at 15 02 07](https://user-images.githubusercontent.com/1945542/84988623-e4baee00-b174-11ea-9493-7c5ac6e6a9bd.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
