### PR TITLE
Allow Injection of Dependencies for SwitchStoreNoticePresenter

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -51,7 +51,8 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
             }
 
             if siteChanged {
-                SwitchStoreNoticePresenter.presentStoreSwitchedNotice(stores: ServiceLocator.stores, configuration: self?.selectedConfiguration)
+                let presenter = SwitchStoreNoticePresenter()
+                presenter.presentStoreSwitchedNotice(configuration: self?.selectedConfiguration)
             }
             onCompletion()
             self?.onDismiss?()

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class SwitchStoreNoticePresenter: NSObject {
+final class SwitchStoreNoticePresenter {
 
     /// Present the switch notice to the user, with the new configured store name.
     ///

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -1,8 +1,17 @@
 import Foundation
 
-/// Constructs and enqueues a `Notice` for informing the user that the site was switched.
+/// Constructs and enqueues a `Notice` for informing the user that the selected site was changed.
 ///
 final class SwitchStoreNoticePresenter {
+
+    private let sessionManager: SessionManager
+    private let noticePresenter: NoticePresenter
+
+    init(sessionManager: SessionManager = ServiceLocator.stores.sessionManager,
+         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter) {
+        self.sessionManager = sessionManager
+        self.noticePresenter = noticePresenter
+    }
 
     /// Present the switch notice to the user, with the new configured store name.
     ///

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Constructs and enqueues a `Notice` for informing the user that the site was switched.
+///
 final class SwitchStoreNoticePresenter {
 
     /// Present the switch notice to the user, with the new configured store name.

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift
@@ -15,11 +15,11 @@ final class SwitchStoreNoticePresenter {
 
     /// Present the switch notice to the user, with the new configured store name.
     ///
-    static func presentStoreSwitchedNotice(stores: StoresManager, configuration: StorePickerConfiguration?) {
+    func presentStoreSwitchedNotice(configuration: StorePickerConfiguration?) {
         guard configuration == .switchingStores else {
             return
         }
-        guard let newStoreName = stores.sessionManager.defaultSite?.name else {
+        guard let newStoreName = sessionManager.defaultSite?.name else {
             return
         }
 
@@ -28,6 +28,6 @@ final class SwitchStoreNoticePresenter {
                 + "Reads like: Switched to {store name}. You will only receive notifications from this store.")
         let notice = Notice(title: message, feedbackType: .success)
 
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        noticePresenter.enqueue(notice: notice)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -292,7 +292,8 @@ extension MainTabBarController {
                 presentNotificationDetails(for: note)
 
                 if siteChanged {
-                    SwitchStoreNoticePresenter.presentStoreSwitchedNotice(stores: ServiceLocator.stores, configuration: .switchingStores)
+                    let presenter = SwitchStoreNoticePresenter()
+                    presenter.presentStoreSwitchedNotice(configuration: .switchingStores)
                 }
             }
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
 		5798191324526FE8000817F8 /* PublishSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5798191224526FE8000817F8 /* PublishSubjectTests.swift */; };
 		57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B374B5245B331100D58BE0 /* EmptyStateViewControllerTests.swift */; };
+		57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */; };
 		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
@@ -1249,6 +1250,7 @@
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
 		5798191224526FE8000817F8 /* PublishSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSubjectTests.swift; sourceTree = "<group>"; };
 		57B374B5245B331100D58BE0 /* EmptyStateViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewControllerTests.swift; sourceTree = "<group>"; };
+		57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreNoticePresenterTests.swift; sourceTree = "<group>"; };
 		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
@@ -2640,6 +2642,22 @@
 			path = EmptyStateViewController;
 			sourceTree = "<group>";
 		};
+		57C2F6E324C27B0C00131012 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				57C2F6E424C27B1E00131012 /* Epilogue */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		57C2F6E424C27B1E00131012 /* Epilogue */ = {
+			isa = PBXGroup;
+			children = (
+				57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */,
+			);
+			path = Epilogue;
+			sourceTree = "<group>";
+		};
 		57CFCD26248844A0003F51EC /* Section Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3011,6 +3029,7 @@
 		B56DB3E02049BFAA00D4AA8E /* WooCommerceTests */ = {
 			isa = PBXGroup;
 			children = (
+				57C2F6E324C27B0C00131012 /* Authentication */,
 				CCDC49F1240060F3003166BA /* UnitTests.xctestplan */,
 				D816DDBA22265D8000903E59 /* ViewRelated */,
 				B5F571A821BEECA50010D1B8 /* Responses */,
@@ -5234,6 +5253,7 @@
 				578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
+				57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */,
 				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,
 				CE50345A21B1F8F7007573C6 /* ZendeskManagerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		57C503DC23E8C70C00EC0790 /* OrdersMasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */; };
 		57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */; };
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
+		57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */; };
 		57CFCD28248845B4003F51EC /* PrimarySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */; };
 		57CFCD2A2488496F003F51EC /* PrimarySectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */; };
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
@@ -1251,6 +1252,7 @@
 		57C503DB23E8C70C00EC0790 /* OrdersMasterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewController.swift; sourceTree = "<group>"; };
 		57C503DD23E8CE0D00EC0790 /* OrdersMasterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrdersMasterViewController.xib; sourceTree = "<group>"; };
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
+		57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNoticePresenter.swift; sourceTree = "<group>"; };
 		57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimarySectionHeaderView.swift; sourceTree = "<group>"; };
 		57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrimarySectionHeaderView.xib; sourceTree = "<group>"; };
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
@@ -2764,6 +2766,7 @@
 				02EA6BFB2435EC3500FFF90A /* MockImageDownloader.swift */,
 				6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */,
 				0259EF78246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift */,
+				57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */,
 			);
 			path = Mockups;
 			sourceTree = "<group>";
@@ -5147,6 +5150,7 @@
 				021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */,
 				0235BFDB246E99A700778909 /* ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift in Sources */,
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
+				57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				B57C745120F56EE900EEFC87 /* UITableViewCellHelpersTests.swift in Sources */,
 				0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Authentication/Epilogue/SwitchStoreNoticePresenterTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Epilogue/SwitchStoreNoticePresenterTests.swift
@@ -1,0 +1,75 @@
+
+import Foundation
+import XCTest
+
+import Yosemite
+
+@testable import WooCommerce
+
+/// Test cases for `SwitchStoreNoticePresenter`.
+///
+final class SwitchStoreNoticePresenterTests: XCTestCase {
+
+    private var sessionManager: SessionManager!
+    private var noticePresenter: MockNoticePresenter!
+
+    override func setUp() {
+        super.setUp()
+
+        sessionManager = SessionManager.testingInstance
+        noticePresenter = MockNoticePresenter()
+    }
+
+    override func tearDown() {
+        noticePresenter = nil
+        sessionManager = nil
+
+        super.tearDown()
+    }
+
+    func testItEnqueuesANoticeWhenSwitchingStores() throws {
+        // Given
+        let site = makeSite()
+        sessionManager.defaultSite = site
+
+        let presenter = SwitchStoreNoticePresenter(sessionManager: sessionManager, noticePresenter: noticePresenter)
+
+        assertEmpty(noticePresenter.queuedNotices)
+
+        // When
+        presenter.presentStoreSwitchedNotice(configuration: .switchingStores)
+
+        // Then
+        XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
+
+        let notice = try XCTUnwrap(noticePresenter.queuedNotices.first)
+        assertThat(notice.title, contains: site.name)
+    }
+
+    func testItDoesNotEnqueueANoticeWhenNotSwitchingStores() throws {
+        // Given
+        let presenter = SwitchStoreNoticePresenter(sessionManager: sessionManager, noticePresenter: noticePresenter)
+
+        // When
+        presenter.presentStoreSwitchedNotice(configuration: .login)
+
+        // Then
+        assertEmpty(noticePresenter.queuedNotices)
+    }
+}
+
+// MARK: - Private Utils
+
+private extension SwitchStoreNoticePresenterTests {
+    func makeSite() -> Site {
+        Site(siteID: 999,
+             name: "Fugiat",
+             description: "",
+             url: "",
+             plan: "",
+             isWooCommerceActive: true,
+             isWordPressStore: true,
+             timezone: "",
+             gmtOffset: 0)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mockups/MockNoticePresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockNoticePresenter.swift
@@ -1,0 +1,17 @@
+
+import Foundation
+import UIKit
+
+@testable import WooCommerce
+
+/// A mock `NoticePresenter` that just records the queued `Notice` instances.
+///
+final class MockNoticePresenter: NoticePresenter {
+    var presentingViewController: UIViewController?
+
+    private(set) var queuedNotices = [Notice]()
+
+    func enqueue(notice: Notice) {
+        queuedNotices.append(notice)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
@@ -19,4 +19,13 @@ extension XCTestCase {
                       file: file,
                       line: line)
     }
+
+    /// Asserts that `subject` contains the given string.
+    ///
+    func assertThat(_ subject: String, contains value: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(subject.contains(value),
+                      "Expected “\(subject)” to contain “\(value)”.",
+                      file: file,
+                      line: line)
+    }
 }


### PR DESCRIPTION
Ref #2254. 

I needed to use `SwitchStoreUseCase` and `SwitchStoreNoticePresenter` for my [WIP branch](https://github.com/woocommerce/woocommerce-ios/compare/issue/2254-fix-review-push-navigation?expand=1) for #2254. I wanted to write a unit test involving `SwitchStoreNoticePresenter` but I needed to be able to inject `NoticePresenter`. This can be tricky because it's using `ServiceLocator` **inline** instead of injection. 

https://github.com/woocommerce/woocommerce-ios/blob/02d00261738596044f92c91b84d6d9a18873adc6/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreNoticePresenter.swift#L20

It's always better to inject it directly without relying on another third-party (ServiceLocator). 

## Changes

This PR refactors `SwitchStoreNoticePresenter` a bit so that:

- Dependencies can be injected
- There is no `static` function

I also added a small unit test.

## Testing

Please do a quick regression test:

1. Log in to the app. 
2. Confirm that there is no notice shown after the site picker. 
3. Switch to a different store.
4. Confirm that a notice is shown, informing the user that they will only receive notifications for the current store. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

