### PR TITLE
Fix: now we send the `application_upgraded` event correctly

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -331,7 +331,7 @@ private extension AppDelegate {
             ServiceLocator.analytics.track(.applicationInstalled)
         } else if versionOfLastRun != currentVersion {
             // App was upgraded
-            ServiceLocator.analytics.track(.applicationInstalled, withProperties: ["previous_version": versionOfLastRun ?? String()])
+            ServiceLocator.analytics.track(.applicationUpgraded, withProperties: ["previous_version": versionOfLastRun ?? String()])
         }
 
         UserDefaults.standard[.versionOfLastRun] = currentVersion


### PR DESCRIPTION
Fixes #2455 

When the app is updated, we send erroneously the event `application_installed`. I fixed it in this PR.

## Testing
Try to upgrade from an old version to a new version of the app, and check that in the console you are able to see the `application_upgraded` event fired correctly.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
