### PR TITLE
Improve CoreDataIterativeMigrator Testability

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
 		45E1862E2370450C009241F3 /* ShippingLine+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862D2370450C009241F3 /* ShippingLine+CoreDataClass.swift */; };
 		45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */; };
+		574B774C24AA87FA0042116F /* FileManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774B24AA87FA0042116F /* FileManagerProtocol.swift */; };
 		68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */; };
 		7028A41485A08AC748206184 /* Pods_Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */; };
 		7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */; };
@@ -177,6 +178,7 @@
 		45E1862D2370450C009241F3 /* ShippingLine+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+CoreDataClass.swift"; sourceTree = "<group>"; };
 		45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		574B774B24AA87FA0042116F /* FileManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerProtocol.swift; sourceTree = "<group>"; };
 		5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74159626224D5644003C21CF /* Model 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 13.xcdatamodel"; sourceTree = "<group>"; };
 		7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCoupon+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 				B505F6DF20BEEA8100BB1B69 /* StorageType.swift */,
 				D87F61522265AA230031A13B /* FileStorage.swift */,
 				02EAB6D62480A86D00FD873C /* CrashLogger.swift */,
+				574B774B24AA87FA0042116F /* FileManagerProtocol.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -804,6 +807,7 @@
 				74938EC9216FA9B200540BA1 /* OrderStatsItem+CoreDataProperties.swift in Sources */,
 				CE4FD44A2350EB7600A16B31 /* OrderItemTax+CoreDataProperties.swift in Sources */,
 				747453A02242C85E00E0B5EE /* ProductImage+CoreDataProperties.swift in Sources */,
+				574B774C24AA87FA0042116F /* FileManagerProtocol.swift in Sources */,
 				CE4FD44E2350EB7600A16B31 /* Refund+CoreDataProperties.swift in Sources */,
 				CE4FD44B2350EB7600A16B31 /* OrderItemTaxRefund+CoreDataClass.swift in Sources */,
 				B54CA5BB20A4BD2800F38CD1 /* NSManagedObject+Object.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		45E1862E2370450C009241F3 /* ShippingLine+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862D2370450C009241F3 /* ShippingLine+CoreDataClass.swift */; };
 		45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */; };
 		574B774C24AA87FA0042116F /* FileManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774B24AA87FA0042116F /* FileManagerProtocol.swift */; };
+		574B774E24AA883D0042116F /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774D24AA883D0042116F /* MockFileManager.swift */; };
 		574B775024AA897E0042116F /* FileManager+FileManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */; };
 		68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */; };
 		7028A41485A08AC748206184 /* Pods_Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */; };
@@ -180,6 +181,7 @@
 		45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		574B774B24AA87FA0042116F /* FileManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerProtocol.swift; sourceTree = "<group>"; };
+		574B774D24AA883D0042116F /* MockFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+FileManagerProtocol.swift"; sourceTree = "<group>"; };
 		5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74159626224D5644003C21CF /* Model 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 13.xcdatamodel"; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 			isa = PBXGroup;
 			children = (
 				02A098262480D160002F8C7A /* MockCrashLogger.swift */,
+				574B774D24AA883D0042116F /* MockFileManager.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -929,6 +932,7 @@
 				B54CA5C320A4BF6900F38CD1 /* NSManagedObjectContextStorageTests.swift in Sources */,
 				02A098272480D160002F8C7A /* MockCrashLogger.swift in Sources */,
 				B54CA5C720A4BFDC00F38CD1 /* DummyStack.swift in Sources */,
+				574B774E24AA883D0042116F /* MockFileManager.swift in Sources */,
 				02F25AE024A446E700092B06 /* XCTestCase+Wait.swift in Sources */,
 				B54CA5C220A4BF6900F38CD1 /* NSManagedObjectStorageTests.swift in Sources */,
 				D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		45E1862E2370450C009241F3 /* ShippingLine+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862D2370450C009241F3 /* ShippingLine+CoreDataClass.swift */; };
 		45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */; };
 		574B774C24AA87FA0042116F /* FileManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774B24AA87FA0042116F /* FileManagerProtocol.swift */; };
