### PR TITLE
Fix: order_open event is now fired correctly

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -497,7 +497,11 @@ extension OrdersViewController: UITableViewDelegate {
             assertionFailure("Expected OrderDetailsViewController to be instantiated")
             return
         }
-        orderDetailsVC.viewModel = viewModel.detailsViewModel(at: indexPath)
+        let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath)
+        orderDetailsVC.viewModel = orderDetailsViewModel
+
+        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": orderDetailsViewModel.order.orderID,
+        "status": orderDetailsViewModel.order.statusKey])
 
         navigationController?.pushViewController(orderDetailsVC, animated: true)
     }
@@ -507,23 +511,6 @@ extension OrdersViewController: UITableViewDelegate {
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
     }
 }
-
-
-// MARK: - Segues
-//
-extension OrdersViewController {
-
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard let singleOrderViewController = segue.destination as? OrderDetailsViewController, let viewModel = sender as? OrderDetailsViewModel else {
-            return
-        }
-
-        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": viewModel.order.orderID,
-                                                               "status": viewModel.order.statusKey])
-        singleOrderViewController.viewModel = viewModel
-    }
-}
-
 
 // MARK: - Finite State Machine Management
 //


### PR DESCRIPTION
It turned out that the event `order_open` is no longer fired, because we substituted the “segue”, pushing directly the order detail view controller. Since the `track:` method was called inside the segue method, it’s no more fired correctly. I fixed it removing the unused segue method and moving the `track:` method in the right place.


## Testing
1. From the Order List screen, tap an order. -> Check that in the console you are able to see the `order_open` event logged.
2. No app changes should be introduced, please feel free to sanity check that you are able to open an order detail from all the entry points.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
