### PR TITLE
Set transformer to `NSSecureUnarchiveFromData` for model versions 20-28 to fix warnings on iOS 13

### DIFF
--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 20.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 20.xcdatamodel/contents
@@ -203,7 +203,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -212,7 +212,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -226,7 +226,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -243,8 +243,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -259,7 +259,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 21.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 21.xcdatamodel/contents
@@ -232,7 +232,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -241,7 +241,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -255,7 +255,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -272,8 +272,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -288,7 +288,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 22.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 22.xcdatamodel/contents
@@ -233,7 +233,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -242,7 +242,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -256,7 +256,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -273,8 +273,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -289,7 +289,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 23.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 23.xcdatamodel/contents
@@ -239,7 +239,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -248,7 +248,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -262,7 +262,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -279,8 +279,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -296,7 +296,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 24.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 24.xcdatamodel/contents
@@ -239,7 +239,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -250,7 +250,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -264,7 +264,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -281,8 +281,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -299,7 +299,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 25.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 25.xcdatamodel/contents
@@ -239,7 +239,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -250,7 +250,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -264,7 +264,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -281,8 +281,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -299,7 +299,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 26.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 26.xcdatamodel/contents
@@ -239,7 +239,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -250,7 +250,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -264,7 +264,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -281,8 +281,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -299,7 +299,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 27.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 27.xcdatamodel/contents
@@ -239,7 +239,7 @@
         <attribute name="backordersKey" attributeType="String"/>
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -250,7 +250,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -264,7 +264,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -281,8 +281,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -299,7 +299,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 28.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 28.xcdatamodel/contents
@@ -240,7 +240,7 @@
         <attribute name="briefDescription" optional="YES" attributeType="String"/>
         <attribute name="buttonText" attributeType="String" defaultValueString=""/>
         <attribute name="catalogVisibilityKey" attributeType="String"/>
-        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -251,7 +251,7 @@
         <attribute name="externalURL" optional="YES" attributeType="String"/>
         <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" optional="YES" attributeType="String"/>
-        <attribute name="groupedProducts" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
@@ -265,7 +265,7 @@
         <attribute name="purchaseNote" optional="YES" attributeType="String"/>
         <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="regularPrice" optional="YES" attributeType="String"/>
-        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="salePrice" optional="YES" attributeType="String"/>
         <attribute name="shippingClass" optional="YES" attributeType="String"/>
@@ -282,8 +282,8 @@
         <attribute name="taxClass" optional="YES" attributeType="String"/>
         <attribute name="taxStatusKey" attributeType="String"/>
         <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
-        <attribute name="variations" optional="YES" attributeType="Transformable" customClassName="[Int64]"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="weight" optional="YES" attributeType="String"/>
         <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
@@ -300,7 +300,7 @@
     <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
         <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="options" optional="YES" attributeType="Transformable" customClassName="[String]"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -116,9 +116,9 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Arrange - step 2: populating data, migrating persistent store from model 26 to 27, then loading with model 27.
         let context = model26Container.viewContext
-        _ = insertAccount(to: context)
-        let product = insertProduct(to: context)
-        let productCategory = insertProductCategory(to: context)
+        _ = insertAccountWithRequiredProperties(to: context)
+        let product = insertProductWithRequiredProperties(to: context)
+        let productCategory = insertProductCategoryWithRequiredProperties(to: context)
         product.addToCategories([productCategory])
         context.saveIfNeeded()
 
@@ -152,11 +152,99 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         // Product categories should be deleted.
         XCTAssertEqual(model27Container.viewContext.countObjects(ofType: ProductCategory.self), 0)
     }
