### PR TITLE
Edit Product: Tags Cell and appearance logic

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -53,6 +53,12 @@ extension UIImage {
         return UIImage.gridicon(.folder).imageFlippedForRightToLeftLayoutDirection()
     }
 
+    /// Product tags Icon
+    ///
+    static var tagsIcon: UIImage {
+        return UIImage.gridicon(.tag).imageFlippedForRightToLeftLayoutDirection()
+    }
+
     /// Add Image icon
     ///
     static var addImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactory.swift
@@ -9,6 +9,7 @@ enum ProductFormEditAction {
     case inventorySettings
     case shippingSettings
     case categories
+    case tags
     case briefDescription
     // Affiliate products only
     case sku
@@ -79,12 +80,14 @@ private extension ProductFormActionsFactory {
         let shouldShowShippingSettingsRow = product.isShippingEnabled
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
+        let shouldShowTagsRow = isEditProductsRelease3Enabled
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
             shouldShowShippingSettingsRow ? .shippingSettings: nil,
             .inventorySettings,
             shouldShowCategoriesRow ? .categories: nil,
+            shouldShowTagsRow ? .tags: nil,
             shouldShowBriefDescriptionRow ? .briefDescription: nil
         ]
         return actions.compactMap { $0 }
@@ -93,12 +96,14 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForAffiliateProduct() -> [ProductFormEditAction] {
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
+        let shouldShowTagsRow = isEditProductsRelease3Enabled
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
             .externalURL,
             .sku,
             shouldShowCategoriesRow ? .categories: nil,
+            shouldShowTagsRow ? .tags: nil,
             shouldShowBriefDescriptionRow ? .briefDescription: nil
         ]
         return actions.compactMap { $0 }
@@ -107,11 +112,13 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForGroupedProduct() -> [ProductFormEditAction] {
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
+        let shouldShowTagsRow = isEditProductsRelease3Enabled
 
         let actions: [ProductFormEditAction?] = [
             .groupedProducts,
             .sku,
             shouldShowCategoriesRow ? .categories: nil,
+            shouldShowTagsRow ? .tags: nil,
             shouldShowBriefDescriptionRow ? .briefDescription: nil
         ]
         return actions.compactMap { $0 }
@@ -136,6 +143,8 @@ private extension ProductFormActionsFactory {
                 product.dimensions.height.isNotEmpty || product.dimensions.width.isNotEmpty || product.dimensions.length.isNotEmpty
         case .categories:
             return product.categories.isNotEmpty
+        case .tags:
+            return product.tags.isNotEmpty
         case .briefDescription:
             return product.briefDescription.isNilOrEmpty == false
         // Affiliate products only.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormBottomSheetAction.swift
@@ -6,6 +6,7 @@ enum ProductFormBottomSheetAction {
     case editInventorySettings
     case editShippingSettings
     case editCategories
+    case editTags
     case editBriefDescription
     case editSKU
 
@@ -17,6 +18,8 @@ enum ProductFormBottomSheetAction {
             self = .editShippingSettings
         case .categories:
             self = .editCategories
+        case .tags:
+            self = .editTags
         case .briefDescription:
             self = .editBriefDescription
         case .sku:
@@ -39,6 +42,9 @@ extension ProductFormBottomSheetAction {
         case .editCategories:
             return NSLocalizedString("Categories",
                                      comment: "Title of the product form bottom sheet action for editing categories.")
+        case .editTags:
+            return NSLocalizedString("Tags",
+                                     comment: "Title of the product form bottom sheet action for editing tags.")
         case .editBriefDescription:
             return NSLocalizedString("Short description",
                                      comment: "Title of the product form bottom sheet action for editing short description.")
@@ -59,6 +65,9 @@ extension ProductFormBottomSheetAction {
         case .editCategories:
             return NSLocalizedString("Organise your products into related groups",
                                      comment: "Subtitle of the product form bottom sheet action for editing categories.")
+        case .editTags:
+            return NSLocalizedString("Make your products easier to find with tags",
+                                     comment: "Subtitle of the product form bottom sheet action for editing tags.")
         case .editBriefDescription:
             return NSLocalizedString("A brief excerpt about your product",
                                      comment: "Subtitle of the product form bottom sheet action for editing short description.")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -54,6 +54,8 @@ private extension DefaultProductFormTableViewModel {
                 return .inventory(viewModel: inventorySettingsRow(product: product))
             case .categories:
                 return .categories(viewModel: categoriesRow(product: product))
+            case .tags:
+                return .tags(viewModel: tagsRow(product: product))
             case .briefDescription:
                 return .briefDescription(viewModel: briefDescriptionRow(product: product))
             case .externalURL:
@@ -189,6 +191,13 @@ private extension DefaultProductFormTableViewModel {
         return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details)
     }
 
+    func tagsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.categoriesIcon
+        let title = Constants.tagsTitle
+        let details = product.tagsDescription() ?? Constants.tagsPlaceholder
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details)
+    }
+
     func briefDescriptionRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.briefDescriptionImage
         let title = Constants.briefDescriptionTitle
@@ -259,6 +268,8 @@ private extension DefaultProductFormTableViewModel {
                                                              comment: "Title of the Shipping Settings row on Product main screen")
         static let categoriesTitle = NSLocalizedString("Categories",
                                                        comment: "Title of the Categories row on Product main screen")
+        static let tagsTitle = NSLocalizedString("Tags",
+                                                 comment: "Title of the Tags row on Product main screen")
         static let briefDescriptionTitle = NSLocalizedString("Short description",
                                                              comment: "Title of the Short Description row on Product main screen")
         static let skuTitle = NSLocalizedString("SKU",
@@ -309,6 +320,9 @@ private extension DefaultProductFormTableViewModel {
         // Categories
         static let categoriesPlaceholder = NSLocalizedString("Uncategorized",
                                                              comment: "Placeholder of the Product Categories row on Product main screen")
+        // Tags
+        static let tagsPlaceholder = NSLocalizedString("No tags",
+                                                       comment: "Placeholder of the Product Tags row on Product main screen")
 
         // Grouped products
         static let singularGroupedProductFormat = NSLocalizedString("%ld product",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -192,7 +192,7 @@ private extension DefaultProductFormTableViewModel {
     }
 
     func tagsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
-        let icon = UIImage.categoriesIcon
+        let icon = UIImage.tagsIcon
         let title = Constants.tagsTitle
         let details = product.tagsDescription() ?? Constants.tagsPlaceholder
         return ProductFormSection.SettingsRow.ViewModel(icon: icon, title: title, details: details)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -43,7 +43,7 @@ extension Product {
             return nil
         }
 
-        let tagsNames = tags.map { $0.name.capitalized }
+        let tagsNames = tags.map { $0.name }
         if #available(iOS 13.0, *) {
             let formatter = ListFormatter()
             formatter.locale = locale

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -34,4 +34,22 @@ extension Product {
             return categoriesNames.joined(separator: ", ")
         }
     }
+
+    /// Returns a comma separated string with each tags names.
+    /// Returns `nil` if the product doesn't have any associated tag
+    /// iOS 13+ set a specific locale on to properly format the list with the `ListFormatter` class
+    func tagsDescription(using locale: Locale = .autoupdatingCurrent) -> String? {
+        guard tags.isNotEmpty else {
+            return nil
+        }
+
+        let tagsNames = tags.map { $0.name.capitalized }
+        if #available(iOS 13.0, *) {
+            let formatter = ListFormatter()
+            formatter.locale = locale
+            return formatter.string(from: tagsNames)
+        } else {
+            return tagsNames.joined(separator: ", ")
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -52,7 +52,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
 extension ProductFormSection.SettingsRow: ReusableTableRow {
     var cellTypes: [UITableViewCell.Type] {
         switch self {
-        case .price, .inventory, .shipping, .categories, .briefDescription, .externalURL, .sku, .groupedProducts:
+        case .price, .inventory, .shipping, .categories, .tags, .briefDescription, .externalURL, .sku, .groupedProducts:
             return [ImageAndTitleAndTextTableViewCell.self]
         }
     }
@@ -63,7 +63,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
 
     private var cellType: UITableViewCell.Type {
         switch self {
-        case .price, .inventory, .shipping, .categories, .briefDescription, .externalURL, .sku, .groupedProducts:
+        case .price, .inventory, .shipping, .categories, .tags, .briefDescription, .externalURL, .sku, .groupedProducts:
             return ImageAndTitleAndTextTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -163,7 +163,7 @@ private extension ProductFormTableViewDataSource {
             fatalError()
         }
         switch row {
-        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel), .categories(let viewModel),
+        case .price(let viewModel), .inventory(let viewModel), .shipping(let viewModel), .categories(let viewModel), .tags(let viewModel),
              .briefDescription(let viewModel), .externalURL(let viewModel), .sku(let viewModel), .groupedProducts(let viewModel):
             configureSettings(cell: cell, viewModel: viewModel)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -16,6 +16,7 @@ enum ProductFormSection {
         case shipping(viewModel: ViewModel)
         case inventory(viewModel: ViewModel)
         case categories(viewModel: ViewModel)
+        case tags(viewModel: ViewModel)
         case briefDescription(viewModel: ViewModel)
         case externalURL(viewModel: ViewModel)
         case sku(viewModel: ViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -282,6 +282,8 @@ private extension ProductFormViewController {
                                                                             self?.editShippingSettings()
                                                                         case .editCategories:
                                                                             self?.editCategories()
+                                                                        case .editTags:
+                                                                            self?.editTags()
                                                                         case .editBriefDescription:
                                                                             self?.editBriefDescription()
                                                                         case .editSKU:
@@ -534,6 +536,9 @@ extension ProductFormViewController: UITableViewDelegate {
             case .categories:
                 // TODO-2000 Edit Product M3 analytics
                 editCategories()
+            case .tags:
+                // TODO-2081 Edit Product M3 analytics
+                editTags()
             case .briefDescription:
                 ServiceLocator.analytics.track(.productDetailViewShortDescriptionTapped)
                 editBriefDescription()
@@ -826,6 +831,19 @@ private extension ProductFormViewController {
             return
         }
         viewModel.updateProductCategories(categories)
+    }
+}
+
+// MARK: Action - Edit Product Tags
+//
+
+private extension ProductFormViewController {
+    func editTags() {
+        //TODO-2081: add action
+    }
+
+    func onEditTagsCompletion(tags: [ProductTag]) {
+        //TODO-2081: manage completion in editTags()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -534,20 +534,20 @@ extension ProductFormViewController: UITableViewDelegate {
                 ServiceLocator.analytics.track(.productDetailViewInventorySettingsTapped)
                 editInventorySettings()
             case .categories:
-                // TODO-2000 Edit Product M3 analytics
+                // TODO-2509 Edit Product M3 analytics
                 editCategories()
             case .tags:
-                // TODO-2081 Edit Product M3 analytics
+                // TODO-2509 Edit Product M3 analytics
                 editTags()
             case .briefDescription:
                 ServiceLocator.analytics.track(.productDetailViewShortDescriptionTapped)
                 editBriefDescription()
             case .externalURL:
-                // TODO-2000 Edit Product M3 analytics
+                // TODO-2509 Edit Product M3 analytics
                 editExternalLink()
                 break
             case .sku:
-                // TODO-2000 Edit Product M3 analytics
+                // TODO-2509 Edit Product M3 analytics
                 editSKU()
                 break
             case .groupedProducts:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -172,6 +172,10 @@ extension ProductFormViewModel {
         product = product.copy(categories: categories)
     }
 
+    func updateProductTags(_ tags: [ProductTag]) {
+        product = product.copy(tags: tags)
+    }
+
     func updateBriefDescription(_ briefDescription: String) {
         product = product.copy(briefDescription: briefDescription)
     }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -267,6 +267,15 @@ final class IconsTests: XCTestCase {
         XCTAssertEqual(categoriesIcon.size, Gridicon.defaultSize)
     }
 
+    func testTagsIconIsNotNil() {
+        XCTAssertNotNil(UIImage.tagsIcon)
+    }
+
+    func testTagsIconHasDefaultSize() {
+        let tagsIcon = UIImage.tagsIcon
+        XCTAssertEqual(tagsIcon.size, Gridicon.defaultSize)
+    }
+
     func testSyncIconIsNotNil() {
         XCTAssertNotNil(UIImage.syncImage)
     }

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -40,6 +40,7 @@ final class MockProduct {
                  slug: String = "book-the-green-room",
                  menuOrder: Int = 0,
                  categories: [ProductCategory] = [],
+                 tags: [ProductTag] = [],
                  images: [ProductImage] = []) -> Product {
 
     return Product(siteID: testSiteID,
@@ -96,7 +97,7 @@ final class MockProduct {
                    parentID: 0,
                    purchaseNote: "Thank you!",
                    categories: categories,
-                   tags: [],
+                   tags: tags,
                    images: images,
                    attributes: [],
                    defaultAttributes: [],

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -125,7 +125,11 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings, .editInventorySettings, .editCategories, .editTags, .editBriefDescription]
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings,
+                                                                          .editInventorySettings,
+                                                                          .editCategories,
+                                                                          .editTags,
+                                                                          .editBriefDescription]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -125,7 +125,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings, .editInventorySettings, .editCategories, .editBriefDescription]
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings, .editInventorySettings, .editCategories, .editTags, .editBriefDescription]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
@@ -142,7 +142,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editBriefDescription]
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editBriefDescription]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
@@ -159,7 +159,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editBriefDescription]
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editBriefDescription]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
@@ -167,20 +167,23 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
 
 private extension ProductFormActionsFactory_NonEmptyBottomSheetActionsTests {
     enum Fixtures {
-        // downloadable: false, virtual: false, missing inventory/shipping/categories/brief description
+        // downloadable: false, virtual: false, missing inventory/shipping/categories/tags/brief description
         static let physicalProduct = MockProduct().product(downloadable: false, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
                                                            dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
                                                            virtual: false,
-                                                           categories: [])
-        // downloadable: false, virtual: true, missing inventory/shipping/categories/brief description
+                                                           categories: [],
+                                                           tags: [])
+        // downloadable: false, virtual: true, missing inventory/shipping/categories/tags/brief description
         static let virtualProduct = MockProduct().product(downloadable: false, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
                                                           dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
                                                           virtual: true,
-                                                          categories: [])
-        // downloadable: true, virtual: true, missing inventory/shipping/categories/brief description
+                                                          categories: [],
+                                                          tags: [])
+        // downloadable: true, virtual: true, missing inventory/shipping/categories/tags/brief description
         static let downloadableProduct = MockProduct().product(downloadable: true, briefDescription: "", manageStock: true, sku: nil, stockQuantity: nil,
                                                                dimensions: ProductDimensions(length: "", width: "", height: ""), weight: nil,
                                                                virtual: true,
-                                                               categories: [])
+                                                               categories: [],
+                                                               tags: [])
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -20,7 +20,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .shippingSettings, .inventorySettings, .categories, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .shippingSettings, .inventorySettings, .categories, .tags, .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -40,7 +40,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .shippingSettings, .inventorySettings, .categories, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .shippingSettings, .inventorySettings, .categories, .tags, .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -60,7 +60,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .inventorySettings, .categories, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .inventorySettings, .categories, .tags, .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -80,7 +80,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .inventorySettings, .categories, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .inventorySettings, .categories, .tags, .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -103,7 +103,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .externalURL]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editBriefDescription]
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editBriefDescription]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
@@ -123,7 +123,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editBriefDescription]
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editBriefDescription]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 }
@@ -137,37 +137,45 @@ private extension ProductFormActionsFactory_EditProductsM3Tests {
                                         src: "https://photo.jpg",
                                         name: "Tshirt",
                                         alt: "")
-        // downloadable: false, virtual: false, with inventory/shipping/categories/brief description
+        static let tag = ProductTag(siteID: 123, tagID: 1, name: "", slug: "")
+        // downloadable: false, virtual: false, with inventory/shipping/categories/tags/brief description
         static let physicalSimpleProductWithoutImages = MockProduct().product(downloadable: false, briefDescription: "desc", productType: .simple,
                                                                               manageStock: true, sku: "uks", stockQuantity: nil,
                                                                               dimensions: ProductDimensions(length: "", width: "", height: ""), weight: "2",
                                                                               virtual: false,
-                                                                              categories: [category], images: [])
-        // downloadable: false, virtual: true, with inventory/shipping/categories/brief description
+                                                                              categories: [category],
+                                                                              tags: [tag],
+                                                                              images: [])
+        // downloadable: false, virtual: true, with inventory/shipping/categories/tags/brief description
         static let physicalSimpleProductWithImages = MockProduct().product(downloadable: false, briefDescription: "desc", productType: .simple,
                                                                               manageStock: true, sku: "uks", stockQuantity: nil,
                                                                               dimensions: ProductDimensions(length: "", width: "", height: ""), weight: "2",
                                                                               virtual: false,
-                                                                              categories: [category], images: [image])
-        // downloadable: false, virtual: true, with inventory/shipping/categories/brief description
+                                                                              categories: [category],
+                                                                              tags: [tag],
+                                                                              images: [image])
+        // downloadable: false, virtual: true, with inventory/shipping/categories/tags/brief description
         static let virtualSimpleProduct = MockProduct().product(downloadable: false, briefDescription: "desc", productType: .simple,
                                                                 manageStock: true, sku: "uks", stockQuantity: nil,
                                                                 dimensions: ProductDimensions(length: "", width: "", height: ""), weight: "2",
                                                                 virtual: true,
-                                                                categories: [category])
+                                                                categories: [category],
+                                                                tags: [tag])
         // downloadable: true, virtual: true, missing inventory/shipping/categories/brief description
         static let downloadableSimpleProduct = MockProduct().product(downloadable: true, briefDescription: "desc", productType: .simple,
                                                                      manageStock: true, sku: "uks", stockQuantity: nil,
                                                                      dimensions: ProductDimensions(length: "", width: "", height: ""), weight: "3",
                                                                      virtual: true,
-                                                                     categories: [category])
-        // Affiliate product, missing external URL/sku/inventory/brief description/categories
+                                                                     categories: [category],
+                                                                     tags: [tag])
+        // Affiliate product, missing external URL/sku/inventory/brief description/categories/tags
         static let affiliateProduct = MockProduct().product(briefDescription: "",
                                                             externalURL: "",
                                                             productType: .affiliate,
                                                             sku: "",
-                                                            categories: [])
-        // Grouped product, missing grouped products/sku/brief description/categories
+                                                            categories: [],
+                                                            tags: [])
+        // Grouped product, missing grouped products/sku/brief description/categories/tags
         static let groupedProduct = MockProduct().product(briefDescription: "",
                                                           productType: .grouped,
                                                           sku: "")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -20,7 +20,12 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .shippingSettings, .inventorySettings, .categories, .tags, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .shippingSettings,
