### PR TITLE
Remove `ProductCategory` entry from model 26 to 27 mapping model XML with a test case

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64162313C26400284168 /* StatsVersionBySite.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
 		02EAB6D72480A86D00FD873C /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAB6D62480A86D00FD873C /* CrashLogger.swift */; };
+		02F25AE024A446E700092B06 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F25ADF24A446E600092B06 /* XCTestCase+Wait.swift */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
 		450106892399AC7400E24722 /* TaxClass+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */; };
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
@@ -166,6 +167,7 @@
 		02DA64182313C2AA00284168 /* StatsVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersion.swift; sourceTree = "<group>"; };
 		02E4F5E223CD552F003B0010 /* Model 26.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 26.xcdatamodel"; sourceTree = "<group>"; };
 		02EAB6D62480A86D00FD873C /* CrashLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogger.swift; sourceTree = "<group>"; };
+		02F25ADF24A446E600092B06 /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		262CD20224317C2F00932241 /* Model 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 27.xcdatamodel"; sourceTree = "<group>"; };
 		26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV26toV27.xcmappingmodel; sourceTree = "<group>"; };
 		450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -339,6 +341,14 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		02F25ADE24A446C500092B06 /* Testing */ = {
+			isa = PBXGroup;
+			children = (
+				02F25ADF24A446E600092B06 /* XCTestCase+Wait.swift */,
+			);
+			path = Testing;
+			sourceTree = "<group>";
+		};
 		4DD3D0BDDE216A90FC1335D7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -472,6 +482,7 @@
 				B54CA5C520A4BFC800F38CD1 /* Tools */,
 				B52B0F7D20AA2F1200477698 /* Extensions */,
 				B59E11DC20A9F1E6004121A4 /* CoreData */,
+				02F25ADE24A446C500092B06 /* Testing */,
 				B54CA5A920A4BBA600F38CD1 /* Info.plist */,
 			);
 			path = StorageTests;
@@ -910,6 +921,7 @@
 				B54CA5C320A4BF6900F38CD1 /* NSManagedObjectContextStorageTests.swift in Sources */,
 				02A098272480D160002F8C7A /* MockCrashLogger.swift in Sources */,
 				B54CA5C720A4BFDC00F38CD1 /* DummyStack.swift in Sources */,
+				02F25AE024A446E700092B06 /* XCTestCase+Wait.swift in Sources */,
 				B54CA5C220A4BF6900F38CD1 /* NSManagedObjectStorageTests.swift in Sources */,
 				D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */,
 				B59E11DE20A9F1FB004121A4 /* CoreDataManagerTests.swift in Sources */,

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -3,7 +3,10 @@ import CocoaLumberjack
 import CoreData
 @testable import Storage
 
