### PR TITLE
Stats: Show Contact Us Page When "Contact Us" Button is Tapped

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -13,11 +13,21 @@ extension NSNotification.Name {
     static let ZDPNCleared = NSNotification.Name(rawValue: "ZDPNCleared")
 }
 
+/// Defines methods for showing Zendesk UI.
+///
+/// This is primarily used for testability. Not all methods in `ZendeskManager` are defined but
+/// feel free to add them when needed.
+///
+protocol ZendeskManagerProtocol {
+    /// Displays the Zendesk New Request view from the given controller, for users to submit new tickets.
+    ///
+    func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: String?)
+}
 
 /// This class provides the functionality to communicate with Zendesk for Help Center and support ticket interaction,
 /// as well as displaying views for the Help Center, new tickets, and ticket list.
 ///
-final class ZendeskManager: NSObject {
+final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 
     /// Shared Instance
     ///

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -17,7 +17,7 @@ extension NSNotification.Name {
 /// This class provides the functionality to communicate with Zendesk for Help Center and support ticket interaction,
 /// as well as displaying views for the Help Center, new tickets, and ticket list.
 ///
-class ZendeskManager: NSObject {
+final class ZendeskManager: NSObject {
 
     /// Shared Instance
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -16,7 +16,8 @@ final class DeprecatedDashboardStatsViewController: UIViewController {
         return .withLink(message: message,
                          image: .noStoreImage,
                          details: Constants.details,
-                         action: .text(title: Constants.buttonTitle, linkURL: WooConstants.helpCenterURL))
+                         linkTitle: Constants.buttonTitle,
+                         linkURL: WooConstants.helpCenterURL)
     }()
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -13,11 +13,10 @@ final class DeprecatedDashboardStatsViewController: UIViewController {
     ///
     private let emptyStateConfig: EmptyStateViewController.Config = {
         let message = NSAttributedString(string: Constants.title, attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
-        return .withLink(message: message,
-                         image: .noStoreImage,
-                         details: Constants.details,
-                         linkTitle: Constants.buttonTitle,
-                         linkURL: WooConstants.helpCenterURL)
+        return .withSupportRequest(message: message,
+                                   image: .noStoreImage,
+                                   details: Constants.details,
+                                   buttonTitle: Constants.buttonTitle)
     }()
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -13,10 +13,10 @@ final class DeprecatedDashboardStatsViewController: UIViewController {
     ///
     private let emptyStateConfig: EmptyStateViewController.Config = {
         let message = NSAttributedString(string: Constants.title, attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
-        return EmptyStateViewController.Config.withLink(message: message,
-                                                        image: .noStoreImage,
-                                                        details: Constants.details,
-                                                        action: .text(title: Constants.buttonTitle, linkURL: WooConstants.helpCenterURL))
+        return .withLink(message: message,
+                         image: .noStoreImage,
+                         details: Constants.details,
+                         action: .text(title: Constants.buttonTitle, linkURL: WooConstants.helpCenterURL))
     }()
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -106,8 +106,8 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
                 image: .emptyOrdersImage,
                 details: NSLocalizedString("We'll notify you when you receive a new order. In the meantime, explore how you can increase your store sales.",
                                            comment: "The detailed message shown in the Orders → All Orders tab if the list is empty."),
-                action: .button(title: NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty."),
-                                linkURL: WooConstants.blogURL)
+                linkTitle: NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty."),
+                linkURL: WooConstants.blogURL
             )
         )
         allOrdersVC.delegate = self

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -124,25 +124,14 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
         detailsLabel.text = config.details
         detailsLabel.isHidden = config.details == nil
 
-        actionButton.setTitle(config.action?.title, for: .normal)
-        actionButton.isHidden = config.action == nil
-
-        switch config.action {
-        case .button:
-            actionButton.applyPrimaryButtonStyle()
-        case .text:
-            actionButton.applyLinkButtonStyle()
-            actionButton.contentEdgeInsets = .zero
-        default:
-            break
-        }
+        configureActionButton(config)
 
         lastActionButtonTapHandler = {
             switch config {
-            case .withLink(_, _, _, let action):
+            case .withLink(_, _, _, _, let linkURL):
                 return { [weak self] in
                     if let self = self {
-                        WebviewHelper.launch(action.linkURL, with: self)
+                        WebviewHelper.launch(linkURL, with: self)
                     }
                 }
             default:
@@ -199,6 +188,27 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     }
 }
 
+// MARK: - Configuration
+
+private extension EmptyStateViewController {
+    /// Configures the `actionButton` based on the given `config`.
+    func configureActionButton(_ config: Config) {
+        switch config {
+        case .simple:
+            actionButton.isHidden = true
+        case .withLink(_, _, _, let linkTitle, _):
+            actionButton.isHidden = false
+            actionButton.applyPrimaryButtonStyle()
+            actionButton.setTitle(linkTitle, for: .normal)
+        case .withSupportRequest(_, _, _, let buttonTitle):
+            actionButton.isHidden = false
+            actionButton.applyLinkButtonStyle()
+            actionButton.contentEdgeInsets = .zero
+            actionButton.setTitle(buttonTitle, for: .normal)
+        }
+    }
+}
+
 // MARK: - KeyboardScrollable
 
 extension EmptyStateViewController: KeyboardScrollable {
@@ -231,43 +241,33 @@ extension EmptyStateViewController {
     }
 
     /// The configuration for this Empty State View
+    ///
+    /// The options like `simple`, `withLink`, etc define the standard behaviors or styles that
+    /// we use throughout the app. Right now, the options are generally split by the behavior
+    /// of the `actionButton`.
+    ///
+    /// There are probably better solutions than this but we should try to limit these to
+    /// what the design standards tell us. I believe it's better to have simple options than
+    /// having a high degree of customizability.
+    ///
     enum Config {
-
-        /// Configuration for the actionable button
-        enum LinkAction {
-
-            /// Represent a prominent pink putton style
-            case button(title: String, linkURL: URL)
-
-            /// Represent a pink link style
-            case text(title: String, linkURL: URL)
-
-            fileprivate var title: String {
-                switch self {
-                case let .button(title, _), let .text(title, _):
-                    return title
-                }
-            }
-
-            fileprivate var linkURL: URL {
-                switch self {
-                case let .button(_, url), let .text(_, url):
-                    return url
-                }
-            }
-        }
-
         /// Show a message and image only.
         ///
         case simple(message: NSAttributedString, image: UIImage)
 
-        /// Show all the elements and a button which navigates to a URL when tapped.
+        /// Show all the elements and a prominent button which navigates to a URL when tapped.
         ///
-        case withLink(message: NSAttributedString, image: UIImage, details: String, action: LinkAction)
+        /// - Parameters:
+        ///     - linkTitle: The content shown on the `actionButton`.
+        ///     - linkURL: The URL that will be navigated to when the `actionButton` is activated.
+        ///
+        case withLink(message: NSAttributedString, image: UIImage, details: String, linkTitle: String, linkURL: URL)
 
-        /// Shows all the elements and a link which shows the Contact Support dialog.
+        /// Shows all the elements and a text-style button which shows the Contact Support dialog when activated.
         ///
-        case withSupportRequest(message: NSAttributedString, image: UIImage, details: String)
+        /// - Parameter buttonTitle: The content shown on the button that displays the Contact Support dialog.
+        ///
+        case withSupportRequest(message: NSAttributedString, image: UIImage, details: String, buttonTitle: String)
 
         /// The font used by the message's `UILabel`.
         ///
@@ -281,8 +281,8 @@ extension EmptyStateViewController {
         fileprivate var message: NSAttributedString {
             switch self {
             case .simple(let message, _),
-                 .withLink(let message, _, _, _),
-                 .withSupportRequest(let message, _, _):
+                 .withLink(let message, _, _, _, _),
+                 .withSupportRequest(let message, _, _, _):
                 return message
             }
         }
@@ -290,8 +290,8 @@ extension EmptyStateViewController {
         fileprivate var image: UIImage {
             switch self {
             case .simple(_, let image),
-                 .withLink(_, let image, _, _),
-                 .withSupportRequest(_, let image, _):
+                 .withLink(_, let image, _, _, _),
+                 .withSupportRequest(_, let image, _, _):
                 return image
             }
         }
@@ -300,19 +300,9 @@ extension EmptyStateViewController {
             switch self {
             case .simple:
                 return nil
-            case .withLink(_, _, let detail, _),
-                 .withSupportRequest(_, _, let detail):
+            case .withLink(_, _, let detail, _, _),
+                 .withSupportRequest(_, _, let detail, _):
                 return detail
-            }
-        }
-
-        fileprivate var action: LinkAction? {
-            switch self {
-            case .simple,
-                 .withSupportRequest:
-                return nil
-            case .withLink(_, _, _, let action):
-                return action
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -87,9 +87,9 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     var additionalKeyboardFrameHeight: CGFloat = 0
 
     /// Used to present the Contact Support dialog if the `Config` is `.withSupportRequest`.
-    private let zendeskManager: ZendeskManager
+    private let zendeskManager: ZendeskManagerProtocol
 
-    init(style: Style = .basic, zendeskManager: ZendeskManager = .shared) {
+    init(style: Style = .basic, zendeskManager: ZendeskManagerProtocol = ZendeskManager.shared) {
         self.style = style
         self.zendeskManager = zendeskManager
         super.init(nibName: type(of: self).nibName, bundle: nil)
@@ -141,7 +141,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
             case .withSupportRequest:
                 return { [weak self] in
                     if let self = self {
-                        self.zendeskManager.showNewRequestIfPossible(from: self)
+                        self.zendeskManager.showNewRequestIfPossible(from: self, with: nil)
                     }
                 }
             default:

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -86,8 +86,12 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     /// Required implementation by `KeyboardFrameAdjustmentProvider`.
     var additionalKeyboardFrameHeight: CGFloat = 0
 
-    init(style: Style = .basic) {
+    /// Used to present the Contact Support dialog if the `Config` is `.withSupportRequest`.
+    private let zendeskManager: ZendeskManager
+
+    init(style: Style = .basic, zendeskManager: ZendeskManager = .shared) {
         self.style = style
+        self.zendeskManager = zendeskManager
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -132,6 +136,12 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
                 return { [weak self] in
                     if let self = self {
                         WebviewHelper.launch(linkURL, with: self)
+                    }
+                }
+            case .withSupportRequest:
+                return { [weak self] in
+                    if let self = self {
+                        self.zendeskManager.showNewRequestIfPossible(from: self)
                     }
                 }
             default:

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -260,9 +260,14 @@ extension EmptyStateViewController {
         /// Show a message and image only.
         ///
         case simple(message: NSAttributedString, image: UIImage)
+
         /// Show all the elements and a button which navigates to a URL when tapped.
         ///
         case withLink(message: NSAttributedString, image: UIImage, details: String, action: LinkAction)
+
+        /// Shows all the elements and a link which shows the Contact Support dialog.
+        ///
+        case withSupportRequest(message: NSAttributedString, image: UIImage, details: String)
 
         /// The font used by the message's `UILabel`.
         ///
@@ -276,7 +281,8 @@ extension EmptyStateViewController {
         fileprivate var message: NSAttributedString {
             switch self {
             case .simple(let message, _),
-                 .withLink(let message, _, _, _):
+                 .withLink(let message, _, _, _),
+                 .withSupportRequest(let message, _, _):
                 return message
             }
         }
@@ -284,7 +290,8 @@ extension EmptyStateViewController {
         fileprivate var image: UIImage {
             switch self {
             case .simple(_, let image),
-                 .withLink(_, let image, _, _):
+                 .withLink(_, let image, _, _),
+                 .withSupportRequest(_, let image, _):
                 return image
             }
         }
@@ -293,14 +300,16 @@ extension EmptyStateViewController {
             switch self {
             case .simple:
                 return nil
-            case .withLink(_, _, let detail, _):
+            case .withLink(_, _, let detail, _),
+                 .withSupportRequest(_, _, let detail):
                 return detail
             }
         }
 
         fileprivate var action: LinkAction? {
             switch self {
-            case .simple:
+            case .simple,
+                 .withSupportRequest:
                 return nil
             case .withLink(_, _, _, let action):
                 return action

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -265,7 +265,7 @@ extension EmptyStateViewController {
         ///
         case simple(message: NSAttributedString, image: UIImage)
 
-        /// Show all the elements and a prominent button which navigates to a URL when tapped.
+        /// Show all the elements and a prominent button which navigates to a URL when activated.
         ///
         /// - Parameters:
         ///     - linkTitle: The content shown on the `actionButton`.
@@ -273,7 +273,7 @@ extension EmptyStateViewController {
         ///
         case withLink(message: NSAttributedString, image: UIImage, details: String, linkTitle: String, linkURL: URL)
 
-        /// Shows all the elements and a text-style button which shows the Contact Support dialog when activated.
+        /// Shows all the elements and a text-style button which shows the Contact Us dialog when activated.
         ///
         /// - Parameter buttonTitle: The content shown on the button that displays the Contact Support dialog.
         ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -105,7 +105,6 @@
 		023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A059824135F2600E3FC99 /* ReviewsViewController.swift */; };
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
-		02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */; };
 		02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionCoordinator.swift */; };
 		02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EDF2314FE5900FF1170 /* DashboardUIFactoryTests.swift */; };
 		02404EE2231501E000FF1170 /* StatsVersionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EE1231501E000FF1170 /* StatsVersionCoordinatorTests.swift */; };
@@ -361,6 +360,7 @@
 		45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */; };
 		570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */; };
 		571E4674249D1615002ADCB8 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */; };
+		571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */; };
 		573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */; };
 		57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57448D27242E775000A56A74 /* EmptyStateViewController.swift */; };
 		57448D2A242E777700A56A74 /* EmptyStateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57448D29242E777700A56A74 /* EmptyStateViewController.xib */; };
@@ -987,7 +987,6 @@
 		023A059824135F2600E3FC99 /* ReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsViewController.swift; sourceTree = "<group>"; };
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
-		02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinator.swift; sourceTree = "<group>"; };
 		02404ED92314C36200FF1170 /* StatsVersionCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionCoordinator.swift; sourceTree = "<group>"; };
 		02404EDF2314FE5900FF1170 /* DashboardUIFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactoryTests.swift; sourceTree = "<group>"; };
 		02404EE1231501E000FF1170 /* StatsVersionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -1246,6 +1245,7 @@
 		45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OrderDetailsDataSourceTests.swift; path = "Order Details/OrderDetailsDataSourceTests.swift"; sourceTree = "<group>"; };
 		571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
+		571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZendeskManager.swift; sourceTree = "<group>"; };
 		573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
 		57448D27242E775000A56A74 /* EmptyStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewController.swift; sourceTree = "<group>"; };
 		57448D29242E777700A56A74 /* EmptyStateViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyStateViewController.xib; sourceTree = "<group>"; };
@@ -2728,6 +2728,7 @@
 				6856D66A1963092C34D20674 /* Calendar+Extensions.swift */,
 				578187B12481D9290063B46B /* XCTestCase+Assertions.swift */,
 				571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */,
+				571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */,
 			);
 			path = Testing;
 			sourceTree = "<group>";
@@ -5300,6 +5301,7 @@
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,
 				B53A56A22112470C000776C9 /* MockupStorage+Sample.swift in Sources */,
 				D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */,
+				571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */,
 				45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */,
 				02279590237A5DC900787C63 /* AztecUnorderedListFormatBarCommandTests.swift in Sources */,
 				B5F571AB21BEECB60010D1B8 /* NoteWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -1,0 +1,24 @@
+
+import Foundation
+import UIKit
+
+@testable import WooCommerce
+
+final class MockZendeskManager: ZendeskManagerProtocol {
+
+    struct NewRequestIfPossibleInvocation {
+        let controller: UIViewController
+        let sourceTag: String?
+    }
+
+    /// The invocations of `showNewRequestIfPossible` with the passed arguments.
+    ///
+    /// The number of elements match the number of invocations.
+    ///
+    private(set) var newRequestIfPossibleInvocations = [NewRequestIfPossibleInvocation]()
+
+    func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: String?) {
+        let invocation = NewRequestIfPossibleInvocation(controller: controller, sourceTag: sourceTag)
+        newRequestIfPossibleInvocations.append(invocation)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -130,6 +130,60 @@ final class EmptyStateViewControllerTests: XCTestCase {
         // Then
         XCTAssertFalse(mirror.imageView.isHidden)
     }
+
+    func testGivenASupportRequestConfigThenItShowsAllTheElements() throws {
+        // Given
+        let viewController = EmptyStateViewController()
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        // When
+        viewController.configure(.withSupportRequest(
+            message: NSAttributedString(string: "aTque"),
+            image: .infoImage,
+            details: "Sequi corrupti explicabo",
+            buttonTitle: "Contact You!"
+        ))
+
+        // Then
+        XCTAssertFalse(mirror.messageLabel.isHidden)
+        XCTAssertFalse(mirror.detailsLabel.isHidden)
+        XCTAssertFalse(mirror.actionButton.isHidden)
+
+        XCTAssertEqual(mirror.messageLabel.attributedText, NSAttributedString(string: "aTque"))
+        XCTAssertEqual(mirror.imageView.image, UIImage.infoImage)
+        XCTAssertEqual(mirror.detailsLabel.text, "Sequi corrupti explicabo")
+        XCTAssertEqual(mirror.actionButton.titleLabel?.text, "Contact You!")
+    }
+
+    func testGivenASupportRequestConfigWhenTappingOnButtonThenTheContactUsPageIsPresented() throws {
+        // Given
+        let zendeskManager = MockZendeskManager()
+        let viewController = EmptyStateViewController(style: .basic, zendeskManager: zendeskManager)
+        XCTAssertNotNil(viewController.view)
+
+        let mirror = try self.mirror(of: viewController)
+
+        viewController.configure(.withSupportRequest(
+            message: NSAttributedString(string: ""),
+            image: .appleIcon,
+            details: "",
+            buttonTitle: "Dolores"
+        ))
+
+        assertEmpty(zendeskManager.newRequestIfPossibleInvocations)
+
+        // When
+        mirror.actionButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertEqual(zendeskManager.newRequestIfPossibleInvocations.count, 1)
+
+        let invocation = try XCTUnwrap(zendeskManager.newRequestIfPossibleInvocations.first)
+        XCTAssertEqual(invocation.controller, viewController)
+        XCTAssertNil(invocation.sourceTag)
+    }
 }
 
 // MARK: - Mirroring

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -59,7 +59,8 @@ final class EmptyStateViewControllerTests: XCTestCase {
             message: NSAttributedString(string: "Ola"),
             image: .appleIcon,
             details: "Dolores eum",
-            action: .button(title: "Bakero!", linkURL: WooConstants.blogURL)
+            linkTitle: "Bakero!",
+            linkURL: WooConstants.blogURL
         ))
 
         // Then


### PR DESCRIPTION
Closes #2535. 

In https://github.com/woocommerce/woocommerce-ios/pull/2521, Ernesto implemented the empty state shown if the user is still using WC < 4.0. The empty state implemented in that PR currently opens a URL about WCiOS. This PR changes that so that the Zendesk Contact Us page is shown instead.

## Design

<img src="https://user-images.githubusercontent.com/198826/88093781-c1a6a400-cb4f-11ea-9848-2156a3e008a0.gif" width="320">

## Changes

### EmptyStateViewController - withSupportRequest

I added a new `Config` option, [`withSupportRequest`](https://github.com/woocommerce/woocommerce-ios/blob/80f94af5719219b361f77ae94e41a733eb0875e6/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift#L276-L280). When used, this option: 

- Shows all the UI elements
- Shows a text-style button (like the one implemented in #2521)
- Shows the Zendesk “Contact us” page when the button is tapped. 

I contemplated allowing consumers to specify a custom `block` but I believe supporting this *inside* `EmptyStateViewController` is simpler. And it keeps the original goal I had with `EmptyStateViewController` where it should provide simple options for configuration and the options are based on the design standards. I explained that more in a new comment:

https://github.com/woocommerce/woocommerce-ios/blob/80f94af5719219b361f77ae94e41a733eb0875e6/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift#L253-L263

My bad, I should have documented this important fact beforehand. I even forgot what I was trying to do here and only remembered once I was going through the code. 🤦 

### EmptyStateViewController - LinkAction

I removed the `LinkAction` added in #2521 since it is no longer used after this change. If we ever need it again, we'll probably have to question why we have so many different empty state designs variations. 

## Testing

1. In `DashboardUIFactory`, change `september1st2020` to be `2019`.
2. In `StatsVersionCoordinator`, change the `let nextVersion: StatsVersion = isStatsV4Available ? .v4: .v3` line to:

    ```swift
    let nextVersion = StatsVersion.v3
    ```
3. Run the app. 
4. You should be seeing the empty state shown in the GIF above. 
5. Tap on the “Still need help?...” button. 
6. Confirm that the “Contact us” dialog was shown. 
7. Submit a message. 
8. Confirm that the message was submitted to Zendesk. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

