### PR TITLE
Copiable `ProductVariation` and update `Product.stockQuantity` type from `Int?` to `Int64?`

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -37,7 +37,7 @@ extension Product {
         taxStatusKey: CopiableProp<String> = .copy,
         taxClass: NullableCopiableProp<String> = .copy,
         manageStock: CopiableProp<Bool> = .copy,
-        stockQuantity: NullableCopiableProp<Int> = .copy,
+        stockQuantity: NullableCopiableProp<Int64> = .copy,
         stockStatusKey: CopiableProp<String> = .copy,
         backordersKey: CopiableProp<String> = .copy,
         backordersAllowed: CopiableProp<Bool> = .copy,
@@ -218,6 +218,123 @@ extension ProductImage {
             src: src,
             name: name,
             alt: alt
+        )
+    }
+}
+
+extension ProductVariation {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        productID: CopiableProp<Int64> = .copy,
+        productVariationID: CopiableProp<Int64> = .copy,
+        attributes: CopiableProp<[ProductVariationAttribute]> = .copy,
+        image: NullableCopiableProp<ProductImage> = .copy,
+        permalink: CopiableProp<String> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        dateModified: NullableCopiableProp<Date> = .copy,
+        dateOnSaleStart: NullableCopiableProp<Date> = .copy,
+        dateOnSaleEnd: NullableCopiableProp<Date> = .copy,
+        status: CopiableProp<ProductStatus> = .copy,
+        description: NullableCopiableProp<String> = .copy,
+        sku: NullableCopiableProp<String> = .copy,
+        price: CopiableProp<String> = .copy,
+        regularPrice: NullableCopiableProp<String> = .copy,
+        salePrice: NullableCopiableProp<String> = .copy,
+        onSale: CopiableProp<Bool> = .copy,
+        purchasable: CopiableProp<Bool> = .copy,
+        virtual: CopiableProp<Bool> = .copy,
+        downloadable: CopiableProp<Bool> = .copy,
+        downloads: CopiableProp<[ProductDownload]> = .copy,
+        downloadLimit: CopiableProp<Int64> = .copy,
+        downloadExpiry: CopiableProp<Int64> = .copy,
+        taxStatusKey: CopiableProp<String> = .copy,
+        taxClass: NullableCopiableProp<String> = .copy,
+        manageStock: CopiableProp<Bool> = .copy,
+        stockQuantity: NullableCopiableProp<Int64> = .copy,
+        stockStatus: CopiableProp<ProductStockStatus> = .copy,
+        backordersKey: CopiableProp<String> = .copy,
+        backordersAllowed: CopiableProp<Bool> = .copy,
+        backordered: CopiableProp<Bool> = .copy,
+        weight: NullableCopiableProp<String> = .copy,
+        dimensions: CopiableProp<ProductDimensions> = .copy,
+        shippingClass: NullableCopiableProp<String> = .copy,
+        shippingClassID: CopiableProp<Int64> = .copy,
+        menuOrder: CopiableProp<Int64> = .copy
+    ) -> ProductVariation {
+        let siteID = siteID ?? self.siteID
+        let productID = productID ?? self.productID
+        let productVariationID = productVariationID ?? self.productVariationID
+        let attributes = attributes ?? self.attributes
+        let image = image ?? self.image
+        let permalink = permalink ?? self.permalink
+        let dateCreated = dateCreated ?? self.dateCreated
+        let dateModified = dateModified ?? self.dateModified
+        let dateOnSaleStart = dateOnSaleStart ?? self.dateOnSaleStart
+        let dateOnSaleEnd = dateOnSaleEnd ?? self.dateOnSaleEnd
+        let status = status ?? self.status
+        let description = description ?? self.description
+        let sku = sku ?? self.sku
+        let price = price ?? self.price
+        let regularPrice = regularPrice ?? self.regularPrice
+        let salePrice = salePrice ?? self.salePrice
+        let onSale = onSale ?? self.onSale
+        let purchasable = purchasable ?? self.purchasable
+        let virtual = virtual ?? self.virtual
+        let downloadable = downloadable ?? self.downloadable
+        let downloads = downloads ?? self.downloads
+        let downloadLimit = downloadLimit ?? self.downloadLimit
+        let downloadExpiry = downloadExpiry ?? self.downloadExpiry
+        let taxStatusKey = taxStatusKey ?? self.taxStatusKey
+        let taxClass = taxClass ?? self.taxClass
+        let manageStock = manageStock ?? self.manageStock
+        let stockQuantity = stockQuantity ?? self.stockQuantity
+        let stockStatus = stockStatus ?? self.stockStatus
+        let backordersKey = backordersKey ?? self.backordersKey
+        let backordersAllowed = backordersAllowed ?? self.backordersAllowed
+        let backordered = backordered ?? self.backordered
+        let weight = weight ?? self.weight
+        let dimensions = dimensions ?? self.dimensions
+        let shippingClass = shippingClass ?? self.shippingClass
+        let shippingClassID = shippingClassID ?? self.shippingClassID
+        let menuOrder = menuOrder ?? self.menuOrder
+
+        return ProductVariation(
+            siteID: siteID,
+            productID: productID,
+            productVariationID: productVariationID,
+            attributes: attributes,
+            image: image,
+            permalink: permalink,
+            dateCreated: dateCreated,
+            dateModified: dateModified,
+            dateOnSaleStart: dateOnSaleStart,
+            dateOnSaleEnd: dateOnSaleEnd,
+            status: status,
+            description: description,
+            sku: sku,
+            price: price,
+            regularPrice: regularPrice,
+            salePrice: salePrice,
+            onSale: onSale,
+            purchasable: purchasable,
+            virtual: virtual,
+            downloadable: downloadable,
+            downloads: downloads,
+            downloadLimit: downloadLimit,
+            downloadExpiry: downloadExpiry,
+            taxStatusKey: taxStatusKey,
+            taxClass: taxClass,
+            manageStock: manageStock,
+            stockQuantity: stockQuantity,
+            stockStatus: stockStatus,
+            backordersKey: backordersKey,
+            backordersAllowed: backordersAllowed,
+            backordered: backordered,
+            weight: weight,
+            dimensions: dimensions,
+            shippingClass: shippingClass,
+            shippingClassID: shippingClassID,
+            menuOrder: menuOrder
         )
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -44,7 +44,7 @@ public struct Product: Codable, GeneratedCopiable {
     public let taxClass: String?
 
     public let manageStock: Bool
-    public let stockQuantity: Int?      // API reports Int or null
+    public let stockQuantity: Int64?    // API reports Int or null
     public let stockStatusKey: String   // instock, outofstock, backorder
 
     public let backordersKey: String    // no, notify, yes
@@ -142,7 +142,7 @@ public struct Product: Codable, GeneratedCopiable {
                 taxStatusKey: String,
                 taxClass: String?,
                 manageStock: Bool,
-                stockQuantity: Int?,
+                stockQuantity: Int64?,
                 stockStatusKey: String,
                 backordersKey: String,
                 backordersAllowed: Bool,
@@ -311,7 +311,7 @@ public struct Product: Codable, GeneratedCopiable {
             manageStock = parsedStringValue.lowercased() == Values.manageStockParent ? true : false
         }
 
-        let stockQuantity = try container.decodeIfPresent(Int.self, forKey: .stockQuantity)
+        let stockQuantity = try container.decodeIfPresent(Int64.self, forKey: .stockQuantity)
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
 
         let backordersKey = try container.decode(String.self, forKey: .backordersKey)

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Product Variation Entity.
 ///
-public struct ProductVariation: Decodable {
+public struct ProductVariation: Decodable, GeneratedCopiable {
     public let siteID: Int64
     public let productID: Int64
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -12,7 +12,7 @@ extension Product {
                                                         onTextChange: onTextChange)
     }
 
-    static func createStockQuantityViewModel(stockQuantity: Int?, onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
+    static func createStockQuantityViewModel(stockQuantity: Int64?, onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Quantity", comment: "Title of the cell in Product Inventory Settings > Quantity")
         let value = "\(stockQuantity ?? 0)"
         let accessibilityHint = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
@@ -6,7 +6,7 @@ struct ProductInventoryEditableData {
     let sku: String?
     let manageStock: Bool
     let soldIndividually: Bool
-    let stockQuantity: Int?
+    let stockQuantity: Int64?
     let backordersSetting: ProductBackordersSetting?
     let stockStatus: ProductStockStatus?
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -26,7 +26,7 @@ final class ProductInventorySettingsViewController: UIViewController {
     private var soldIndividually: Bool
 
     // Editable data - manage stock enabled.
-    private var stockQuantity: Int?
+    private var stockQuantity: Int64?
     private var backordersSetting: ProductBackordersSetting?
 
     // Editable data - manage stock disabled.
@@ -309,7 +309,7 @@ private extension ProductInventorySettingsViewController {
         guard let stockQuantity = stockQuantity else {
             return
         }
-        self.stockQuantity = Int(stockQuantity)
+        self.stockQuantity = Int64(stockQuantity)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -149,7 +149,7 @@ extension ProductFormViewModel {
     func updateInventorySettings(sku: String?,
                                  manageStock: Bool,
                                  soldIndividually: Bool,
-                                 stockQuantity: Int?,
+                                 stockQuantity: Int64?,
                                  backordersSetting: ProductBackordersSetting?,
                                  stockStatus: ProductStockStatus?) {
         product = product.copy(sku: sku,

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -22,7 +22,7 @@ final class MockProduct {
                  productType: ProductType = .simple,
                  manageStock: Bool = false,
                  sku: String? = "",
-                 stockQuantity: Int? = nil,
+                 stockQuantity: Int64? = nil,
                  taxClass: String? = "",
                  taxStatus: ProductTaxStatus = .taxable,
                  stockStatus: ProductStockStatus = .inStock,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -115,7 +115,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let newSKU = "94115"
         let newManageStock = !product.manageStock
         let newSoldIndividually = !product.soldIndividually
-        let newStockQuantity = 17
+        let newStockQuantity: Int64 = 17
         let newBackordersSetting = ProductBackordersSetting.allowedAndNotifyCustomer
         let newStockStatus = ProductStockStatus.onBackOrder
         viewModel.updateInventorySettings(sku: newSKU,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -15,7 +15,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
     }
 
     func testDetailsForProductInStockWithQuantity() {
-        let stockQuantity = 6
+        let stockQuantity: Int64 = 6
         let product = productMock(name: "Yay", stockQuantity: stockQuantity, stockStatus: .inStock)
         let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
@@ -58,7 +58,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
 
 extension ProductsTabProductViewModelTests {
     func productMock(name: String = "Hogsmeade",
-                     stockQuantity: Int? = nil,
+                     stockQuantity: Int64? = nil,
                      stockStatus: ProductStockStatus = .inStock,
                      variations: [Int64] = [],
                      images: [ProductImage] = []) -> Product {

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -90,9 +90,9 @@ extension Storage.Product: ReadOnlyConvertible {
         let productDefaultAttributes = defaultAttributes?.map { $0.toReadOnly() } ?? [Yosemite.ProductDefaultAttribute]()
         let productShippingClassModel = productShippingClass?.toReadOnly()
 
-        var quantity: Int?
+        var quantity: Int64?
         if let stockQuantity = stockQuantity {
-            quantity = Int(stockQuantity)
+            quantity = Int64(stockQuantity)
         }
 
         return Product(siteID: siteID,

--- a/Yosemite/YosemiteTests/Mockups/MockProduct.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockProduct.swift
@@ -11,7 +11,7 @@ final class MockProduct {
                  productStatus: ProductStatus = .publish,
                  productType: ProductType = .simple,
                  sku: String? = nil,
-                 stockQuantity: Int? = nil,
+                 stockQuantity: Int64? = nil,
                  stockStatus: ProductStockStatus = .inStock,
                  variations: [Int64] = [],
                  virtual: Bool = true,

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -834,7 +834,7 @@ final class ProductStoreTests: XCTestCase {
         let expectedProductSKU = "94115"
         let expectedProductManageStock = true
         let expectedProductSoldIndividually = false
-        let expectedStockQuantity = 99
+        let expectedStockQuantity: Int64 = 99
         let expectedBackordersSetting = ProductBackordersSetting.allowed
         let expectedStockStatus = ProductStockStatus.inStock
         let expectedProductRegularPrice = "12.00"


### PR DESCRIPTION
Prerequisite for #2085 

## Changes

- In Networking layer:
  - Updated `ProductVariation` to conform to `GeneratedCopiable`
  - Updated `Product.stockQuantity` from `Int?` to `Int64?` and updated its current usage in Networking & Yosemite layers
    - The reason for this change: I'm planning to create a data model protocol (temporarily called `ProductFormDataModel`) that both `Product` and `ProductVariation` conform to so that `ProductFormViewController` and its view model can support both product model types. However, before this PR `ProductVariation.stockQuantity` is `Int64?` while `Product.stockQuantity` is `Int?`. `Int` is `Int64` underneath but they are considered different types in Swift, so I updated `Product.stockQuantity` to use `Int64` as in `ProductVariation.stockQuantity` to be more explicit.
  - Ran `rake generate` to auto generate the Copiable code in `Models+Copiable.generated.swift`

## Testing

CI should be sufficient, but feel free to sanity check on updating a product's stock quantity:

- Go to the Products tab
- Tap on a simple product
- Tap on the inventory row
- Turn on "Manage stock" toggle if it's disabled, and update its quantity field
- Tap "Done"
- Tap "Update" --> the product's stock quantity should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
