### PR TITLE
Fix CoreDataIterativeMigratorTests Build Faliure

### DIFF
--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -240,10 +240,11 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         destinationModelContainer.persistentStoreDescriptions = [coreDataManager.storeDescription]
 
         // Action - step 2
-        let (migrateResult, migrationDebugMessages) = try CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
-                                                                                                      storeType: NSSQLiteStoreType,
-                                                                                                      to: destinationModel,
-                                                                                                      using: allModelNames)
+        let iterativeMigrator = CoreDataIterativeMigrator()
+        let (migrateResult, migrationDebugMessages) = try iterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
+                                                                                             storeType: NSSQLiteStoreType,
+                                                                                             to: destinationModel,
+                                                                                             using: allModelNames)
         XCTAssertTrue(migrateResult, "Failed to migrate to model version 28: \(migrationDebugMessages)")
 
         var destinationModelLoadingError: Error?


### PR DESCRIPTION
Fixes the `develop` build failure caused by a merge conflict-ish after merging #2485. 

## Testing

The CI passing should be enough. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

