### PR TITLE
Refactoring on `updateProduct` in preparation for sharing product form logic with `ProductVariation`

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -176,7 +176,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///     - product: the Product to update remotely.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateProduct(product: Product, completion: @escaping (Product?, Error?) -> Void) {
+    public func updateProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void) {
         do {
             let parameters = try product.toDictionary()
             let productID = product.productID
@@ -187,7 +187,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
 
             enqueue(request, mapper: mapper, completion: completion)
         } catch {
-            completion(nil, error)
+            completion(.failure(error))
         }
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 /// ProductsRemoteTests
 ///
-class ProductsRemoteTests: XCTestCase {
+final class ProductsRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
@@ -259,11 +259,13 @@ class ProductsRemoteTests: XCTestCase {
         let productName = "This is my new product name!"
         let productDescription = "Learn something!"
         let product = sampleProduct()
-        remote.updateProduct(product: product) { (product, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(product)
-            XCTAssertEqual(product?.name, productName)
-            XCTAssertEqual(product?.fullDescription, productDescription)
+        remote.updateProduct(product: product) { result in
+            guard case let .success(product) = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
+            XCTAssertEqual(product.name, productName)
+            XCTAssertEqual(product.fullDescription, productDescription)
             expectation.fulfill()
         }
 
@@ -277,9 +279,11 @@ class ProductsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for product name update")
 
         let product = sampleProduct()
-        remote.updateProduct(product: product) { (product, error) in
-            XCTAssertNil(product)
-            XCTAssertNotNil(error)
+        remote.updateProduct(product: product) { result in
+            guard case .failure = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
             expectation.fulfill()
         }
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -251,43 +251,47 @@ final class ProductsRemoteTests: XCTestCase {
     /// Verifies that updateProduct properly parses the `product-update` sample response.
     ///
     func testUpdateProductProperlyReturnsParsedProduct() {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Wait for product update")
-
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-update")
 
         let productName = "This is my new product name!"
         let productDescription = "Learn something!"
-        let product = sampleProduct()
-        remote.updateProduct(product: product) { result in
-            guard case let .success(product) = result else {
-                XCTFail("Unexpected result: \(result)")
-                return
-            }
-            XCTAssertEqual(product.name, productName)
-            XCTAssertEqual(product.fullDescription, productDescription)
-            expectation.fulfill()
-        }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // When
+        let product = sampleProduct()
+        waitForExpectation { expectation in
+            remote.updateProduct(product: product) { result in
+                // Then
+                guard case let .success(product) = result else {
+                    XCTFail("Unexpected result: \(result)")
+                    return
+                }
+                XCTAssertEqual(product.name, productName)
+                XCTAssertEqual(product.fullDescription, productDescription)
+                expectation.fulfill()
+            }
+        }
     }
 
     /// Verifies that updateProduct properly relays Networking Layer errors.
     ///
     func testUpdateProductProperlyRelaysNetwokingErrors() {
+        // Given
         let remote = ProductsRemote(network: network)
-        let expectation = self.expectation(description: "Wait for product name update")
 
+        // When
         let product = sampleProduct()
-        remote.updateProduct(product: product) { result in
-            guard case .failure = result else {
-                XCTFail("Unexpected result: \(result)")
-                return
+        waitForExpectation { expectation in
+            remote.updateProduct(product: product) { result in
+                // Then
+                guard case .failure = result else {
+                    XCTFail("Unexpected result: \(result)")
+                    return
+                }
+                expectation.fulfill()
             }
-            expectation.fulfill()
         }
-
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -364,24 +364,22 @@ private extension ProductFormViewController {
         // Updated Product
         if viewModel.hasProductChanged() {
             group.enter()
-            let updateProductAction = ProductAction.updateProduct(product: product) { [weak self] (product, error) in
-                guard let product = product, error == nil else {
-                    let errorDescription = error?.localizedDescription ?? "No error specified"
+
+            viewModel.updateProductRemotely { [weak self] result in
+                switch result {
+                case .failure(let error):
+                    let errorDescription = error.localizedDescription
                     DDLogError("⛔️ Error updating Product: \(errorDescription)")
                     ServiceLocator.analytics.track(.productDetailUpdateError)
                     // Dismisses the in-progress UI then presents the error alert.
                     self?.navigationController?.dismiss(animated: true) {
                         self?.displayError(error: error)
                     }
-                    group.leave()
-                    return
+                case .success:
+                    ServiceLocator.analytics.track(.productDetailUpdateSuccess)
                 }
-                self?.viewModel.resetProduct(product)
-
-                ServiceLocator.analytics.track(.productDetailUpdateSuccess)
                 group.leave()
             }
-            ServiceLocator.stores.dispatch(updateProductAction)
         }
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -204,10 +204,27 @@ extension ProductFormViewModel {
     }
 }
 
+// MARK: Remote actions
+//
+extension ProductFormViewModel {
+    func updateProductRemotely(onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {
+        let updateProductAction = ProductAction.updateProduct(product: product) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let product):
+                self?.resetProduct(product)
+                onCompletion(.success(product))
+            }
+        }
+        ServiceLocator.stores.dispatch(updateProductAction)
+    }
+}
+
 // MARK: Reset actions
 //
 extension ProductFormViewModel {
-    func resetProduct(_ product: Product) {
+    private func resetProduct(_ product: Product) {
         originalProduct = product
     }
 

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -45,7 +45,7 @@ public enum ProductAction: Action {
 
     /// Updates a specified Product.
     ///
-    case updateProduct(product: Product, onCompletion: (Product?, ProductUpdateError?) -> Void)
+    case updateProduct(product: Product, onCompletion: (Result<Product, ProductUpdateError>) -> Void)
 
     /// Checks whether a Product SKU is valid against other Products in the store.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -239,7 +239,7 @@ private extension ProductStore {
             case .success(let product):
                 self?.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
                     guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: product.siteID, productID: product.productID) else {
-                        onCompletion(.failure(.storage))
+                        onCompletion(.failure(.notFoundInStorage))
                         return
                     }
                     onCompletion(.success(storageProduct.toReadOnly()))
@@ -528,7 +528,7 @@ extension ProductStore {
 public enum ProductUpdateError: Error {
     case duplicatedSKU
     case invalidSKU
-    case storage
+    case notFoundInStorage
     case unknown
 
     init(error: Error) {

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -857,30 +857,32 @@ final class ProductStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
         XCTAssertEqual(viewStorage.countObjects(ofType: StorageProduct.self), 1)
 
-        let action = ProductAction.updateProduct(product: product) { (product, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(product)
-            XCTAssertEqual(product?.productID, expectedProductID)
-            XCTAssertEqual(product?.name, expectedProductName)
-            XCTAssertEqual(product?.fullDescription, expectedProductDescription)
+        let action = ProductAction.updateProduct(product: product) { result in
+            guard case let .success(product) = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
+            XCTAssertEqual(product.productID, expectedProductID)
+            XCTAssertEqual(product.name, expectedProductName)
+            XCTAssertEqual(product.fullDescription, expectedProductDescription)
             // Shipping settings.
-            XCTAssertEqual(product?.shippingClassID, expectedProductShippingClassID)
-            XCTAssertEqual(product?.shippingClass, expectedProductShippingClassSlug)
-            XCTAssertEqual(product?.productShippingClass, expectedProductShippingClass)
+            XCTAssertEqual(product.shippingClassID, expectedProductShippingClassID)
+            XCTAssertEqual(product.shippingClass, expectedProductShippingClassSlug)
+            XCTAssertEqual(product.productShippingClass, expectedProductShippingClass)
             // Inventory settings.
-            XCTAssertEqual(product?.sku, expectedProductSKU)
-            XCTAssertEqual(product?.manageStock, expectedProductManageStock)
-            XCTAssertEqual(product?.soldIndividually, expectedProductSoldIndividually)
-            XCTAssertEqual(product?.stockQuantity, expectedStockQuantity)
-            XCTAssertEqual(product?.backordersSetting, expectedBackordersSetting)
-            XCTAssertEqual(product?.productStockStatus, expectedStockStatus)
+            XCTAssertEqual(product.sku, expectedProductSKU)
+            XCTAssertEqual(product.manageStock, expectedProductManageStock)
+            XCTAssertEqual(product.soldIndividually, expectedProductSoldIndividually)
+            XCTAssertEqual(product.stockQuantity, expectedStockQuantity)
+            XCTAssertEqual(product.backordersSetting, expectedBackordersSetting)
+            XCTAssertEqual(product.productStockStatus, expectedStockStatus)
             // Price settings.
-            XCTAssertEqual(product?.regularPrice, expectedProductRegularPrice)
-            XCTAssertEqual(product?.salePrice, expectedProductSalePrice)
-            XCTAssertEqual(product?.dateOnSaleStart, expectedProductSaleStart)
-            XCTAssertEqual(product?.dateOnSaleEnd, expectedProductSaleEnd)
-            XCTAssertEqual(product?.taxStatusKey, expectedProductTaxStatus)
-            XCTAssertEqual(product?.taxClass, expectedProductTaxClass)
+            XCTAssertEqual(product.regularPrice, expectedProductRegularPrice)
+            XCTAssertEqual(product.salePrice, expectedProductSalePrice)
+            XCTAssertEqual(product.dateOnSaleStart, expectedProductSaleStart)
+            XCTAssertEqual(product.dateOnSaleEnd, expectedProductSaleEnd)
+            XCTAssertEqual(product.taxStatusKey, expectedProductTaxStatus)
+            XCTAssertEqual(product.taxClass, expectedProductTaxClass)
 
             let storedProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: expectedProductID)
             let readOnlyStoredProduct = storedProduct?.toReadOnly()
@@ -918,9 +920,11 @@ final class ProductStoreTests: XCTestCase {
         existingStorageShippingClass.update(with: existingShippingClass)
 
         let product = sampleProduct(productID: expectedProductID)
-        let action = ProductAction.updateProduct(product: product) { (product, error) in
-            XCTAssertNotNil(product)
-            XCTAssertNil(error)
+        let action = ProductAction.updateProduct(product: product) { result in
+            guard case .success = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 1)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductTag.self), 0)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductCategory.self), 0)
@@ -953,8 +957,11 @@ final class ProductStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "generic_error")
         let product = sampleProduct()
-        let action = ProductAction.updateProduct(product: product) { (product, error) in
-            XCTAssertNotNil(error)
+        let action = ProductAction.updateProduct(product: product) { result in
+            guard case .failure = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
             expectation.fulfill()
         }
 
@@ -969,9 +976,11 @@ final class ProductStoreTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let product = sampleProduct()
-        let action = ProductAction.updateProduct(product: product) { (product, error) in
-            XCTAssertNotNil(error)
-            XCTAssertNil(product)
+        let action = ProductAction.updateProduct(product: product) { result in
+            guard case .failure = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
             expectation.fulfill()
         }
 
@@ -991,9 +1000,11 @@ final class ProductStoreTests: XCTestCase {
 
         network.simulateError(requestUrlSuffix: "products/\(sampleProductID)", error: NetworkError.notFound)
         let product = sampleProduct()
-        let action = ProductAction.updateProduct(product: product) { (product, error) in
-            XCTAssertNotNil(error)
-            XCTAssertNil(product)
+        let action = ProductAction.updateProduct(product: product) { result in
+            guard case .failure = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
             // The existing Product should not be deleted on 404 response.
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 1)
 


### PR DESCRIPTION
Prerequisite for #2085

## Changes

- Updated `updateProduct` completion block to return a `Result<Product, Error>` in Networking layer, and `Result<Product, ProductUpdateError>` in Yosemite layer. Updated related tests
- Moved `updateProduct` action from `ProductFormViewController` to `ProductFormViewModel` so that `func updateProductRemotely` can be in a protocol implemented with both `Product` and `ProductVariation`

## Testing

Please sanity check on updating a product remotely:

- Go to the Products tab
- Tap on a simple product
- Try updating any supported fields (e.g. name, images, description, price, inventory, shipping)
- Tap "Update" --> the product should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
