### PR TITLE
Fix the model name in debug messages for Core Data crash investigation

### DIFF
--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -92,8 +92,13 @@ public struct CoreDataIterativeMigrator {
                     return (false, debugMessages)
             }
 
+            guard let modelFromIndex = objectModels.firstIndex(of: modelFrom),
+                let modelToIndex = objectModels.firstIndex(of: modelTo) else {
+                    return (false, debugMessages)
+            }
+
             // Migrate the model to the next step
-            let migrationAttemptMessage = "⚠️ Attempting migration from \(modelNames[index]) to \(modelNames[index + 1])"
+            let migrationAttemptMessage = "⚠️ Attempting migration from \(modelNames[modelFromIndex]) to \(modelNames[modelToIndex])"
             debugMessages.append(migrationAttemptMessage)
             DDLogWarn(migrationAttemptMessage)
 


### PR DESCRIPTION
Logging improvement for #2371 for release 4.5

## Changes

I took a look at the [log events for the Core Data crash from release 4.5 beta build](https://sentry.io/organizations/a8c/issues/1711092978/events/?project=1458804&query=release%3A4.5.0.0&statsPeriod=14d) where we started logging the migration process, and noticed that the app was migrating first from model v0 (the first version) to model v1:
```
⚠️ [CoreDataManager] Migration required for persistent store
⚠️ Attempting migration from Model to Model 2
☠️ [CoreDataManager] Unable to migrate store.
```

 It's quite unlikely that the app was first on model v0, and I saw that we were using the index from the array of **models to migrate** (model versions between the source and destination models) for the array of all model names.

This PR fixed the model name by first finding the index of the source and destination models in the array of model names, and then got the model name from the index.

## Testing

This can be tested by just console logging, like `print`ing the `debugMessages` after this line:

https://github.com/woocommerce/woocommerce-ios/blob/b4d71241de758523b520150360c5473f440072f5/Storage/Storage/CoreData/CoreDataManager.swift#L211

- Launch the app, logged in, at an earlier Core Data model version (e.g. from [release 3.9](https://github.com/woocommerce/woocommerce-ios/releases/tag/3.9))
- Launch the app with the PR branch --> the debug messages should include a message attempting migration from the expected model versions (e.g. from my testing from 3.9.0.0 to this branch, I got `["⚠️ [CoreDataManager] Migration required for persistent store", "⚠️ Attempting migration from Model 26 to Model 27", "⚠️ Attempting migration from Model 27 to Model 28"]`)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
