### PR TITLE
Fix release builds on XCode 11.5 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,6 @@ jobs:
       - run: 
           name: Install other tools
           command: |
-            brew unlink python@2
             brew install imagemagick
             brew install ghostscript
             curl -sL https://sentry.io/get-cli/ | bash


### PR DESCRIPTION
This PR fixes a small issue with the new XCode 11.5 CircleCI image where the release builds fail because Python 2 has been removed (according to https://discuss.circleci.com/t/xcode-11-5-gm-released/36029)

We didn't use it anyway, but the unlink step now fails and makes the build fail. The fix is as simple as remove the unlink step. 

# To Test:
1. Checkout a new branch from this one. 
2. Update the app version, making sure to use a version older than 4.6 and to only update the build number. Please make sure you're not using any version number we may need in production because the build will be uploaded to TestFlight. 
3. Commit your changes and push the branch.
4. Tag your version with a beta tag (4 numbers) and push the tag.
5. Check on CircleCI that the release builds succeeds. 
6. **Cleanup**: Delete your tag and the test branch from GitHub and from your local repository. 


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
