### PR TITLE
Issue/2254 rename foreground notification

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -14,12 +14,12 @@ final class PushNotificationsManager: PushNotesManager {
     let configuration: PushNotificationsConfiguration
 
     /// Mutable reference to `foregroundNotifications`.
-    private let foregroundNotificationsSubject = PublishSubject<ForegroundNotification>()
+    private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
 
     /// An observable that emits values when the Remote Notifications are received while the app is
     /// in the foreground.
     ///
-    var foregroundNotifications: Observable<ForegroundNotification> {
+    var foregroundNotifications: Observable<PushNotification> {
         foregroundNotificationsSubject
     }
 
@@ -326,7 +326,7 @@ private extension PushNotificationsManager {
             return false
         }
 
-        if let foregroundNotification = ForegroundNotification.from(userInfo: userInfo) {
+        if let foregroundNotification = PushNotification.from(userInfo: userInfo) {
             configuration.application.presentInAppNotification(message: foregroundNotification.message)
 
             foregroundNotificationsSubject.send(foregroundNotification)
@@ -480,8 +480,8 @@ private extension PushNotificationsManager {
 
 // MARK: - ForegroundNotification Extension
 
-private extension ForegroundNotification {
-    static func from(userInfo: [AnyHashable: Any]) -> ForegroundNotification? {
+private extension PushNotification {
+    static func from(userInfo: [AnyHashable: Any]) -> PushNotification? {
         guard let noteID = userInfo.integer(forKey: APNSKey.identifier),
               let message = userInfo.dictionary(forKey: APNSKey.aps)?.string(forKey: APNSKey.alert),
               let type = userInfo.string(forKey: APNSKey.type),
@@ -489,7 +489,7 @@ private extension ForegroundNotification {
             return nil
         }
 
-        return ForegroundNotification(noteID: noteID, kind: noteKind, message: message)
+        return PushNotification(noteID: noteID, kind: noteKind, message: message)
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -7,7 +7,7 @@ protocol PushNotesManager {
     /// An observable that emits values when the Remote Notifications are received while the app is
     /// in the foreground.
     ///
-    var foregroundNotifications: Observable<ForegroundNotification> { get }
+    var foregroundNotifications: Observable<PushNotification> { get }
 
     /// Resets the Badge Count.
     ///

--- a/WooCommerce/Classes/ServiceLocator/PushNotification.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotification.swift
@@ -5,7 +5,7 @@ import struct Yosemite.Note
 /// Emitted by `PushNotificationsManager` when a remote notification is received while
 /// the app is active.
 ///
-struct ForegroundNotification {
+struct PushNotification {
     /// The `note_id` value received from the Remote Notification's `userInfo`.
     ///
     let noteID: Int

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 		5754727B2451F14600A94C3C /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727A2451F14600A94C3C /* Observable.swift */; };
 		5754727D2451F1D800A94C3C /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727C2451F1D800A94C3C /* PublishSubject.swift */; };
 		5754727F24520B2A00A94C3C /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5754727E24520B2A00A94C3C /* Observer.swift */; };
-		575472812452185300A94C3C /* ForegroundNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* ForegroundNotification.swift */; };
+		575472812452185300A94C3C /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */; };
 		5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */; };
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
@@ -1237,7 +1237,7 @@
 		5754727A2451F14600A94C3C /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		5754727C2451F1D800A94C3C /* PublishSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSubject.swift; sourceTree = "<group>"; };
 		5754727E24520B2A00A94C3C /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
-		575472802452185300A94C3C /* ForegroundNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundNotification.swift; sourceTree = "<group>"; };
+		575472802452185300A94C3C /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
 		57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlus.swift"; sourceTree = "<group>"; };
 		5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlusTests.swift"; sourceTree = "<group>"; };
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
@@ -4005,7 +4005,7 @@
 				D831E2DB230E0558000037D0 /* Authentication.swift */,
 				D831E2DF230E0BA7000037D0 /* Logs.swift */,
 				02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */,
-				575472802452185300A94C3C /* ForegroundNotification.swift */,
+				575472802452185300A94C3C /* PushNotification.swift */,
 			);
 			path = ServiceLocator;
 			sourceTree = "<group>";
@@ -5047,7 +5047,7 @@
 				021AEF9E2407F55C00029D28 /* PHAssetImageLoader.swift in Sources */,
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
-				575472812452185300A94C3C /* ForegroundNotification.swift in Sources */,
+				575472812452185300A94C3C /* PushNotification.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				02279587237A50C900787C63 /* AztecHeaderFormatBarCommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
@@ -6,11 +6,11 @@ import Yosemite
 
 final class MockPushNotificationsManager: PushNotesManager {
 
-    var foregroundNotifications: Observable<ForegroundNotification> {
+    var foregroundNotifications: Observable<PushNotification> {
         foregroundNotificationsSubject
     }
 
-    private let foregroundNotificationsSubject = PublishSubject<ForegroundNotification>()
+    private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
 
     func resetBadgeCount(type: Note.Kind) {
 
@@ -55,7 +55,7 @@ extension MockPushNotificationsManager {
     /// Send a ForegroundNotification that will be emitted by the `foregroundNotifications`
     /// observable.
     ///
-    func sendForegroundNotification(_ notification: ForegroundNotification) {
+    func sendForegroundNotification(_ notification: PushNotification) {
         foregroundNotificationsSubject.send(notification)
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -392,7 +392,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         application.applicationState = .active
 
-        var emittedNotifications = [ForegroundNotification]()
+        var emittedNotifications = [PushNotification]()
         _ = manager.foregroundNotifications.subscribe { notification in
             emittedNotifications.append(notification)
         }
@@ -417,7 +417,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         application.applicationState = .background
 
-        var emittedNotifications = [ForegroundNotification]()
+        var emittedNotifications = [PushNotification]()
         _ = manager.foregroundNotifications.subscribe { notification in
             emittedNotifications.append(notification)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -380,7 +380,7 @@ final class OrdersViewModelTests: XCTestCase {
         viewModel.activateAndForwardUpdates(to: UITableView())
 
         // Act
-        let notification = ForegroundNotification(noteID: 1, kind: .storeOrder, message: "")
+        let notification = PushNotification(noteID: 1, kind: .storeOrder, message: "")
         pushNotificationsManager.sendForegroundNotification(notification)
 
         // Assert
@@ -400,7 +400,7 @@ final class OrdersViewModelTests: XCTestCase {
         viewModel.activateAndForwardUpdates(to: UITableView())
 
         // Act
-        let notification = ForegroundNotification(noteID: 1, kind: .comment, message: "")
+        let notification = PushNotification(noteID: 1, kind: .comment, message: "")
         pushNotificationsManager.sendForegroundNotification(notification)
 
         // Assert


### PR DESCRIPTION
Refs #2254. 

I'm planning to add an additional observable to [`PushNotesManager`](https://github.com/woocommerce/woocommerce-ios/blob/66d9e2403fa0126ba3c1193677e072e99a7e8d86/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift#L5-L10). The observable will emit `ForegroundNotification` objects when the app is inactive. The observable code will look like this:

```swift
    /// An observable that emits values when the app is activated due to a Remote Notification.
    /// The Remote Notification is emitted.
    ///
    var inactiveNotifications: Observable<ForegroundNotification> { get }
```

I can use the same [`ForegroundNotification`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ServiceLocator/ForegroundNotification.swift) object for the result. But the name is not really appropriate anymore. 

This PR renames `ForegroundNotification` to `PushNotification`. 

## Testing

There are no functional changes. Checking that the build passes should be good enough.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

