### PR TITLE
Add ProductReviewAction.retrieveProductReviewFromNote

### DIFF
--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Networking Errors
 ///
-public enum NetworkError: Error {
+public enum NetworkError: Error, Equatable {
 
     /// Resource Not Found (statusCode = 404)
     ///

--- a/Storage/Storage/Protocols/StorageType.swift
+++ b/Storage/Storage/Protocols/StorageType.swift
@@ -5,7 +5,7 @@ import CoreData.NSFetchRequest
 
 /// Defines all of the methods made available by the Storage.
 ///
-public protocol StorageType {
+public protocol StorageType: class {
 
     var parentStorage: StorageType? {get}
 

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		572F2B8D247312E4005A5F74 /* StorageManagerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */; };
 		570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
+		578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7872475D70E00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift */; };
 		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
 		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
 		578CE7922475EC9200492EBF /* MockProductsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7912475EC9200492EBF /* MockProductsRemote.swift */; };
@@ -329,6 +330,7 @@
 		572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManagerConcurrencyTests.swift; sourceTree = "<group>"; };
 		570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCase.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
+		578CE7872475D70E00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCaseTests.swift; sourceTree = "<group>"; };
 		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
 		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
 		578CE7912475EC9200492EBF /* MockProductsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductsRemote.swift; sourceTree = "<group>"; };
@@ -658,6 +660,22 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
+		570B05CD246B6A2F00C186AE /* ProductReview */ = {
+			isa = PBXGroup;
+			children = (
+				570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */,
+			);
+			path = ProductReview;
+			sourceTree = "<group>";
+		};
+		578CE7862475D6FA00492EBF /* ProductReview */ = {
+			isa = PBXGroup;
+			children = (
+				578CE7872475D70E00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift */,
+			);
+			path = ProductReview;
+			sourceTree = "<group>";
+		};
 		578CE7892475E78C00492EBF /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -846,6 +864,7 @@
 		B5BC736620D1AA8F00B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				578CE7862475D6FA00492EBF /* ProductReview */,
 				D87F615D2265B1BC0031A13B /* AppSettingsStoreTests.swift */,
 				0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */,
 				02DA641A2313D6D200284168 /* AppSettingsStoreTests+StatsVersion.swift */,
@@ -1400,6 +1419,7 @@
 				74A7688E20D45ED400F9D437 /* OrderStoreTests.swift in Sources */,
 				57FDD6BB246B583200B8344B /* XCTestCase+Wait.swift in Sources */,
 				022F00C72472963E008CD97F /* NotificationCountStoreTests.swift in Sources */,
+				578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */,
 				02FF056723DEB2180058E6E7 /* MediaStoreTests.swift in Sources */,
 				B5C9DE272087FF20006B910A /* MockupAcount.swift in Sources */,
 				02DA641B2313D6D200284168 /* AppSettingsStoreTests+StatsVersion.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		45E18632237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */; };
 		45ED4F16239E939A004F1BE3 /* TaxClassStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */; };
 		572F2B8D247312E4005A5F74 /* StorageManagerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */; };
+		570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
 		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
 		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
@@ -326,6 +327,7 @@
 		45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStoreTests.swift; sourceTree = "<group>"; };
 		572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManagerConcurrencyTests.swift; sourceTree = "<group>"; };
+		570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCase.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
 		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
 		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
