### PR TITLE
Remove `fatalError` in case of persistent store backup failure and add more logging to store migration

### DIFF
--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -59,8 +59,7 @@ public class CoreDataManager: StorageManagerType {
                                                                 "backupError": error,
                                                                 "appState": UIApplication.shared.applicationState.rawValue,
                                                                 "migrationMessages": migrationDebugMessages],
-                                                   level: .fatal)
-                fatalError(message)
+                                                   level: .error)
             }
 
             /// Remove the old Store
@@ -74,8 +73,7 @@ public class CoreDataManager: StorageManagerType {
                                                                 "removeStoreError": error,
                                                                 "appState": UIApplication.shared.applicationState.rawValue,
                                                                 "migrationMessages": migrationDebugMessages],
-                                                   level: .fatal)
-                fatalError(message)
+                                                   level: .error)
             }
 
             /// Retry!


### PR DESCRIPTION
Part of #2371 

## Changes

Since we really see a flood of crashes on Sentry and mentions on App Store reviews, I think removing the `fatalError` when the app fails to back up the store (removing and copying the pre-existing store) would be a good first step. After checking the [crash events from release 4.5](https://sentry.io/organizations/a8c/issues/1711092978/events/?project=1458804&query=release%3A4.5%2A&statsPeriod=14d), it seems like the crashes weren't only migrating from model version 26 to 27 but also from 27 to 28. Now that we know lots of users couldn't get past the backup step, I think it'd be great to know whether the [retry of persistent store loading](https://github.com/woocommerce/woocommerce-ios/blob/8a982eb73f30057aa1fa55c2c0f6f6003f6b8d97/Storage/Storage/CoreData/CoreDataManager.swift#L83-L96) would work.

- This PR removed the `fatalError` when the app couldn't remove or copy the pre-existing persistent store when it failed to migrate for the first time. The errors that occurred in the backup step are then recorded in the log event where the app either recovers from the retry or not
- Added more logging to `CoreDataIterativeMigrator` on the migration step (including a similar backup step)

It'd still be great to understand why the migration fails in the first place. We'll continue monitoring the logs in the upcoming crash events to know more about the model versions and migration process, and see if the app could recover from the retry.

## Testing

I think just CI is sufficient, since we haven't got to reproduce the crash yet. Feel free to manually add a similar logging event, and run in WooCommerce Alpha target with "Release-Alpha" configuration to verify on Sentry. [Here](https://sentry.io/organizations/a8c/issues/1737817640/events/cc7d6d5941004b32845eb2f82120ce4f/?project=1458804&statsPeriod=14d)'s an example of a similar Sentry event that I added.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
