### PR TITLE
Add custom paging support to `SyncingCoordinator`

### DIFF
--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Wait.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Wait.swift
@@ -15,9 +15,11 @@ extension XCTestCase {
     /// ```
     ///
     func waitForExpectation(description: String? = nil,
+                            count: Int = 1,
                             timeout: TimeInterval = Constants.expectationTimeout,
                             _ block: (XCTestExpectation) -> ()) {
         let exp = expectation(description: description ?? "")
+        exp.expectedFulfillmentCount = count
         block(exp)
         wait(for: [exp], timeout: timeout)
     }


### PR DESCRIPTION
Prerequisite for #2199 

## Changes

More details in p91TBi-30X-p2

This custom paging behavior for syncing is required for #2199 since we exclude certain products from the paginated product list.

- Added `SyncingCoordinatorCustomPagingDelegate` as an optional delegate to `SyncingCoordinator` to manually determine the timing for syncing the next page. This only changed how the last visible index is calculated, and not triggering syncing when the delegate's `hasSyncedLastPage` is `true`.
- Added test cases for `SyncingCoordinator` when `SyncingCoordinatorCustomPagingDelegate` is set

## Testing

This PR is not expected to introduce any changes on all the `SyncingCoordinator` use cases, but it'd be nice to sanity check on the more prominent screens that use `SyncingCoordinator`:

- Go to the orders tab --> the infinite scroll should work correctly for the order list on both "processing" and "all" tabs, as well as the search results
- Go to the products tab --> the infinite scroll should work correctly for the product list, as well as the search results
- Go to the reviews tab --> the infinite scroll should work correctly for the review list

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