+
+    func testModel20To28MigrationWithTransformableAttributesPassed() throws {
+        // Arrange
+        let sourceModelURL = urlForModel(name: "Model 20")
+        let sourceModel = NSManagedObjectModel(contentsOf: sourceModelURL)!
+        let destinationModelURL = urlForModel(name: "Model 28")
+        let destinationModel = NSManagedObjectModel(contentsOf: destinationModelURL)!
+        let name = "WooCommerce"
+        let crashLogger = MockCrashLogger()
+        let coreDataManager = CoreDataManager(name: name, crashLogger: crashLogger)
+
+        // Destroys any pre-existing persistence store.
+        let psc = NSPersistentStoreCoordinator(managedObjectModel: coreDataManager.managedModel)
+        try? psc.destroyPersistentStore(at: coreDataManager.storeURL, ofType: NSSQLiteStoreType, options: nil)
+
+        // Action - step 1: loading persistence store with model 20
+        let sourceModelContainer = NSPersistentContainer(name: name, managedObjectModel: sourceModel)
+        sourceModelContainer.persistentStoreDescriptions = [coreDataManager.storeDescription]
+
+        var sourceModelLoadingError: Error?
+        waitForExpectation { expectation in
+            sourceModelContainer.loadPersistentStores { (storeDescription, error) in
+                sourceModelLoadingError = error
+                expectation.fulfill()
+            }
+        }
+
+        // Assert - step 1
+        XCTAssertNil(sourceModelLoadingError, "Migration error: \(String(describing: sourceModelLoadingError?.localizedDescription))")
+
+        // Arrange - step 2: populating data, migrating persistent store from model 20 to 28, then loading with model 28.
+        let context = sourceModelContainer.viewContext
+
+        let product = insertProductWithRequiredProperties(to: context)
+        // Populates transformable attributes.
+        let productCrossSellIDs: [Int64] = [630, 688]
+        let groupedProductIDs: [Int64] = [94, 134]
+        let productRelatedIDs: [Int64] = [270, 37]
+        let productUpsellIDs: [Int64] = [1126, 1216]
+        let productVariationIDs: [Int64] = [927, 1110]
+        product.crossSellIDs = productCrossSellIDs
+        product.groupedProducts = groupedProductIDs
+        product.relatedIDs = productRelatedIDs
+        product.upsellIDs = productUpsellIDs
+        product.variations = productVariationIDs
+
+        let productAttribute = insertProductAttributeWithRequiredProperties(to: context)
+        // Populates transformable attributes.
+        let attributeOptions = ["Woody", "Andy Panda"]
+        productAttribute.options = attributeOptions
+
+        product.addToAttributes(productAttribute)
+        context.saveIfNeeded()
+
+        XCTAssertEqual(context.countObjects(ofType: Product.self), 1)
+        XCTAssertEqual(context.countObjects(ofType: ProductAttribute.self), 1)
+
+        let destinationModelContainer = NSPersistentContainer(name: name, managedObjectModel: destinationModel)
+        destinationModelContainer.persistentStoreDescriptions = [coreDataManager.storeDescription]
+
+        // Action - step 2
+        let (migrateResult, migrationDebugMessages) = try! CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
+                                                                                                      storeType: NSSQLiteStoreType,
+                                                                                                      to: destinationModel,
+                                                                                                      using: allModelNames)
+        XCTAssertTrue(migrateResult, "Failed to migrate to model version 27: \(migrationDebugMessages)")
+
+        var destinationModelLoadingError: Error?
+        waitForExpectation { expectation in
+            destinationModelContainer.loadPersistentStores { (storeDescription, error) in
+                destinationModelLoadingError = error
+                expectation.fulfill()
+            }
+        }
+
+        // Assert - step 2
+        XCTAssertNil(destinationModelLoadingError, "Migration error: \(String(describing: destinationModelLoadingError?.localizedDescription))")
+
+        let persistedProduct = try XCTUnwrap(destinationModelContainer.viewContext.firstObject(ofType: Product.self))
+        XCTAssertEqual(persistedProduct.crossSellIDs, productCrossSellIDs)
+        XCTAssertEqual(persistedProduct.groupedProducts, groupedProductIDs)
+        XCTAssertEqual(persistedProduct.relatedIDs, productRelatedIDs)
+        XCTAssertEqual(persistedProduct.upsellIDs, productUpsellIDs)
+        XCTAssertEqual(persistedProduct.variations, productVariationIDs)
+
+        let persistedAttribute = try XCTUnwrap(destinationModelContainer.viewContext.firstObject(ofType: ProductAttribute.self))
+        XCTAssertEqual(persistedAttribute.options, attributeOptions)
+    }
 }
 
 /// Helpers for generating data in migration tests
 private extension CoreDataIterativeMigratorTests {
-    func insertAccount(to context: NSManagedObjectContext) -> Account {
+    func insertAccountWithRequiredProperties(to context: NSManagedObjectContext) -> Account {
         let account = context.insertNewObject(ofType: Account.self)
         // Populates the required attributes.
         account.userID = 17
@@ -164,7 +252,7 @@ private extension CoreDataIterativeMigratorTests {
         return account
     }
 
-    func insertProduct(to context: NSManagedObjectContext) -> Product {
+    func insertProductWithRequiredProperties(to context: NSManagedObjectContext) -> Product {
         let product = context.insertNewObject(ofType: Product.self)
         // Populates the required attributes.
         product.price = ""
@@ -195,12 +283,21 @@ private extension CoreDataIterativeMigratorTests {
         return product
     }
 
-    func insertProductCategory(to context: NSManagedObjectContext) -> ProductCategory {
+    func insertProductCategoryWithRequiredProperties(to context: NSManagedObjectContext) -> ProductCategory {
         let productCategory = context.insertNewObject(ofType: ProductCategory.self)
         // Populates the required attributes.
         productCategory.name = "testing"
         productCategory.slug = ""
         return productCategory
+    }
+
+    func insertProductAttributeWithRequiredProperties(to context: NSManagedObjectContext) -> ProductAttribute {
+        let productAttribute = context.insertNewObject(ofType: ProductAttribute.self)
+        // Populates the required attributes.
+        productAttribute.name = "woodpecker"
+        productAttribute.variation = true
+        productAttribute.visible = true
+        return productAttribute
     }
 }
 

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -85,7 +85,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Destroys any pre-existing persistence store.
         let psc = NSPersistentStoreCoordinator(managedObjectModel: coreDataManager.managedModel)
-        try? psc.destroyPersistentStore(at: coreDataManager.storeURL, ofType: NSSQLiteStoreType, options: nil)
+        try psc.destroyPersistentStore(at: coreDataManager.storeURL, ofType: NSSQLiteStoreType, options: nil)
 
         // Action - step 1: loading persistence store with model 26
         let model26Container = NSPersistentContainer(name: name, managedObjectModel: model26)
@@ -165,7 +165,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
 
         // Destroys any pre-existing persistence store.
         let psc = NSPersistentStoreCoordinator(managedObjectModel: coreDataManager.managedModel)
-        try? psc.destroyPersistentStore(at: coreDataManager.storeURL, ofType: NSSQLiteStoreType, options: nil)
+        try psc.destroyPersistentStore(at: coreDataManager.storeURL, ofType: NSSQLiteStoreType, options: nil)
 
         // Action - step 1: loading persistence store with model 20
         let sourceModelContainer = NSPersistentContainer(name: name, managedObjectModel: sourceModel)
@@ -180,7 +180,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         }
 
         // Assert - step 1
-        XCTAssertNil(sourceModelLoadingError, "Migration error: \(String(describing: sourceModelLoadingError?.localizedDescription))")
+        XCTAssertNil(sourceModelLoadingError, "Persistence store loading error: \(String(describing: sourceModelLoadingError?.localizedDescription))")
 
         // Arrange - step 2: populating data, migrating persistent store from model 20 to 28, then loading with model 28.
         let context = sourceModelContainer.viewContext
@@ -213,11 +213,11 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         destinationModelContainer.persistentStoreDescriptions = [coreDataManager.storeDescription]
 
         // Action - step 2
-        let (migrateResult, migrationDebugMessages) = try! CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
+        let (migrateResult, migrationDebugMessages) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
                                                                                                       storeType: NSSQLiteStoreType,
                                                                                                       to: destinationModel,
                                                                                                       using: allModelNames)
-        XCTAssertTrue(migrateResult, "Failed to migrate to model version 27: \(migrationDebugMessages)")
+        XCTAssertTrue(migrateResult, "Failed to migrate to model version 28: \(migrationDebugMessages)")
 
         var destinationModelLoadingError: Error?
         waitForExpectation { expectation in


### PR DESCRIPTION
Fixes #1372 

## Changes

Set the transformer to `NSSecureUnarchiveFromData` for `Transformable` attributes for model versions 20-28. For model versions below 20, the diffs are crazy large probably due to different Xcode versions so I didn't 

- Property ‘options’ on Entity ‘ProductAttribute’
- Property ‘crossSellIDs’ on Entity ‘Product’
- Property ‘groupedProducts’ on Entity ‘Product’
- Property ‘relatedIDs’ on Entity ‘Product’
- Property ‘upsellIDs’ on Entity ‘Product’
- Property ‘variations’ on Entity ‘Product’

## Testing

Please test migration from an earlier model version on an iOS 13 simulator/device, the earlier the better but not earlier than release 2.8.0.0 (model version 20), and make sure no warnings show up in the console about the transformer like in #1372. However, I saw a separate warning that I couldn't find a concrete fix for yet 😞

```
CoreData: annotation:  Failed to load optimized model at path '/Users/jaclynchen/Library/Developer/Xcode/DerivedData/WooCommerce-gyxkpbqewsthczdmcrmapoocxjsd/Build/Products/Debug-iphonesimulator/Storage.framework/WooCommerce.momd/Model 28.omo'
```

I've tested migrating from [release 3.9](https://github.com/woocommerce/woocommerce-ios/releases/tag/3.9) and [release 2.8](https://github.com/woocommerce/woocommerce-ios/releases/tag/2.8).

To build release 2.8:
- run `g checkout de299224ecddd3f7c7011e0a65325700db5706dd`
- run `bundle exec pod install`
- build the app from Xcode 11.1 (Zendesk used to be very sensitive to the Xcode version) onto an iOS 13.1 simulator

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