+                                                                       .inventorySettings,
+                                                                       .categories,
+                                                                       .tags,
+                                                                       .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -40,7 +45,12 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .shippingSettings, .inventorySettings, .categories, .tags, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .shippingSettings,
+                                                                       .inventorySettings,
+                                                                       .categories,
+                                                                       .tags,
+                                                                       .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -37,6 +37,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
                                           stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
         viewModel.updateProductCategories(product.categories)
+        viewModel.updateProductTags(product.tags)
 
         // Assert
         XCTAssertFalse(viewModel.hasUnsavedChanges())
@@ -164,6 +165,28 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let slug = "test-category"
         let newCategories = [ProductCategory(categoryID: categoryID, siteID: product.siteID, parentID: parentID, name: name, slug: slug)]
         viewModel.updateProductCategories(newCategories)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductHasUnsavedChangesFromEditingProductTags() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: true)
+
+        // Action
+        let tagID = Int64(1234)
+        let name = "Test tag"
+        let slug = "test-tag"
+        let newTags = [ProductTag(siteID: defaultSiteID, tagID: tagID, name: name, slug: slug)]
+        viewModel.updateProductTags(newTags)
 
         // Assert
         XCTAssertTrue(viewModel.hasUnsavedChanges())

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -63,6 +63,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                           stockStatus: product.productStockStatus)
         viewModel.updateShippingSettings(weight: product.weight, dimensions: product.dimensions, shippingClass: product.productShippingClass)
         viewModel.updateProductCategories(product.categories)
