### PR TITLE
Product Settings: switch to update whether a simple product is physical/virtual

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -456,6 +456,7 @@ public struct Product: Codable, GeneratedCopiable {
         try container.encode(stockQuantity, forKey: .stockQuantity)
         try container.encode(backordersKey, forKey: .backordersKey)
         try container.encode(stockStatusKey, forKey: .stockStatusKey)
+        try container.encode(virtual, forKey: .virtual)
 
         // Categories
         try container.encode(categories, forKey: .categories)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -154,6 +154,37 @@ enum ProductSettingsRows {
         let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
     }
 
+    struct VirtualProduct: ProductSettingsRowMediator {
+        private let settings: ProductSettings
+
+        init(_ settings: ProductSettings) {
+            self.settings = settings
+        }
+
+        func configure(cell: UITableViewCell) {
+            guard let cell = cell as? SwitchTableViewCell else {
+                return
+            }
+
+            let title = NSLocalizedString("Virtual Product", comment: "Virtual Product label in Product Settings")
+
+            cell.title = title
+            cell.isOn = settings.reviewsAllowed
+            cell.onChange = { newValue in
+                // TODO-2509 Edit Product M3 analytics
+                self.settings.reviewsAllowed = newValue
+            }
+        }
+
+        func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
+            // Empty because we don't need to handle the tap on this cell
+        }
+
+        let reuseIdentifier: String = SwitchTableViewCell.reuseIdentifier
+
+        let cellTypes: [UITableViewCell.Type] = [SwitchTableViewCell.self]
+    }
+
     struct ReviewsAllowed: ProductSettingsRowMediator {
         private let settings: ProductSettings
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -169,10 +169,10 @@ enum ProductSettingsRows {
             let title = NSLocalizedString("Virtual Product", comment: "Virtual Product label in Product Settings")
 
             cell.title = title
-            cell.isOn = settings.reviewsAllowed
+            cell.isOn = settings.virtual
             cell.onChange = { newValue in
                 // TODO-2509 Edit Product M3 analytics
-                self.settings.reviewsAllowed = newValue
+                self.settings.virtual = newValue
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -26,8 +26,7 @@ enum ProductSettingsSections {
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
                         ProductSettingsRows.VirtualProduct(settings)]
-            }
-            else {
+            } else {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings)]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,7 +8,7 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings)
+    init(_ settings: ProductSettings, productType: ProductType)
 }
 
 // MARK: - Sections declaration for Product Settings
@@ -20,8 +20,18 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings) {
-            rows = [ProductSettingsRows.Status(settings), ProductSettingsRows.Visibility(settings), ProductSettingsRows.CatalogVisibility(settings), ProductSettingsRows.VirtualProduct(settings)]
+        init(_ settings: ProductSettings, productType: ProductType) {
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease3) && productType == .simple {
+                rows = [ProductSettingsRows.Status(settings),
+                        ProductSettingsRows.Visibility(settings),
+                        ProductSettingsRows.CatalogVisibility(settings),
+                        ProductSettingsRows.VirtualProduct(settings)]
+            }
+            else {
+                rows = [ProductSettingsRows.Status(settings),
+                        ProductSettingsRows.Visibility(settings),
+                        ProductSettingsRows.CatalogVisibility(settings)]
+            }
         }
     }
 
