### PR TITLE
Networking/Yosemite changes for editing grouped products

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -70,7 +70,12 @@ public final class ProductsRemote: Remote, ProductsEndpointsProviding {
     ///     - productIDs: The array of product IDs that are requested.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func loadProducts(for siteID: Int64, by productIDs: [Int64], completion: @escaping ([Product]?, Error?) -> Void) {
+    public func loadProducts(for siteID: Int64, by productIDs: [Int64], completion: @escaping (Result<[Product], Error>) -> Void) {
+        guard productIDs.isEmpty == false else {
+            completion(.success([]))
+            return
+        }
+
         let stringOfProductIDs = productIDs.map { String($0) }
             .filter { !$0.isEmpty }
             .joined(separator: ",")

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -6,6 +6,8 @@ import Foundation
 ///
 public protocol ProductsEndpointsProviding {
     func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
+
+    func loadProducts(for siteID: Int64, by productIDs: [Int64], completion: @escaping (Result<[Product], Error>) -> Void)
 }
 
 /// Product: Remote Endpoints

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
@@ -145,12 +145,13 @@ extension ReviewsViewModel {
             return
         }
 
-        let action = ProductAction.retrieveProducts(siteID: siteID, productIDs: reviewsProductIDs) { error in
-            if let error = error {
+        let action = ProductAction.retrieveProducts(siteID: siteID, productIDs: reviewsProductIDs) { result in
+            switch result {
+            case .failure(let error):
                 DDLogError("⛔️ Error synchronizing products: \(error)")
                 ServiceLocator.analytics.track(.reviewsProductsLoadFailed,
                                                withError: error)
-            } else {
+            case .success:
                 ServiceLocator.analytics.track(.reviewsProductsLoaded)
             }
 

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -186,7 +186,7 @@ final class MockReviewsStoresManager: DefaultStoresManager {
         switch action {
         case .retrieveProducts(_, _, onCompletion: let onCompletion):
             retrieveProductsIsHit = true
-            onCompletion(nil)
+            onCompletion(.success([]))
         default:
             return
         }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -27,7 +27,7 @@ public enum ProductAction: Action {
 
     /// Retrieves a specified list of Products.
     ///
-    case retrieveProducts(siteID: Int64, productIDs: [Int64], onCompletion: (Error?) -> Void)
+    case retrieveProducts(siteID: Int64, productIDs: [Int64], onCompletion: (Result<[Product], Error>) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -159,15 +159,15 @@ private extension ProductStore {
         }
 
         let remote = ProductsRemote(network: network)
-        remote.loadProducts(for: order.siteID, by: missingIDs) { [weak self] (products, error) in
-            guard let products = products else {
+        remote.loadProducts(for: order.siteID, by: missingIDs) { [weak self] result in
+            switch result {
+            case .success(let products):
+                self?.upsertStoredProductsInBackground(readOnlyProducts: products, onCompletion: {
+                    onCompletion(nil)
+                })
+            case .failure(let error):
                 onCompletion(error)
-                return
             }
-
-            self?.upsertStoredProductsInBackground(readOnlyProducts: products, onCompletion: {
-                onCompletion(nil)
-            })
         }
     }
 
@@ -176,18 +176,18 @@ private extension ProductStore {
     ///
     func retrieveProducts(siteID: Int64,
                           productIDs: [Int64],
-                          onCompletion: @escaping (Error?) -> Void) {
+                          onCompletion: @escaping (Result<[Product], Error>) -> Void) {
         let remote = ProductsRemote(network: network)
 
-        remote.loadProducts(for: siteID, by: productIDs) { [weak self] (products, error) in
-            guard let products = products else {
-                onCompletion(error)
-                return
+        remote.loadProducts(for: siteID, by: productIDs) { [weak self] result in
+            switch result {
+            case .success(let products):
+                self?.upsertStoredProductsInBackground(readOnlyProducts: products, onCompletion: {
+                    onCompletion(result)
+                })
+            case .failure:
+                onCompletion(result)
             }
-
-            self?.upsertStoredProductsInBackground(readOnlyProducts: products, onCompletion: {
-                onCompletion(nil)
-            })
         }
     }
 

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -177,7 +177,10 @@ private extension ProductStore {
     func retrieveProducts(siteID: Int64,
                           productIDs: [Int64],
                           onCompletion: @escaping (Result<[Product], Error>) -> Void) {
-        let remote = ProductsRemote(network: network)
+        guard productIDs.isEmpty == false else {
+            onCompletion(.success([]))
+            return
+        }
 
         remote.loadProducts(for: siteID, by: productIDs) { [weak self] result in
             switch result {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
@@ -9,17 +9,27 @@ import XCTest
 final class MockProductsRemote {
     private struct ResultKey: Hashable {
         let siteID: Int64
-        let productID: Int64
+        let productIDs: [Int64]
     }
 
     /// The results to return based on the given arguments in `loadProduct`
     private var productLoadingResults = [ResultKey: Result<Product, Error>]()
 
+    /// The results to return based on the given arguments in `loadProducts`
+    private var productsLoadingResults = [ResultKey: Result<[Product], Error>]()
+
     /// Set the value passed to the `completion` block if `loadProduct()` is called.
     ///
     func whenLoadingProduct(siteID: Int64, productID: Int64, thenReturn result: Result<Product, Error>) {
-        let key = ResultKey(siteID: siteID, productID: productID)
+        let key = ResultKey(siteID: siteID, productIDs: [productID])
         productLoadingResults[key] = result
+    }
+
+    /// Set the value passed to the `completion` block if `loadProducts()` is called.
+    ///
+    func whenLoadingProducts(siteID: Int64, productIDs: [Int64], thenReturn result: Result<[Product], Error>) {
+        let key = ResultKey(siteID: siteID, productIDs: productIDs)
+        productsLoadingResults[key] = result
     }
 }
 
@@ -35,8 +45,23 @@ extension MockProductsRemote: ProductsEndpointsProviding {
                 return
             }
 
-            let key = ResultKey(siteID: siteID, productID: productID)
+            let key = ResultKey(siteID: siteID, productIDs: [productID])
             if let result = self.productLoadingResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+
+    func loadProducts(for siteID: Int64, by productIDs: [Int64], completion: @escaping (Result<[Product], Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key = ResultKey(siteID: siteID, productIDs: productIDs)
+            if let result = self.productsLoadingResults[key] {
                 completion(result)
             } else {
                 XCTFail("\(String(describing: self)) Could not find Result for \(key)")


### PR DESCRIPTION
Part of #2199 

## Changes

- Updated `ProductAction.retrieveProducts` to return `Result<[Product], Error>` instead of `Error?` since the grouped product list in #2199 fetches a fixed list of products and doesn't use results controller
  - Updated its usage in `ReviewsViewModel` and `ProductStore`
- Added unit tests for `ProductAction.retrieveProducts` in `ProductStoreTests`
  - Added `loadProducts` to `ProductsEndpointsProviding` and implemented it in `MockProductsRemote`

## Testing

Since the changes touch the part where we fetch the products for reviews and an order, it'd be nice to sanity check the following:

- Log out and in to the app to clear any pre-existing data
- Go to the Orders tab
- Tap an order with multiple products --> the products should be loaded correctly
- Go to the Reviews tab --> the products should show up in the cells eventually
- Tap a few reviews --> the product should be loaded eventually

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
