### PR TITLE
Update TopBannerView to be expandable and actionable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -9,7 +9,7 @@ final class DashboardTopBannerFactory {
                                            infoText: DeprecatedStatsConstants.info,
                                            icon: DeprecatedStatsConstants.icon,
                                            isExpanded: true,
-                                           expandedStateChangeHandler: nil)
+                                           topButton: .chevron(handler: nil))
         return TopBannerView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -16,7 +16,7 @@ struct ProductsTopBannerFactory {
                                                infoText: infoText,
                                                icon: .workInProgressBanner,
                                                isExpanded: isExpanded,
-                                               expandedStateChangeHandler: expandedStateChangeHandler)
+                                               topButton: .chevron(handler: expandedStateChangeHandler))
             let topBannerView = TopBannerView(viewModel: viewModel)
             topBannerView.translatesAutoresizingMaskIntoConstraints = false
             onCompletion(topBannerView)

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -3,30 +3,41 @@ import UIKit
 /// View model for `TopBannerView`.
 ///
 struct TopBannerViewModel {
+
+    enum TopButtonType {
+        case chevron(handler: (() -> Void)?)
+        case dismiss(handler: (() -> Void)?)
+
+        var handler: (() -> Void)? {
+            switch self {
+            case let .chevron(handler), let .dismiss(handler):
+                return handler
+            }
+        }
+    }
+
     let title: String?
     let infoText: String?
     let icon: UIImage?
     let actionButtonTitle: String?
     let isExpanded: Bool
     let actionHandler: (() -> Void)?
-    let dismissHandler: (() -> Void)?
-    let expandedStateChangeHandler: (() -> Void)?
+    let topButton: TopButtonType
 
     /// Used when the top banner is not actionable.
     ///
     init(title: String?,
          infoText: String?,
          icon: UIImage?,
-         isExpanded: Bool = true,
-         expandedStateChangeHandler: (() -> Void)?) {
+         isExpanded: Bool,
+         topButton: TopButtonType) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
         self.isExpanded = isExpanded
         self.actionButtonTitle = nil
         self.actionHandler = nil
-        self.dismissHandler = nil
-        self.expandedStateChangeHandler = expandedStateChangeHandler
+        self.topButton = topButton
     }
 
     /// Used when the top banner is actionable.
@@ -37,14 +48,13 @@ struct TopBannerViewModel {
          actionButtonTitle: String,
          isExpanded: Bool = true,
          actionHandler: @escaping () -> Void,
-         dismissHandler: @escaping () -> Void) {
+         topButton: TopButtonType) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
         self.actionButtonTitle = actionButtonTitle
         self.isExpanded = isExpanded
         self.actionHandler = actionHandler
-        self.dismissHandler = dismissHandler
-        self.expandedStateChangeHandler = nil
+        self.topButton = topButton
     }
 }


### PR DESCRIPTION
Refers to https://github.com/woocommerce/woocommerce-ios/issues/2464

# Why

The new deprecated stats banner is supposed to be expandable and actionable which is something our current `TopBannerView` does not support.

This PR aims to add such functionality to be able to dismiss the banner.
The implementation of that feature can be found [here](https://github.com/woocommerce/woocommerce-ios/pull/2503)

# How

1. Add a new enum to `TopBannerViewModel` to indicate which type of button we want with it's respective handler.
```swift
enum TopButtonType {
  case chevron(handler: (() -> Void)?)
  case dismiss(handler: (() -> Void)?)
}
```

This allows us to remove the previous `onDismiss` and `onExpandedStateChange` parameters on `TopBannerViewModel`

2. Reorganize the internal view layout to be able to hide the action button when the user wants to collapse the banner.

*PS:*  I've decided to not go into a deeper refactor on this view as it could go out of scope.

# GIF
![correct-banners](https://user-images.githubusercontent.com/562080/87310215-47d54180-c4e3-11ea-84a6-bb29cd531fde.gif)

# Testing steps
Run the app and see that the current banners(stats and products) behave correctly.
- To test the stats banner you need to manage a store running an older WC version or disable the wc-admin using [a plugin](https://wordpress.org/plugins/disable-dashboard-for-woocommerce/)