### PR TITLE
CircleCI: Update Xcode to 11.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
   Build Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.5.0"
     steps:
       - git/shallow-checkout
       - fix-circleci
@@ -38,11 +38,11 @@ jobs:
   Unit Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.5.0"
     steps:
       - git/shallow-checkout
       - ios/boot-simulator:
-          xcode-version: "11.2.1"
+          xcode-version: "11.5.0"
           device: iPhone 11
       - attach_workspace:
           at: ./
@@ -68,11 +68,11 @@ jobs:
         default: false
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.5.0"
     steps:
       - git/shallow-checkout
       - ios/boot-simulator:
-          xcode-version: "11.2.1"
+          xcode-version: "11.5.0"
           device: << parameters.device >>
       - attach_workspace:
           at: ./
@@ -110,7 +110,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.5.0"
     steps:
       - git/shallow-checkout
       - fix-circleci
@@ -134,7 +134,7 @@ jobs:
   Release Build:
     executor: 
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.5.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           name: Run Unit Tests
           command: >
             bundle exec fastlane test_without_building
-            xctestrun:DerivedData/Build/Products/WooCommerce_UnitTests_iphonesimulator13.2-x86_64.xctestrun
+            xctestrun:DerivedData/Build/Products/WooCommerce_UnitTests_iphonesimulator13.5-x86_64.xctestrun
             destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
@@ -88,7 +88,7 @@ jobs:
           name: Run UI Tests
           command: >
             bundle exec fastlane test_without_building
-            xctestrun:DerivedData/Build/Products/WooCommerce_UITests_iphonesimulator13.2-x86_64.xctestrun
+            xctestrun:DerivedData/Build/Products/WooCommerce_UITests_iphonesimulator13.5-x86_64.xctestrun
             destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results


### PR DESCRIPTION
Closes #2471. 

I attempted to upgrade the Xcode version in #2190 but we decided that we have to get #2138 resolved first. After some deliberation, we decided that we should just push through with the upgrade since:

- #2138 only happens on iOS 12.
- We're dropping iOS 12 very soon anyway.
- We weren't sure if it's really a problem because we're having trouble reproducing it. 

Ref: C70PAM3RA-p1594949432474000-slack

## Reason For Upgrading

Please see the description in https://github.com/woocommerce/woocommerce-ios/pull/2190 for why we would like to upgrade the Xcode version.

## Changes

This PR upgrades the Xcode version in CircleCI to 11.5.0. At this time, it's a GM version which I think should be fine? I also upgraded the iOS simulator to 13.5. 

## Testing 

I believe checking if the build passed is good enough. Unit tests and UI tests should be green. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 
