### PR TITLE
Add ResultsController.safeObject(at:)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -38,29 +38,29 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     /// Renders the specified Order ViewModel
     ///
+    /// If the `viewModel` is not given, then the UI will be set to empty.
+    ///
     func configureCell(viewModel: OrderDetailsViewModel?, orderStatus: OrderStatus?) {
-        if let viewModel = viewModel {
-            titleLabel.text = title(for: viewModel.order)
-            totalLabel.text = viewModel.totalFriendlyString
-            dateCreatedLabel.text = viewModel.formattedDateCreated
-        } else {
-            titleLabel.text = nil
-            totalLabel.text = nil
-            dateCreatedLabel.text = nil
+        guard let viewModel = viewModel else {
+            resetLabels()
+            return
         }
+
+        titleLabel.text = title(for: viewModel.order)
+        totalLabel.text = viewModel.totalFriendlyString
+        dateCreatedLabel.text = viewModel.formattedDateCreated
 
         if let orderStatus = orderStatus {
             paymentStatusLabel.applyStyle(for: orderStatus.status)
             paymentStatusLabel.text = orderStatus.name
-        } else if let statusKey = viewModel?.order.statusKey {
+        } else {
+            let statusKey = viewModel.order.statusKey
+
             // There are unsupported extensions with even more statuses available.
             // So let's use the order.statusKey to display those as slugs.
             let statusEnum = OrderStatusEnum(rawValue: statusKey)
             paymentStatusLabel.applyStyle(for: statusEnum)
             paymentStatusLabel.text = statusKey
-        } else {
-            paymentStatusLabel.applyStyle(for: .failed)
-            paymentStatusLabel.text = nil
         }
     }
 
@@ -103,6 +103,17 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 // MARK: - Private
 //
 private extension OrderTableViewCell {
+
+    /// Reset the UI to a "no data" state.
+    ///
+    func resetLabels() {
+        titleLabel.text = nil
+        totalLabel.text = nil
+        dateCreatedLabel.text = nil
+        paymentStatusLabel.applyStyle(for: .failed)
+        paymentStatusLabel.text = nil
+    }
+
     /// Preserves the current Payment BG Color
     ///
     func preserveLabelColors(action: () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -52,17 +52,15 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         if let orderStatus = orderStatus {
             paymentStatusLabel.applyStyle(for: orderStatus.status)
             paymentStatusLabel.text = orderStatus.name
-        } else {
+        } else if let statusKey = viewModel?.order.statusKey {
             // There are unsupported extensions with even more statuses available.
             // So let's use the order.statusKey to display those as slugs.
-            if let statusKey = viewModel?.order.statusKey {
-                let statusEnum = OrderStatusEnum(rawValue: statusKey)
-                paymentStatusLabel.applyStyle(for: statusEnum)
-                paymentStatusLabel.text = statusKey
-            } else {
-                paymentStatusLabel.applyStyle(for: .failed)
-                paymentStatusLabel.text = nil
-            }
+            let statusEnum = OrderStatusEnum(rawValue: statusKey)
+            paymentStatusLabel.applyStyle(for: statusEnum)
+            paymentStatusLabel.text = statusKey
+        } else {
+            paymentStatusLabel.applyStyle(for: .failed)
+            paymentStatusLabel.text = nil
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -54,10 +54,9 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
             paymentStatusLabel.applyStyle(for: orderStatus.status)
             paymentStatusLabel.text = orderStatus.name
         } else {
-            let statusKey = viewModel.order.statusKey
-
             // There are unsupported extensions with even more statuses available.
             // So let's use the order.statusKey to display those as slugs.
+            let statusKey = viewModel.order.statusKey
             let statusEnum = OrderStatusEnum(rawValue: statusKey)
             paymentStatusLabel.applyStyle(for: statusEnum)
             paymentStatusLabel.text = statusKey

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -38,10 +38,16 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     /// Renders the specified Order ViewModel
     ///
-    func configureCell(viewModel: OrderDetailsViewModel, orderStatus: OrderStatus?) {
-        titleLabel.text = title(for: viewModel.order)
-        totalLabel.text = viewModel.totalFriendlyString
-        dateCreatedLabel.text = viewModel.formattedDateCreated
+    func configureCell(viewModel: OrderDetailsViewModel?, orderStatus: OrderStatus?) {
+        if let viewModel = viewModel {
+            titleLabel.text = title(for: viewModel.order)
+            totalLabel.text = viewModel.totalFriendlyString
+            dateCreatedLabel.text = viewModel.formattedDateCreated
+        } else {
+            titleLabel.text = nil
+            totalLabel.text = nil
+            dateCreatedLabel.text = nil
+        }
 
         if let orderStatus = orderStatus {
             paymentStatusLabel.applyStyle(for: orderStatus.status)
@@ -49,10 +55,14 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         } else {
             // There are unsupported extensions with even more statuses available.
             // So let's use the order.statusKey to display those as slugs.
-            let statusKey = viewModel.order.statusKey
-            let statusEnum = OrderStatusEnum(rawValue: statusKey)
-            paymentStatusLabel.applyStyle(for: statusEnum)
-            paymentStatusLabel.text = viewModel.order.statusKey
+            if let statusKey = viewModel?.order.statusKey {
+                let statusEnum = OrderStatusEnum(rawValue: statusKey)
+                paymentStatusLabel.applyStyle(for: statusEnum)
+                paymentStatusLabel.text = statusKey
+            } else {
+                paymentStatusLabel.applyStyle(for: .failed)
+                paymentStatusLabel.text = nil
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -462,7 +462,7 @@ extension OrdersViewController: UITableViewDataSource {
         }
 
         let detailsViewModel = viewModel.detailsViewModel(at: indexPath)
-        let orderStatus = lookUpOrderStatus(for: detailsViewModel.order)
+        let orderStatus = lookUpOrderStatus(for: detailsViewModel?.order)
         cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
         cell.layoutIfNeeded()
         return cell
@@ -496,15 +496,20 @@ extension OrdersViewController: UITableViewDelegate {
             return
         }
 
+        guard let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath) else {
+            return
+        }
+
         guard let orderDetailsVC = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
             assertionFailure("Expected OrderDetailsViewController to be instantiated")
             return
         }
-        let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath)
+
         orderDetailsVC.viewModel = orderDetailsViewModel
 
-        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": orderDetailsViewModel.order.orderID,
-        "status": orderDetailsViewModel.order.statusKey])
+        let order = orderDetailsViewModel.order
+        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
+                                                                    "status": order.statusKey])
 
         navigationController?.pushViewController(orderDetailsVC, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -435,7 +435,11 @@ private extension OrdersViewController {
 private extension OrdersViewController {
 
     func lookUpOrderStatus(for order: Order?) -> OrderStatus? {
-        for orderStatus in currentSiteStatuses where orderStatus.slug == order?.statusKey {
+        guard let order = order else {
+            return nil
+        }
+
+        for orderStatus in currentSiteStatuses where orderStatus.slug == order.statusKey {
             return orderStatus
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -434,8 +434,8 @@ private extension OrdersViewController {
 //
 private extension OrdersViewController {
 
-    func lookUpOrderStatus(for order: Order) -> OrderStatus? {
-        for orderStatus in currentSiteStatuses where orderStatus.slug == order.statusKey {
+    func lookUpOrderStatus(for order: Order?) -> OrderStatus? {
+        for orderStatus in currentSiteStatuses where orderStatus.slug == order?.statusKey {
             return orderStatus
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -270,8 +270,10 @@ extension OrdersViewModel {
     /// TODO Ideally we should have a very tiny ViewModel for the cell instead of
     /// `OrderDetailsViewModel` which is used in `OrderDetailsViewController` too.
     ///
-    func detailsViewModel(at indexPath: IndexPath) -> OrderDetailsViewModel {
-        let order = resultsController.object(at: indexPath)
+    func detailsViewModel(at indexPath: IndexPath) -> OrderDetailsViewModel? {
+        guard let order = resultsController.safeObject(at: indexPath) else {
+            return nil
+        }
 
         return OrderDetailsViewModel(order: order)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -415,8 +415,8 @@ private extension OrdersViewModel {
     ///
     var fetchedOrders: [Yosemite.Order] {
         (0..<numberOfSections).flatMap { section in
-            (0..<numberOfRows(in: section)).map { row in
-                detailsViewModel(at: IndexPath(row: row, section: section)).order
+            (0..<numberOfRows(in: section)).compactMap { row in
+                detailsViewModel(at: IndexPath(row: row, section: section))?.order
             }
         }
     }

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -125,13 +125,30 @@ public class ResultsController<T: ResultsControllerMutableType> {
 
     /// Returns the fetched object at a given indexPath.
     ///
+    /// Prefer to use `safeObject(at:)` instead.
+    ///
     public func object(at indexPath: IndexPath) -> T.ReadOnlyType {
         return controller.object(at: indexPath).toReadOnly()
     }
 
-    #warning("TODO")
+    /// Returns the fetched object at the given `indexPath`. Returns `nil` if the `indexPath`
+    /// does not exist.
+    ///
     public func safeObject(at indexPath: IndexPath) -> T.ReadOnlyType? {
-        object(at: indexPath)
+        guard !isEmpty else {
+            return nil
+        }
+        guard let sections = controller.sections, sections.count > indexPath.section else {
+            return nil
+        }
+
+        let section = sections[indexPath.section]
+
+        guard section.numberOfObjects > indexPath.row else {
+            return nil
+        }
+
+        return controller.object(at: indexPath).toReadOnly()
     }
 
     /// Returns the Plain ObjectIndex corresponding to a given IndexPath. You can use this index to map the

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -129,6 +129,11 @@ public class ResultsController<T: ResultsControllerMutableType> {
         return controller.object(at: indexPath).toReadOnly()
     }
 
+    #warning("TODO")
+    public func safeObject(at indexPath: IndexPath) -> T.ReadOnlyType? {
+        object(at: indexPath)
+    }
+
     /// Returns the Plain ObjectIndex corresponding to a given IndexPath. You can use this index to map the
     /// `fetchedObject[index]` collection.
     ///

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -310,4 +310,16 @@ final class ResultsControllerTests: XCTestCase {
             }
         }
     }
+
+    func testWhenNoFetchPerformedThenSafeObjectAtIndexPathDoesNotCrash() {
+        // Given
+        let resultsController = ResultsController<Storage.Account>(viewStorage: viewStorage, sortedBy: [sampleSortDescriptor])
+
+        // When
+        let object = resultsController.safeObject(at: IndexPath(row: 0, section: 0))
+
+        // Then
+        // If we reached this line, that means that it did not crash.
+        XCTAssertNil(object)
+    }
 }


### PR DESCRIPTION
Fixes #2241. 

My attempts at fixing #2241 didn't work. Even though [we're calling `performFetch` on `viewDidLoad`](https://github.com/woocommerce/woocommerce-ios/blob/10eb6cf847c11da1179dab35fb04f7854610271a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift#L118), the crash log still indicate that somehow, the user is able to _select_ something before `performFetch` is called.

I could not reproduce the crash but we can pinpoint that the crash happens when [`NSFetchedResultsController.object(at:)` is accessed](https://github.com/woocommerce/woocommerce-ios/blob/10eb6cf847c11da1179dab35fb04f7854610271a/Yosemite/Yosemite/Tools/ResultsController.swift#L129).

<img src="https://user-images.githubusercontent.com/198826/87362543-2ba9c280-c52c-11ea-9d0a-f3c8c89f2d7e.png" width="520">

https://github.com/woocommerce/woocommerce-ios/blob/10eb6cf847c11da1179dab35fb04f7854610271a/Yosemite/Yosemite/Tools/ResultsController.swift#L126-L130

## Solution

I added a safer version of `object(at:)` that can return `nil` in these conditions:

- `performFetch` was not called
- the `IndexPath` is invalid

I added test cases to prove its resilience. 

https://github.com/woocommerce/woocommerce-ios/blob/2c3adfeb26793a49f64c6a33e06b6817c75eddb4/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift#L314-L324

I then used this new method in `OrdersViewModel` which is used by `OrdersViewController`, the source of the crash. 

https://github.com/woocommerce/woocommerce-ios/blob/2c3adfeb26793a49f64c6a33e06b6817c75eddb4/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L273-L279

## Testing

1. In `OrdersViewController.viewDidLoad`, add this line after  `configureGhostableTableView()`:

    ```swift
        self.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
    ```
2. Run the app
3. Navigate to Orders
4. Confirm that the app did not crash.

The same steps will make the app crash with the same exception when using `develop`.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

