### PR TITLE
Update the product banner to match M2 designs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -26,10 +26,10 @@ struct ProductsTopBannerFactory {
 private extension ProductsTopBannerFactory {
     enum Strings {
         static let title =
-            NSLocalizedString("Limited editing available",
+            NSLocalizedString("New editing options available",
                               comment: "The title of the Work In Progress top banner on the Products tab.")
         static let info =
-            NSLocalizedString("We've added editing functionality to simple products. Keep an eye out for more options soon!",
+            NSLocalizedString("We've added more editing functionalities to products! You can now update images, see previews and share your products.",
                               comment: "The info of the Work In Progress top banner on the Products tab.")
     }
 }


### PR DESCRIPTION
Fixes #2495 

Updated the copy for the Products banner to match the design for Milestone 2 release. There's a chance that this won't get translated in time for the release in a week.

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-03 at 13 44 40](https://user-images.githubusercontent.com/373903/86492466-d56e9f80-bd33-11ea-89ae-e4b32eed043a.png)

cc: @loremattei @jkmassel @oguzkocer We'll need to do another beta release with this change.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
