### PR TITLE
Fix Remote Protocols Naming

### DIFF
--- a/Networking/Networking/Remote/NotificationsRemote.swift
+++ b/Networking/Networking/Remote/NotificationsRemote.swift
@@ -4,13 +4,13 @@ import Foundation
 ///
 /// The required methods are intentionally incomplete. Feel free to add the other ones.
 ///
-public protocol NotificationsEndpointsProviding {
+public protocol NotificationsRemoteProtocol {
     func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void)
 }
 
 /// Notifications: Remote Endpoints
 ///
-public final class NotificationsRemote: Remote, NotificationsEndpointsProviding {
+public final class NotificationsRemote: Remote, NotificationsRemoteProtocol {
 
     /// Retrieves latest Notifications (OR collection of specified Notifications, whenever the NoteIds is present).
     ///

--- a/Networking/Networking/Remote/ProductReviewsRemote.swift
+++ b/Networking/Networking/Remote/ProductReviewsRemote.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// The required methods are intentionally incomplete. Feel free to add the other ones.
 ///
-public protocol ProductReviewsEndpointsProviding {
+public protocol ProductReviewsRemoteProtocol {
     func loadProductReview(for siteID: Int64,
                            reviewID: Int64,
                            completion: @escaping (Result<ProductReview, Error>) -> Void)
@@ -12,7 +12,7 @@ public protocol ProductReviewsEndpointsProviding {
 
 /// Product reviews: Remote Endpoints
 ///
-public final class ProductReviewsRemote: Remote, ProductReviewsEndpointsProviding {
+public final class ProductReviewsRemote: Remote, ProductReviewsRemoteProtocol {
 
     // MARK: - Product Reviews
 

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// The required methods are intentionally incomplete. Feel free to add the other ones.
 ///
-public protocol ProductsEndpointsProviding {
+public protocol ProductsRemoteProtocol {
     func loadProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void)
 
     func loadProducts(for siteID: Int64, by productIDs: [Int64], pageNumber: Int, pageSize: Int, completion: @escaping (Result<[Product], Error>) -> Void)
@@ -12,7 +12,7 @@ public protocol ProductsEndpointsProviding {
 
 /// Product: Remote Endpoints
 ///
-public final class ProductsRemote: Remote, ProductsEndpointsProviding {
+public final class ProductsRemote: Remote, ProductsRemoteProtocol {
 
     // MARK: - Products
 

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -46,7 +46,7 @@ final class RetrieveProductReviewFromNoteUseCase {
         case storageNoLongerAvailable
     }
 
-    private let notificationsRemote: NotificationsEndpointsProviding
+    private let notificationsRemote: NotificationsRemoteProtocol
     private let productReviewsRemote: ProductReviewsEndpointsProviding
     private let productsRemote: ProductsEndpointsProviding
 
@@ -62,7 +62,7 @@ final class RetrieveProductReviewFromNoteUseCase {
     /// - Parameters:
     ///   - derivedStorage: The derived (background) `StorageType` of `ProductReviewStore`.
     init(derivedStorage: StorageType,
-         notificationsRemote: NotificationsEndpointsProviding,
+         notificationsRemote: NotificationsRemoteProtocol,
          productReviewsRemote: ProductReviewsEndpointsProviding,
          productsRemote: ProductsEndpointsProviding) {
         self.derivedStorage = derivedStorage

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -47,7 +47,7 @@ final class RetrieveProductReviewFromNoteUseCase {
     }
 
     private let notificationsRemote: NotificationsRemoteProtocol
-    private let productReviewsRemote: ProductReviewsEndpointsProviding
+    private let productReviewsRemote: ProductReviewsRemoteProtocol
     private let productsRemote: ProductsEndpointsProviding
 
     /// The derived `StorageType` used by the `ProductReviewStore`.
@@ -63,7 +63,7 @@ final class RetrieveProductReviewFromNoteUseCase {
     ///   - derivedStorage: The derived (background) `StorageType` of `ProductReviewStore`.
     init(derivedStorage: StorageType,
          notificationsRemote: NotificationsRemoteProtocol,
-         productReviewsRemote: ProductReviewsEndpointsProviding,
+         productReviewsRemote: ProductReviewsRemoteProtocol,
          productsRemote: ProductsEndpointsProviding) {
         self.derivedStorage = derivedStorage
         self.notificationsRemote = notificationsRemote

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -48,7 +48,7 @@ final class RetrieveProductReviewFromNoteUseCase {
 
     private let notificationsRemote: NotificationsRemoteProtocol
     private let productReviewsRemote: ProductReviewsRemoteProtocol
-    private let productsRemote: ProductsEndpointsProviding
+    private let productsRemote: ProductsRemoteProtocol
 
     /// The derived `StorageType` used by the `ProductReviewStore`.
     ///
@@ -64,7 +64,7 @@ final class RetrieveProductReviewFromNoteUseCase {
     init(derivedStorage: StorageType,
          notificationsRemote: NotificationsRemoteProtocol,
          productReviewsRemote: ProductReviewsRemoteProtocol,
-         productsRemote: ProductsEndpointsProviding) {
+         productsRemote: ProductsRemoteProtocol) {
         self.derivedStorage = derivedStorage
         self.notificationsRemote = notificationsRemote
         self.productReviewsRemote = productReviewsRemote

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -6,7 +6,7 @@ import Storage
 // MARK: - ProductStore
 //
 public class ProductStore: Store {
-    private let remote: ProductsEndpointsProviding
+    private let remote: ProductsRemoteProtocol
 
     private lazy var sharedDerivedStorage: StorageType = {
         return storageManager.newDerivedStorage()
@@ -17,7 +17,7 @@ public class ProductStore: Store {
         self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
     }
 
-    init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: ProductsEndpointsProviding) {
+    init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: ProductsRemoteProtocol) {
         self.remote = remote
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockNotificationsRemote.swift
@@ -23,7 +23,7 @@ final class MockNotificationsRemote {
 
 // MARK: NotificationsEndpointsProviding
 
-extension MockNotificationsRemote: NotificationsEndpointsProviding {
+extension MockNotificationsRemote: NotificationsRemoteProtocol {
 
     func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void) {
         guard let noteIDs = noteIDs else {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductReviewsRemote.swift
@@ -28,7 +28,7 @@ final class MockProductReviewsRemote {
 
 // MARK: - ProductReviewsEndpointsProviding
 
-extension MockProductReviewsRemote: ProductReviewsEndpointsProviding {
+extension MockProductReviewsRemote: ProductReviewsRemoteProtocol {
     func loadProductReview(for siteID: Int64,
                            reviewID: Int64,
                            completion: @escaping (Result<ProductReview, Error>) -> Void) {

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductsRemote.swift
@@ -38,7 +38,7 @@ final class MockProductsRemote {
 
 // MARK: - ProductsEndpointsProviding
 
-extension MockProductsRemote: ProductsEndpointsProviding {
+extension MockProductsRemote: ProductsRemoteProtocol {
 
     func loadProduct(for siteID: Int64,
                      productID: Int64,


### PR DESCRIPTION
Following up on the protocol naming convention described in #2524, I'm renaming these silly `*EndpointsProviding` protocols that I created to just `*RemoteProtocol`. 

I thought I'd name these right away to prevent ourselves from copying that name in the future. "Endpoints Providing" really doesn't mean anything. I just invented that phrase. 😁 

## Testing

There are no functional changes. Confirming that the build passes should be good enough. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

