### PR TITLE
Document Protocol Naming Convention

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 - [Architecture](#architecture)
 - [Coding Guidelines](#coding-guidelines)
     - [Naming Conventions](#naming-conventions)
-        - [Protocols](#protocol)
+        - [Protocols](#protocols)
     - [Coding Style](#coding-style)
     - [Choosing Between Structures and Classes](#choosing-between-structures-and-classes)
 - [Design Patterns](#design-patterns)


### PR DESCRIPTION
A couple of months ago, we agreed that it is acceptable to use `*Protocol` in protocol names. This documents that agreement. I'm sorry it's a little bit late though. 😅 

Ref: CGPNUU63E-p1590167145050700-slack

😱 Sorry for the other line changes. VS Code automatically removed the extra spaces. Only the **Naming Convention** should be new. 

## Testing

Review the documentation [here](https://github.com/woocommerce/woocommerce-ios/tree/docs/add-protocol-naming/docs#naming-conventions). Please let me know if I missed anything. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

