### PR TITLE
Remove total orders row from readonly product details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - [*] Fix an issue in the y-axis values on the dashboard charts where a negative value could show two minus signs.
 - [*] When a simple product doesn't have a price set, the price row on the product details screen now shows "Add Price" placeholder instead of an empty regular price.
+- [*] The total orders row is removed from the readonly product details (products that are not a simple product) to avoid confusion since it's not shown on the editable form for simple products.
 
 4.5
 -----

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -239,8 +239,6 @@ extension ProductDetailsViewModel {
             configureProductImages(cell)
         case let cell as TitleBodyTableViewCell where row == .productName:
             configureProductName(cell)
-        case let cell as TwoColumnTableViewCell where row == .totalOrders:
-            configureTotalOrders(cell)
         case let cell as ProductReviewsTableViewCell:
             configureReviews(cell)
         case let cell as WooBasicTableViewCell where row == .permalink:
@@ -286,17 +284,6 @@ extension ProductDetailsViewModel {
         cell.titleLabel?.text = NSLocalizedString("Title",
                                                   comment: "Product details screen — product title descriptive label")
         cell.bodyLabel?.text = product.name
-    }
-
-    /// Total Orders cell.
-    ///
-    func configureTotalOrders(_ cell: TwoColumnTableViewCell) {
-        cell.selectionStyle = .none
-        cell.leftLabel?.text = NSLocalizedString("Total Orders",
-                                                 comment: "Product details screen - total orders descriptive label")
-        cell.rightLabel?.applySecondaryBodyStyle()
-        cell.rightLabel.textInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
-        cell.rightLabel?.text = String(product.totalSales)
     }
 
     /// Reviews cell.
@@ -598,9 +585,9 @@ extension ProductDetailsViewModel {
         }
 
         if shouldShowProductVariantsInfo() {
-            rows += [.productName, .totalOrders, .reviews, .productVariants, .permalink]
+            rows += [.productName, .reviews, .productVariants, .permalink]
         } else {
-            rows += [.productName, .totalOrders, .reviews, .permalink]
+            rows += [.productName, .reviews, .permalink]
         }
 
         return Section(rows: rows)
@@ -793,7 +780,6 @@ extension ProductDetailsViewModel {
     enum Row {
         case productImages
         case productName
-        case totalOrders
         case reviews
         case productVariants
         case permalink
@@ -812,8 +798,6 @@ extension ProductDetailsViewModel {
                 return ProductImagesHeaderTableViewCell.reuseIdentifier
             case .productName:
                 return TitleBodyTableViewCell.reuseIdentifier
-            case .totalOrders:
-                return TwoColumnTableViewCell.reuseIdentifier
             case .reviews:
                 return ProductReviewsTableViewCell.reuseIdentifier
             case .productVariants:


### PR DESCRIPTION
Fixes #2450 

## Changes

- Removed the `totalOrders` row and its related logic from `ProductDetailsViewModel`, since we aren't showing the total orders on the editable product form in the long term either

## Testing

- Go to the Products tab
- Tap on a variable product --> the total orders row shouldn't be visible anymore

## Example screenshots

(Note that the total orders row is gone!)

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-06-19 at 17 10 06](https://user-images.githubusercontent.com/1945542/85116363-c70e8700-b24f-11ea-81ef-85d5408bd7c1.png) | ![Simulator Screen Shot - iPhone 11 - 2020-06-19 at 16 35 50](https://user-images.githubusercontent.com/1945542/85116360-c37b0000-b24f-11ea-9156-dc37023c644b.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