@@ -684,6 +686,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		570B05CD246B6A2F00C186AE /* ProductReview */ = {
+			isa = PBXGroup;
+			children = (
+				570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */,
+			);
+			path = ProductReview;
+			sourceTree = "<group>";
+		};
 		57FDD6B9246B580700B8344B /* Testing */ = {
 			isa = PBXGroup;
 			children = (
@@ -805,6 +815,7 @@
 		B5BC736320D1A98500B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				570B05CD246B6A2F00C186AE /* ProductReview */,
 				0212AC5F242C680800C51F6C /* Enums */,
 				B5BC736420D1A98500B5B6FA /* AccountStore.swift */,
 				D87F614B22657B150031A13B /* AppSettingsStore.swift */,
@@ -1288,6 +1299,7 @@
 				B52E002B2119E64800700FDE /* ManagedObjectsDidChangeNotification.swift in Sources */,
 				93E7507A226E2D6C00BAF88A /* AccountSettings+ReadOnlyConvertible.swift in Sources */,
 				749374FE2249601F007D85D1 /* ProductStore.swift in Sources */,
+				570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */,
 				B5B5C797208E49B600642956 /* Action+Internal.swift in Sources */,
 				74A7688C20D45EBA00F9D437 /* OrderStore.swift in Sources */,
 				749375002249605E007D85D1 /* ProductAction.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/ProductReviewAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductReviewAction.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Networking
 
-
 /// ProductReviewAction: Defines all of the Actions supported by the ProductReviewStore.
 ///
 public enum ProductReviewAction: Action {
@@ -13,6 +12,14 @@ public enum ProductReviewAction: Action {
     /// Retrieves the specified ProductReview.
     ///
     case retrieveProductReview(siteID: Int64, reviewID: Int64, onCompletion: (ProductReview?, Error?) -> Void)
+
+    /// Retrieves the `Note`, `ProductReview`, and `Product` in sequence.
+    ///
+    /// Only the `ProductReview` is stored in the database. Please see
+    /// `RetrieveProductReviewFromNoteUseCase` for the reason why.
+    ///
+    case retrieveProductReviewFromNote(noteID: Int64,
+                                       onCompletion: (Result<ProductReviewFromNoteParcel, Error>) -> Void)
 
     /// Updates the approval status of a review (approved/on hold).
     /// The completion closure will return the updated review status or error (if any).

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -174,4 +174,3 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 }
-

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -11,7 +11,8 @@ public struct ProductReviewFromNoteParcel {
 
 /// Fetches the `Note`, `ProductReview`, and `Product` in sequence from the API using a `noteID`.
 ///
-/// This can be used to present a view when a push notification is received.
+/// This can be used to present a view when a push notification is received. This should only
+/// be used as part of `ProductReviewStore`.
 ///
 /// ## Saving
 ///

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -89,6 +89,8 @@ final class RetrieveProductReviewFromNoteUseCase {
             completion(.failure($0))
         }
 
+        // Do not use `weak self` because we want to retain this class
+        // until all the callbacks are finished.
         fetchNote(noteID: noteID, abort: abort) { note in
             self.fetchProductReview(from: note, abort: abort) { review in
                 self.saveProductReview(review, abort: abort) {

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -137,6 +137,8 @@ final class RetrieveProductReviewFromNoteUseCase {
             let storageReview = derivedStorage.loadProductReview(siteID: review.siteID, reviewID: review.reviewID)
                 ?? derivedStorage.insertNewObject(ofType: StorageProductReview.self)
             storageReview.update(with: review)
+
+            DispatchQueue.main.async(execute: next)
         }
     }
 

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -3,6 +3,8 @@ import Foundation
 import Networking
 import protocol Storage.StorageType
 
+/// The result from `RetrieveProductReviewFromNoteUseCase`.
+///
 public struct ProductReviewFromNoteParcel {
     public let note: Note
     public let review: ProductReview
@@ -66,11 +68,17 @@ final class RetrieveProductReviewFromNoteUseCase {
     ///
     private weak var derivedStorage: StorageType?
 
+    /// Create an instance of self.
+    ///
+    /// - Parameters:
+    ///   - derivedStorage: The derived (background) `StorageType` of `ProductReviewStore`.
     init(network: Network, derivedStorage: StorageType) {
         self.network = network
         self.derivedStorage = derivedStorage
     }
 
+    /// Retrieve the `Note`, `ProductReview`, and `Product` based on the given `noteID`.
+    ///
     func retrieve(noteID: Int64, completion: @escaping CompletionBlock) {
         let abort: (Error) -> () = {
             completion(.failure($0))
@@ -88,6 +96,8 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
+    /// Fetch the Note from the API.
+    ///
     private func fetchNote(noteID: Int64,
                            abort: @escaping AbortBlock,
                            next: @escaping (Note) -> Void) {
@@ -107,6 +117,8 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
+    /// Fetch the ProductReview based on the given Note from the API.
+    ///
     private func fetchProductReview(from note: Note,
                                     abort: @escaping AbortBlock,
                                     next: @escaping (ProductReview) -> Void) {
@@ -127,6 +139,8 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
+    /// Save the given ProductReview to the database.
+    ///
     private func saveProductReview(_ review: ProductReview,
                                    abort: @escaping AbortBlock,
                                    next: @escaping () -> Void) {
@@ -143,6 +157,8 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
+    /// Fetch the `Product` from the API.
+    ///
     private func fetchProduct(siteID: Int64,
                               productID: Int64,
                               abort: @escaping AbortBlock,

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -75,12 +75,12 @@ final class RetrieveProductReviewFromNoteUseCase {
             completion(.failure($0))
         }
 
-        fetchNote(noteID: noteID, abort: abort) { [weak self] note in
-            self?.fetchProductReview(from: note, abort: abort) { review in
-                self?.saveProductReview(review, abort: abort) {
-                    self?.fetchProduct(siteID: review.siteID, productID: review.productID, abort: abort, next: { product in
-                        let payload = ProductReviewFromNoteParcel(note: note, review: review, product: product)
-                        completion(.success(payload))
+        fetchNote(noteID: noteID, abort: abort) { note in
+            self.fetchProductReview(from: note, abort: abort) { review in
+                self.saveProductReview(review, abort: abort) {
+                    self.fetchProduct(siteID: review.siteID, productID: review.productID, abort: abort, next: { product in
+                        let parcel = ProductReviewFromNoteParcel(note: note, review: review, product: product)
+                        completion(.success(parcel))
                     })
                 }
             }

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -1,0 +1,159 @@
+
+import Foundation
+import Networking
+import protocol Storage.StorageType
+
+public struct ProductReviewFromNoteParcel {
+    public let note: Note
+    public let review: ProductReview
+    public let product: Product
+}
+
+/// Fetches the `Note`, `ProductReview`, and `Product` in sequence from the API using a `noteID`.
+///
+/// This can be used to present a view when a push notification is received.
+///
+/// ## Saving
+///
+/// Only the `ProductReview` is saved to the database for now. This is to avoid possible
+/// conflicts if a scenario like this happens:
+///
+/// 1. This UseCase is executed.
+/// 2. A `Product` sync is also happening in the background.
+///
+/// Because the `Product` sync in `ProductStore` is using its own child/derived `StorageType`
+/// (`NSManagedObjectContext`), this could mean that `ProductStore` and this `UseCase`
+/// could have separate snapshots and would think that **the same** `Product` does not
+/// currently exist in the database. Both would end up saving the same `Product` and we'll
+/// show duplicate products to the user.
+///
+/// Perhaps in the future we can make it possible to _share_ these `StorageType` instances
+/// behind a well-protected abstraction so we can safely persist these objects. Something like:
+///
+/// ```
+/// // Hopefully not a singleton!
+/// let productDAO = storageManager.productDAO
+/// // The saveProduct can do the performBlock() on the correct NSManagedObjectContext
+/// productDAO.saveProduct(aProduct) {
+///     // do something after
+/// }
+/// ```
+///
+/// Note that this is only based on my understanding of how child `NSManagedObjectContexts` work
+/// and I could be wrong. ¯\_(ツ)_/¯
+///
+/// ## Site ID
+///
+/// The `siteID` is automatically determined from the fetched `Note` (`noteID`).
+///
+final class RetrieveProductReviewFromNoteUseCase {
+    typealias CompletionBlock = (Result<ProductReviewFromNoteParcel, Error>) -> Void
+    private typealias AbortBlock = (Error) -> Void
+
+    enum ProductReviewFromNoteRetrieveError: Error {
+        case notificationNotFound
+        case reviewNotFound
+        case storageNoLongerAvailable
+    }
+
+    private let network: Network
+
+    /// The derived `StorageType` used by the `ProductReviewStore`.
+    ///
+    /// We should use `weak` because we have to guarantee that we will not do any saving if this
+    /// `StorageType` is deallocated, which is part of the `ProductReviewStore` lifecycle.
+    ///
+    private weak var derivedStorage: StorageType?
+
+    init(network: Network, derivedStorage: StorageType) {
+        self.network = network
+        self.derivedStorage = derivedStorage
+    }
+
+    func retrieve(noteID: Int64, completion: @escaping CompletionBlock) {
+        let abort: (Error) -> () = {
+            completion(.failure($0))
+        }
+
+        fetchNote(noteID: noteID, abort: abort) { [weak self] note in
+            self?.fetchProductReview(from: note, abort: abort) { review in
+                self?.saveProductReview(review, abort: abort) {
+                    self?.fetchProduct(siteID: review.siteID, productID: review.productID, abort: abort, next: { product in
+                        let payload = ProductReviewFromNoteParcel(note: note, review: review, product: product)
+                        completion(.success(payload))
+                    })
+                }
+            }
+        }
+    }
+
+    private func fetchNote(noteID: Int64,
+                           abort: @escaping AbortBlock,
+                           next: @escaping (Note) -> Void) {
+        let remote = NotificationsRemote(network: network)
+
+        remote.loadNotes(noteIDs: [noteID]) { result in
+            switch result {
+            case .failure(let error):
+                abort(error)
+            case .success(let notes):
+                guard let note = notes.first else {
+                    return abort(ProductReviewFromNoteRetrieveError.notificationNotFound)
+                }
+
+                next(note)
+            }
+        }
+    }
+
+    private func fetchProductReview(from note: Note,
+                                    abort: @escaping AbortBlock,
+                                    next: @escaping (ProductReview) -> Void) {
+        guard let siteID = note.meta.identifier(forKey: .site),
+            let reviewID = note.meta.identifier(forKey: .comment) else {
+                return abort(ProductReviewFromNoteRetrieveError.reviewNotFound)
+        }
+
+        let remote = ProductReviewsRemote(network: network)
+
+        remote.loadProductReview(for: Int64(siteID), reviewID: Int64(reviewID)) { result in
+            switch result {
+            case .failure(let error):
+                abort(error)
+            case .success(let review):
+                next(review)
+            }
+        }
+    }
+
+    private func saveProductReview(_ review: ProductReview,
+                                   abort: @escaping AbortBlock,
+                                   next: @escaping () -> Void) {
+        guard let derivedStorage = derivedStorage else {
+            return abort(ProductReviewFromNoteRetrieveError.storageNoLongerAvailable)
+        }
+
+        derivedStorage.perform {
+            let storageReview = derivedStorage.loadProductReview(siteID: review.siteID, reviewID: review.reviewID)
+                ?? derivedStorage.insertNewObject(ofType: StorageProductReview.self)
+            storageReview.update(with: review)
+        }
+    }
+
+    private func fetchProduct(siteID: Int64,
+                              productID: Int64,
+                              abort: @escaping AbortBlock,
+                              next: @escaping (Product) -> Void) {
+        let remote = ProductsRemote(network: network)
+
+        remote.loadProduct(for: siteID, productID: productID) { result in
+            switch result {
+            case .failure(let error):
+                abort(error)
+            case .success(let product):
+                next(product)
+            }
+        }
+    }
+}
+

--- a/Yosemite/Yosemite/Stores/ProductReviewStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductReviewStore.swift
@@ -32,6 +32,8 @@ public final class ProductReviewStore: Store {
             synchronizeProductReviews(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .retrieveProductReview(let siteID, let reviewID, let onCompletion):
             retrieveProductReview(siteID: siteID, reviewID: reviewID, onCompletion: onCompletion)
+        case .retrieveProductReviewFromNote(let noteID, let onCompletion):
+            retrieveProductReviewFromNote(noteID: noteID, onCompletion: onCompletion)
         case .updateApprovalStatus(let siteID, let reviewID, let isApproved, let onCompletion):
             updateApprovalStatus(siteID: siteID, reviewID: reviewID, isApproved: isApproved, onCompletion: onCompletion)
         case .updateTrashStatus(let siteID, let reviewID, let isTrashed, let onCompletion):
@@ -97,6 +99,18 @@ private extension ProductReviewStore {
                 }
             }
         }
+    }
+
+    /// Retrieves the `Note`, `ProductReview`, and `Product` in sequence.
+    ///
+    /// Only the `ProductReview` is stored in the database. Please see
+    /// `RetrieveProductReviewFromNoteUseCase` for the reason why.
+    ///
+    func retrieveProductReviewFromNote(noteID: Int64,
+                                       onCompletion: @escaping (Result<ProductReviewFromNoteParcel, Error>) -> Void) {
+        let useCase = RetrieveProductReviewFromNoteUseCase(network: network,
+                                                           derivedStorage: sharedDerivedStorage)
+        useCase.retrieve(noteID: noteID, completion: onCompletion)
     }
 
     /// Updates the review's approval status

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
@@ -12,6 +12,9 @@ final class MockNotificationsRemote {
     /// The results to pass to the `completion` block if `loadNotes()` is called.
     private var notesLoadingResults = [ResultKey: Result<[Note], Error>]()
 
+    /// The number of times that `loadNotes` was invoked.
+    private(set) var invocationCountOfLoadNotes: Int = 0
+
     func whenLoadingNotes(noteIDs: [Int64], thenReturn result: Result<[Note], Error>) {
         let key: ResultKey = noteIDs
         notesLoadingResults[key] = result
@@ -31,6 +34,8 @@ extension MockNotificationsRemote: NotificationsEndpointsProviding {
             guard let self = self else {
                 return
             }
+
+            self.invocationCountOfLoadNotes += 1
 
             let key: ResultKey = noteIDs
             if let result = self.notesLoadingResults[key] {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
@@ -15,6 +15,9 @@ final class MockProductReviewsRemote {
     /// The results to return based on the given arguments in `loadProductReview`
     private var productReviewLoadingResults = [ResultKey: Result<ProductReview, Error>]()
 
+    /// The number of times that the `loadProductReview` method was called.
+    private(set) var invocationCountOfLoadProductReview: Int = 0
+
     /// Set the value passed to the `completion` block if `loadProductReview()` is called.
     ///
     func whenLoadingProductReview(siteID: Int64, reviewID: Int64, thenReturn result: Result<ProductReview, Error>) {
@@ -33,6 +36,8 @@ extension MockProductReviewsRemote: ProductReviewsEndpointsProviding {
             guard let self = self else {
                 return
             }
+
+            self.invocationCountOfLoadProductReview += 1
 
             let key = ResultKey(siteID: siteID, reviewID: reviewID)
             if let result = self.productReviewLoadingResults[key] {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
@@ -15,6 +15,9 @@ final class MockProductsRemote {
     /// The results to return based on the given arguments in `loadProduct`
     private var productLoadingResults = [ResultKey: Result<Product, Error>]()
 
+    /// The number of times that `loadProduct()` was invoked.
+    private(set) var invocationCountOfLoadProduct: Int = 0
+
     /// Set the value passed to the `completion` block if `loadProduct()` is called.
     ///
     func whenLoadingProduct(siteID: Int64, productID: Int64, thenReturn result: Result<Product, Error>) {
@@ -34,6 +37,8 @@ extension MockProductsRemote: ProductsEndpointsProviding {
             guard let self = self else {
                 return
             }
+
+            self.invocationCountOfLoadProduct += 1
 
             let key = ResultKey(siteID: siteID, productID: productID)
             if let result = self.productLoadingResults[key] {

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -4,6 +4,8 @@ import Storage
 
 @testable import Yosemite
 
+/// Test cases for `RetrieveProductReviewFromNoteUseCase`.
+///
 final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
 
     private var storageManager: StorageManagerType!
@@ -71,6 +73,33 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertEqual(parcel.note.noteID, note.noteID)
         XCTAssertEqual(parcel.review, productReview)
         XCTAssertEqual(parcel.product, product)
+    }
+
+    func testWhenSuccessfulThenItSavesTheProductReviewToStorage() throws {
+        // Given
+        let note = TestData.note
+        let productReview = TestData.productReview
+        let product = TestData.product
+
+        notificationsRemote.whenLoadingNotes(noteIDs: [note.noteID], thenReturn: .success([note]))
+        productReviewsRemote.whenLoadingProductReview(siteID: productReview.siteID,
+                                                      reviewID: productReview.reviewID,
+                                                      thenReturn: .success(productReview))
+        productsRemote.whenLoadingProduct(siteID: product.siteID,
+                                          productID: product.productID,
+                                          thenReturn: .success(product))
+
+        XCTAssertEqual(storage.countObjects(ofType: StorageProductReview.self), 0)
+
+        // When
+        let result = try retrieve(noteID: note.noteID)
+
+        // Then
+        XCTAssert(result.isSuccess)
+        XCTAssertEqual(storage.countObjects(ofType: StorageProductReview.self), 1)
+
+        let reviewFromStorage = storage.loadProductReview(siteID: productReview.siteID, reviewID: productReview.reviewID)
+        XCTAssertNotNil(reviewFromStorage)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+import Storage
+
+@testable import Yosemite
+
+final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
+
+    private var storageManager: StorageManagerType!
+
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    private var notificationsRemote: MockNotificationsRemote!
+    private var productReviewsRemote: MockProductReviewsRemote!
+    private var productsRemote: MockProductsRemote!
+
+    /// The system being tested
+    ///
+    private var useCase: RetrieveProductReviewFromNoteUseCase!
+
+    override func setUp() {
+        super.setUp()
+
+        storageManager = MockupStorageManager()
+
+        notificationsRemote = MockNotificationsRemote()
+        productReviewsRemote = MockProductReviewsRemote()
+        productsRemote = MockProductsRemote()
+
+        useCase = RetrieveProductReviewFromNoteUseCase(derivedStorage: storage,
+                                                       notificationsRemote: notificationsRemote,
+                                                       productReviewsRemote: productReviewsRemote,
+                                                       productsRemote: productsRemote)
+    }
+
+    override func tearDown() {
+        useCase = nil
+
+        productsRemote = nil
+        productReviewsRemote = nil
+        notificationsRemote = nil
+
+        storageManager = nil
+
+        super.tearDown()
+    }
+
+    func testItFetchesAllEntitiesAndReturnsTheParcel() throws {
+        // Given
+        let note = TestData.note
+        let productReview = TestData.productReview
+        let product = TestData.product
+
+        notificationsRemote.whenLoadingNotes(noteIDs: [note.noteID], thenReturn: .success([note]))
+        productReviewsRemote.whenLoadingProductReview(siteID: productReview.siteID,
+                                                      reviewID: productReview.reviewID,
+                                                      thenReturn: .success(productReview))
+        productsRemote.whenLoadingProduct(siteID: product.siteID,
+                                          productID: product.productID,
+                                          thenReturn: .success(product))
+
+        // When
+        let result = try retrieve(noteID: note.noteID)
+
+        // Then
+        XCTAssert(result.isSuccess)
+
+        let parcel = try XCTUnwrap(result.get())
+        XCTAssertEqual(parcel.note.noteID, note.noteID)
+        XCTAssertEqual(parcel.review, productReview)
+        XCTAssertEqual(parcel.product, product)
+    }
+}
+
+// MARK: - Utils
+
+private extension RetrieveProductReviewFromNoteUseCaseTests {
+    func retrieve(noteID: Int64) throws -> Result<ProductReviewFromNoteParcel, Error> {
+        var result: Result<ProductReviewFromNoteParcel, Error>?
+
+        waitForExpectation { exp in
+            useCase.retrieve(noteID: noteID) { aResult in
+                print(aResult)
+                result = aResult
+                exp.fulfill()
+            }
+        }
+
+        return try XCTUnwrap(result)
+    }
+}
+
+// MARK: - Test Data
+
+private extension RetrieveProductReviewFromNoteUseCaseTests {
+    enum TestData {
+        static let siteID: Int64 = 398
+        static let product = MockProduct().product(siteID: siteID, productID: 756_611)
+        static let productReview = MockProductReview().make(siteID: siteID, reviewID: 1_981_157, productID: product.productID)
+        static let note = MockNote().make(noteID: 9_981, metaSiteID: siteID, metaReviewID: productReview.reviewID)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -91,8 +91,8 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertNotNil(reviewFromStorage)
     }
 
-    /// Simulate a scenario where the StorageManager is no longer available, which may happen
-    /// if the user has logged out before the network call has finished.
+    /// Simulate a scenario where the StorageType is no longer available, which may happen
+    /// if the owning `ProductReviewStore` is deallocated during user log out.
     ///
     func testWhenSuccessfulButStorageIsNoLongerAvailableThenItReturnsAFailure() throws {
         // Given

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -8,12 +8,6 @@ import Storage
 ///
 final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
 
-    private var storageManager: StorageManagerType!
-
-    private var storage: StorageType {
-        storageManager.viewStorage
-    }
-
     private var notificationsRemote: MockNotificationsRemote!
     private var productReviewsRemote: MockProductReviewsRemote!
     private var productsRemote: MockProductsRemote!
@@ -21,12 +15,9 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        storageManager = MockupStorageManager()
-
         notificationsRemote = MockNotificationsRemote()
         productReviewsRemote = MockProductReviewsRemote()
         productsRemote = MockProductsRemote()
-
     }
 
     override func tearDown() {
@@ -34,14 +25,13 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         productReviewsRemote = nil
         notificationsRemote = nil
 
-        storageManager = nil
-
         super.tearDown()
     }
 
     func testItFetchesAllEntitiesAndReturnsTheParcel() throws {
         // Given
-        let useCase = makeUseCase()
+        let storageManager = MockupStorageManager()
+        let useCase = makeUseCase(storage: storageManager.viewStorage)
         let note = TestData.note
         let productReview = TestData.productReview
         let product = TestData.product
@@ -68,7 +58,11 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
 
     func testWhenSuccessfulThenItSavesTheProductReviewToStorage() throws {
         // Given
-        let useCase = makeUseCase()
+        let storageManager = MockupStorageManager()
+        let storage = storageManager.viewStorage
+
+        let useCase = makeUseCase(storage: storage)
+
         let note = TestData.note
         let productReview = TestData.productReview
         let product = TestData.product
@@ -111,7 +105,7 @@ private extension RetrieveProductReviewFromNoteUseCaseTests {
 
     /// Create a UseCase using the mocks
     ///
-    func makeUseCase() -> RetrieveProductReviewFromNoteUseCase {
+    func makeUseCase(storage: StorageType) -> RetrieveProductReviewFromNoteUseCase {
         RetrieveProductReviewFromNoteUseCase(derivedStorage: storage,
                                              notificationsRemote: notificationsRemote,
                                              productReviewsRemote: productReviewsRemote,

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -171,6 +171,29 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertEqual(productReviewsRemote.invocationCountOfLoadProductReview, 1)
         XCTAssertEqual(productsRemote.invocationCountOfLoadProduct, 0)
     }
+
+    func testWhenNoteHasMissingMetaThenItReturnsAFailure() throws {
+        // Given
+        let storageManager = MockupStorageManager()
+        let useCase = makeUseCase(storage: storageManager.viewStorage)
+
+        // No `.comment` identifier. This can mean that we fetched the incorrect notification.
+        let note = MockNote().make(noteID: 9_135, metaSiteID: TestData.siteID)
+
+        notificationsRemote.whenLoadingNotes(noteIDs: [note.noteID], thenReturn: .success([note]))
+
+        // When
+        let result = try retrieveAndWait(using: useCase, noteID: note.noteID)
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? ProductReviewFromNoteRetrieveError,
+                       ProductReviewFromNoteRetrieveError.reviewNotFound)
+
+        XCTAssertEqual(notificationsRemote.invocationCountOfLoadNotes, 1)
+        XCTAssertEqual(productReviewsRemote.invocationCountOfLoadProductReview, 0)
+        XCTAssertEqual(productsRemote.invocationCountOfLoadProduct, 0)
+    }
 }
 
 // MARK: - Utils

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -217,7 +217,6 @@ private extension RetrieveProductReviewFromNoteUseCaseTests {
 
         waitForExpectation { exp in
             useCase.retrieve(noteID: noteID) { aResult in
-                print(aResult)
                 result = aResult
                 exp.fulfill()
             }

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -50,7 +50,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         let result = try retrieveAndWait(using: useCase, noteID: note.noteID)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertTrue(result.isSuccess)
 
         let parcel = try XCTUnwrap(result.get())
         XCTAssertEqual(parcel.note.noteID, note.noteID)
@@ -83,7 +83,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         let result = try retrieveAndWait(using: useCase, noteID: note.noteID)
 
         // Then
-        XCTAssert(result.isSuccess)
+        XCTAssertTrue(result.isSuccess)
         XCTAssertEqual(storage.countObjects(ofType: StorageProductReview.self), 1)
 
         let reviewFromStorage = storage.loadProductReview(siteID: productReview.siteID, reviewID: productReview.reviewID)
@@ -118,7 +118,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         let result = try retrieveAndWait(using: useCase, noteID: note.noteID)
 
         // Then
-        XCTAssert(result.isFailure)
+        XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? ProductReviewFromNoteRetrieveError,
                        ProductReviewFromNoteRetrieveError.storageNoLongerAvailable)
     }


### PR DESCRIPTION
Refs #2254. This continues #2326. When the UI part of this (up next) is done, instances of #1907 should no longer be happening for push notifications. 

## Problem

The crash log in #2326 suggests that the app was presenting a push notification while the `syncingCoordinator.delegate` was not set. This means that the view was not loaded yet. It's particularly odd because the view **should** have been loaded already since we [switch to the Reviews tab](https://github.com/woocommerce/woocommerce-ios/blob/a60d39bca5e065db153a0f38379eb3a73e176adf/WooCommerce/Classes/ViewRelated/MainTabBarController.swift#L306-L310) before doing any presentation. iOS disagrees. 

I also found that when presenting a review push notification, this flow happens:

![image](https://user-images.githubusercontent.com/198826/85342748-865d7a80-b4a8-11ea-8f9d-9b9e281fffdf.png)

In my opinion, this is very inefficient and has quite a few points of failure. There are at least 4 API calls fetching lots of objects. And, in the context of the push notification flow, we also rely on an unrelated `ReviewsViewController` to be correctly synchronized in order to present the `ReviewDetailsViewController`.

## Solution

I'd like to propose that we simplify this by: 

1. Creating a `ReviewsCoordinator` which will be a child of `MainTabBarController`.
2. Make the `ReviewsCoordinator` observe notifications from `PushNotesManager`. This gives **full control** of how push notifications are handled to `ReviewsCoordinator` and should make unit testing easier. 
3. For every review push notification, dispatch a new Yosemite action, `ProductReviewAction. retrieveProductReviewFromNote`. This action fetches the `Note`, then the `ProductReview`, and then the `Product` and returns all of them at once. 

With this, whenever we present the `ReviewDetailsVC`, we are confident that we have all the objects that we need and we don't end up with the scenario shown by #1907. This should also eliminate the #2326 crash. 

This is how the flow should look like:

![image](https://user-images.githubusercontent.com/198826/85342852-ba38a000-b4a8-11ea-910a-057ce811c44f.png)

Unfortunately, there are 3 API calls. However, unlike the current implementation, we only need to fetch **single objects**, which should be faster.

## What This PR Does

This PR only handles the **third part** of the solution, creating the **`ProductReviewAction. retrieveProductReviewFromNote`**. 

### UseCase

Because the API calls are in sequence and so is a bit complex and unreadable when using blocks, I created a new class, [`RetrieveProductReviewFromNoteUseCase`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2254-add-review-action/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift), to try and make the flow clearer and easily testable. 

With this `UseCase` class, I was able to cleanly (IMO) express how the API calls and DB saving are related to each other. I was able to hide the complexities inside their corresponding functions. 

https://github.com/woocommerce/woocommerce-ios/blob/1194c5ba4ac7fa3c94934b57d83da72f15c45b1e/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift#L92-L101

This is probably the first `UseCase` class in the app so I'm happy to answer any questions and concerns that you may have. I also called these `Interactors` and they are interchangeable. I don't know why I used `UseCase` in here. If you like `Interactor` (`RetrieveProductReviewFromNoteInteractor`) more, then we can certainly do that. 😄 

The `UseCase`/`Interactor` pattern is [based on VIPER](https://www.objc.io/issues/13-architecture/viper/#interactor). It is also used in [Android's Clean Architecture](https://www.raywenderlich.com/3595916-clean-architecture-tutorial-for-android-getting-started#toc-anchor-011). For me, a `UseCase`/`Interactor`:

- A business logic unit only. It can connect to the DB and Network. Quite perfect as a container for complex Yosemite actions.  
- Ideally, have one function. I used to break this rule but most of the time, stick to it. 
- Ideally are just one-offs. Instances should be instantiated, used, and then disposed of right away. This is based on my experience. I have never had a scenario where I needed to keep a `UseCase` in memory. Maybe that will change in the future. 

Again, this is only based on my understanding of `UseCases` and your experience may be different. So I'm happy to discuss this!

### Database Saving

Because of p91TBi-2ND-p2, I chose to only persist the `ProductReview` for now. It would have been nice to save all of them but I'd rather avoid the concurrency issues. 

## Testing

No UI changes yet. Please scrutinize the unit test and find holes!

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