-class CoreDataIterativeMigratorTests: XCTestCase {
+final class CoreDataIterativeMigratorTests: XCTestCase {
+    private let allModelNames = ["Model", "Model 2", "Model 3", "Model 4", "Model 5", "Model 6", "Model 7", "Model 8", "Model 9", "Model 10",
+                                 "Model 11", "Model 12", "Model 13", "Model 14", "Model 15", "Model 16", "Model 17", "Model 18", "Model 19", "Model 20",
+                                 "Model 21", "Model 22", "Model 23", "Model 24", "Model 25", "Model 26", "Model 27", "Model 28"]
 
     override func setUp() {
         DDLog.add(DDOSLogger.sharedInstance)
@@ -56,8 +59,10 @@ class CoreDataIterativeMigratorTests: XCTestCase {
         XCTAssertNotNil(model)
 
         do {
-            let modelNames = ["Model", "Model 2", "Model 3", "Model 4", "Model 5", "Model 6", "Model 7", "Model 8", "Model 9", "Model 10"]
-            let (result, _) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL, storeType: NSSQLiteStoreType, to: model!, using: modelNames)
+            let (result, _) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL,
+                                                                             storeType: NSSQLiteStoreType,
+                                                                             to: model!,
+                                                                             using: allModelNames)
             XCTAssertTrue(result)
         } catch {
             XCTFail("Error when attempting to migrate: \(error)")
@@ -70,6 +75,134 @@ class CoreDataIterativeMigratorTests: XCTestCase {
         XCTAssertNotNil(ps)
     }
 
+    func testModel26To27Passed() throws {
+        // Arrange
+        let model26URL = urlForModel(name: "Model 26")
+        let model26 = NSManagedObjectModel(contentsOf: model26URL)!
+        let model27URL = urlForModel(name: "Model 27")
+        let model27 = NSManagedObjectModel(contentsOf: model27URL)!
+        let name = "WooCommerce"
+        let crashLogger = MockCrashLogger()
+        let coreDataManager = CoreDataManager(name: name, crashLogger: crashLogger)
+
+        // Destroys any pre-existing persistence store.
+        let psc = NSPersistentStoreCoordinator(managedObjectModel: coreDataManager.managedModel)
+        try? psc.destroyPersistentStore(at: coreDataManager.storeURL, ofType: NSSQLiteStoreType, options: nil)
+
+        // Action - step 1: loading persistence store with model 26
+        let model26Container = NSPersistentContainer(name: name, managedObjectModel: model26)
+        model26Container.persistentStoreDescriptions = [coreDataManager.storeDescription]
+
+        var model26LoadingError: Error?
+        waitForExpectation { expectation in
+            model26Container.loadPersistentStores { (storeDescription, error) in
+                model26LoadingError = error
+                expectation.fulfill()
+            }
+        }
+
+        // Assert - step 1
+        XCTAssertNil(model26LoadingError, "Migration error: \(String(describing: model26LoadingError?.localizedDescription))")
+
+        guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType,
+                                                                                          at: coreDataManager.storeURL,
+                                                                                          options: nil) else {
+                                                                                            XCTFail("Cannot get metadata for persistent store at URL \(coreDataManager.storeURL)")
+                                                                                            return
+        }
+
+        // The persistent store should be compatible with model 26 now and incompatible with model 27.
+        XCTAssertTrue(model26.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata))
+        XCTAssertFalse(model27.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata))
+
+        // Arrange - step 2: populating data, migrating persistent store from model 26 to 27, then loading with model 27.
+        let context = model26Container.viewContext
+        _ = self.insertAccount(to: context)
+        let product = self.insertProduct(to: context)
+        let productCategory = self.insertProductCategory(to: context)
+        product.addToCategories([productCategory])
+        context.saveIfNeeded()
+
+        XCTAssertEqual(context.countObjects(ofType: Account.self), 1)
+        XCTAssertEqual(context.countObjects(ofType: Product.self), 1)
+        XCTAssertEqual(context.countObjects(ofType: ProductCategory.self), 1)
+
+        let model27Container = NSPersistentContainer(name: name, managedObjectModel: model27)
+        model27Container.persistentStoreDescriptions = [coreDataManager.storeDescription]
+
+        // Action - step 2
+        let (migrateResult, migrationDebugMessages) = try! CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
+                                                                                                      storeType: NSSQLiteStoreType,
+                                                                                                      to: model27,
+                                                                                                      using: self.allModelNames)
+        XCTAssertTrue(migrateResult, "Failed to migrate to model version 27: \(migrationDebugMessages)")
+
+        var model27LoadingError: Error?
+        waitForExpectation { expectation in
+            model27Container.loadPersistentStores { (storeDescription, error) in
+                model27LoadingError = error
+                expectation.fulfill()
+            }
+        }
+
+        // Assert - step 2
+        XCTAssertNil(model27LoadingError, "Migration error: \(String(describing: model27LoadingError?.localizedDescription))")
+
+        XCTAssertEqual(model27Container.viewContext.countObjects(ofType: Account.self), 1)
+        XCTAssertEqual(model27Container.viewContext.countObjects(ofType: Product.self), 1)
+        // Product categories should be deleted.
+        XCTAssertEqual(model27Container.viewContext.countObjects(ofType: ProductCategory.self), 0)
+    }
+}
+
+/// Helpers for generating data in migration tests
+private extension CoreDataIterativeMigratorTests {
+    func insertAccount(to context: NSManagedObjectContext) -> Account {
+        let account = context.insertNewObject(ofType: Account.self)
+        // Populates the required attributes.
+        account.userID = 17
+        account.username = "hi"
+        return account
+    }
+
+    func insertProduct(to context: NSManagedObjectContext) -> Product {
+        let product = context.insertNewObject(ofType: Product.self)
+        // Populates the required attributes.
+        product.price = ""
+        product.permalink = ""
+        product.productTypeKey = "simple"
+        product.purchasable = true
+        product.averageRating = ""
+        product.backordered = true
+        product.backordersAllowed = false
+        product.backordersKey = ""
+        product.catalogVisibilityKey = ""
+        product.dateCreated = Date()
+        product.downloadable = true
+        product.featured = true
+        product.manageStock = true
+        product.name = "product"
+        product.onSale = true
+        product.soldIndividually = true
+        product.slug = ""
+        product.shippingRequired = false
+        product.shippingTaxable = false
+        product.reviewsAllowed = true
+        product.groupedProducts = []
+        product.virtual = true
+        product.stockStatusKey = ""
+        product.statusKey = ""
+        product.taxStatusKey = ""
+        return product
+    }
+
+    func insertProductCategory(to context: NSManagedObjectContext) -> ProductCategory {
+        let productCategory = context.insertNewObject(ofType: ProductCategory.self)
+        // Populates the required attributes.
+        productCategory.name = "testing"
+        productCategory.slug = ""
+        return productCategory
+    }
 }
 
 /// Helpers for the Core Data migration tests

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -31,8 +31,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         try psc.remove(ps!)
 
-        model = NSManagedObjectModel(contentsOf: model10URL)
-        XCTAssertNotNil(model)
+        model = try XCTUnwrap(NSManagedObjectModel(contentsOf: model10URL))
         psc = NSPersistentStoreCoordinator(managedObjectModel: model!)
 
         ps = try? psc.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: options)