+        viewModel.updateProductTags(product.tags)
     }
 
     /// When only product name is updated, the product name observable should be triggered but no the product observable.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -178,6 +178,26 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.product.categories, newCategories)
     }
 
+    func testUpdatingProductTags() {
+        // Arrange
+        let product = MockProduct().product()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: product)
+        let viewModel = ProductFormViewModel(product: product,
+                                             productImageActionHandler: productImageActionHandler,
+                                             isEditProductsRelease2Enabled: true,
+                                             isEditProductsRelease3Enabled: true)
+
+        // Action
+        let tagID = Int64(1234)
+        let name = "Test tag"
+        let slug = "test-tag"
+        let newTags = [ProductTag(siteID: 0, tagID: tagID, name: name, slug: slug)]
+        viewModel.updateProductTags(newTags)
+
+        // Assert
+        XCTAssertEqual(viewModel.product.tags, newTags)
+    }
+
     func testUpdatingBriefDescription() {
         // Arrange
         let product = MockProduct().product()


### PR DESCRIPTION
Part of #2081 

## Description
In this PR, I handled the logic for showing/hiding the Tags cell in the Edit Product screen, and the logic for showing the "Tags" cell in the bottom action sheet. No actions are supported at the moment.

## Changes
- Modified `ProductFormActionsFactory` to support tags
- Modified `ProductFormBottomSheetAction` to support edit tags
- Modified `DefaultProductFormTableViewModel` to support tags
- Implemented a utility method `tagsDescription:` that returns a comma-separated string with each tag names, used in the Product Tags cell.
- Makes all the changed to show Tags in the Edit Product Screen
- Implemented `updatedProductTags:` method in `ProductFormViewModel` which returns a copy of the product with tags updated.
- `MockProduct` now accepts tags.
- Updated test cases with the support for tags.

## Testing

#### Test case 1
1)  Navigate to a product that contains some tags.
2) Make sure that the Tags cell is showed correctly.

