### PR TITLE
Update Product Categories remotely saving the product

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -457,6 +457,9 @@ public struct Product: Codable, GeneratedCopiable {
         try container.encode(backordersKey, forKey: .backordersKey)
         try container.encode(stockStatusKey, forKey: .stockStatusKey)
 
+        // Categories
+        try container.encode(categories, forKey: .categories)
+
         // Brief description (short description).
         try container.encode(briefDescription, forKey: .briefDescription)
 

--- a/Networking/Networking/Model/Product/ProductCategory.swift
+++ b/Networking/Networking/Model/Product/ProductCategory.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a ProductCategory entity.
 ///
-public struct ProductCategory: Decodable {
+public struct ProductCategory: Codable {
     public let categoryID: Int64
     public let siteID: Int64
     public let parentID: Int64
@@ -40,6 +40,14 @@ public struct ProductCategory: Decodable {
         let slug = try container.decode(String.self, forKey: .slug)
 
         self.init(categoryID: categoryID, siteID: siteID, parentID: parentID, name: name, slug: slug)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(categoryID, forKey: .categoryID)
+        try container.encode(name, forKey: .name)
+        try container.encode(slug, forKey: .slug)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -13,7 +13,7 @@ final class ProductCategoryListViewController: UIViewController {
 
     // Completion callback
     //
-    typealias Completion = (_ productCategories: [ProductCategory]) -> Void
+    typealias Completion = (_ categories: [ProductCategory]) -> Void
     private let onCompletion: Completion
 
     init(product: Product, completion: @escaping Completion) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -120,20 +120,8 @@ extension ProductCategoryListViewController {
     }
 
     @objc private func doneButtonTapped() {
-        // TODO-2020: Submit category changes
+        onCompletion(viewModel.selectedCategories)
     }
-//    @objc private func completeUpdating() {
-//        viewModel.completeUpdating(onCompletion: { [weak self] (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass) in
-//            self?.onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass)
-//            }, onError: { [weak self] error in
-//                switch error {
-//                case .salePriceWithoutRegularPrice:
-//                    self?.displaySalePriceWithoutRegularPriceErrorNotice()
-//                case .salePriceHigherThanRegularPrice:
-//                    self?.displaySalePriceErrorNotice()
-//                }
-//        })
-//    }
 
     private func presentBackNavigationActionSheet() {
         UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -11,8 +11,14 @@ final class ProductCategoryListViewController: UIViewController {
 
     private let viewModel: ProductCategoryListViewModel
 
-    init(product: Product) {
+    // Completion callback
+    //
+    typealias Completion = (_ productCategories: [ProductCategory]) -> Void
+    private let onCompletion: Completion
+
+    init(product: Product, completion: @escaping Completion) {
         self.viewModel = ProductCategoryListViewModel(product: product)
+        onCompletion = completion
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -27,6 +33,7 @@ final class ProductCategoryListViewController: UIViewController {
         configureGhostTableView()
         configureNavigationBar()
         configureViewModel()
+        handleSwipeBackGesture()
     }
 }
 
@@ -96,11 +103,42 @@ private extension ProductCategoryListViewController {
     }
 }
 
-// MARK: - Actions
+// MARK: - Navigation actions handling
 //
-private extension ProductCategoryListViewController {
+extension ProductCategoryListViewController {
+
+    override func shouldPopOnBackButton() -> Bool {
+        if viewModel.hasUnsavedChanges() {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+
     @objc private func doneButtonTapped() {
         // TODO-2020: Submit category changes
+    }
+//    @objc private func completeUpdating() {
+//        viewModel.completeUpdating(onCompletion: { [weak self] (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass) in
+//            self?.onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass)
+//            }, onError: { [weak self] error in
+//                switch error {
+//                case .salePriceWithoutRegularPrice:
+//                    self?.displaySalePriceWithoutRegularPriceErrorNotice()
+//                case .salePriceHigherThanRegularPrice:
+//                    self?.displaySalePriceErrorNotice()
+//                }
+//        })
+//    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
@@ -28,7 +28,7 @@ final class ProductCategoryListViewModel {
 
     /// Product categories that will be eventually modified by the user
     ///
-    private var selectedCategories: [ProductCategory]
+    private(set) var selectedCategories: [ProductCategory]
 
     /// Array of view models to be rendered by the View Controller.
     ///

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -807,7 +807,9 @@ private extension ProductFormViewController {
 
 private extension ProductFormViewController {
     func editCategories() {
-        let categoryListViewController = ProductCategoryListViewController(product: product)
+        let categoryListViewController = ProductCategoryListViewController(product: product) { (productCategories) in
+            
+        }
         show(categoryListViewController, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -807,10 +807,22 @@ private extension ProductFormViewController {
 
 private extension ProductFormViewController {
     func editCategories() {
-        let categoryListViewController = ProductCategoryListViewController(product: product) { (productCategories) in
-
+        let categoryListViewController = ProductCategoryListViewController(product: product) { [weak self] (categories) in
+            self?.onEditCategoriesCompletion(categories: categories)
         }
         show(categoryListViewController, sender: self)
+    }
+
+    func onEditCategoriesCompletion(categories: [ProductCategory]) {
+        defer {
+            navigationController?.popViewController(animated: true)
+        }
+        //TODO: Edit Product M3 analytics
+        let hasChangedData = categories.sorted() != product.categories.sorted()
+        guard hasChangedData else {
+            return
+        }
+        viewModel.updateProductCategories(categories)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -808,7 +808,7 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func editCategories() {
         let categoryListViewController = ProductCategoryListViewController(product: product) { (productCategories) in
-            
+
         }
         show(categoryListViewController, sender: self)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -168,6 +168,10 @@ extension ProductFormViewModel {
                                productShippingClass: shippingClass)
     }
 
+    func updateProductCategories(_ categories: [ProductCategory]) {
+        product = product.copy(categories: categories)
+    }
+
     func updateBriefDescription(_ briefDescription: String) {
         product = product.copy(briefDescription: briefDescription)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -36,6 +36,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
                                           backordersSetting: product.backordersSetting,
                                           stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
+        viewModel.updateProductCategories(product.categories)
 
         // Assert
         XCTAssertFalse(viewModel.hasUnsavedChanges())
@@ -140,6 +141,29 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
 
         // Action
         viewModel.updateDescription("Another way to describe the product?")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingProductCategories() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: true)
+
+        // Action
+        let categoryID = Int64(1234)
+        let parentID = Int64(1)
+        let name = "Test category"
+        let slug = "test-category"
+        let newCategories = [ProductCategory(categoryID: categoryID, siteID: product.siteID, parentID: parentID, name: name, slug: slug)]
+        viewModel.updateProductCategories(newCategories)
 
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -62,6 +62,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                           backordersSetting: product.backordersSetting,
                                           stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
+        viewModel.updateProductCategories(product.categories)
     }
 
     /// When only product name is updated, the product name observable should be triggered but no the product observable.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -157,6 +157,27 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.product.images, newImages)
     }
 
+    func testUpdatingProductCategories() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: true)
+
+        // Action
+        let categoryID = Int64(1234)
+        let parentID = Int64(1)
+        let name = "Test category"
+        let slug = "test-category"
+        let newCategories = [ProductCategory(categoryID: categoryID, siteID: product.siteID, parentID: parentID, name: name, slug: slug)]
+        viewModel.updateProductCategories(newCategories)
+
+        // Assert
+        XCTAssertEqual(viewModel.product.categories, newCategories)
+    }
+
     func testUpdatingBriefDescription() {
         // Arrange
         let product = MockProduct().product()


### PR DESCRIPTION
Part of #2000 

## Description
In this PR I implemented a way to update product categories remotely when the user save the product, and I managed the discard action sheet which appears if the user taps back after having selected/deselected a product category.

## Changes
- `Product` model: categories encoding.
- `ProductCategory` model now conform to `Codable`.
- Handled navigation actions in `ProductCategoryListViewController`
- Implemented `editCategories:` and `onEditCategoriesCompletion:` methods in `ProductFormViewController`
- Added tests for: `ProductFormViewModel+ChangesTests`, `ProductFormViewModel+ObservableTests` and `ProductFormViewModel+UpdatesTests`

## Testing
1. Navigate to a product with categories
2. Tap categories, and select one or more new categories.
3. Tap "done", and tap update in the product screen. -> Make sure you will be able to see the newly selected categories in the product, also on the web.
4. Try to deselect categories from a product, and tap update in the product screen. -> Make sure you will be able to see the update of this product also on the web.
5. Run the app on iOS 12. Select or deselect some categories from a product, and tap back. -> The discard action sheet should appear.

## GIF
![2020-06-18 13-06-51 2020-06-18 13_08_38](https://user-images.githubusercontent.com/495617/85013434-db298a00-b164-11ea-8646-e5fb3164e933.gif)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