@@ -55,8 +54,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         try psc.remove(ps!)
 
-        model = NSManagedObjectModel(contentsOf: model10URL)
-        XCTAssertNotNil(model)
+        model = try XCTUnwrap(NSManagedObjectModel(contentsOf: model10URL))
 
         do {
             let (result, _) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL,

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -75,7 +75,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         XCTAssertNotNil(ps)
     }
 
-    func testModel26To27Passed() throws {
+    func testModel26To27MigrationPassed() throws {
         // Arrange
         let model26URL = urlForModel(name: "Model 26")
         let model26 = NSManagedObjectModel(contentsOf: model26URL)!
@@ -104,11 +104,12 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         // Assert - step 1
         XCTAssertNil(model26LoadingError, "Migration error: \(String(describing: model26LoadingError?.localizedDescription))")
 
-        guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType,
-                                                                                          at: coreDataManager.storeURL,
-                                                                                          options: nil) else {
-                                                                                            XCTFail("Cannot get metadata for persistent store at URL \(coreDataManager.storeURL)")
-                                                                                            return
+        guard let metadata = try? NSPersistentStoreCoordinator
+            .metadataForPersistentStore(ofType: NSSQLiteStoreType,
+                                        at: coreDataManager.storeURL,
+                                        options: nil) else {
+                                            XCTFail("Cannot get metadata for persistent store at URL \(coreDataManager.storeURL)")
+                                            return
         }
 
         // The persistent store should be compatible with model 26 now and incompatible with model 27.
@@ -117,9 +118,9 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Arrange - step 2: populating data, migrating persistent store from model 26 to 27, then loading with model 27.
         let context = model26Container.viewContext
-        _ = self.insertAccount(to: context)
-        let product = self.insertProduct(to: context)
-        let productCategory = self.insertProductCategory(to: context)
+        _ = insertAccount(to: context)
+        let product = insertProduct(to: context)
+        let productCategory = insertProductCategory(to: context)
         product.addToCategories([productCategory])
         context.saveIfNeeded()
 
@@ -134,7 +135,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         let (migrateResult, migrationDebugMessages) = try! CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
                                                                                                       storeType: NSSQLiteStoreType,
                                                                                                       to: model27,
-                                                                                                      using: self.allModelNames)
+                                                                                                      using: allModelNames)
         XCTAssertTrue(migrateResult, "Failed to migrate to model version 27: \(migrationDebugMessages)")
 
         var model27LoadingError: Error?

--- a/Storage/StorageTests/Testing/XCTestCase+Wait.swift
+++ b/Storage/StorageTests/Testing/XCTestCase+Wait.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+extension XCTestCase {
+    /// Creates an XCTestExpectation and waits for `block` to call `fulfill()`.
+    ///
+    /// Example usage:
+    ///
+    /// ```
+    /// waitForExpectation(timeout: TimeInterval(10)) { expectation in
+    ///     doSomethingInTheBackground {
+    ///         expectation.fulfill()
+    ///     }
+    /// }
+    /// ```
+    ///
+    func waitForExpectation(description: String? = nil,
+                            count: Int = 1,
+                            timeout: TimeInterval = Constants.expectationTimeout,
+                            _ block: (XCTestExpectation) -> ()) {
+        let exp = expectation(description: description ?? "")
+        exp.expectedFulfillmentCount = count
+        block(exp)
+        wait(for: [exp], timeout: timeout)
+    }
+}


### PR DESCRIPTION
Migration from model version 26 to 27 and attempted improvement for #2371 

## Changes

Our Sentry crash logs indicated that most of the crashes were migrating from model version 26 to 27 (*). While inspecting the [Core Data v26 to v27 mapping model](https://github.com/woocommerce/woocommerce-ios/blob/9e605417971a9dda9333b8f63c8b00d83b2de598/Storage/Storage/Model/WooCommerceModelV26toV27.xcmappingmodel/xcmapping.xml), I noticed that `ProductCategory` is still in the XML even though it was removed in Xcode. The `ProductCategory` entry had the same `mappingnumber` value at 24 (the position in the mapping entity list) as `Account`, and I just had a slight suspicion that the duplicate entry in the XML might cause some issues in the migration process for certain devices.

- This PR removed `ProductCategory` entry from model version 26 to 27 mapping model XML
- A test case was added to migrate from model version 26 to 27 with some data (`Product`, `ProductCategory`, `Account`) populated

*: we can check the model version that the user's device was stuck on by comparing the `NSStoreModelVersionHashes` value. Lots of events shared the same `NSStoreModelVersionHashes` as that of model version 26.

## Testing

Please test migration from a model version earlier than v27 (e.g. from [release 3.9](https://github.com/woocommerce/woocommerce-ios/releases/tag/3.9)).

- Launch the app, logged in, at an earlier Core Data model version than v27
- Launch the app with the PR branch --> the app should run as expected, and feel free to try editing product categories

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
