### PR TITLE
Products (M3): Add a new Product Category

### DIFF
--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -18,10 +18,15 @@ extension UIViewController {
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
 
-    /// Show the X close button on the left bar button item position
+    /// Show the X close button or a custom close button with title on the left bar button item position
     ///
-    func addCloseNavigationBarButton(target: Any? = self, action: Selector? = #selector(dismissVC)) {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: target, action: action)
+    func addCloseNavigationBarButton(title: String? = nil, target: Any? = self, action: Selector? = #selector(dismissVC)) {
+        if let title = title {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(title: title, style: .plain, target: target, action: action)
+        }
+        else {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(image: .closeButton, style: .plain, target: target, action: action)
+        }
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -83,11 +83,11 @@ extension AddProductCategoryViewController {
     @objc private func saveNewCategory() {
         //TODO: add remotely new category
         //onCompletion(newCategory)
-        
+
         guard let categoryName = newCategoryTitle, let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
-        
+
         let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID, name: categoryName, parentID: selectedParentCategory?.categoryID) { (result) in
             //TODO: to be completed
 //            switch result {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -20,7 +20,11 @@ final class AddProductCategoryViewController: UIViewController {
 
     /// Selected parent category
     ///
-    private var selectedParentCategory: ProductCategory?
+    private var selectedParentCategory: ProductCategory? {
+        didSet {
+            tableView.reloadData()
+        }
+    }
 
     // Completion callback
     //
@@ -50,7 +54,7 @@ final class AddProductCategoryViewController: UIViewController {
 private extension AddProductCategoryViewController {
 
     func configureNavigationBar() {
-        title = NSLocalizedString("Add Category", comment: "Product Add Category navigation title")
+        title = Strings.titleView
 
         addCloseNavigationBarButton(title: Strings.cancelButton)
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.saveButton, style: .done, target: self, action: #selector(saveNewCategory))
@@ -130,8 +134,11 @@ extension AddProductCategoryViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch sections[indexPath.section].rows[indexPath.row] {
         case .parentCategory:
-            let parentCategoryViewController = ProductParentCategoriesViewController(siteID: siteID) { (parentCategory) in
-                //TODO: parent category selected
+            let parentCategoryViewController = ProductParentCategoriesViewController(siteID: siteID) { [weak self] (parentCategory) in
+                defer {
+                    self?.navigationController?.popViewController(animated: true)
+                }
+                self?.selectedParentCategory = parentCategory
             }
             navigationController?.pushViewController(parentCategoryViewController, animated: true)
         default:
@@ -167,7 +174,7 @@ private extension AddProductCategoryViewController {
     }
 
     func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
-        cell.updateUI(title: Strings.parentCellTitle, value: Strings.parentCellPlaceholder)
+        cell.updateUI(title: Strings.parentCellTitle, value: selectedParentCategory?.name ?? Strings.parentCellPlaceholder)
         cell.selectionStyle = .none
     }
 }
@@ -203,6 +210,7 @@ private extension AddProductCategoryViewController {
 //
 private extension AddProductCategoryViewController {
     enum Strings {
+        static let titleView = NSLocalizedString("Add Category", comment: "Product Add Category navigation title")
         static let cancelButton = NSLocalizedString("Cancel", comment: "Add Product Category. Cancel button title in navbar.")
         static let saveButton = NSLocalizedString("Save", comment: "Add Product Category. Save button title in navbar.")
         static let titleCellPlaceholder = NSLocalizedString("Title", comment: "Add Product Category. Placeholder of cell presenting the title of the category.")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -117,7 +117,7 @@ private extension AddProductCategoryViewController {
     ///
     func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
         switch cell {
-        case let cell as TitleAndTextFieldTableViewCell where row == .title:
+        case let cell as TextFieldTableViewCell where row == .title:
             configureTitle(cell: cell)
         case let cell as SettingTitleAndValueTableViewCell where row == .parentCategory:
             configureParentCategory(cell: cell)
@@ -127,14 +127,15 @@ private extension AddProductCategoryViewController {
         }
     }
 
-    func configureTitle(cell: TitleAndTextFieldTableViewCell) {
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: nil,
-        text: nil,
-        placeholder: Strings.titleCellPlaceholder
-        ) { (text) in
+    func configureTitle(cell: TextFieldTableViewCell) {
+        let viewModel = TextFieldTableViewCell.ViewModel(text: nil, placeholder: Strings.titleCellPlaceholder, onTextChange: { [weak self] newCategoryName in
+            if let newCategoryName = newCategoryName {
 
-        }
+            }
+            }, onTextDidBeginEditing: {
+        }, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
+        cell.applyStyle(style: .body)
     }
 
     func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
@@ -157,7 +158,7 @@ private extension AddProductCategoryViewController {
         var type: UITableViewCell.Type {
             switch self {
             case .title:
-                return TitleAndTextFieldTableViewCell.self
+                return TextFieldTableViewCell.self
             case .parentCategory:
                 return SettingTitleAndValueTableViewCell.self
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Networking
 
 /// AddProductCategoryViewController: Add a new category associated to the active Account.
 ///
@@ -11,7 +12,17 @@ final class AddProductCategoryViewController: UIViewController {
     ///
     private var sections: [Section] = [Section(rows: [.title]), Section(rows: [.parentCategory])]
 
-    init() {
+    /// Selected parent category
+    ///
+    private var selectedParentCategory: ProductCategory?
+
+    // Completion callback
+    //
+    typealias Completion = (_ category: ProductCategory) -> Void
+    private let onCompletion: Completion
+
+    init(completion: @escaping Completion) {
+        onCompletion = completion
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -34,8 +45,9 @@ private extension AddProductCategoryViewController {
     func configureNavigationBar() {
         title = NSLocalizedString("Add Category", comment: "Product Add Category navigation title")
 
-        //navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
-        //removeNavigationBackBarButtonText()
+        addCloseNavigationBarButton(title: Strings.cancelButton)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.saveButton, style: .done, target: self, action: #selector(saveNewCategory))
+        removeNavigationBackBarButtonText()
     }
 
     func configureMainView() {
@@ -56,6 +68,16 @@ private extension AddProductCategoryViewController {
         for row in Row.allCases {
             tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
         }
+    }
+}
+
+// MARK: - Navigation actions handling
+//
+extension AddProductCategoryViewController {
+
+    @objc private func saveNewCategory() {
+        //TODO: add remotely new category
+        //onCompletion(newCategory)
     }
 }
 
@@ -106,11 +128,17 @@ private extension AddProductCategoryViewController {
     }
 
     func configureTitle(cell: TitleAndTextFieldTableViewCell) {
+        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: nil,
+        text: nil,
+        placeholder: Strings.titleCellPlaceholder
+        ) { (text) in
 
+        }
+        cell.configure(viewModel: viewModel)
     }
 
     func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
-
+        cell.updateUI(title: Strings.parentCellTitle, value: Strings.parentCellPlaceholder)
     }
 }
 
@@ -138,5 +166,17 @@ private extension AddProductCategoryViewController {
         var reuseIdentifier: String {
             return type.reuseIdentifier
         }
+    }
+}
+
+// MARK: - Constants!
+//
+private extension AddProductCategoryViewController {
+    enum Strings {
+        static let cancelButton = NSLocalizedString("Cancel", comment: "Add Product Category. Cancel button title in navbar.")
+        static let saveButton = NSLocalizedString("Save", comment: "Add Product Category. Save button title in navbar.")
+        static let titleCellPlaceholder = NSLocalizedString("Title", comment: "Add Product Category. Placeholder of cell presenting the title of the category.")
+        static let parentCellTitle = NSLocalizedString("Parent Category", comment: "Add Product Category. Title of cell presenting the parent category.")
+        static let parentCellPlaceholder = NSLocalizedString("Optional", comment: "Add Product Category. Placeholder of cell presenting the parent category.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -128,7 +128,15 @@ extension AddProductCategoryViewController: UITableViewDataSource {
 //
 extension AddProductCategoryViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-
+        switch sections[indexPath.section].rows[indexPath.row] {
+        case .parentCategory:
+            let parentCategoryViewController = ProductParentCategoriesViewController(siteID: siteID) { (parentCategory) in
+                //TODO: parent category selected
+            }
+            navigationController?.pushViewController(parentCategoryViewController, animated: true)
+        default:
+            return
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Networking
+import Yosemite
 
 /// AddProductCategoryViewController: Add a new category associated to the active Account.
 ///
@@ -82,6 +83,21 @@ extension AddProductCategoryViewController {
     @objc private func saveNewCategory() {
         //TODO: add remotely new category
         //onCompletion(newCategory)
+        
+        guard let categoryName = newCategoryTitle, let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return
+        }
+        
+        let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID, name: categoryName, parentID: selectedParentCategory?.categoryID) { (result) in
+            //TODO: to be completed
+//            switch result {
+//            case .success(let category):
+//                //onCompletion?(.success(imageResult.image))
+//            case .failure(let error):
+//                //onCompletion?(.failure(kingfisherError))
+//            }
+        }
+        ServiceLocator.stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -4,6 +4,13 @@ import UIKit
 ///
 final class AddProductCategoryViewController: UIViewController {
 
+    @IBOutlet private weak var tableView: UITableView!
+
+
+    /// Table Sections to be rendered
+    ///
+    private var sections: [Section] = [Section(rows: [.title]), Section(rows: [.parentCategory])]
+
     init() {
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
@@ -14,10 +21,72 @@ final class AddProductCategoryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        configureNavigationBar()
+        configureMainView()
+        configureTableView()
     }
 }
 
+// MARK: - View Configuration
+//
+private extension AddProductCategoryViewController {
+
+    func configureNavigationBar() {
+        title = NSLocalizedString("Add Category", comment: "Product Add Category navigation title")
+
+        //navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeUpdating))
+        //removeNavigationBackBarButtonText()
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+
+        registerTableViewCells()
+
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension AddProductCategoryViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = sections[indexPath.section].rows[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        //configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension AddProductCategoryViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
+    }
+}
 
 // MARK: - Private Types
 //
@@ -34,9 +103,9 @@ private extension AddProductCategoryViewController {
         var type: UITableViewCell.Type {
             switch self {
             case .title:
-                return UnitInputTableViewCell.self
+                return TitleAndTextFieldTableViewCell.self
             case .parentCategory:
-                return SwitchTableViewCell.self
+                return SettingTitleAndValueTableViewCell.self
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -18,7 +18,7 @@ final class AddProductCategoryViewController: UIViewController {
     ///
     private var newCategoryTitle: String? {
         didSet {
-            navigationItem.rightBarButtonItem?.isEnabled = newCategoryTitle != nil || newCategoryTitle?.isEmpty == true
+            navigationItem.rightBarButtonItem?.isEnabled = newCategoryTitle?.isNotEmpty == true
         }
     }
 
@@ -85,7 +85,7 @@ private extension AddProductCategoryViewController {
 
     func configureRightBarButtomitemAsSave() {
         navigationItem.setRightBarButton(UIBarButtonItem(title: Strings.saveButton, style: .done, target: self, action: #selector(saveNewCategory)), animated: true)
-        navigationItem.rightBarButtonItem?.isEnabled = newCategoryTitle != nil
+        navigationItem.rightBarButtonItem?.isEnabled = newCategoryTitle?.isNotEmpty == true
     }
 
     func configureRightButtonItemAsSpinner() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Networking
 import Yosemite
 
-/// AddProductCategoryViewController: Add a new category associated to the active Account.
+/// AddProductCategoryViewController: Add a new category associated to the active site.
 ///
 final class AddProductCategoryViewController: UIViewController {
 
@@ -12,7 +12,7 @@ final class AddProductCategoryViewController: UIViewController {
 
     /// Table Sections to be rendered
     ///
-    private var sections: [Section] = [Section(rows: [.title]), Section(rows: [.parentCategory])]
+    private let sections: [Section] = [Section(rows: [.title]), Section(rows: [.parentCategory])]
 
     /// New category title
     ///
@@ -32,12 +32,9 @@ final class AddProductCategoryViewController: UIViewController {
 
     /// Keyboard management
     ///
-    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
-        let keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
-            self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
-        }
-        return keyboardFrameObserver
-    }()
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
+        self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
+    }
 
     /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
@@ -206,7 +203,7 @@ extension AddProductCategoryViewController: UITableViewDelegate {
 
     /// Dismiss keyboard on Title Category Text Field
     ///
-    func titleCategoryTextFieldResignFirstResponder() {
+    private func titleCategoryTextFieldResignFirstResponder() {
         if let indexPath = sections.indexPathForRow(.title) {
             let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
             cell?.resignFirstResponder()
@@ -262,6 +259,7 @@ private extension AddProductCategoryViewController {
     func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
         cell.updateUI(title: Strings.parentCellTitle, value: selectedParentCategory?.name ?? Strings.parentCellPlaceholder)
         cell.selectionStyle = .none
+        cell.accessoryType = .disclosureIndicator
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -57,8 +57,24 @@ private extension AddProductCategoryViewController {
         title = Strings.titleView
 
         addCloseNavigationBarButton(title: Strings.cancelButton)
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.saveButton, style: .done, target: self, action: #selector(saveNewCategory))
+        configureRightBarButtomitemAsSave()
         removeNavigationBackBarButtonText()
+    }
+
+    func configureRightBarButtomitemAsSave() {
+        navigationItem.setRightBarButton(UIBarButtonItem(title: Strings.saveButton, style: .done, target: self, action: #selector(saveNewCategory)), animated: true)
+        navigationItem.rightBarButtonItem?.isEnabled = newCategoryTitle == nil
+    }
+
+    func configureRightButtonItemAsSpinner() {
+        let activityIndicator = UIActivityIndicatorView(style: .white)
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.startAnimating()
+
+        let rightBarButton = UIBarButtonItem(customView: activityIndicator)
+
+        navigationItem.setRightBarButton(rightBarButton, animated: true)
+        navigationItem.rightBarButtonItem?.isEnabled = false
     }
 
     func configureMainView() {
@@ -82,28 +98,41 @@ private extension AddProductCategoryViewController {
     }
 }
 
-// MARK: - Navigation actions handling
+// MARK: - Remote Update actions
 //
 extension AddProductCategoryViewController {
 
     @objc private func saveNewCategory() {
-        //TODO: add remotely new category
-        //onCompletion(newCategory)
+        configureRightButtonItemAsSpinner()
 
         guard let categoryName = newCategoryTitle, let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return
         }
 
-        let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID, name: categoryName, parentID: selectedParentCategory?.categoryID) { (result) in
-            //TODO: to be completed
-//            switch result {
-//            case .success(let category):
-//                //onCompletion?(.success(imageResult.image))
-//            case .failure(let error):
-//                //onCompletion?(.failure(kingfisherError))
-//            }
+        let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID, name: categoryName, parentID: selectedParentCategory?.categoryID) { [weak self] (result) in
+            self?.configureRightBarButtomitemAsSave()
+            switch result {
+            case .success(let category):
+                self?.onCompletion(category)
+            case .failure:
+                self?.displayAddCategoryErrorNotice { [weak self] in
+                    self?.saveNewCategory()
+                }
+            }
         }
         ServiceLocator.stores.dispatch(action)
+    }
+
+    /// Displays the `Unable to create category` Notice.
+    ///
+    func displayAddCategoryErrorNotice(onAction: @escaping () -> Void) {
+        let notice = Notice(title: Strings.addCategoryErrorNotice,
+                            message: nil,
+                            feedbackType: .error,
+                            actionTitle: Strings.retryErrorAction) {
+                                onAction()
+        }
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
     }
 }
 
@@ -216,5 +245,7 @@ private extension AddProductCategoryViewController {
         static let titleCellPlaceholder = NSLocalizedString("Title", comment: "Add Product Category. Placeholder of cell presenting the title of the category.")
         static let parentCellTitle = NSLocalizedString("Parent Category", comment: "Add Product Category. Title of cell presenting the parent category.")
         static let parentCellPlaceholder = NSLocalizedString("Optional", comment: "Add Product Category. Placeholder of cell presenting the parent category.")
+        static let addCategoryErrorNotice = NSLocalizedString("Unable to create the new category", comment: "Content of error presented when Create New Category Action Failed.")
+        static let retryErrorAction = NSLocalizedString("Retry", comment: "Retry Action")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -74,7 +74,7 @@ extension AddProductCategoryViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = sections[indexPath.section].rows[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
-        //configure(cell, for: row, at: indexPath)
+        configure(cell, for: row, at: indexPath)
 
         return cell
     }
@@ -84,6 +84,32 @@ extension AddProductCategoryViewController: UITableViewDataSource {
 //
 extension AddProductCategoryViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
+    }
+}
+
+// MARK: - Cell configuration
+//
+private extension AddProductCategoryViewController {
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TitleAndTextFieldTableViewCell where row == .title:
+            configureTitle(cell: cell)
+        case let cell as SettingTitleAndValueTableViewCell where row == .parentCategory:
+            configureParentCategory(cell: cell)
+        default:
+            fatalError()
+            break
+        }
+    }
+
+    func configureTitle(cell: TitleAndTextFieldTableViewCell) {
+
+    }
+
+    func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
 
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// AddProductCategoryViewController: Add a new category associated to the active Account.
+///
+final class AddProductCategoryViewController: UIViewController {
+
+    init() {
+        super.init(nibName: type(of: self).nibName, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+    
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -125,6 +125,7 @@ private extension AddProductCategoryViewController {
 extension AddProductCategoryViewController {
 
     @objc private func saveNewCategory() {
+        titleCategoryTextFieldResignFirstResponder()
         configureRightButtonItemAsSpinner()
 
         guard let categoryName = newCategoryTitle, let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
@@ -196,6 +197,15 @@ extension AddProductCategoryViewController: UITableViewDelegate {
             return
         }
     }
+
+    /// Dismiss keyboard on Title Category Text Field
+    ///
+    func titleCategoryTextFieldResignFirstResponder() {
+        if let indexPath = sections.indexPathForRow(.title) {
+            let cell = tableView.cellForRow(at: indexPath) as? TextFieldTableViewCell
+            cell?.resignFirstResponder()
+        }
+    }
 }
 
 // MARK: - Keyboard management
@@ -250,7 +260,7 @@ private extension AddProductCategoryViewController {
 //
 private extension AddProductCategoryViewController {
 
-    struct Section {
+    struct Section: RowIterable {
         let rows: [Row]
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -36,14 +36,6 @@ final class AddProductCategoryViewController: UIViewController {
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
     }
 
-    /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
-    ///
-    private lazy var noticePresenter: DefaultNoticePresenter = {
-        let noticePresenter = DefaultNoticePresenter()
-        noticePresenter.presentingViewController = self
-        return noticePresenter
-    }()
-
     // Completion callback
     //
     typealias Completion = (_ category: ProductCategory) -> Void
@@ -140,25 +132,11 @@ extension AddProductCategoryViewController {
             switch result {
             case .success(let category):
                 self?.onCompletion(category)
-            case .failure:
-                self?.displayAddCategoryErrorNotice { [weak self] in
-                    self?.saveNewCategory()
-                }
+            case .failure(let error):
+                self?.displayErrorAlert(error: error)
             }
         }
         ServiceLocator.stores.dispatch(action)
-    }
-
-    /// Displays the `Unable to create category` Notice.
-    ///
-    func displayAddCategoryErrorNotice(onAction: @escaping () -> Void) {
-        let notice = Notice(title: Strings.addCategoryErrorNotice,
-                            message: nil,
-                            feedbackType: .error,
-                            actionTitle: Strings.retryErrorAction) {
-                                onAction()
-        }
-        noticePresenter.enqueue(notice: notice)
     }
 }
 
@@ -290,6 +268,22 @@ private extension AddProductCategoryViewController {
     }
 }
 
+// MARK: Error handling
+//
+private extension AddProductCategoryViewController {
+    func displayErrorAlert(error: Error?) {
+        let alertController = UIAlertController(title: Strings.errorAlertTitle,
+                                                message: error?.localizedDescription,
+                                                preferredStyle: .alert)
+        let cancel = UIAlertAction(title: Strings.okErrorAlertButton,
+                                   style: .cancel,
+                                   handler: nil)
+        alertController.addAction(cancel)
+        present(alertController, animated: true)
+    }
+}
+
+
 // MARK: - Constants!
 //
 private extension AddProductCategoryViewController {
@@ -300,8 +294,9 @@ private extension AddProductCategoryViewController {
         static let titleCellPlaceholder = NSLocalizedString("Title", comment: "Add Product Category. Placeholder of cell presenting the title of the category.")
         static let parentCellTitle = NSLocalizedString("Parent Category", comment: "Add Product Category. Title of cell presenting the parent category.")
         static let parentCellPlaceholder = NSLocalizedString("Optional", comment: "Add Product Category. Placeholder of cell presenting the parent category.")
-        static let addCategoryErrorNotice = NSLocalizedString("Unable to create the new category",
-                                                              comment: "Content of error presented when Create New Category Action Failed.")
-        static let retryErrorAction = NSLocalizedString("Retry", comment: "Retry Action")
+        static let errorAlertTitle = NSLocalizedString("Cannot Add Category",
+                                                       comment: "Title of the alert when there is an error creating a new product category")
+        static let okErrorAlertButton = NSLocalizedString("OK",
+                                                          comment: "Dismiss button on the alert when there is an error creating a new product category")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -11,10 +11,37 @@ final class AddProductCategoryViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
     }
-    
+}
+
+
+// MARK: - Private Types
+//
+private extension AddProductCategoryViewController {
+
+    struct Section {
+        let rows: [Row]
+    }
+
+    enum Row: CaseIterable {
+        case title
+        case parentCategory
+
+        var type: UITableViewCell.Type {
+            switch self {
+            case .title:
+                return UnitInputTableViewCell.self
+            case .parentCategory:
+                return SwitchTableViewCell.self
+            }
+        }
+
+        var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -84,7 +84,11 @@ private extension AddProductCategoryViewController {
     }
 
     func configureRightBarButtomitemAsSave() {
-        navigationItem.setRightBarButton(UIBarButtonItem(title: Strings.saveButton, style: .done, target: self, action: #selector(saveNewCategory)), animated: true)
+        navigationItem.setRightBarButton(UIBarButtonItem(title: Strings.saveButton,
+                                                         style: .done,
+                                                         target: self,
+                                                         action: #selector(saveNewCategory)),
+                                         animated: true)
         navigationItem.rightBarButtonItem?.isEnabled = newCategoryTitle?.isNotEmpty == true
     }
 
@@ -132,7 +136,9 @@ extension AddProductCategoryViewController {
             return
         }
 
-        let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID, name: categoryName, parentID: selectedParentCategory?.categoryID) { [weak self] (result) in
+        let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID,
+                                                              name: categoryName,
+                                                              parentID: selectedParentCategory?.categoryID) { [weak self] (result) in
             self?.configureRightBarButtomitemAsSave()
             switch result {
             case .success(let category):
@@ -242,8 +248,11 @@ private extension AddProductCategoryViewController {
     }
 
     func configureTitle(cell: TextFieldTableViewCell) {
-        let viewModel = TextFieldTableViewCell.ViewModel(text: newCategoryTitle, placeholder: Strings.titleCellPlaceholder, onTextChange: { [weak self] newCategoryName in
-                self?.newCategoryTitle = newCategoryName
+        let viewModel = TextFieldTableViewCell.ViewModel(text: newCategoryTitle,
+                                                         placeholder: Strings.titleCellPlaceholder,
+                                                         onTextChange: { [weak self] newCategoryName in
+                                                            self?.newCategoryTitle = newCategoryName
+
             }, onTextDidBeginEditing: {
         }, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
@@ -293,7 +302,8 @@ private extension AddProductCategoryViewController {
         static let titleCellPlaceholder = NSLocalizedString("Title", comment: "Add Product Category. Placeholder of cell presenting the title of the category.")
         static let parentCellTitle = NSLocalizedString("Parent Category", comment: "Add Product Category. Title of cell presenting the parent category.")
         static let parentCellPlaceholder = NSLocalizedString("Optional", comment: "Add Product Category. Placeholder of cell presenting the parent category.")
-        static let addCategoryErrorNotice = NSLocalizedString("Unable to create the new category", comment: "Content of error presented when Create New Category Action Failed.")
+        static let addCategoryErrorNotice = NSLocalizedString("Unable to create the new category",
+                                                              comment: "Content of error presented when Create New Category Action Failed.")
         static let retryErrorAction = NSLocalizedString("Retry", comment: "Retry Action")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -12,6 +12,10 @@ final class AddProductCategoryViewController: UIViewController {
     ///
     private var sections: [Section] = [Section(rows: [.title]), Section(rows: [.parentCategory])]
 
+    /// New category title
+    ///
+    private var newCategoryTitle: String?
+
     /// Selected parent category
     ///
     private var selectedParentCategory: ProductCategory?
@@ -128,10 +132,8 @@ private extension AddProductCategoryViewController {
     }
 
     func configureTitle(cell: TextFieldTableViewCell) {
-        let viewModel = TextFieldTableViewCell.ViewModel(text: nil, placeholder: Strings.titleCellPlaceholder, onTextChange: { [weak self] newCategoryName in
-            if let newCategoryName = newCategoryName {
-
-            }
+        let viewModel = TextFieldTableViewCell.ViewModel(text: newCategoryTitle, placeholder: Strings.titleCellPlaceholder, onTextChange: { [weak self] newCategoryName in
+                self?.newCategoryTitle = newCategoryName
             }, onTextDidBeginEditing: {
         }, inputFormatter: nil, keyboardType: .default)
         cell.configure(viewModel: viewModel)
@@ -140,6 +142,7 @@ private extension AddProductCategoryViewController {
 
     func configureParentCategory(cell: SettingTitleAndValueTableViewCell) {
         cell.updateUI(title: Strings.parentCellTitle, value: Strings.parentCellPlaceholder)
+        cell.selectionStyle = .none
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -8,6 +8,7 @@ final class AddProductCategoryViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
 
+    private let siteID: Int64
 
     /// Table Sections to be rendered
     ///
@@ -26,7 +27,8 @@ final class AddProductCategoryViewController: UIViewController {
     typealias Completion = (_ category: ProductCategory) -> Void
     private let onCompletion: Completion
 
-    init(completion: @escaping Completion) {
+    init(siteID: Int64, completion: @escaping Completion) {
+        self.siteID = siteID
         onCompletion = completion
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.xib
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddProductCategoryViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="132" y="110"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AddProductCategoryViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="td9-Av-zbK" id="A51-wx-dkw"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -17,7 +18,19 @@
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="td9-Av-zbK">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="td9-Av-zbK" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Aeh-7c-PSq"/>
+                <constraint firstItem="td9-Av-zbK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Emk-hi-fae"/>
+                <constraint firstItem="td9-Av-zbK" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="FXj-Zn-OmD"/>
+                <constraint firstItem="td9-Av-zbK" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Hol-MO-b1Z"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="132" y="110"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.xib
@@ -19,7 +19,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="td9-Av-zbK">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="td9-Av-zbK">
                     <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                 </tableView>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -98,6 +98,8 @@ extension ProductParentCategoriesViewController: UITableViewDataSource {
 //
 extension ProductParentCategoriesViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-
+        if let category = resultController.fetchedObjects.first(where: { $0.categoryID == categoryViewModels[indexPath.row].categoryID }) {
+            onCompletion(category)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -1,12 +1,103 @@
 import UIKit
+import Yosemite
 
+/// ProductParentCategoriesViewController: fetch all the stored category associated to the active Account.
+///
 final class ProductParentCategoriesViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    /// The siteID for which we will fetch the product categories
+    ///
+    private let siteID: Int64
 
+    /// Array of view models to be rendered by the View Controller.
+    ///
+    private var categoryViewModels: [ProductCategoryCellViewModel] = []
+
+    private lazy var resultController: ResultsController<StorageProductCategory> = {
+        let storageManager = ServiceLocator.storageManager
+        let predicate = NSPredicate(format: "siteID = %ld", siteID)
+        let descriptor = NSSortDescriptor(keyPath: \StorageProductCategory.name, ascending: true)
+        return ResultsController<StorageProductCategory>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+    }()
+
+    // Completion callback
+    //
+    typealias Completion = (_ category: ProductCategory) -> Void
+    private let onCompletion: Completion
+
+
+    init(siteID: Int64, completion: @escaping Completion) {
+        self.siteID = siteID
+        onCompletion = completion
+        super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTitle()
+        registerTableViewCells()
+        configureTableView()
+
+        try? resultController.performFetch()
+        let fetchedCategories = resultController.fetchedObjects
+        categoryViewModels = ProductCategoryListViewModel.CellViewModelBuilder.viewModels(from: fetchedCategories, selectedCategories: [])
+    }
+
+}
+
+// MARK: - View Configuration
+//
+private extension ProductParentCategoriesViewController {
+
+    func configureTitle() {
+        title = NSLocalizedString("Categories", comment: "Edit product categories screen - Screen title")
+    }
+
+    func registerTableViewCells() {
+        tableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
+    }
+
+    func configureTableView() {
+        view.backgroundColor = .listBackground
+        tableView.backgroundColor = .listBackground
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.removeLastCellSeparator()
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductParentCategoriesViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return categoryViewModels.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductCategoryTableViewCell.reuseIdentifier,
+                                                       for: indexPath) as? ProductCategoryTableViewCell else {
+            fatalError()
+        }
+
+        if let categoryViewModel = categoryViewModels[safe: indexPath.row] {
+            cell.configure(with: categoryViewModel)
+        }
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductParentCategoriesViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+final class ProductParentCategoriesViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -56,7 +56,7 @@ final class ProductParentCategoriesViewController: UIViewController {
 private extension ProductParentCategoriesViewController {
 
     func configureTitle() {
-        title = NSLocalizedString("Categories", comment: "Edit product categories screen - Screen title")
+        title = NSLocalizedString("Select Parent Category", comment: "Select parent category screen - Screen title")
     }
 
     func registerTableViewCells() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Yosemite
 
-/// ProductParentCategoriesViewController: fetch all the stored category associated to the active Account.
+/// ProductParentCategoriesViewController: fetch all the stored categories associated to the active site.
 ///
 final class ProductParentCategoriesViewController: UIViewController {
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -2,20 +2,11 @@ import UIKit
 
 final class ProductParentCategoriesViewController: UIViewController {
 
+    @IBOutlet private weak var tableView: UITableView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductParentCategoriesViewController" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.xib
@@ -1,22 +1,38 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductParentCategoriesViewController" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductParentCategoriesViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="H3B-RM-SoD" id="u8f-et-jmE"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="H3B-RM-SoD">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="H3B-RM-SoD" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Yky-f5-I11"/>
+                <constraint firstItem="H3B-RM-SoD" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="gfy-d3-xOw"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="H3B-RM-SoD" secondAttribute="bottom" id="iYq-KL-3Id"/>
+                <constraint firstItem="H3B-RM-SoD" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="kJc-zl-olL"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="131.8840579710145" y="111.83035714285714"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -12,6 +12,8 @@ final class ProductCategoryListViewController: UIViewController {
     private let ghostTableView = UITableView()
 
     private let viewModel: ProductCategoryListViewModel
+    
+    private let siteID: Int64
 
     // Completion callback
     //
@@ -20,6 +22,7 @@ final class ProductCategoryListViewController: UIViewController {
 
     init(product: Product, completion: @escaping Completion) {
         self.viewModel = ProductCategoryListViewModel(product: product)
+        self.siteID = product.siteID
         onCompletion = completion
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
@@ -138,7 +141,7 @@ extension ProductCategoryListViewController {
     }
 
     @objc private func addButtonTapped() {
-        let addCategoryViewController = AddProductCategoryViewController { (newCategory) in
+        let addCategoryViewController = AddProductCategoryViewController(siteID: siteID) { (newCategory) in
             //TODO: new category added
         }
         let navController = WooNavigationController(rootViewController: addCategoryViewController)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -141,8 +141,11 @@ extension ProductCategoryListViewController {
     }
 
     @objc private func addButtonTapped() {
-        let addCategoryViewController = AddProductCategoryViewController(siteID: siteID) { (newCategory) in
-            //TODO: new category added
+        let addCategoryViewController = AddProductCategoryViewController(siteID: siteID) { [weak self] (newCategory) in
+            defer {
+                self?.dismiss(animated: true, completion: nil)
+            }
+            self?.viewModel.addAndSelectNewCategory(category: newCategory)
         }
         let navController = WooNavigationController(rootViewController: addCategoryViewController)
         present(navController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -139,7 +139,8 @@ extension ProductCategoryListViewController {
 
     @objc private func addButtonTapped() {
         let addCategoryViewController = AddProductCategoryViewController()
-        present(addCategoryViewController, animated: true, completion: nil)
+        let navController = WooNavigationController(rootViewController: addCategoryViewController)
+        present(navController, animated: true, completion: nil)
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -138,7 +138,9 @@ extension ProductCategoryListViewController {
     }
 
     @objc private func addButtonTapped() {
-        let addCategoryViewController = AddProductCategoryViewController()
+        let addCategoryViewController = AddProductCategoryViewController { (newCategory) in
+            //TODO: new category added
+        }
         let navController = WooNavigationController(rootViewController: addCategoryViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -146,6 +146,7 @@ extension ProductCategoryListViewController {
                 self?.dismiss(animated: true, completion: nil)
             }
             self?.viewModel.addAndSelectNewCategory(category: newCategory)
+            self?.tableView.reloadData()
         }
         let navController = WooNavigationController(rootViewController: addCategoryViewController)
         present(navController, animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -6,6 +6,8 @@ import WordPressUI
 ///
 final class ProductCategoryListViewController: UIViewController {
 
+    @IBOutlet private weak var addButton: UIButton!
+    @IBOutlet private weak var addButtonSeparator: UIView!
     @IBOutlet private var tableView: UITableView!
     private let ghostTableView = UITableView()
 
@@ -28,6 +30,8 @@ final class ProductCategoryListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureAddButton()
+        configureAddButtonSeparator()
         registerTableViewCells()
         configureTableView()
         configureGhostTableView()
@@ -43,6 +47,16 @@ private extension ProductCategoryListViewController {
     func registerTableViewCells() {
         tableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
         ghostTableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
+    }
+
+    func configureAddButton() {
+        addButton.setTitle(NSLocalizedString("Add Category", comment: "Action to add category on the Product Categories screen"), for: .normal)
+        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+        addButton.applySecondaryButtonStyle()
+    }
+
+    func configureAddButtonSeparator() {
+        addButtonSeparator.backgroundColor = .systemColor(.separator)
     }
 
     func configureTableView() {
@@ -121,6 +135,10 @@ extension ProductCategoryListViewController {
 
     @objc private func doneButtonTapped() {
         onCompletion(viewModel.selectedCategories)
+    }
+
+    @objc private func addButtonTapped() {
+        //TODO: open add category screen
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -138,7 +138,8 @@ extension ProductCategoryListViewController {
     }
 
     @objc private func addButtonTapped() {
-        //TODO: open add category screen
+        let addCategoryViewController = AddProductCategoryViewController()
+        present(addCategoryViewController, animated: true, completion: nil)
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -12,7 +12,7 @@ final class ProductCategoryListViewController: UIViewController {
     private let ghostTableView = UITableView()
 
     private let viewModel: ProductCategoryListViewModel
-    
+
     private let siteID: Int64
 
     // Completion callback

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.xib
@@ -10,6 +10,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductCategoryListViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="addButton" destination="FeT-Cz-Ejn" id="n2Y-in-VwH"/>
+                <outlet property="addButtonSeparator" destination="cj6-dK-CbB" id="rCK-Gr-Sa2"/>
                 <outlet property="tableView" destination="4pa-Cw-LKR" id="uF3-aL-9kf"/>
                 <outlet property="view" destination="iN0-l3-epB" id="t1s-Mw-tT3"/>
             </connections>
@@ -20,16 +22,45 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="4pa-Cw-LKR">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="106" width="414" height="756"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                 </tableView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="db8-Tb-7MB" userLabel="Top Container View">
+                    <rect key="frame" x="0.0" y="44" width="414" height="62"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FeT-Cz-Ejn">
+                            <rect key="frame" x="16" y="16" width="382" height="30"/>
+                            <state key="normal" title="Button"/>
+                        </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cj6-dK-CbB">
+                            <rect key="frame" x="0.0" y="61.5" width="414" height="0.5"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.5" id="vow-Jx-oM9"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstItem="FeT-Cz-Ejn" firstAttribute="leading" secondItem="db8-Tb-7MB" secondAttribute="leading" constant="16" id="Am7-l4-hDz"/>
+                        <constraint firstItem="cj6-dK-CbB" firstAttribute="leading" secondItem="db8-Tb-7MB" secondAttribute="leading" id="Btq-hz-rZ1"/>
+                        <constraint firstAttribute="trailing" secondItem="cj6-dK-CbB" secondAttribute="trailing" id="dFJ-9F-4Nv"/>
+                        <constraint firstItem="FeT-Cz-Ejn" firstAttribute="centerY" secondItem="db8-Tb-7MB" secondAttribute="centerY" id="m1b-nm-28o"/>
+                        <constraint firstAttribute="bottom" secondItem="cj6-dK-CbB" secondAttribute="bottom" id="qah-eP-4FJ"/>
+                        <constraint firstItem="FeT-Cz-Ejn" firstAttribute="top" secondItem="db8-Tb-7MB" secondAttribute="top" constant="16" id="scH-Hy-cbc"/>
+                        <constraint firstItem="FeT-Cz-Ejn" firstAttribute="centerX" secondItem="db8-Tb-7MB" secondAttribute="centerX" id="ucM-Jh-FDJ"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="4pa-Cw-LKR" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="0d8-Xy-4Fp"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="top" secondItem="4pa-Cw-LKR" secondAttribute="top" id="NIw-KU-oxA"/>
+                <constraint firstItem="db8-Tb-7MB" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="4L0-xE-z0A"/>
+                <constraint firstItem="4pa-Cw-LKR" firstAttribute="top" secondItem="db8-Tb-7MB" secondAttribute="bottom" id="hxN-Cc-Zs8"/>
+                <constraint firstItem="db8-Tb-7MB" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="iFc-6t-3d8"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="4pa-Cw-LKR" secondAttribute="trailing" id="j6T-xA-y2b"/>
                 <constraint firstItem="4pa-Cw-LKR" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="ttj-uA-s0c"/>
+                <constraint firstItem="db8-Tb-7MB" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="zYm-K0-76Y"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="137.68115942028987" y="128.57142857142856"/>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
@@ -104,6 +104,13 @@ final class ProductCategoryListViewModel {
         updateViewModelsArray()
     }
 
+    /// Add a new category added remotely, and that will be selected
+    ///
+    func addAndSelectNewCategory(category: ProductCategory) {
+        selectedCategories.append(category)
+        updateViewModelsArray()
+    }
+
     func hasUnsavedChanges() -> Bool {
         return product.categories.sorted() != selectedCategories.sorted()
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -44,6 +44,11 @@ final class TextFieldTableViewCell: UITableViewCell {
     override func becomeFirstResponder() -> Bool {
         textField.becomeFirstResponder()
     }
+
+    @discardableResult
+    override func resignFirstResponder() -> Bool {
+        textField.resignFirstResponder()
+    }
 }
 
 private extension TextFieldTableViewCell {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -311,6 +311,8 @@
 		4590CEE5249BA46700949F05 /* AddProductCategoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4590CEE3249BA46700949F05 /* AddProductCategoryViewController.xib */; };
 		45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */; };
 		45A24E602451DF1A0050606B /* ProductMenuOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */; };
+		45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */; };
+		45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */; };
 		45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
@@ -1177,6 +1179,8 @@
 		4590CEE3249BA46700949F05 /* AddProductCategoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddProductCategoryViewController.xib; sourceTree = "<group>"; };
 		45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductMenuOrderViewController.swift; sourceTree = "<group>"; };
 		45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductMenuOrderViewController.xib; sourceTree = "<group>"; };
+		45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductParentCategoriesViewController.swift; sourceTree = "<group>"; };
+		45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductParentCategoriesViewController.xib; sourceTree = "<group>"; };
 		45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
@@ -2469,6 +2473,8 @@
 			children = (
 				4590CEE2249BA46700949F05 /* AddProductCategoryViewController.swift */,
 				4590CEE3249BA46700949F05 /* AddProductCategoryViewController.xib */,
+				45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */,
+				45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */,
 			);
 			path = "Add Category";
 			sourceTree = "<group>";
@@ -4297,6 +4303,7 @@
 				B5BE75DD213F1D3D00909A14 /* OverlayMessageView.xib in Resources */,
 				57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */,
 				02F4F510237AFC1E00E13A9C /* ImageAndTitleAndTextTableViewCell.xib in Resources */,
+				45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */,
 				45FBDF39238D3F8800127F77 /* ExtendedAddProductImageCollectionViewCell.xib in Resources */,
 				D8149F542251CFE60006A245 /* EditableOrderTrackingTableViewCell.xib in Resources */,
 				D81D9229222E7F0800FFA585 /* OrderStatusListViewController.xib in Resources */,
@@ -4637,6 +4644,7 @@
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
+				45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
 				D8C251D9230D256F00F49782 /* NoticePresenter.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -307,6 +307,8 @@
 		4580BA7523F192D400B5F764 /* ProductSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */; };
 		4580BA7723F19D4A00B5F764 /* ProductSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */; };
 		459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */; };
+		4590CEE4249BA46700949F05 /* AddProductCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4590CEE2249BA46700949F05 /* AddProductCategoryViewController.swift */; };
+		4590CEE5249BA46700949F05 /* AddProductCategoryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4590CEE3249BA46700949F05 /* AddProductCategoryViewController.xib */; };
 		45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */; };
 		45A24E602451DF1A0050606B /* ProductMenuOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */; };
 		45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */; };
@@ -1171,6 +1173,8 @@
 		4580BA7323F192D400B5F764 /* ProductSettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductSettingsViewController.xib; sourceTree = "<group>"; };
 		4580BA7623F19D4A00B5F764 /* ProductSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsViewModel.swift; sourceTree = "<group>"; };
 		459097F723CDE47F00DEA9E0 /* UIAlertController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Helpers.swift"; sourceTree = "<group>"; };
+		4590CEE2249BA46700949F05 /* AddProductCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductCategoryViewController.swift; sourceTree = "<group>"; };
+		4590CEE3249BA46700949F05 /* AddProductCategoryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddProductCategoryViewController.xib; sourceTree = "<group>"; };
 		45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductMenuOrderViewController.swift; sourceTree = "<group>"; };
 		45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductMenuOrderViewController.xib; sourceTree = "<group>"; };
 		45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
@@ -2346,6 +2350,7 @@
 				265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */,
 				267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */,
 				265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */,
+				4590CEE1249BA44100949F05 /* Add Category */,
 				265BCA0A2430E719004E53EE /* Cell */,
 			);
 			path = "Edit Categories";
@@ -2457,6 +2462,15 @@
 				4524CD9F242D023300B2F20A /* List Selector Data Source */,
 			);
 			path = "Product Settings";
+			sourceTree = "<group>";
+		};
+		4590CEE1249BA44100949F05 /* Add Category */ = {
+			isa = PBXGroup;
+			children = (
+				4590CEE2249BA46700949F05 /* AddProductCategoryViewController.swift */,
+				4590CEE3249BA46700949F05 /* AddProductCategoryViewController.xib */,
+			);
+			path = "Add Category";
 			sourceTree = "<group>";
 		};
 		45A24E5C2451DB710050606B /* Menu Order */ = {
@@ -4244,6 +4258,7 @@
 				02162727237963AF000208D2 /* ProductFormViewController.xib in Resources */,
 				B56DB3D42049BFAA00D4AA8E /* Assets.xcassets in Resources */,
 				CE2A9FCF23C4F2C8002BEC1C /* RefundedProductsViewController.xib in Resources */,
+				4590CEE5249BA46700949F05 /* AddProductCategoryViewController.xib in Resources */,
 				B573B1A0219DC2690081C78C /* Localizable.strings in Resources */,
 				B559EBAF20A0BF8F00836CD4 /* README.md in Resources */,
 				CE583A082107849F00D73C1C /* SwitchTableViewCell.xib in Resources */,
@@ -4896,6 +4911,7 @@
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,
 				45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */,
 				02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */,
+				4590CEE4249BA46700949F05 /* AddProductCategoryViewController.swift in Sources */,
 				CE37C04422984E81008DCB39 /* PickListTableViewCell.swift in Sources */,
 				020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */,
 				B5A56BF5219F5AB20065A902 /* NSNotificationName+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		45A24E602451DF1A0050606B /* ProductMenuOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */; };
 		45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */; };
 		45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */; };
+		45AE150424A25322005AA948 /* ProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */; };
 		45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
@@ -5179,6 +5180,7 @@
 				45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */,
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
+				45AE150424A25322005AA948 /* ProductCategoryListViewModel.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -313,7 +313,6 @@
 		45A24E602451DF1A0050606B /* ProductMenuOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */; };
 		45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */; };
 		45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */; };
-		45AE150424A25322005AA948 /* ProductCategoryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA082430E6E0004E53EE /* ProductCategoryListViewModel.swift */; };
 		45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
@@ -5180,7 +5179,6 @@
 				45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */,
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,
-				45AE150424A25322005AA948 /* ProductCategoryListViewModel.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Categories/ProductCategoryListViewModelTests.swift
@@ -62,6 +62,19 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(storesManager.numberOfResponsesConsumed, 1)
     }
+
+    func testAddAndSelectNewCategory() {
+        // Given
+        let product = MockProduct().product()
+        let viewModel = ProductCategoryListViewModel(storesManager: storesManager, product: product)
+        let newCategory = sampleCategory(categoryID: 1234, name: "Test")
+
+        // When
+        viewModel.addAndSelectNewCategory(category: newCategory)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedCategories.first, newCategory)
+    }
 }
 
 private extension ProductCategoryListViewModelTests {


### PR DESCRIPTION
Resolves #2000 

## Description
This PR implements the last part for completing the management of Product Categories (part of Products Milestone 3). In particular, in this PR it's possible to create a new product category and to select a parent category.

## Changes
- The `addCloseNavigationBarButton:` method helper now accept also a custom title.
- Implemented the `AddProductCategoryViewController`
- Implemented the `ProductParentCategoriesViewController`
- `ProductCategoryListViewController` now contains the new “Add Button” on top of the view.
- Implemented a new method `addAndSelectedNewCategory:` in `ProductCategoryListViewModel`
- `TextFieldTableViewCell` now contains a new method `resignFirstResponder:`

## Testing
1. Open a product with or without product categories
2. Open the Product Categories screen
3. Tap "Add Category" button on top
4. Try to create a new category without parent category -> When it's saved, you will see it in category list selected. Save the product and make sure that it will be updated correctly.
5. Try to create a new category with parent category -> The new parent category should be selected in "New category" screen. Save the product and make sure that it will be updated correctly.
6. Try to create a new category where the title it's just a space ` `. -> Make sure to see an error notice which appears on the screen, and where you are able to retry.


## Add Product Category in action (GIF)
![add product category](https://user-images.githubusercontent.com/495617/85430090-f4c13c00-b57f-11ea-93bf-6b2842b287f6.gif)


## Screenshots (dark mode enabled)
| Categories             |  Add Category | Select Parent Category |
:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-06-23 at 18 31 01](https://user-images.githubusercontent.com/495617/85430042-e6732000-b57f-11ea-9efa-ac63631384dc.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-06-23 at 18 31 12](https://user-images.githubusercontent.com/495617/85430053-e96e1080-b57f-11ea-92c9-c067894884f4.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-06-23 at 18 31 17](https://user-images.githubusercontent.com/495617/85430061-eb37d400-b57f-11ea-87fb-65b26043b391.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