#### Test case 2
1)  Navigate to a product without tags.
2) Make sure that the Tags cell is not shown, and that if you tap on "Add more details" you will be able to see the tags cell in the Bottom action sheet.

#### Test case 3
1) Set in the code the `editProductsRelease3` to `false`, and run the app.
2) Navigate to a product that contains some tags.
3) Make sure that the Tags cell is now shown.

#### Test case 4
1) Set in the code the `editProductsRelease3` to `false`, and run the app.
2) Navigate to a product without tags.
3) Make sure that the Tags cell is not shown, and that if you tap on "Add more details" you are not able to see the tags cell in the Bottom action sheet.



## Screenshots
| Tags cell             |  Tags cell (dark mode) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-07-14 at 17 45 20](https://user-images.githubusercontent.com/495617/87447863-5d3d8f00-c5fb-11ea-8393-9e013b8dd79e.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-07-14 at 17 45 49](https://user-images.githubusercontent.com/495617/87447874-5f9fe900-c5fb-11ea-900d-2b9c3d9f3938.png)

| Tags cell in Bottom action sheet             |  Tags cell in Bottom action sheet (dark mode) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-07-14 at 17 45 09](https://user-images.githubusercontent.com/495617/87447942-79413080-c5fb-11ea-92bf-5bc232444e60.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-07-14 at 17 46 00](https://user-images.githubusercontent.com/495617/87447946-7b0af400-c5fb-11ea-8898-aafae7ea87e6.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
