### PR TITLE
Fixes UITests around stats and beta features

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -123,7 +123,10 @@ extension StoreStatsAndTopPerformersPeriodViewController {
 //
 extension StoreStatsAndTopPerformersPeriodViewController: IndicatorInfoProvider {
     func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
-        return IndicatorInfo(title: timeRange.tabTitle)
+        return IndicatorInfo(
+            title: timeRange.tabTitle,
+            accessibilityIdentifier: "period-data-" + timeRange.rawValue + "-tab"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -67,6 +67,7 @@ class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripViewContro
         /// Hide the ImageView:
         /// We don't use it, and if / when "Ghostified" produces a quite awful placeholder UI!
         cell.imageView.isHidden = true
+        cell.accessibilityIdentifier = indicatorInfo.accessibilityIdentifier
 
         /// Flip the cells back to their proper state for RTL languages.
         if traitCollection.layoutDirection == .rightToLeft {

--- a/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
+++ b/WooCommerce/WooCommerceScreenshots/WooCommerceScreenshots.swift
@@ -24,11 +24,6 @@ class WooCommerceScreenshots: XCTestCase {
             .proceedWith(password: ScreenshotCredentials.password)
             .continueWithSelectedSite()
 
-            // Enable Products
-            .openSettingsPane().openBetaFeatures()
-            .enableProducts()
-            .goBackToSettingsScreen().goBackToMyStore()
-
             // My Store
             .dismissTopBannerIfNeeded()
             .then { ($0 as! MyStoreScreen).periodStatsTable.switchToYearsTab() }

--- a/WooCommerce/WooCommerceUITests/Screens/MyStore/PeriodStatsTable.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/MyStore/PeriodStatsTable.swift
@@ -4,10 +4,10 @@ import XCTest
 final class PeriodStatsTable: BaseScreen {
 
     struct ElementStringIDs {
-        static let daysTab = "period-data-granularity-day-tab"
-        static let weeksTab = "period-data-granularity-week-tab"
-        static let monthsTab = "period-data-granularity-month-tab"
-        static let yearsTab = "period-data-granularity-year-tab"
+        static let daysTab = "period-data-today-tab"
+        static let weeksTab = "period-data-thisWeek-tab"
+        static let monthsTab = "period-data-thisMonth-tab"
+        static let yearsTab = "period-data-thisYear-tab"
     }
 
 

--- a/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
+++ b/WooCommerce/WooCommerceUITests/Screens/Settings/SettingsScreen.swift
@@ -7,26 +7,17 @@ final class SettingsScreen: BaseScreen {
         static let headlineLabel = "headline-label"
         static let bodyLabel = "body-label"
         static let logOutButton = "settings-log-out-button"
-        static let betaFeaturesButton = "settings-beta-features-button"
     }
 
     private let selectedSiteUrl = XCUIApplication().cells.staticTexts[ElementStringIDs.headlineLabel]
     private let selectedDisplayName = XCUIApplication().cells.staticTexts[ElementStringIDs.bodyLabel]
     private let logOutButton = XCUIApplication().cells[ElementStringIDs.logOutButton]
     private let logOutAlert = XCUIApplication().alerts.element(boundBy: 0)
-    private let betaFeaturesButton = XCUIApplication().cells[ElementStringIDs.betaFeaturesButton]
 
     init() {
-        super.init(element: betaFeaturesButton)
+        super.init(element: logOutButton)
 
         XCTAssert(logOutButton.waitForExistence(timeout: 3))
-        XCTAssert(betaFeaturesButton.waitForExistence(timeout: 3))
-    }
-
-    @discardableResult
-    func openBetaFeatures() -> BetaFeaturesScreen {
-        betaFeaturesButton.tap()
-        return BetaFeaturesScreen()
     }
 
     @discardableResult


### PR DESCRIPTION
# Why

Today, after merging #2467 and #2452 we noticed that some UITests began to fail. This happened because we forgot to update the UITests to reflect the new behavior of the project.

# How
- We removed code that was trying to open the beta features screen in tests. In `WooCommerceScreenshots` and `SettingsScreen`

- Updated `StoreStatsAndTopPerformersPeriodViewController` to asign the correct `accesibilityIdentifier` property to be found by UITests.

# Testing Steps 
- Run UITests

PS: ScreenshotTests currently compile and run but fail around the product screenshots.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