@@ -31,7 +41,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings) {
+        init(_ settings: ProductSettings, productType: ProductType) {
             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease3) {
                 rows = [ProductSettingsRows.ReviewsAllowed(settings),
                         ProductSettingsRows.Slug(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -21,7 +21,7 @@ enum ProductSettingsSections {
         let rows: [ProductSettingsRowMediator]
 
         init(_ settings: ProductSettings) {
-            rows = [ProductSettingsRows.Status(settings), ProductSettingsRows.Visibility(settings), ProductSettingsRows.CatalogVisibility(settings)]
+            rows = [ProductSettingsRows.Status(settings), ProductSettingsRows.Visibility(settings), ProductSettingsRows.CatalogVisibility(settings), ProductSettingsRows.VirtualProduct(settings)]
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -11,7 +11,7 @@ final class ProductSettingsViewModel {
 
     var productSettings: ProductSettings {
         didSet {
-            sections = Self.configureSections(productSettings)
+            sections = Self.configureSections(productSettings, productType: product.productType)
         }
     }
 
@@ -31,7 +31,7 @@ final class ProductSettingsViewModel {
         self.product = product
         self.password = password
         productSettings = ProductSettings(from: product, password: password)
-        sections = Self.configureSections(productSettings)
+        sections = Self.configureSections(productSettings, productType: product.productType)
 
         /// If nil, we fetch the password from site post API because it was never fetched
         if password == nil {
@@ -45,7 +45,7 @@ final class ProductSettingsViewModel {
                 self.onPasswordRetrieved?(password)
                 self.password = password
                 self.productSettings.password = password
-                self.sections = Self.configureSections(self.productSettings)
+                self.sections = Self.configureSections(self.productSettings, productType: product.productType)
             }
         }
     }
@@ -89,9 +89,9 @@ private extension ProductSettingsViewModel {
 // MARK: Configure sections and rows in Product Settings
 //
 private extension ProductSettingsViewModel {
-    static func configureSections(_ settings: ProductSettings) -> [ProductSettingsSectionMediator] {
-        return [ProductSettingsSections.PublishSettings(settings),
-                     ProductSettingsSections.MoreOptions(settings)
+    static func configureSections(_ settings: ProductSettings, productType: ProductType) -> [ProductSettingsSectionMediator] {
+        return [ProductSettingsSections.PublishSettings(settings, productType: productType),
+                ProductSettingsSections.MoreOptions(settings, productType: productType)
         ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -193,6 +193,7 @@ extension ProductFormViewModel {
                                statusKey: settings.status.rawValue,
                                featured: settings.featured,
                                catalogVisibilityKey: settings.catalogVisibility.rawValue,
+                               virtual: settings.virtual,
                                reviewsAllowed: settings.reviewsAllowed,
                                purchaseNote: settings.purchaseNote,
                                menuOrder: settings.menuOrder)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		453DBF9023882814006762A5 /* ProductImagesFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */; };
 		454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */; };
 		45527A412472C6160078D609 /* SwitchStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45527A402472C6160078D609 /* SwitchStoreUseCase.swift */; };
+		455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455800CB24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift */; };
 		455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */; };
 		456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F3247D5434001203F6 /* UITableView+Helpers.swift */; };
 		456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */; };
@@ -1178,6 +1179,7 @@
 		453DBF8F23882814006762A5 /* ProductImagesFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesFlowLayout.swift; sourceTree = "<group>"; };
 		454B28BD23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateIntervalFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		45527A402472C6160078D609 /* SwitchStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreUseCase.swift; sourceTree = "<group>"; };
+		455800CB24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsSectionsTests.swift; sourceTree = "<group>"; };
 		455A2FDA246B1349000CA72C /* ProductVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibilityTests.swift; sourceTree = "<group>"; };
 		456417F3247D5434001203F6 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		456417F5247D5643001203F6 /* UITableView+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+HelpersTests.swift"; sourceTree = "<group>"; };
@@ -2461,6 +2463,7 @@
 			isa = PBXGroup;
 			children = (
 				453770D02431FF4700AC718D /* ProductSettingsViewModelTests.swift */,
+				455800CB24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -5159,6 +5162,7 @@
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
+				455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,
 				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,
 				45C8B25B231521510002FA77 /* CustomerNoteTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -229,6 +229,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let featured = true
         let password = ""
         let catalogVisibility = "search"
+        let virtual = true
         let reviewsAllowed = true
         let slug = "this-is-a-test"
         let purchaseNote = "This is a purchase note"
@@ -237,6 +238,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
                                               featured: featured,
                                               password: password,
                                               catalogVisibility: .search,
+                                              virtual: virtual,
                                               reviewsAllowed: reviewsAllowed,
                                               slug: slug,
                                               purchaseNote: purchaseNote,
@@ -247,6 +249,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         XCTAssertEqual(viewModel.product.statusKey, newStatus)
         XCTAssertEqual(viewModel.product.featured, featured)
         XCTAssertEqual(viewModel.product.catalogVisibilityKey, catalogVisibility)
+        XCTAssertEqual(viewModel.product.virtual, virtual)
         XCTAssertEqual(viewModel.product.reviewsAllowed, reviewsAllowed)
         XCTAssertEqual(viewModel.product.slug, slug)
         XCTAssertEqual(viewModel.product.purchaseNote, purchaseNote)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+/// Test cases for `ProductSettingsSections`.
+///
+final class ProductSettingsSectionsTests: XCTestCase {
+
+    func testGivenANonSimpleProductThenItDoesNotShowTheVirtualProductOption() {
+        // Given
+        let settings = ProductSettings(status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0)
+        let productType = ProductType.grouped
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType)
+
+        // Then
+        XCTAssertNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.VirtualProduct
+        }))
+    }
+
+    func testGivenASimpleProductThenItShowsTheVirtualProductOption() {
+        // Given
+        let settings = ProductSettings(status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0)
+        let productType = ProductType.simple
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType)
+
+        // Then
+        XCTAssertNotNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.VirtualProduct
+        }))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -6,7 +6,8 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
     func testOnReloadClosure() {
 
-        let product = MockProduct().product(status: .publish,
+        let product = MockProduct().product(virtual: true,
+                                            status: .publish,
                                             featured: true,
                                             catalogVisibility: .search,
                                             reviewsAllowed: false,
@@ -26,6 +27,7 @@ final class ProductSettingsViewModelTests: XCTestCase {
                                                     featured: true,
                                                     password: "1234",
                                                     catalogVisibility: .search,
+                                                    virtual: true,
                                                     reviewsAllowed: true,
                                                     slug: "this-is-a-slug",
                                                     purchaseNote: "This is a purchase note",

--- a/Yosemite/Yosemite/Model/Products/ProductSettings.swift
+++ b/Yosemite/Yosemite/Model/Products/ProductSettings.swift
@@ -8,6 +8,7 @@ public final class ProductSettings {
     public var featured: Bool
     public var password: String?
     public var catalogVisibility: ProductCatalogVisibility
+    public var virtual: Bool
     public var reviewsAllowed: Bool
     public var slug: String
     public var purchaseNote: String?
@@ -17,6 +18,7 @@ public final class ProductSettings {
                 featured: Bool,
                 password: String?,
                 catalogVisibility: ProductCatalogVisibility,
+                virtual: Bool,
                 reviewsAllowed: Bool,
                 slug: String,
                 purchaseNote: String?,
@@ -25,6 +27,7 @@ public final class ProductSettings {
         self.featured = featured
         self.password = password
         self.catalogVisibility = catalogVisibility
+        self.virtual = virtual
         self.reviewsAllowed = reviewsAllowed
         self.slug = slug
         self.purchaseNote = purchaseNote
@@ -36,6 +39,7 @@ public final class ProductSettings {
                   featured: product.featured,
                   password: password,
                   catalogVisibility: product.productCatalogVisibility,
+                  virtual: product.virtual,
                   reviewsAllowed: product.reviewsAllowed,
                   slug: product.slug,
                   purchaseNote: product.purchaseNote,
@@ -51,6 +55,7 @@ extension ProductSettings: Equatable {
             lhs.featured == rhs.featured &&
             lhs.password == rhs.password &&
             lhs.catalogVisibility.rawValue == rhs.catalogVisibility.rawValue &&
+            lhs.virtual == rhs.virtual &&
             lhs.reviewsAllowed == rhs.reviewsAllowed &&
             lhs.slug == rhs.slug &&
             lhs.purchaseNote == rhs.purchaseNote &&


### PR DESCRIPTION
Fixes #2514 

## Description
As part of Milestone 3, we want to give to users the ability to update a simple product from physical to virtual and viceversa. In this PR I added a new cell under the section "Publish Settings" in Product Settings, which allows the user to change the virtual status of the product.

## Testing

#### Test case 1
1. Lunch the app, and navigate to a simple product's detail.
2. Open product settings, and edit the "Virtual Product" flag.
3. Save the product, and make sure the changes are applied correctly, also on the web.

#### Test case 2
1. Lunch the app, and navigate to a NON-simple product's detail (for example, a grouped product).
2. Open product settings, and make sure that the "Virtual Product" cell is not shown.
3. Edit a setting on this product, and make sure that the changes are applied correctly, also on the web.

#### Test case 3
1. Set the `editProductsRelease3` flag to `false` in the code.
2. Lunch the app, and navigate to a simple product's detail.
3. Open product settings, and make sure that the "Virtual Product" cell is not shown.

## Screenshots
| Virtual Product cell            |  Virtual Product cell (dark mode) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-07-20 at 14 12 22](https://user-images.githubusercontent.com/495617/87937315-c9edd900-ca94-11ea-8167-a13172ff3b53.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-07-20 at 14 12 32](https://user-images.githubusercontent.com/495617/87937322-cce8c980-ca94-11ea-998f-fceb0bcdaee4.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
