### PR TITLE
Fix: failing test on `develop` about CoreDataIterativeMigrator

### DIFF
--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -237,10 +237,10 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         model29Container.persistentStoreDescriptions = [coreDataManager.storeDescription]
 
         // Action - step 2
-        let (migrateResult, migrationDebugMessages) = try! CoreDataIterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
-                                                                                                      storeType: NSSQLiteStoreType,
-                                                                                                      to: model29,
-                                                                                                      using: allModelNames)
+    let iterativeMigrator = CoreDataIterativeMigrator()
+    let (migrateResult, migrationDebugMessages) = try iterativeMigrator.iterativeMigrate(sourceStore: coreDataManager.storeURL,
+                                                                                         storeType: NSSQLiteStoreType,
+                                                                                         to: model29, using: allModelNames)
         XCTAssertTrue(migrateResult, "Failed to migrate to model version 29: \(migrationDebugMessages)")
 
         var model29LoadingError: Error?


### PR DESCRIPTION
On `develop` branch, we have a failing test on `CoreDataIterativeMigrator` after that I merged [this PR](https://github.com/woocommerce/woocommerce-ios/pull/2486). Something changed before the PR was merged, so I need to update how the `iterativeMigrate:` method works.

## Testing 
- Look at the code
- CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
