### PR TITLE
Remove stats experiment switch

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -114,7 +114,6 @@ public enum WooAnalyticsStat: String {
     case settingsContactSupportTapped           = "main_menu_contact_support_tapped"
 
     case settingsBetaFeaturesButtonTapped       = "settings_beta_features_button_tapped"
-    case settingsBetaFeaturesNewStatsUIToggled  = "settings_beta_features_new_stats_ui_toggled"
     case settingsBetaFeaturesProductsToggled    = "settings_beta_features_products_toggled"
 
     case settingsPrivacySettingsTapped          = "settings_privacy_settings_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
@@ -53,10 +53,6 @@ final class StatsVersionStateCoordinator {
                 }
                 let statsVersion: StatsVersion = isStatsV4Available ? .v4: .v3
 
-                // Sets eligible stats version to app settings.
-                let setEligibleStatsVersionAction = AppSettingsAction.setStatsVersionEligible(siteID: self.siteID, statsVersion: statsVersion)
-                ServiceLocator.stores.dispatch(setEligibleStatsVersionAction)
-
                 let nextState = StatsVersionState.initial(statsVersion: statsVersion)
                 if nextState != self.state {
                     self.state = nextState

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
@@ -51,8 +51,7 @@ final class StatsVersionStateCoordinator {
                 guard let self = self else {
                     return
                 }
-                let statsVersion = StatsVersion.v3
-                //let statsVersion: StatsVersion = isStatsV4Available ? .v4: .v3
+                let statsVersion: StatsVersion = isStatsV4Available ? .v4: .v3
 
                 let nextState = StatsVersionState.initial(statsVersion: statsVersion)
                 if nextState != self.state {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionStateCoordinator.swift
@@ -51,7 +51,8 @@ final class StatsVersionStateCoordinator {
                 guard let self = self else {
                     return
                 }
-                let statsVersion: StatsVersion = isStatsV4Available ? .v4: .v3
+                let statsVersion = StatsVersion.v3
+                //let statsVersion: StatsVersion = isStatsV4Available ? .v4: .v3
 
                 let nextState = StatsVersionState.initial(statsVersion: statsVersion)
                 if nextState != self.state {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -82,20 +82,8 @@ private extension BetaFeaturesViewController {
     /// Configure sections for table view.
     ///
     func configureSections() {
-        let action = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { [weak self] eligibleStatsVersion in
-            guard let self = self else {
-                return
-            }
-            guard eligibleStatsVersion == .v4 else {
-                self.sections = [
-                ]
-
-                return
-            }
-            // This is empty because there aren't any ongoing experiments
-            self.sections = []
-        }
-        ServiceLocator.stores.dispatch(action)
+        // This is empty because there aren't any ongoing experiments
+        self.sections = []
     }
 
     func productsSection() -> Section {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -92,16 +92,10 @@ private extension BetaFeaturesViewController {
 
                 return
             }
-            self.sections = [
-                self.statsSection()
-            ]
+            // This is empty because there aren't any ongoing experiments
+            self.sections = []
         }
         ServiceLocator.stores.dispatch(action)
-    }
-
-    func statsSection() -> Section {
-        return Section(rows: [.statsVersionSwitch,
-                              .statsVersionDescription])
     }
 
     func productsSection() -> Section {
@@ -126,11 +120,6 @@ private extension BetaFeaturesViewController {
         }
 
         switch cell {
-        // Stats v4
-        case let cell as SwitchTableViewCell where row == .statsVersionSwitch:
-            configureStatsVersionSwitch(cell: cell)
-        case let cell as BasicTableViewCell where row == .statsVersionDescription:
-            configureStatsVersionDescription(cell: cell)
         // Product list
         case let cell as SwitchTableViewCell where row == .productsSwitch:
             configureProductsSwitch(cell: cell)
@@ -139,41 +128,6 @@ private extension BetaFeaturesViewController {
         default:
             fatalError()
         }
-    }
-
-    // MARK: - Stats version feature
-
-    func configureStatsVersionSwitch(cell: SwitchTableViewCell) {
-        configureCommonStylesForSwitchCell(cell)
-
-        let statsVersionTitle = NSLocalizedString("Improved stats",
-                                                  comment: "My Store > Settings > Experimental features > Switch stats version")
-        cell.title = statsVersionTitle
-
-        let action = AppSettingsAction.loadInitialStatsVersionToShow(siteID: siteID) { initialStatsVersion in
-            cell.isOn = initialStatsVersion == .v4
-        }
-        ServiceLocator.stores.dispatch(action)
-
-        cell.onChange = { [weak self] isSwitchOn in
-            guard let siteID = self?.siteID else {
-                return
-            }
-            ServiceLocator.analytics.track(.settingsBetaFeaturesNewStatsUIToggled)
-
-            let statsVersion: StatsVersion = isSwitchOn ? .v4: .v3
-            let action = AppSettingsAction.setStatsVersionPreference(siteID: siteID,
-                                                                     statsVersion: statsVersion)
-            ServiceLocator.stores.dispatch(action)
-        }
-    }
-
-    func configureStatsVersionDescription(cell: BasicTableViewCell) {
-        configureCommonStylesForDescriptionCell(cell)
-        cell.textLabel?.text = NSLocalizedString("Try the new stats available with the WooCommerce Admin plugin",
-                                                 comment: "My Store > Settings > Experimental features > Stats version description")
-
-        cell.accessibilityIdentifier = "beta-features-improved-stats-cell"
     }
 
     // MARK: - Product List feature
@@ -281,19 +235,15 @@ private struct Section {
 }
 
 private enum Row: CaseIterable {
-    // Stats v4.
-    case statsVersionSwitch
-    case statsVersionDescription
-
     // Products.
     case productsSwitch
     case productsDescription
 
     var type: UITableViewCell.Type {
         switch self {
-        case .statsVersionSwitch, .productsSwitch:
+        case .productsSwitch:
             return SwitchTableViewCell.self
-        case .statsVersionDescription, .productsDescription:
+        case .productsDescription:
             return BasicTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -281,8 +281,9 @@ private extension SettingsViewController {
         return sections[indexPath.section].rows[indexPath.row]
     }
 
+    /// This is false because there are no ongoing expriments
     func couldShowBetaFeaturesRow() -> Bool {
-        return true
+        return false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -131,7 +131,7 @@ private extension TopBannerView {
         let titleStackView = UIStackView(arrangedSubviews: [titleLabel, actionButon])
         titleStackView.axis = .horizontal
         titleStackView.spacing = 16
-        
+
         let textStackView = UIStackView(arrangedSubviews: [titleStackView, infoLabel])
         textStackView.axis = .vertical
         textStackView.spacing = 9

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -127,8 +127,12 @@ private extension TopBannerView {
     }
 
     func createContentView() -> UIView {
-        let textStackView = UIStackView(arrangedSubviews: [titleLabel, infoLabel])
-        textStackView.translatesAutoresizingMaskIntoConstraints = false
+        let actionButon = isActionEnabled ? dismissButton : expandCollapseButton
+        let titleStackView = UIStackView(arrangedSubviews: [titleLabel, actionButon])
+        titleStackView.axis = .horizontal
+        titleStackView.spacing = 16
+        
+        let textStackView = UIStackView(arrangedSubviews: [titleStackView, infoLabel])
         textStackView.axis = .vertical
         textStackView.spacing = 9
 
@@ -139,13 +143,7 @@ private extension TopBannerView {
         expandCollapseButton.setContentHuggingPriority(.required, for: .horizontal)
         expandCollapseButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        let subviews: [UIView]
-        if isActionEnabled {
-            subviews = [iconImageView, textStackView, dismissButton]
-        } else {
-            subviews = [iconImageView, textStackView, expandCollapseButton]
-        }
-        let contentStackView = UIStackView(arrangedSubviews: subviews)
+        let contentStackView = UIStackView(arrangedSubviews: [iconImageView, textStackView])
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .horizontal
         contentStackView.spacing = 16

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -130,7 +130,7 @@ private extension TopBannerView {
         let textStackView = UIStackView(arrangedSubviews: [titleLabel, infoLabel])
         textStackView.translatesAutoresizingMaskIntoConstraints = false
         textStackView.axis = .vertical
-        textStackView.spacing = 3
+        textStackView.spacing = 9
 
         iconImageView.setContentHuggingPriority(.required, for: .horizontal)
         iconImageView.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -148,7 +148,7 @@ private extension TopBannerView {
         let contentStackView = UIStackView(arrangedSubviews: subviews)
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.axis = .horizontal
-        contentStackView.spacing = 10
+        contentStackView.spacing = 16
         contentStackView.alignment = .leading
         return contentStackView
     }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -42,28 +42,13 @@ public enum AppSettingsAction: Action {
     ///
     case loadStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner, onCompletion: (Bool) -> Void)
 
-    /// Loads the eligible stats version given the latest app settings associated with the `siteID`
-    ///
-    case loadStatsVersionEligible(siteID: Int64,
-        onCompletion: (StatsVersion?) -> Void)
-
     /// Sets whether a stats version banner should be shown
     ///
     case setStatsVersionBannerVisibility(banner: StatsVersionBannerVisibility.StatsVersionBanner, shouldShowBanner: Bool)
 
-    /// Sets the latest highest eligible stats version associated with the `siteID`
-    ///
-    case setStatsVersionEligible(siteID: Int64,
-        statsVersion: StatsVersion)
-
     /// Sets the last shown stats version associated with the `siteID`
     ///
     case setStatsVersionLastShown(siteID: Int64,
-        statsVersion: StatsVersion)
-
-    /// Sets the user preferred stats version associated with the `siteID`
-    ///
-    case setStatsVersionPreference(siteID: Int64,
         statsVersion: StatsVersion)
 
     /// Loads the user preferred Product feature switch given the latest app settings

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -44,13 +44,6 @@ public class AppSettingsStore: Store {
         return documents!.appendingPathComponent(Constants.statsVersionBannerVisibilityFileName)
     }()
 
-    /// URL to the plist file that we use to store the eligible stats version.
-    ///
-    private lazy var statsVersionEligibleURL: URL = {
-        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        return documents!.appendingPathComponent(Constants.statsVersionEligibleFileName)
-    }()
-
     /// URL to the plist file that we use to store the stats version displayed on Dashboard UI.
     ///
     private lazy var statsVersionLastShownURL: URL = {
@@ -101,11 +94,7 @@ public class AppSettingsStore: Store {
                                         onCompletion: onCompletion)
         case .resetStoredProviders(let onCompletion):
             resetStoredProviders(onCompletion: onCompletion)
-        case .loadStatsVersionEligible(let siteID, let onCompletion):
-            loadStatsVersionEligible(siteID: siteID, onCompletion: onCompletion)
-        case .setStatsVersionEligible(let siteID, let statsVersion):
-            setStatsVersionEligible(siteID: siteID, statsVersion: statsVersion)
-        case .setStatsVersionLastShown(let siteID, let statsVersion), .setStatsVersionPreference(let siteID, let statsVersion):
+        case .setStatsVersionLastShown(let siteID, let statsVersion):
             setStatsVersionLastShownOrFromUserPreference(siteID: siteID, statsVersion: statsVersion)
         case .loadInitialStatsVersionToShow(let siteID, let onCompletion):
             loadInitialStatsVersionToShow(siteID: siteID, onCompletion: onCompletion)
@@ -290,29 +279,11 @@ private extension AppSettingsStore {
         })
     }
 
-    func setStatsVersionEligible(siteID: Int64,
-                                 statsVersion: StatsVersion) {
-        set(statsVersion: statsVersion, for: siteID, to: statsVersionEligibleURL, onCompletion: { error in
-            if let error = error {
-                DDLogError("⛔️ Saving the eligible stats version to \(statsVersion) failed: siteID \(siteID). Error: \(error)")
-            }
-        })
-    }
-
     func loadInitialStatsVersionToShow(siteID: Int64, onCompletion: (StatsVersion?) -> Void) {
         guard let existingData: StatsVersionBySite = try? fileStorage.data(for: statsVersionLastShownURL),
             let statsVersion = existingData.statsVersionBySite[siteID] else {
             onCompletion(nil)
             return
-        }
-        onCompletion(statsVersion)
-    }
-
-    func loadStatsVersionEligible(siteID: Int64, onCompletion: (StatsVersion?) -> Void) {
-        guard let existingData: StatsVersionBySite = try? fileStorage.data(for: statsVersionEligibleURL),
-            let statsVersion = existingData.statsVersionBySite[siteID] else {
-                onCompletion(nil)
-                return
         }
         onCompletion(statsVersion)
     }
@@ -386,7 +357,6 @@ private extension AppSettingsStore {
     func resetStatsVersionStates() {
         do {
             try fileStorage.deleteFile(at: statsVersionBannerVisibilityURL)
-            try fileStorage.deleteFile(at: statsVersionEligibleURL)
             try fileStorage.deleteFile(at: statsVersionLastShownURL)
         } catch {
             let error = AppSettingsStoreErrors.deleteStatsVersionStates
@@ -419,7 +389,6 @@ private enum Constants {
     static let shipmentProvidersFileName = "shipment-providers.plist"
     static let customShipmentProvidersFileName = "custom-shipment-providers.plist"
     static let statsVersionBannerVisibilityFileName = "stats-version-banner-visibility.plist"
-    static let statsVersionEligibleFileName = "stats-version-eligible.plist"
     static let statsVersionLastShownFileName = "stats-version-last-shown.plist"
     static let productsFeatureSwitchFileName = "products-feature-switch.plist"
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+StatsVersion.swift
@@ -76,25 +76,6 @@ final class AppSettingsStoreTests_StatsVersion: XCTestCase {
         subject.onAction(readActionForSite2)
     }
 
-    func testStatsVersionEligibleActions() {
-        let siteID: Int64 = 134
-
-        let initialReadAction = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
-            // Before any write actions, the stats version should be nil.
-            XCTAssertNil(eligibleStatsVersion)
-        }
-        subject.onAction(initialReadAction)
-
-        let statsVersionToWrite = StatsVersion.v4
-        let writeAction = AppSettingsAction.setStatsVersionEligible(siteID: siteID, statsVersion: statsVersionToWrite)
-        subject.onAction(writeAction)
-
-        let readAction = AppSettingsAction.loadStatsVersionEligible(siteID: siteID) { eligibleStatsVersion in
-            XCTAssertEqual(eligibleStatsVersion, statsVersionToWrite)
-        }
-        subject.onAction(readAction)
-    }
-
     func testStatsVersionBannerVisibilityActions() {
         let initialV3ToV4ReadAction = AppSettingsAction.loadStatsVersionBannerVisibility(banner: .v3ToV4, onCompletion: { shouldShowBanner in
             // Before any write actions, the default should be to show the banner.


### PR DESCRIPTION
closes #2452 

# Why

As a result of #2467 there is not need to keep the "Improved Stats" feature toggle switch as well as the "Experimental Features"  row on settings since there isn't any on-going experiment.

# How

- Remove the `stats` sections on the `configureSections` method of `BetaFeaturesViewController`
- Return `false` on `couldShowBetaFeaturesRow` method of `SettingsViewController`
- Removed dead code as a result of those deletions.

# Testing Steps

- Load the app and see that the "Experimental Features" row on sections is hidden.

# Screenshots

<img width="421" alt="Screen Shot 2020-06-24 at 11 02 32 AM" src="https://user-images.githubusercontent.com/562080/85600025-b1fc7400-b612-11ea-9ad6-36f6b3648fe9.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
