### PR TITLE
Allow stats banner to be dismissed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -4,11 +4,13 @@ import UIKit
 /// Generates top banner view that is shown at the top of Dashboard UI.
 ///
 final class DashboardTopBannerFactory {
-    static func deprecatedStatsBannerView() -> TopBannerView {
+    static func deprecatedStatsBannerView(actionHandler: @escaping () -> Void) -> TopBannerView {
         let viewModel = TopBannerViewModel(title: DeprecatedStatsConstants.title,
                                            infoText: DeprecatedStatsConstants.info,
                                            icon: DeprecatedStatsConstants.icon,
+                                           actionButtonTitle: DeprecatedStatsConstants.actionTitle,
                                            isExpanded: true,
+                                           actionHandler: actionHandler,
                                            topButton: .chevron(handler: nil))
         return TopBannerView(viewModel: viewModel)
     }
@@ -21,6 +23,7 @@ private extension DashboardTopBannerFactory {
             "We’ve rolled out improvements to our analytics. Upgrade to WooCommerce 4.0 or above or install WooCommerce Admin plugin to keep seeing " +
             "your stats after September 1, 2020.",
             comment: "Banner caption in my store when the stats will be deprecated")
+        static let actionTitle = NSLocalizedString("Remind me later", comment: "Banner action button text in my store when stats will be deprecated")
         static let icon = UIImage.syncImage
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -14,7 +14,7 @@ protocol DashboardUI: UIViewController {
     /// Called when the default account was updated
     func defaultAccountDidUpdate()
 
-    /// Called when the user has decided to not be bother with the deprecated stats banner right now.
+    /// Called when the user has decided to not be bothered with the deprecated stats banner right now.
     func remindStatsUpgradeLater()
 
     /// Reloads data in Dashboard

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -14,6 +14,9 @@ protocol DashboardUI: UIViewController {
     /// Called when the default account was updated
     func defaultAccountDidUpdate()
 
+    /// Called when the user has decided to not be bother with the deprecated stats banner right now.
+    func remindStatsUpgradeLater()
+
     /// Reloads data in Dashboard
     ///
     /// - Parameter completion: called when Dashboard data reload finishes
@@ -88,7 +91,9 @@ private extension DashboardUIFactory {
             if let topBannerPresenter = updatedDashboardUI as? TopBannerPresenter {
                 switch statsVersion {
                 case .v3:
-                    let topBannerView = DashboardTopBannerFactory.deprecatedStatsBannerView()
+                    let topBannerView = DashboardTopBannerFactory.deprecatedStatsBannerView {
+                        updatedDashboardUI.remindStatsUpgradeLater()
+                    }
                     topBannerPresenter.hideTopBanner(animated: false)
                     topBannerPresenter.showTopBanner(topBannerView)
                 case .v4:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -8,7 +8,7 @@ class DashboardStatsV3ViewController: UIViewController {
     var onPullToRefresh: () -> Void = {}
 
     /// Prevent stats banner to be shown, useful when the user has opted out of the banner for this session
-    var preventStatsBannerToBeShown = false
+    private var preventStatsBannerToBeShown = false
 
     /// MARK: TopBannerPresenter
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DashboardStatsV3ViewController.swift
@@ -7,6 +7,9 @@ class DashboardStatsV3ViewController: UIViewController {
 
     var onPullToRefresh: () -> Void = {}
 
+    /// Prevent stats banner to be shown, useful when the user has opted out of the banner for this session
+    var preventStatsBannerToBeShown = false
+
     /// MARK: TopBannerPresenter
 
     private(set) var topBannerView: UIView?
@@ -107,10 +110,19 @@ extension DashboardStatsV3ViewController: DashboardUI {
             }
         }
     }
+
+    func remindStatsUpgradeLater() {
+        hideTopBanner(animated: true)
+        preventStatsBannerToBeShown = true
+    }
 }
 
 extension DashboardStatsV3ViewController: TopBannerPresenter {
     func showTopBanner(_ topBannerView: UIView) {
+        guard preventStatsBannerToBeShown == false else {
+            return
+        }
+
         self.topBannerView = topBannerView
 
         topBannerView.isHidden = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -86,6 +86,10 @@ extension StoreStatsAndTopPerformersViewController: DashboardUI {
             completion()
         }
     }
+
+    func remindStatsUpgradeLater() {
+        // No op as this VC represents the latest stats version to date.
+    }
 }
 
 // MARK: - Syncing Data


### PR DESCRIPTION
Depends on https://github.com/woocommerce/woocommerce-ios/pull/2502
Fixes https://github.com/woocommerce/woocommerce-ios/issues/2464

# Why
Users should be able to dismiss the deprecated stats banner and be reminded about it in the next app launch.

# How
- Leverage on the changes made on #2502 to be able to have an actionable and expandable stats banner

- Track the "remind me later" state in a simple in-memory variable `preventStatsBannerToBeShown` in `DashboardStatsV3ViewController.swift`. Since that VC would be removed soon (After Sept 1st) I decided that this simpler approach is good enough. But let me know if you think there is a better/robust way to handle this.

# GIF
![remind-me-later](https://user-images.githubusercontent.com/562080/87320804-02b80c00-c4f1-11ea-8994-b23507a67bf6.gif)


# Testing Steps
- Launch the app with an old woo commerce store or by [disabling the wc-admin plugin](https://wordpress.org/plugins/disable-dashboard-for-woocommerce/)
- See that the banner can be dismissed and it won't show again until the app is re-launched.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.