+		574B775024AA897E0042116F /* FileManager+FileManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */; };
 		68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */; };
 		7028A41485A08AC748206184 /* Pods_Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */; };
 		7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */; };
@@ -179,6 +180,7 @@
 		45E1862F23704519009241F3 /* ShippingLine+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StorageTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		574B774B24AA87FA0042116F /* FileManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerProtocol.swift; sourceTree = "<group>"; };
+		574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+FileManagerProtocol.swift"; sourceTree = "<group>"; };
 		5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74159626224D5644003C21CF /* Model 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 13.xcdatamodel"; sourceTree = "<group>"; };
 		7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCoupon+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 				B54CA5C820A4C17800F38CD1 /* NSObject+Storage.swift */,
 				B54CA5BA20A4BD2800F38CD1 /* NSManagedObject+Object.swift */,
 				B54CA5BC20A4BD3B00F38CD1 /* NSManagedObjectContext+Storage.swift */,
+				574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -837,6 +840,7 @@
 				023FA29723316A4D008C1769 /* ProductSearchResults+CoreDataClass.swift in Sources */,
 				D821645B2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataClass.swift in Sources */,
 				D821645C2239F5FC00F46F89 /* ShipmentTrackingProvider+CoreDataProperties.swift in Sources */,
+				574B775024AA897E0042116F /* FileManager+FileManagerProtocol.swift in Sources */,
 				7499FA45221C7A60004EC0B4 /* ShipmentTracking+CoreDataProperties.swift in Sources */,
 				B5FD111E21D4046E00560344 /* OrderSearchResults+CoreDataProperties.swift in Sources */,
 				7471A515216CF0FE00219F7E /* SiteVisitStatsItem+CoreDataProperties.swift in Sources */,

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -4,7 +4,7 @@ import CoreData
 /// CoreDataIterativeMigrator: Migrates through a series of models to allow for users to skip app versions without risk.
 /// This was derived from ALIterativeMigrator originally used in the WordPress app.
 ///
