### PR TITLE
Call reloadData after performFetch executions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 import WordPressUI
 import Yosemite
 
+import class AutomatticTracks.CrashLogging
+
 /// A generic data source for the paginated list selector UI `PaginatedListSelectorViewController`.
 ///
 protocol PaginatedListSelectorDataSource {
@@ -387,6 +389,10 @@ private extension PaginatedListSelectorViewController {
             onReload()
         }
 
-        try? resultsController.performFetch()
+        do {
+            try resultsController.performFetch()
+        } catch  {
+            CrashLogging.logError(error)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -394,5 +394,7 @@ private extension PaginatedListSelectorViewController {
         } catch  {
             CrashLogging.logError(error)
         }
+        
+        tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -391,10 +391,10 @@ private extension PaginatedListSelectorViewController {
 
         do {
             try resultsController.performFetch()
-        } catch  {
+        } catch {
             CrashLogging.logError(error)
         }
-        
+
         tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
@@ -127,7 +127,7 @@ final class DefaultReviewsDataSource: NSObject, ReviewsDataSource {
     /// Initializes observers for incoming reviews
     ///
     func observeReviews() throws {
-        try? reviewsResultsController.performFetch()
+        try reviewsResultsController.performFetch()
     }
 
     func stopForwardingEvents() {

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
@@ -3,6 +3,8 @@ import UIKit
 import WordPressUI
 import Yosemite
 
+import class AutomatticTracks.CrashLogging
+
 
 final class ReviewsViewModel {
     private let data: ReviewsDataSource
@@ -48,7 +50,12 @@ final class ReviewsViewModel {
 
     func configureResultsController(tableView: UITableView) {
         data.startForwardingEvents(to: tableView)
-        try? data.observeReviews()
+
+        do {
+            try data.observeReviews()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 
     func refreshResults() {

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
@@ -56,6 +56,9 @@ final class ReviewsViewModel {
         } catch {
             CrashLogging.logError(error)
         }
+
+        // Reload table because observeReviews() executes performFetch()
+        tableView.reloadData()
     }
 
     func refreshResults() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -71,6 +71,8 @@ final class OrderStatusListViewController: UIViewController {
         } catch {
             CrashLogging.logError(error)
         }
+
+        tableView.reloadData()
     }
 
     private func preselectStatusIfPossible() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 import Yosemite
 
+import class AutomatticTracks.CrashLogging
+
 final class OrderStatusListViewController: UIViewController {
     /// Main TableView.
     ///
@@ -63,7 +65,12 @@ final class OrderStatusListViewController: UIViewController {
     ///
     private func configureResultsController() {
         statusResultsController.startForwardingEvents(to: tableView)
-        try? statusResultsController.performFetch()
+
+        do {
+            try statusResultsController.performFetch()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 
     private func preselectStatusIfPossible() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -151,6 +151,9 @@ private extension OrdersViewController {
         }
 
         viewModel.activateAndForwardUpdates(to: tableView)
+
+        // Reload table because the activate call above executes a performFetch()
+        tableView.reloadData()
     }
 
     /// Setup: Order status predicate

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -397,6 +397,8 @@ private extension ProductsViewController {
         } catch  {
             CrashLogging.logError(error)
         }
+        
+        tableView.reloadData()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -119,6 +119,10 @@ final class ProductsViewController: UIViewController {
                                                   stockStatus: filters.stockStatus,
                                                   productStatus: filters.productStatus,
                                                   productType: filters.productType)
+
+                /// Reload because `updatePredicate` calls `performFetch` when creating a new predicate
+                tableView.reloadData()
+                
                 syncingCoordinator.resynchronize {}
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -76,6 +76,10 @@ final class ProductsViewController: UIViewController {
         didSet {
             if sortOrder != oldValue {
                 resultsController.updateSortOrder(sortOrder)
+                
+                /// Reload data because `updateSortOrder` generates a new `predicate` which calls `performFetch`
+                tableView.reloadData()
+                
                 syncingCoordinator.resynchronize {}
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 import WordPressUI
 import Yosemite
 
+import class AutomatticTracks.CrashLogging
+
 /// Shows a list of products with pull to refresh and infinite scroll
 ///
 final class ProductsViewController: UIViewController {
@@ -390,7 +392,11 @@ private extension ProductsViewController {
             onReload()
         }
 
-        try? resultsController.performFetch()
+        do {
+            try resultsController.performFetch()
+        } catch  {
+            CrashLogging.logError(error)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -76,10 +76,10 @@ final class ProductsViewController: UIViewController {
         didSet {
             if sortOrder != oldValue {
                 resultsController.updateSortOrder(sortOrder)
-                
+
                 /// Reload data because `updateSortOrder` generates a new `predicate` which calls `performFetch`
                 tableView.reloadData()
-                
+
                 syncingCoordinator.resynchronize {}
             }
         }
@@ -126,7 +126,7 @@ final class ProductsViewController: UIViewController {
 
                 /// Reload because `updatePredicate` calls `performFetch` when creating a new predicate
                 tableView.reloadData()
-                
+
                 syncingCoordinator.resynchronize {}
             }
         }
@@ -402,10 +402,10 @@ private extension ProductsViewController {
 
         do {
             try resultsController.performFetch()
-        } catch  {
+        } catch {
             CrashLogging.logError(error)
         }
-        
+
         tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -174,6 +174,8 @@ private extension ProductVariationsViewController {
         } catch {
             CrashLogging.logError(error)
         }
+        
+        tableView.reloadData()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -174,7 +174,7 @@ private extension ProductVariationsViewController {
         } catch {
             CrashLogging.logError(error)
         }
-        
+
         tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 import WordPressUI
 import Yosemite
 
+import class AutomatticTracks.CrashLogging
+
 /// Displays a paginated list of Product Variations with its price or visibility.
 ///
 final class ProductVariationsViewController: UIViewController {
@@ -167,7 +169,11 @@ private extension ProductVariationsViewController {
             onReload()
         }
 
-        try? resultsController.performFetch()
+        do {
+            try resultsController.performFetch()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -37,6 +37,9 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
         configureTableView()
 
         viewModel.activateAndForwardUpdates(to: tableView)
+
+        // Reload because viewModel.activate executes performFetch
+        tableView.reloadData()
     }
 
     private func configureTableView() {

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -284,13 +284,13 @@ private extension SearchViewController {
     ///
     func configureResultsController() {
         resultsController.startForwardingEvents(to: tableView)
-        
+
         do {
             try resultsController.performFetch()
-        } catch  {
+        } catch {
             CrashLogging.logError(error)
         }
-        
+
         tableView.reloadData()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 import Yosemite
 import WordPressUI
 
+import class AutomatticTracks.CrashLogging
+
 
 /// SearchViewController: Displays the Search Interface for A Generic Model
 ///
@@ -282,7 +284,12 @@ private extension SearchViewController {
     ///
     func configureResultsController() {
         resultsController.startForwardingEvents(to: tableView)
-        try? resultsController.performFetch()
+        
+        do {
+            try resultsController.performFetch()
+        } catch  {
+            CrashLogging.logError(error)
+        }
     }
 
     /// Create and add `starterViewController` to the `view.`

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -290,6 +290,8 @@ private extension SearchViewController {
         } catch  {
             CrashLogging.logError(error)
         }
+        
+        tableView.reloadData()
     }
 
     /// Create and add `starterViewController` to the `view.`


### PR DESCRIPTION
Related: https://github.com/woocommerce/woocommerce-ios/issues/1543

# Why

For the past 7 months(or more!) users have been [experiencing a crash](https://github.com/woocommerce/woocommerce-ios/issues/1543) where a table view ended with an inconsistent state after updating/deleting rows.

After much experimentation, @shiki have been able to reproduce a [scenario](https://gist.github.com/shiki/9c5627b23eed8085c297cf6aeae45a62) where this crash happens. 

Our hypothesis is that the table has the wrong `ResultsController` state initially and then receiving new events from FRC makes it inconsistent and crash.

# How

In order to prevent this from happening we need to make sure that the table view is in sync with the `ResultsController` immediately after a `performFetch` is executed.

So after all `performFetch` executions we have made sure that a `reloadData` is being called.

# Testing Steps
- Go to orders module and verify that everything is loading correctly
- Go to reviews module and verify that everything is loading correctly
- Go to order search module and verify that everything is loading correctly
- Go to order status module and verify that everything is loading correctly
- Go to order details module and verify that everything is loading correctly
- Go to product module(initial load, filter, sort) and verify that everything is loading correctly
- Go to product shipping classes and tax classes and verify that everything is loading correctly

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
