### PR TITLE
Use --repo-update flag when running pod install from Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -70,7 +70,7 @@ namespace :dependencies do
 
     task :install do
       fold("install.cocoapds") do
-        pod %w[install]
+        pod %w[install --repo-update]
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -176,8 +176,8 @@ task :xcode => [:dependencies] do
 end
 
 desc "Run all code generation tasks"
-task :generate do 
-  ["Networking", "Yosemite", "WooCommerce"].each { |prefix| 
+task :generate do
+  ["Networking", "Yosemite", "WooCommerce"].each { |prefix|
     puts "\n\nGenerating Copiable for #{prefix}..."
     puts "=" * 100
 


### PR DESCRIPTION
If CocoaPods' local specs repo out-of-date, `pod install` might not find some of the specified pods and fail.

The `--repo-update` flag make CocoaPods always update its local specs repo, so that that kind of failure won't happen.

This does add a few seconds to the task, but I feel it is time well spent because it will save a lot more time troubleshooting a failure in `rake dependencies` which might not be obvious to someone not used to dealing with CocoaPods.

## To test

First, you'll need to modify the `Podfile` or `Podfile.lock` otherwise the `dependencies` task won't run `pod install` in the first place.

When running `pod install`, you should see it being called with the `--repo-update` option.

<img width="999" alt="Screen Shot 2020-06-23 at 9 26 59 pm" src="https://user-images.githubusercontent.com/1218433/85398267-5097bf00-b598-11ea-9c7f-060bb441c6ba.png">


---

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.