-public class CoreDataIterativeMigrator {
+class CoreDataIterativeMigrator {
 
     /// Migrates a store to a particular model using the list of models to do it iteratively, if required.
     ///

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -18,8 +18,10 @@ public struct CoreDataIterativeMigrator {
     ///
     /// - Throws: A whole bunch of crap is possible to be thrown between Core Data and FileManager.
     ///
-    static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String])
-        throws -> (success: Bool, debugMessages: [String]) {
+    static func iterativeMigrate(sourceStore: URL,
+                                 storeType: String,
+                                 to targetModel: NSManagedObjectModel,
+                                 using modelNames: [String]) throws -> (success: Bool, debugMessages: [String]) {
         // If the persistent store does not exist at the given URL,
         // assume that it hasn't yet been created and return success immediately.
         guard FileManager.default.fileExists(atPath: sourceStore.path) == true else {

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -4,7 +4,7 @@ import CoreData
 /// CoreDataIterativeMigrator: Migrates through a series of models to allow for users to skip app versions without risk.
 /// This was derived from ALIterativeMigrator originally used in the WordPress app.
 ///
-class CoreDataIterativeMigrator {
+final class CoreDataIterativeMigrator {
 
     /// Migrates a store to a particular model using the list of models to do it iteratively, if required.
     ///

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -6,6 +6,12 @@ import CoreData
 ///
 final class CoreDataIterativeMigrator {
 
+    private let fileManager: FileManagerProtocol
+
+    init(fileManager: FileManagerProtocol = FileManager.default) {
+        self.fileManager = fileManager
+    }
+
     /// Migrates a store to a particular model using the list of models to do it iteratively, if required.
     ///
     /// - Parameters:
@@ -24,7 +30,7 @@ final class CoreDataIterativeMigrator {
                           using modelNames: [String]) throws -> (success: Bool, debugMessages: [String]) {
         // If the persistent store does not exist at the given URL,
         // assume that it hasn't yet been created and return success immediately.
-        guard FileManager.default.fileExists(atPath: sourceStore.path) == true else {
+        guard fileManager.fileExists(atPath: sourceStore.path) == true else {
             return (true, [])
         }
 
@@ -130,7 +136,6 @@ private extension CoreDataIterativeMigrator {
     /// Build a temporary path to write the migrated store.
     ///
     func createTemporaryFolder(at storeURL: URL) -> URL {
-        let fileManager = FileManager.default
         let tempDestinationURL = storeURL.deletingLastPathComponent().appendingPathComponent("migration").appendingPathComponent(storeURL.lastPathComponent)
         try? fileManager.removeItem(at: tempDestinationURL.deletingLastPathComponent())
         try? fileManager.createDirectory(at: tempDestinationURL.deletingLastPathComponent(), withIntermediateDirectories: false, attributes: nil)
@@ -141,7 +146,6 @@ private extension CoreDataIterativeMigrator {
     /// Move the original source store to a backup location.
     ///
     func makeBackup(at storeURL: URL) throws -> URL {
-        let fileManager = FileManager.default
         let backupURL = storeURL.deletingLastPathComponent().appendingPathComponent("backup")
         try? fileManager.removeItem(at: backupURL)
         try? fileManager.createDirectory(atPath: backupURL.path, withIntermediateDirectories: false, attributes: nil)
@@ -166,7 +170,6 @@ private extension CoreDataIterativeMigrator {
     ///
     func copyMigratedOverOriginal(from tempDestinationURL: URL, to storeURL: URL) throws {
         do {
-            let fileManager = FileManager.default
             let files = try fileManager.contentsOfDirectory(atPath: tempDestinationURL.deletingLastPathComponent().path)
             try files.forEach { (file) in
                 if file.hasPrefix(tempDestinationURL.lastPathComponent) {
@@ -186,7 +189,6 @@ private extension CoreDataIterativeMigrator {
     ///
     func deleteBackupCopies(at backupURL: URL) throws {
         do {
-            let fileManager = FileManager.default
             let files = try fileManager.contentsOfDirectory(atPath: backupURL.path)
             try files.forEach { (file) in
                 let fullPath = URL(fileURLWithPath: backupURL.path).appendingPathComponent(file).path

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -18,10 +18,10 @@ final class CoreDataIterativeMigrator {
     ///
     /// - Throws: A whole bunch of crap is possible to be thrown between Core Data and FileManager.
     ///
-    static func iterativeMigrate(sourceStore: URL,
-                                 storeType: String,
-                                 to targetModel: NSManagedObjectModel,
-                                 using modelNames: [String]) throws -> (success: Bool, debugMessages: [String]) {
+    func iterativeMigrate(sourceStore: URL,
+                          storeType: String,
+                          to targetModel: NSManagedObjectModel,
+                          using modelNames: [String]) throws -> (success: Bool, debugMessages: [String]) {
         // If the persistent store does not exist at the given URL,
         // assume that it hasn't yet been created and return success immediately.
         guard FileManager.default.fileExists(atPath: sourceStore.path) == true else {
@@ -129,7 +129,7 @@ private extension CoreDataIterativeMigrator {
 
     /// Build a temporary path to write the migrated store.
     ///
-    static func createTemporaryFolder(at storeURL: URL) -> URL {
+    func createTemporaryFolder(at storeURL: URL) -> URL {
         let fileManager = FileManager.default
         let tempDestinationURL = storeURL.deletingLastPathComponent().appendingPathComponent("migration").appendingPathComponent(storeURL.lastPathComponent)
         try? fileManager.removeItem(at: tempDestinationURL.deletingLastPathComponent())
@@ -140,7 +140,7 @@ private extension CoreDataIterativeMigrator {
 
     /// Move the original source store to a backup location.
     ///
-    static func makeBackup(at storeURL: URL) throws -> URL {
+    func makeBackup(at storeURL: URL) throws -> URL {
         let fileManager = FileManager.default
         let backupURL = storeURL.deletingLastPathComponent().appendingPathComponent("backup")
         try? fileManager.removeItem(at: backupURL)
@@ -164,7 +164,7 @@ private extension CoreDataIterativeMigrator {
 
     /// Copy migrated over the original files
     ///
-    static func copyMigratedOverOriginal(from tempDestinationURL: URL, to storeURL: URL) throws {
+    func copyMigratedOverOriginal(from tempDestinationURL: URL, to storeURL: URL) throws {
         do {
             let fileManager = FileManager.default
             let files = try fileManager.contentsOfDirectory(atPath: tempDestinationURL.deletingLastPathComponent().path)
@@ -184,7 +184,7 @@ private extension CoreDataIterativeMigrator {
 
     /// Delete backup copies of the original file before migration
     ///
-    static func deleteBackupCopies(at backupURL: URL) throws {
+    func deleteBackupCopies(at backupURL: URL) throws {
         do {
             let fileManager = FileManager.default
             let files = try fileManager.contentsOfDirectory(atPath: backupURL.path)
@@ -204,7 +204,7 @@ private extension CoreDataIterativeMigrator {
 //
 private extension CoreDataIterativeMigrator {
 
-    static func migrateStore(at url: URL,
+    func migrateStore(at url: URL,
                              storeType: String,
                              fromModel: NSManagedObjectModel,
                              toModel: NSManagedObjectModel,
@@ -237,7 +237,7 @@ private extension CoreDataIterativeMigrator {
         return (true, nil)
     }
 
-    static func metadataForPersistentStore(storeType: String, at url: URL) throws -> [String: Any]? {
+    func metadataForPersistentStore(storeType: String, at url: URL) throws -> [String: Any]? {
 
         guard let sourceMetadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: url, options: nil) else {
             let description = "Failed to find source metadata for store: \(url)"
@@ -247,7 +247,7 @@ private extension CoreDataIterativeMigrator {
         return sourceMetadata
     }
 
-    static func model(for metadata: [String: Any]) throws -> NSManagedObjectModel? {
+    func model(for metadata: [String: Any]) throws -> NSManagedObjectModel? {
         let bundle = Bundle(for: CoreDataManager.self)
         guard let sourceModel = NSManagedObjectModel.mergedModel(from: [bundle], forStoreMetadata: metadata) else {
             let description = "Failed to find source model for metadata: \(metadata)"
@@ -257,7 +257,7 @@ private extension CoreDataIterativeMigrator {
         return sourceModel
     }
 
-    static func models(for names: [String]) throws -> [NSManagedObjectModel] {
+    func models(for names: [String]) throws -> [NSManagedObjectModel] {
         let models = try names.map { (name) -> NSManagedObjectModel in
             guard let url = urlForModel(name: name, in: nil),
                 let model = NSManagedObjectModel(contentsOf: url) else {
@@ -271,7 +271,7 @@ private extension CoreDataIterativeMigrator {
         return models
     }
 
-    static func urlForModel(name: String, in directory: String?) -> URL? {
+    func urlForModel(name: String, in directory: String?) -> URL? {
         let bundle = Bundle(for: CoreDataManager.self)
         var url = bundle.url(forResource: name, withExtension: "mom", subdirectory: directory)
 

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -4,7 +4,7 @@ import CoreData
 /// CoreDataIterativeMigrator: Migrates through a series of models to allow for users to skip app versions without risk.
 /// This was derived from ALIterativeMigrator originally used in the WordPress app.
 ///
-public struct CoreDataIterativeMigrator {
+public class CoreDataIterativeMigrator {
 
     /// Migrates a store to a particular model using the list of models to do it iteratively, if required.
     ///

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -199,10 +199,11 @@ public class CoreDataManager: StorageManagerType {
         }
 
         do {
-            let (migrateResult, migrationDebugMessages) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL,
-                                                                                                         storeType: NSSQLiteStoreType,
-                                                                                                         to: objectModel,
-                                                                                                         using: sortedKeys)
+            let iterativeMigrator = CoreDataIterativeMigrator()
+            let (migrateResult, migrationDebugMessages) = try iterativeMigrator.iterativeMigrate(sourceStore: storeURL,
+                                                                                                 storeType: NSSQLiteStoreType,
+                                                                                                 to: objectModel,
+                                                                                                 using: sortedKeys)
             debugMessages += migrationDebugMessages
             if migrateResult == false {
                 let migrationFailureMessage = "☠️ [CoreDataManager] Unable to migrate store."

--- a/Storage/Storage/Extensions/FileManager+FileManagerProtocol.swift
+++ b/Storage/Storage/Extensions/FileManager+FileManagerProtocol.swift
@@ -1,0 +1,10 @@
+
+import Foundation
+
+// Make `Foundation.FileManager` conform to `FileManagerProtocol`.
+//
+// No other changes are necessary.
+
+extension FileManager: FileManagerProtocol {
+
+}

--- a/Storage/Storage/Protocols/FileManagerProtocol.swift
+++ b/Storage/Storage/Protocols/FileManagerProtocol.swift
@@ -1,0 +1,30 @@
+
+import Foundation
+
+/// A protocol representing `Foundation.FileManager`.
+///
+/// The methods in here are existing methods of `Foundation.FileManager`. Having a `protocol`
+/// just allows us to use a mock `FileManager` in unit tests.
+///
+/// If there are methods not defined in here, feel free to add them.
+///
+protocol FileManagerProtocol {
+
+    func fileExists(atPath path: String) -> Bool
+
+    func removeItem(at URL: URL) throws
+
+    func removeItem(atPath path: String) throws
+
+    func createDirectory(at url: URL,
+                         withIntermediateDirectories createIntermediates: Bool,
+                         attributes: [FileAttributeKey: Any]?) throws
+
+    func createDirectory(atPath path: String,
+                         withIntermediateDirectories createIntermediates: Bool,
+                         attributes: [FileAttributeKey: Any]?) throws
+
+    func contentsOfDirectory(atPath path: String) throws -> [String]
+
+    func moveItem(atPath srcPath: String, toPath dstPath: String) throws
+}

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -9,11 +9,13 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
                                  "Model 21", "Model 22", "Model 23", "Model 24", "Model 25", "Model 26", "Model 27", "Model 28"]
 
     override func setUp() {
+        super.setUp()
         DDLog.add(DDOSLogger.sharedInstance)
     }
 
     override func tearDown() {
         DDLog.remove(DDOSLogger.sharedInstance)
+        super.tearDown()
     }
 
     func testModel0to10MigrationFails() throws {

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -239,11 +239,11 @@ private extension CoreDataIterativeMigratorTests {
         return URL(fileURLWithPath: path)
     }
 
-    private func managedObjectModel(for modelName: String) throws -> NSManagedObjectModel {
+    func managedObjectModel(for modelName: String) throws -> NSManagedObjectModel {
         try XCTUnwrap(NSManagedObjectModel(contentsOf: urlForModel(name: modelName)))
     }
 
-    private func urlForModel(name: String) -> URL {
+    func urlForModel(name: String) -> URL {
 
         let bundle = Bundle(for: CoreDataManager.self)
         guard let path = bundle.paths(forResourcesOfType: "momd", inDirectory: nil).first,
@@ -254,7 +254,7 @@ private extension CoreDataIterativeMigratorTests {
         return url
     }
 
-    private func urlForStore(withName: String, deleteIfExists: Bool = false) -> URL {
+    func urlForStore(withName: String, deleteIfExists: Bool = false) -> URL {
         let storeURL = documentsDirectory.appendingPathComponent(withName)
 
         if deleteIfExists {

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -57,10 +57,11 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         model = try XCTUnwrap(NSManagedObjectModel(contentsOf: model10URL))
 
         do {
-            let (result, _) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: storeURL,
-                                                                             storeType: NSSQLiteStoreType,
-                                                                             to: model!,
-                                                                             using: allModelNames)
+            let iterativeMigrator = CoreDataIterativeMigrator()
+            let (result, _) = try iterativeMigrator.iterativeMigrate(sourceStore: storeURL,
+                                                                     storeType: NSSQLiteStoreType,
+                                                                     to: model!,
+                                                                     using: allModelNames)
             XCTAssertTrue(result)
         } catch {
             XCTFail("Error when attempting to migrate: \(error)")
@@ -130,10 +131,11 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         model27Container.persistentStoreDescriptions = [coreDataManager.storeDescription]
 
         // Action - step 2
-        let (migrateResult, migrationDebugMessages) = try! CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
-                                                                                                      storeType: NSSQLiteStoreType,
-                                                                                                      to: model27,
-                                                                                                      using: allModelNames)
+        let iterativeMigrator = CoreDataIterativeMigrator()
+        let (migrateResult, migrationDebugMessages) = try iterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
+                                                                                             storeType: NSSQLiteStoreType,
+                                                                                             to: model27,
+                                                                                             using: allModelNames)
         XCTAssertTrue(migrateResult, "Failed to migrate to model version 27: \(migrationDebugMessages)")
 
         var model27LoadingError: Error?

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -209,7 +209,12 @@ private extension CoreDataIterativeMigratorTests {
 }
 
 /// Helpers for the Core Data migration tests
-extension CoreDataIterativeMigratorTests {
+private extension CoreDataIterativeMigratorTests {
+
+    var documentsDirectory: URL {
+        let path = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).last!
+        return URL(fileURLWithPath: path)
+    }
     private func urlForModel(name: String) -> URL {
 
         let bundle = Bundle(for: CoreDataManager.self)
@@ -222,14 +227,13 @@ extension CoreDataIterativeMigratorTests {
     }
 
     private func urlForStore(withName: String, deleteIfExists: Bool = false) -> URL {
-        let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).last!
-        let storeURL = URL(fileURLWithPath: documentsDirectory).appendingPathComponent(withName)
+        let storeURL = documentsDirectory.appendingPathComponent(withName)
 
         if deleteIfExists {
             try? FileManager.default.removeItem(at: storeURL)
         }
 
-        try? FileManager.default.createDirectory(at: URL(fileURLWithPath: documentsDirectory), withIntermediateDirectories: true, attributes: nil)
+        try? FileManager.default.createDirectory(at: documentsDirectory, withIntermediateDirectories: true, attributes: nil)
 
         return storeURL
     }

--- a/Storage/StorageTests/Mocks/MockFileManager.swift
+++ b/Storage/StorageTests/Mocks/MockFileManager.swift
@@ -5,7 +5,15 @@ import XCTest
 
 @testable import Storage
 
-final class MockFileManager: FileManagerProtocol {
+/// A mock of `FileManager` via `FileManagerProtocol`.
+///
+final class MockFileManager {
+
+}
+
+// MARK: - FileManagerProtocol Conformance
+
+extension MockFileManager: FileManagerProtocol {
 
     func fileExists(atPath path: String) -> Bool {
         XCTFail("There are no mocked return values for this method.")

--- a/Storage/StorageTests/Mocks/MockFileManager.swift
+++ b/Storage/StorageTests/Mocks/MockFileManager.swift
@@ -9,6 +9,20 @@ import XCTest
 ///
 final class MockFileManager {
 
+    private typealias FilePath = String
+
+    private var fileExistsResults = [FilePath: Bool]()
+
+    /// Invocation count of all mocked methods.
+    private(set) var allMethodsInvocationCount: Int = 0
+
+    /// Invocation count of `fileExists(atPath)`.
+    private(set) var fileExistsInvocationCount: Int = 0
+
+    /// Set the return value if `fileExists(atPath:)` is called.
+    func whenCheckingIfFileExists(atPath path: String, thenReturn result: Bool) {
+        fileExistsResults[path] = result
+    }
 }
 
 // MARK: - FileManagerProtocol Conformance
@@ -16,36 +30,44 @@ final class MockFileManager {
 extension MockFileManager: FileManagerProtocol {
 
     func fileExists(atPath path: String) -> Bool {
-        XCTFail("There are no mocked return values for this method.")
-        return false
+        allMethodsInvocationCount += 1
+        fileExistsInvocationCount += 1
+
+        guard let result = fileExistsResults[path] else {
+            XCTFail("There are no mocked return values for `fileExists` with path \(path).")
+            return false
+        }
+
+        return result
     }
 
     func removeItem(at URL: URL) throws {
-
+        allMethodsInvocationCount += 1
     }
 
     func removeItem(atPath path: String) throws {
-
+        allMethodsInvocationCount += 1
     }
 
     func createDirectory(at url: URL,
                          withIntermediateDirectories createIntermediates: Bool,
                          attributes: [FileAttributeKey: Any]?) throws {
-
+        allMethodsInvocationCount += 1
     }
 
     func createDirectory(atPath path: String,
                          withIntermediateDirectories createIntermediates: Bool,
                          attributes: [FileAttributeKey: Any]?) throws {
-
+        allMethodsInvocationCount += 1
     }
 
     func contentsOfDirectory(atPath path: String) throws -> [String] {
+        allMethodsInvocationCount += 1
         XCTFail("There are no mocked return values for this method.")
         return []
     }
 
     func moveItem(atPath srcPath: String, toPath dstPath: String) throws {
-
+        allMethodsInvocationCount += 1
     }
 }

--- a/Storage/StorageTests/Mocks/MockFileManager.swift
+++ b/Storage/StorageTests/Mocks/MockFileManager.swift
@@ -1,0 +1,43 @@
+
+import Foundation
+
+import XCTest
+
+@testable import Storage
+
+final class MockFileManager: FileManagerProtocol {
+
+    func fileExists(atPath path: String) -> Bool {
+        XCTFail("There are no mocked return values for this method.")
+        return false
+    }
+
+    func removeItem(at URL: URL) throws {
+
+    }
+
+    func removeItem(atPath path: String) throws {
+
+    }
+
+    func createDirectory(at url: URL,
+                         withIntermediateDirectories createIntermediates: Bool,
+                         attributes: [FileAttributeKey: Any]?) throws {
+
+    }
+
+    func createDirectory(atPath path: String,
+                         withIntermediateDirectories createIntermediates: Bool,
+                         attributes: [FileAttributeKey: Any]?) throws {
+
+    }
+
+    func contentsOfDirectory(atPath path: String) throws -> [String] {
+        XCTFail("There are no mocked return values for this method.")
+        return []
+    }
+
+    func moveItem(atPath srcPath: String, toPath dstPath: String) throws {
+
+    }
+}


### PR DESCRIPTION
These are just some small improvements that will possibly help with #2371 and #2473. 

~~🛑 This should be targeting `develop` but I wanted to use @jaclync's changes in #2481 to avoid merge conflicts.~~
⚠️ This is now targeting `develop` but waiting for #2481 to be merged in `develop` before merging this.

## Changes

### No Static Methods

I changed all the methods in `CoreDataIterativeMigrator` so it no longer uses static methods. This allowed mocking of the `FileManager` and possibly more dependencies in the future:

https://github.com/woocommerce/woocommerce-ios/blob/b8b416c0c1672c33ca2807857a6fa0568d872bac/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift#L7-L13

It's now also a `class`. 

### Mocked `FileManager`

I created a [`FileManagerProtocol`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2371-iterative-migrator-improvements/Storage/Storage/Protocols/FileManagerProtocol.swift) `protocol` which defines the methods of `Foundation.FileManager`. The protocol is then used in `CoreDataIterativeMigrator` instead of directly referencing `FileManager.default`. 

There is a companion [`MockFileManager`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2371-iterative-migrator-improvements/Storage/StorageTests/Mocks/MockFileManager.swift) which allows mocking but **not extending** `FileManager`. This mock uses the same pattern as [`MockProductsRemote`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2371-iterative-migrator-improvements/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift) and others.  

### Additional Test

I added a single test for now to make use of all the changes. 

https://github.com/woocommerce/woocommerce-ios/blob/b8b416c0c1672c33ca2807857a6fa0568d872bac/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift#L21-L42

We probably should add more before tackling #2473.  

## Testing

Please run a migration to test that this did not cause any regressions. 

1. `git checkout 3.9`
2. Run and log in. 
3. `git checkout -t origin/issue/2371-iterative-migrator-improvements` (this PR's branch)
4. Run. This should perform a migration from Model 27 to 28. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

