### PR TITLE
Yosemite/Networking: add `updateProductVariation` action

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		020220E223966CD900290165 /* product-shipping-classes-load-one.json in Resources */ = {isa = PBXBuildFile; fileRef = 020220E123966CD900290165 /* product-shipping-classes-load-one.json */; };
+		020C907B24C6E108001E2BEB /* product-variation-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 020C907A24C6E108001E2BEB /* product-variation-update.json */; };
+		020C907F24C7D359001E2BEB /* ProductVariationMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */; };
 		020D07B823D852BB00FD9580 /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07B723D852BB00FD9580 /* Media.swift */; };
 		020D07BA23D8542000FD9580 /* UploadableMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07B923D8542000FD9580 /* UploadableMedia.swift */; };
 		020D07BC23D856BF00FD9580 /* MediaRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020D07BB23D856BF00FD9580 /* MediaRemote.swift */; };
@@ -40,6 +42,7 @@
 		02BA23CA22EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json in Resources */ = {isa = PBXBuildFile; fileRef = 02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */; };
 		02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
 		02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */; };
+		02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */; };
 		02DD6492248A3EC00082523E /* product-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 02DD6491248A3EC00082523E /* product-external.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
@@ -360,6 +363,8 @@
 
 /* Begin PBXFileReference section */
 		020220E123966CD900290165 /* product-shipping-classes-load-one.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-shipping-classes-load-one.json"; sourceTree = "<group>"; };
+		020C907A24C6E108001E2BEB /* product-variation-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation-update.json"; sourceTree = "<group>"; };
+		020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationMapperTests.swift; sourceTree = "<group>"; };
 		020D07B723D852BB00FD9580 /* Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
 		020D07B923D8542000FD9580 /* UploadableMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadableMedia.swift; sourceTree = "<group>"; };
 		020D07BB23D856BF00FD9580 /* MediaRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRemote.swift; sourceTree = "<group>"; };
@@ -392,6 +397,7 @@
 		02BA23C822EEF62C009539E7 /* order-stats-v4-wcadmin-activated.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-stats-v4-wcadmin-activated.json"; sourceTree = "<group>"; };
 		02BDB83423EA98C800BCC63E /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLTests.swift"; sourceTree = "<group>"; };
+		02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationMapper.swift; sourceTree = "<group>"; };
 		02DD6491248A3EC00082523E /* product-external.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-external.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
@@ -1118,6 +1124,7 @@
 				026CF623237D839A009563D4 /* product-variations-load-all.json */,
 				02698CF924C188E8005337C4 /* product-variations-load-all-alternative-types.json */,
 				02698CFB24C1B0CE005337C4 /* product-variations-load-all-first-on-sale-empty-sale-price.json */,
+				020C907A24C6E108001E2BEB /* product-variation-update.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				0282DD90233A120A006A5FDB /* products-search-photo.json */,
 				45D685F923D0C3CF005F87D0 /* product-search-sku.json */,
@@ -1212,6 +1219,7 @@
 				450106902399B2C800E24722 /* TaxClassListMapper.swift */,
 				74ABA1D2213F25AE00FFAD30 /* TopEarnerStatsMapper.swift */,
 				026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */,
+				02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -1300,6 +1308,7 @@
 				74ABA1D4213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift */,
 				D8FBFF0E22D3B25E006E3336 /* WooAPIVersionTests.swift */,
 				02698CF724C183A5005337C4 /* ProductVariationListMapperTests.swift */,
+				020C907E24C7D359001E2BEB /* ProductVariationMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -1497,6 +1506,7 @@
 				743FDB9E210FB36900AC737F /* order-stats-week.json in Resources */,
 				D823D9032237450A00C90817 /* shipment_tracking_new.json in Resources */,
 				7412A8F021B6E416005D182A /* report-orders.json in Resources */,
+				020C907B24C6E108001E2BEB /* product-variation-update.json in Resources */,
 				D8FBFF1822D4DDB9006E3336 /* order-stats-v4-hour.json in Resources */,
 				B554FA8D2180B59700C54DFF /* notifications-load-hashes.json in Resources */,
 				743FDB9C210FB36900AC737F /* order-stats-month.json in Resources */,
@@ -1633,6 +1643,7 @@
 				74ABA1D1213F22CA00FFAD30 /* TopEarnersStatsRemote.swift in Sources */,
 				025CA2C0238EB8CB00B05C81 /* ProductShippingClass.swift in Sources */,
 				74A1196C2110F4BB00E1E5F0 /* OrderStats.swift in Sources */,
+				02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */,
 				B58E5BEA20FFB3D0003C986E /* CodingUserInfoKey+Woo.swift in Sources */,
 				B59325D3217E4206000B0E8E /* NoteMedia.swift in Sources */,
 				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
@@ -1831,6 +1842,7 @@
 				B5969E1520A47F99005E9DF1 /* RemoteTests.swift in Sources */,
 				74C8F06E20EEC1E800B6EDC9 /* OrderNotesMapperTests.swift in Sources */,
 				45ED4F10239E8A54004F1BE3 /* TaxClassListMapperTest.swift in Sources */,
+				020C907F24C7D359001E2BEB /* ProductVariationMapperTests.swift in Sources */,
 				74ABA1D5213F26B300FFAD30 /* TopEarnerStatsMapperTests.swift in Sources */,
 				74AB5B5121AF426D00859C12 /* SiteAPIRemoteTests.swift in Sources */,
 				4599FC6624A633A10056157A /* ProductTagsRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductVariationMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationMapper.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Mapper: ProductVariation
+///
+struct ProductVariationMapper: Mapper {
+    /// Site Identifier associated to the product variation that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Product Variation Endpoints.
+    ///
+    let siteID: Int64
+
+    /// Product Identifier associated to the product variation that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because ProductID is not returned in any of the Product Variation Endpoints.
+    ///
+    let productID: Int64
+
+    /// (Attempts) to convert a dictionary into ProductVariation.
+    ///
+    func map(response: Data) throws -> ProductVariation {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID,
+            .productID: productID
+        ]
+        return try decoder.decode(ProductVariationEnvelope.self, from: response).productVariation
+    }
+}
+
+
+/// ProductVariationEnvelope Disposable Entity
+///
+/// `ProductVariation` endpoint returns the requested product document in the `data` key. This entity
+/// allows us to do parse all the things with JSONDecoder.
+///
+private struct ProductVariationEnvelope: Decodable {
+    let productVariation: ProductVariation
+
+    private enum CodingKeys: String, CodingKey {
+        case productVariation = "data"
+    }
+}

--- a/Networking/Networking/Mapper/ProductVariationMapper.swift
+++ b/Networking/Networking/Mapper/ProductVariationMapper.swift
@@ -31,7 +31,7 @@ struct ProductVariationMapper: Mapper {
 
 /// ProductVariationEnvelope Disposable Entity
 ///
-/// `ProductVariation` endpoint returns the requested product document in the `data` key. This entity
+/// `ProductVariation` endpoint returns the requested product variation document in the `data` key. This entity
 /// allows us to do parse all the things with JSONDecoder.
 ///
 private struct ProductVariationEnvelope: Decodable {

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Product Variation Entity.
 ///
-public struct ProductVariation: Codable, GeneratedCopiable {
+public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
     public let siteID: Int64
     public let productID: Int64
 
@@ -264,14 +264,12 @@ public struct ProductVariation: Codable, GeneratedCopiable {
         // Issue: https://github.com/woocommerce/woocommerce/issues/25350
         if dateOnSaleStart == nil {
             try container.encode("", forKey: .dateOnSaleStart)
-        }
-        else {
+        } else {
             try container.encode(dateOnSaleStart, forKey: .dateOnSaleStart)
         }
         if dateOnSaleEnd == nil {
             try container.encode("", forKey: .dateOnSaleEnd)
-        }
-        else {
+        } else {
             try container.encode(dateOnSaleEnd, forKey: .dateOnSaleEnd)
         }
 
@@ -348,50 +346,6 @@ private extension ProductVariation {
 
         case attributes
         case menuOrder          = "menu_order"
-    }
-}
-
-
-// MARK: - Equatable Conformance
-//
-extension ProductVariation: Equatable {
-    public static func == (lhs: ProductVariation, rhs: ProductVariation) -> Bool {
-        return lhs.siteID == rhs.siteID &&
-            lhs.productID == rhs.productID &&
-            lhs.productVariationID == rhs.productVariationID &&
-            lhs.attributes == rhs.attributes &&
-            lhs.image == rhs.image &&
-            lhs.permalink == rhs.permalink &&
-            lhs.dateCreated == rhs.dateCreated &&
-            lhs.dateModified == rhs.dateModified &&
-            lhs.dateOnSaleStart == rhs.dateOnSaleStart &&
-            lhs.dateOnSaleEnd == rhs.dateOnSaleEnd &&
-            lhs.status == rhs.status &&
-            lhs.description == rhs.description &&
-            lhs.sku == rhs.sku &&
-            lhs.price == rhs.price &&
-            lhs.regularPrice == rhs.regularPrice &&
-            lhs.salePrice == rhs.salePrice &&
-            lhs.onSale == rhs.onSale &&
-            lhs.purchasable == rhs.purchasable &&
-            lhs.virtual == rhs.virtual &&
-            lhs.downloadable == rhs.downloadable &&
-            lhs.downloads == rhs.downloads &&
-            lhs.downloadLimit == rhs.downloadLimit &&
-            lhs.downloadExpiry == rhs.downloadExpiry &&
-            lhs.taxStatusKey == rhs.taxStatusKey &&
-            lhs.taxClass == rhs.taxClass &&
-            lhs.manageStock == rhs.manageStock &&
-            lhs.stockQuantity == rhs.stockQuantity &&
-            lhs.stockStatus == rhs.stockStatus &&
-            lhs.backordersKey == rhs.backordersKey &&
-            lhs.backordersAllowed == rhs.backordersAllowed &&
-            lhs.backordered == rhs.backordered &&
-            lhs.weight == rhs.weight &&
-            lhs.dimensions == rhs.dimensions &&
-            lhs.shippingClass == rhs.shippingClass &&
-            lhs.shippingClassID == rhs.shippingClassID &&
-            lhs.menuOrder == rhs.menuOrder
     }
 }
 

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Product Variation Entity.
 ///
-public struct ProductVariation: Decodable, GeneratedCopiable {
+public struct ProductVariation: Codable, GeneratedCopiable {
     public let siteID: Int64
     public let productID: Int64
 
@@ -247,6 +247,51 @@ public struct ProductVariation: Decodable, GeneratedCopiable {
                   shippingClass: shippingClass,
                   shippingClassID: shippingClassID,
                   menuOrder: menuOrder)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(image, forKey: .image)
+
+        try container.encode(description, forKey: .description)
+
+        // Price Settings.
+        try container.encode(regularPrice, forKey: .regularPrice)
+        try container.encode(salePrice, forKey: .salePrice)
+
+        // We need to send empty string if fields are null, because there is a bug on the API side
+        // Issue: https://github.com/woocommerce/woocommerce/issues/25350
+        if dateOnSaleStart == nil {
+            try container.encode("", forKey: .dateOnSaleStart)
+        }
+        else {
+            try container.encode(dateOnSaleStart, forKey: .dateOnSaleStart)
+        }
+        if dateOnSaleEnd == nil {
+            try container.encode("", forKey: .dateOnSaleEnd)
+        }
+        else {
+            try container.encode(dateOnSaleEnd, forKey: .dateOnSaleEnd)
+        }
+
+        try container.encode(taxStatusKey, forKey: .taxStatusKey)
+        //The backend for the standard tax class return "standard",
+        // but to set the standard tax class it accept only an empty string "" in the POST request
+        let newTaxClass = taxClass == "standard" ? "" : taxClass
+        try container.encode(newTaxClass, forKey: .taxClass)
+
+        // Shipping Settings.
+        try container.encode(weight, forKey: .weight)
+        try container.encode(dimensions, forKey: .dimensions)
+        try container.encode(shippingClass, forKey: .shippingClass)
+
+        // Inventory Settings.
+        try container.encode(sku, forKey: .sku)
+        try container.encode(manageStock, forKey: .manageStock)
+        try container.encode(stockQuantity, forKey: .stockQuantity)
+        try container.encode(backordersKey, forKey: .backordersKey)
+        try container.encode(stockStatus.rawValue, forKey: .stockStatusKey)
     }
 }
 

--- a/Networking/Networking/Remote/ProductVariationsRemote.swift
+++ b/Networking/Networking/Remote/ProductVariationsRemote.swift
@@ -1,10 +1,16 @@
 import Foundation
-import Alamofire
 
+/// Protocol for `ProductVariationsRemote` mainly used for mocking.
+///
+/// The required methods are intentionally incomplete. Feel free to add the other ones.
+///
+public protocol ProductVariationsRemoteProtocol {
+    func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void)
+}
 
 /// ProductVariation: Remote Endpoints
 ///
-public class ProductVariationsRemote: Remote {
+public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
 
     /// Retrieves all of the `ProductVariation`s available.
     ///
@@ -33,6 +39,27 @@ public class ProductVariationsRemote: Remote {
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters)
         let mapper = ProductVariationListMapper(siteID: siteID, productID: productID)
         enqueue(request, mapper: mapper, completion: completion)
+    }
+
+    /// Updates a specific `ProductVariation`.
+    ///
+    /// - Parameters:
+    ///     - productVariation: the ProductVariation to update remotely.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        do {
+            let parameters = try productVariation.toDictionary()
+            let productID = productVariation.productID
+            let siteID = productVariation.siteID
+            let path = "\(Path.products)/\(productID)/variations/\(productVariation.productVariationID)"
+            let request = JetpackRequest(wooApiVersion: .mark3, method: .post, siteID: siteID, path: path, parameters: parameters)
+            let mapper = ProductVariationMapper(siteID: siteID, productID: productID)
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import Networking
+
+/// Unit Tests for `ProductVariationMapper`
+///
+final class ProductVariationMapperTests: XCTestCase {
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 33334444
+
+    /// Dummy Product ID.
+    ///
+    private let dummyProductID: Int64 = 295
+
+    /// Verifies that all of the ProductVariation Fields are parsed correctly.
+    ///
+    func testProductVariationFieldsAreProperlyParsed() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductVariationResponse())
+
+        XCTAssertEqual(productVariation, sampleProductVariation(siteID: dummySiteID, productID: dummyProductID, id: 2783))
+    }
+}
+
+/// Private Helpers
+///
+private extension ProductVariationMapperTests {
+    /// Returns the ProductVariationMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapProductVariation(from filename: String) -> ProductVariation? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try? ProductVariationMapper(siteID: dummySiteID, productID: dummyProductID).map(response: response)
+    }
+
+    /// Returns the ProductVariationMapper output upon receiving `ProductVariation`
+    ///
+    func mapLoadProductVariationResponse() -> ProductVariation? {
+        return mapProductVariation(from: "product-variation-update")
+    }
+}
+
+private extension ProductVariationMapperTests {
+    func sampleProductVariation(siteID: Int64,
+                                productID: Int64,
+                                id: Int64) -> ProductVariation {
+        let imageSource = "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1"
+        return ProductVariation(siteID: siteID,
+                                productID: productID,
+                                productVariationID: id,
+                                attributes: sampleProductVariationAttributes(),
+                                image: ProductImage(imageID: 2432,
+                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
+                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
+                                                    src: imageSource,
+                                                    name: "DSC_0010",
+                                                    alt: ""),
+                                permalink: "https://chocolate.com/marble",
+                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
+                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
+                                dateOnSaleStart: nil,
+                                dateOnSaleEnd: nil,
+                                status: .publish,
+                                description: "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+                                sku: "87%-strawberry-marble",
+                                price: "14.99",
+                                regularPrice: "14.99",
+                                salePrice: "",
+                                onSale: false,
+                                purchasable: true,
+                                virtual: false,
+                                downloadable: true,
+                                downloads: [],
+                                downloadLimit: -1,
+                                downloadExpiry: 0,
+                                taxStatusKey: "taxable",
+                                taxClass: "",
+                                manageStock: true,
+                                stockQuantity: 16,
+                                stockStatus: .inStock,
+                                backordersKey: "notify",
+                                backordersAllowed: true,
+                                backordered: false,
+                                weight: "2.5",
+                                dimensions: ProductDimensions(length: "10",
+                                                              width: "2.5",
+                                                              height: ""),
+                                shippingClass: "",
+                                shippingClassID: 0,
+                                menuOrder: 1)
+    }
+
+    func sampleProductVariationAttributes() -> [ProductVariationAttribute] {
+        return [
+            ProductVariationAttribute(id: 0, name: "Darkness", option: "87%"),
+            ProductVariationAttribute(id: 0, name: "Flavor", option: "strawberry"),
+            ProductVariationAttribute(id: 0, name: "Shape", option: "marble")
+        ]
+    }
+
+    func dateFromGMT(_ dateStringInGMT: String) -> Date {
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+        return dateFormatter.date(from: dateStringInGMT)!
+    }
+}

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -132,11 +132,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         var updatedProductVariation: ProductVariation?
         waitForExpectation { expectation in
             remote.updateProductVariation(productVariation: productVariation) { result in
-                guard case let .success(productVariation) = result else {
-                    XCTFail("Unexpected result: \(result)")
-                    return
-                }
-                updatedProductVariation = productVariation
+                updatedProductVariation = try? result.get()
                 expectation.fulfill()
             }
         }
@@ -163,10 +159,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
         }
 
         // Then
-        guard case .failure = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
     }
 }
 

--- a/Networking/NetworkingTests/Responses/product-variation-update.json
+++ b/Networking/NetworkingTests/Responses/product-variation-update.json
@@ -1,0 +1,89 @@
+{
+    "data": {
+        "id": 2783,
+        "date_created": "2020-06-12T22:36:02",
+        "date_created_gmt": "2020-06-12T14:36:02",
+        "date_modified": "2020-07-21T16:35:47",
+        "date_modified_gmt": "2020-07-21T08:35:47",
+        "description": "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+        "permalink": "https://chocolate.com/marble",
+        "sku": "87%-strawberry-marble",
+        "price": "14.99",
+        "regular_price": "14.99",
+        "sale_price": "",
+        "date_on_sale_from": null,
+        "date_on_sale_from_gmt": null,
+        "date_on_sale_to": null,
+        "date_on_sale_to_gmt": null,
+        "on_sale": false,
+        "status": "publish",
+        "purchasable": true,
+        "virtual": false,
+        "downloadable": true,
+        "downloads": [],
+        "download_limit": -1,
+        "download_expiry": 0,
+        "tax_status": "taxable",
+        "tax_class": "",
+        "manage_stock": "parent",
+        "stock_quantity": 16,
+        "stock_status": "instock",
+        "backorders": "notify",
+        "backorders_allowed": true,
+        "backordered": false,
+        "weight": "2.5",
+        "dimensions": {
+            "length": "10",
+            "width": "2.5",
+            "height": ""
+        },
+        "shipping_class": "",
+        "shipping_class_id": 0,
+        "image": {
+            "id": 2432,
+            "date_created": "2020-03-13T19:13:57",
+            "date_created_gmt": "2020-03-13T03:13:57",
+            "date_modified": "2020-07-22T00:29:16",
+            "date_modified_gmt": "2020-07-21T08:29:16",
+            "src": "https://i0.wp.com/funtestingusa.wpcomstaging.com/wp-content/uploads/2019/11/img_0002-1.jpeg?fit=4288%2C2848&ssl=1",
+            "name": "DSC_0010",
+            "alt": ""
+        },
+        "attributes": [
+            {
+                "id": 0,
+                "name": "Darkness",
+                "option": "87%"
+            },
+            {
+                "id": 0,
+                "name": "Flavor",
+                "option": "strawberry"
+            },
+            {
+                "id": 0,
+                "name": "Shape",
+                "option": "marble"
+            }
+        ],
+        "menu_order": 1,
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/846/variations/2783"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/846/variations"
+                }
+            ],
+            "up": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/products/846"
+                }
+            ]
+        }
+    }
+}

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0202B6972387AFBF00F3EBE0 /* MockInMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6962387AFBF00F3EBE0 /* MockInMemoryStorage.swift */; };
 		0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */; };
 		020B2F9623BDE4DD00BD79AD /* ProductStoreTests+Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020B2F9523BDE4DD00BD79AD /* ProductStoreTests+Validation.swift */; };
+		020C907D24C729D6001E2BEB /* MockProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020C907C24C729D6001E2BEB /* MockProductVariation.swift */; };
+		020C908124C7D71D001E2BEB /* MockProductVariationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020C908024C7D71D001E2BEB /* MockProductVariationsRemote.swift */; };
 		02124DAC24318D6B00980D74 /* Media+MediaTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02124DAB24318D6B00980D74 /* Media+MediaTypeTests.swift */; };
 		02124DAE2431C11600980D74 /* Media+ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02124DAD2431C11500980D74 /* Media+ProductImage.swift */; };
 		02124DB02431C18700980D74 /* Media+ProductImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02124DAF2431C18700980D74 /* Media+ProductImageTests.swift */; };
@@ -250,6 +252,8 @@
 		0202B6962387AFBF00F3EBE0 /* MockInMemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInMemoryStorage.swift; sourceTree = "<group>"; };
 		0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettingsStoreTests+ProductsFeatureSwitch.swift"; sourceTree = "<group>"; };
 		020B2F9523BDE4DD00BD79AD /* ProductStoreTests+Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductStoreTests+Validation.swift"; sourceTree = "<group>"; };
+		020C907C24C729D6001E2BEB /* MockProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductVariation.swift; sourceTree = "<group>"; };
+		020C908024C7D71D001E2BEB /* MockProductVariationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductVariationsRemote.swift; sourceTree = "<group>"; };
 		02124DAB24318D6B00980D74 /* Media+MediaTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+MediaTypeTests.swift"; sourceTree = "<group>"; };
 		02124DAD2431C11500980D74 /* Media+ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+ProductImage.swift"; sourceTree = "<group>"; };
 		02124DAF2431C18700980D74 /* Media+ProductImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+ProductImageTests.swift"; sourceTree = "<group>"; };
@@ -697,6 +701,7 @@
 				578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */,
 				578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */,
 				578CE7912475EC9200492EBF /* MockProductsRemote.swift */,
+				020C908024C7D71D001E2BEB /* MockProductVariationsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1019,6 +1024,7 @@
 				B53A569F211245E0000776C9 /* MockupStorage+Sample.swift */,
 				0202B6962387AFBF00F3EBE0 /* MockInMemoryStorage.swift */,
 				020220E32396969E00290165 /* MockProduct.swift */,
+				020C907C24C729D6001E2BEB /* MockProductVariation.swift */,
 				0248B36A2459127200A271A4 /* MockupNetwork+Path.swift */,
 				02A098232480D0D8002F8C7A /* MockCrashLogger.swift */,
 			);
@@ -1474,6 +1480,8 @@
 				B5BC736E20D1AB3600B5B6FA /* Constants.swift in Sources */,
 				02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */,
 				748525AC218A45360036DF75 /* NotificationStoreTests.swift in Sources */,
+				020C908124C7D71D001E2BEB /* MockProductVariationsRemote.swift in Sources */,
+				020C907D24C729D6001E2BEB /* MockProductVariation.swift in Sources */,
 				7499936820EFC0ED00CF01CD /* OrderNoteStoreTests.swift in Sources */,
 				578CE7972475FD8200492EBF /* MockProductReview.swift in Sources */,
 			);

--- a/Yosemite/Yosemite/Actions/ProductVariationAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductVariationAction.swift
@@ -9,4 +9,8 @@ public enum ProductVariationAction: Action {
     /// Synchronizes the ProductVariation's matching the specified criteria.
     ///
     case synchronizeProductVariations(siteID: Int64, productID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+
+    /// Updates a specified ProductVariation.
+    ///
+    case updateProductVariation(productVariation: ProductVariation, onCompletion: (Result<ProductVariation, ProductUpdateError>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -80,20 +80,23 @@ private extension ProductVariationStore {
     ///
     func updateProductVariation(productVariation: ProductVariation, onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
         remote.updateProductVariation(productVariation: productVariation) { [weak self] result in
+            guard let self = self else {
+                return
+            }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
             case .success(let productVariation):
-                self?.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
-                                                                siteID: productVariation.siteID,
-                                                                productID: productVariation.productID) { [weak self] in
-                                                                    guard let storageProductVariation = self?.storageManager.viewStorage
-                                                                        .loadProductVariation(siteID: productVariation.siteID,
-                                                                                              productVariationID: productVariation.productVariationID) else {
-                                                                                                onCompletion(.failure(.notFoundInStorage))
-                                                                                                return
-                                                                    }
-                                                                    onCompletion(.success(storageProductVariation.toReadOnly()))
+                self.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                                                               siteID: productVariation.siteID,
+                                                               productID: productVariation.productID) { [weak self] in
+                                                                guard let storageProductVariation = self?.storageManager.viewStorage
+                                                                    .loadProductVariation(siteID: productVariation.siteID,
+                                                                                          productVariationID: productVariation.productVariationID) else {
+                                                                                            onCompletion(.failure(.notFoundInStorage))
+                                                                                            return
+                                                                }
+                                                                onCompletion(.success(storageProductVariation.toReadOnly()))
                 }
             }
         }

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -5,10 +5,21 @@ import Storage
 // MARK: - ProductVariationStore
 //
 public final class ProductVariationStore: Store {
+    private let remote: ProductVariationsRemoteProtocol
 
     private lazy var sharedDerivedStorage: StorageType = {
         return storageManager.newDerivedStorage()
     }()
+
+    public override convenience init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
+        let remote = ProductVariationsRemote(network: network)
+        self.init(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+    }
+
+    init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, remote: ProductVariationsRemoteProtocol) {
+        self.remote = remote
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
 
     /// Registers for supported Actions.
     ///
@@ -27,6 +38,8 @@ public final class ProductVariationStore: Store {
         switch action {
         case .synchronizeProductVariations(let siteID, let productID, let pageNumber, let pageSize, let onCompletion):
             synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .updateProductVariation(let productVariation, let onCompletion):
+            updateProductVariation(productVariation: productVariation, onCompletion: onCompletion)
         }
     }
 }
@@ -59,6 +72,29 @@ private extension ProductVariationStore {
                                                             siteID: siteID,
                                                             productID: productID) {
                 onCompletion(nil)
+            }
+        }
+    }
+
+    /// Updates the product variation.
+    ///
+    func updateProductVariation(productVariation: ProductVariation, onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
+        remote.updateProductVariation(productVariation: productVariation) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(ProductUpdateError(error: error)))
+            case .success(let productVariation):
+                self?.upsertStoredProductVariationsInBackground(readOnlyProductVariations: [productVariation],
+                                                                siteID: productVariation.siteID,
+                                                                productID: productVariation.productID) { [weak self] in
+                                                                    guard let storageProductVariation = self?.storageManager.viewStorage
+                                                                        .loadProductVariation(siteID: productVariation.siteID,
+                                                                                              productVariationID: productVariation.productVariationID) else {
+                                                                                                onCompletion(.failure(.notFoundInStorage))
+                                                                                                return
+                                                                    }
+                                                                    onCompletion(.success(storageProductVariation.toReadOnly()))
+                }
             }
         }
     }

--- a/Yosemite/YosemiteTests/Mockups/MockProductVariation.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockProductVariation.swift
@@ -1,0 +1,58 @@
+import Foundation
+@testable import Yosemite
+
+final class MockProductVariation {
+    func productVariation(siteID: Int64 = 2019,
+                          productID: Int64 = 2020,
+                          variationID: Int64 = 2783) -> ProductVariation {
+        return ProductVariation(siteID: siteID,
+                                productID: productID,
+                                productVariationID: variationID,
+                                attributes: [],
+                                image: ProductImage(imageID: 2432,
+                                                    dateCreated: dateFromGMT("2020-03-13T03:13:57"),
+                                                    dateModified: dateFromGMT("2020-07-21T08:29:16"),
+                                                    src: "",
+                                                    name: "DSC_0010",
+                                                    alt: ""),
+                                permalink: "https://chocolate.com/marble",
+                                dateCreated: dateFromGMT("2020-06-12T14:36:02"),
+                                dateModified: dateFromGMT("2020-07-21T08:35:47"),
+                                dateOnSaleStart: nil,
+                                dateOnSaleEnd: nil,
+                                status: .publish,
+                                description: "<p>Nutty chocolate marble, 99% and organic.</p>\n",
+                                sku: "87%-strawberry-marble",
+                                price: "14.99",
+                                regularPrice: "14.99",
+                                salePrice: "",
+                                onSale: false,
+                                purchasable: true,
+                                virtual: false,
+                                downloadable: true,
+                                downloads: [],
+                                downloadLimit: -1,
+                                downloadExpiry: 0,
+                                taxStatusKey: "taxable",
+                                taxClass: "",
+                                manageStock: true,
+                                stockQuantity: 16,
+                                stockStatus: .inStock,
+                                backordersKey: "notify",
+                                backordersAllowed: true,
+                                backordered: false,
+                                weight: "2.5",
+                                dimensions: ProductDimensions(length: "10",
+                                                              width: "2.5",
+                                                              height: ""),
+                                shippingClass: "",
+                                shippingClassID: 0,
+                                menuOrder: 1)
+
+    }
+
+    private func dateFromGMT(_ dateStringInGMT: String) -> Date {
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+        return dateFormatter.date(from: dateStringInGMT)!
+    }
+}

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductVariationsRemote.swift
@@ -18,7 +18,7 @@ final class MockProductVariationsRemote {
 
     /// Set the value passed to the `completion` block if `updateProductVariation()` is called.
     ///
-    func whenUpdatingProduct(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
+    func whenUpdatingProductVariation(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
         let key = ResultKey(siteID: siteID, productID: productID, productVariationIDs: [productVariationID])
         productVariationUpdateResults[key] = result
     }

--- a/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Yosemite/YosemiteTests/Mockups/Networking/Remote/MockProductVariationsRemote.swift
@@ -1,0 +1,46 @@
+
+import Foundation
+import Networking
+
+import XCTest
+
+/// Mock for `MockProductVariationsRemote`.
+///
+final class MockProductVariationsRemote {
+    private struct ResultKey: Hashable {
+        let siteID: Int64
+        let productID: Int64
+        let productVariationIDs: [Int64]
+    }
+
+    /// The results to return based on the given arguments in `updateProductVariation`
+    private var productVariationUpdateResults = [ResultKey: Result<ProductVariation, Error>]()
+
+    /// Set the value passed to the `completion` block if `updateProductVariation()` is called.
+    ///
+    func whenUpdatingProduct(siteID: Int64, productID: Int64, productVariationID: Int64, thenReturn result: Result<ProductVariation, Error>) {
+        let key = ResultKey(siteID: siteID, productID: productID, productVariationIDs: [productVariationID])
+        productVariationUpdateResults[key] = result
+    }
+}
+
+// MARK: - ProductVariationsRemoteProtocol conformance
+
+extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
+    func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let key = ResultKey(siteID: productVariation.siteID,
+                                productID: productVariation.productID,
+                                productVariationIDs: [productVariation.productVariationID])
+            if let result = self.productVariationUpdateResults[key] {
+                completion(result)
+            } else {
+                XCTFail("\(String(describing: self)) Could not find Result for \(key)")
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -289,6 +289,88 @@ final class ProductVariationStoreTests: XCTestCase {
         store.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
+
+    // MARK: - ProductVariationAction.updateProductVariation
+
+    /// Verifies that `ProductVariationAction.updateProductVariation` returns the expected `ProductVariation`.
+    ///
+    func testUpdatingProductVariationReturnsExpectedFieldsAndRelatedObjects() {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let productVariationID: Int64 = 17
+        let expectedProductVariation = MockProductVariation()
+            .productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: productVariationID)
+            .copy(attributes: sampleProductVariationAttributes())
+        let productVariation = MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: productVariationID)
+            .copy(description: "Wooooo", sku: "test-woo")
+        remote.whenUpdatingProduct(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   productVariationID: productVariationID,
+                                   thenReturn: .success(expectedProductVariation))
+
+        // Saves an existing ProductVariation into storage.
+        // Note: at least one field of `ProductVariation` before and after the update should be different.
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 1)
+
+        // When
+        var result: Result<Yosemite.ProductVariation, ProductUpdateError>?
+        waitForExpectation { expectation in
+            let action = ProductVariationAction.updateProductVariation(productVariation: productVariation) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        guard case let .success(updatedProductVariation) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertEqual(updatedProductVariation, expectedProductVariation)
+
+        let storedProductVariation = viewStorage.loadProductVariation(siteID: sampleSiteID, productVariationID: productVariationID)
+        let readOnlyStoredProduct = storedProductVariation?.toReadOnly()
+        XCTAssertEqual(readOnlyStoredProduct, expectedProductVariation)
+    }
+
+    /// Verifies that `ProductVariationAction.updateProductVariation` returns an error whenever there is an error response from the backend.
+    ///
+    func testUpdatingProductVariationReturnsErrorUponReponseError() {
+        // Given
+        let remote = MockProductVariationsRemote()
+        let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+        let productVariationID: Int64 = 17
+        remote.whenUpdatingProduct(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   productVariationID: productVariationID,
+                                   thenReturn: .failure(NSError(domain: "", code: 400, userInfo: nil)))
+        // Saves an existing ProductVariation into storage.
+        let productVariation = MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: productVariationID)
+        storageManager.insertSampleProductVariation(readOnlyProductVariation: productVariation)
+        XCTAssertEqual(viewStorage.countObjects(ofType: StorageProductVariation.self), 1)
+
+        // When
+        var result: Result<Yosemite.ProductVariation, ProductUpdateError>?
+        waitForExpectation { expectation in
+            let action = ProductVariationAction.updateProductVariation(productVariation: productVariation) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        guard case .failure = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+
+        // The existing ProductVariation should not be deleted.
+        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)
+    }
 }
 
 

--- a/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductVariationStoreTests.swift
@@ -304,7 +304,7 @@ final class ProductVariationStoreTests: XCTestCase {
             .copy(attributes: sampleProductVariationAttributes())
         let productVariation = MockProductVariation().productVariation(siteID: sampleSiteID, productID: sampleProductID, variationID: productVariationID)
             .copy(description: "Wooooo", sku: "test-woo")
-        remote.whenUpdatingProduct(siteID: sampleSiteID,
+        remote.whenUpdatingProductVariation(siteID: sampleSiteID,
                                    productID: sampleProductID,
                                    productVariationID: productVariationID,
                                    thenReturn: .success(expectedProductVariation))
@@ -325,10 +325,7 @@ final class ProductVariationStoreTests: XCTestCase {
         }
 
         // Then
-        guard case let .success(updatedProductVariation) = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
+        let updatedProductVariation = try? result?.get()
         XCTAssertEqual(updatedProductVariation, expectedProductVariation)
 
         let storedProductVariation = viewStorage.loadProductVariation(siteID: sampleSiteID, productVariationID: productVariationID)
@@ -343,7 +340,7 @@ final class ProductVariationStoreTests: XCTestCase {
         let remote = MockProductVariationsRemote()
         let store = ProductVariationStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
         let productVariationID: Int64 = 17
-        remote.whenUpdatingProduct(siteID: sampleSiteID,
+        remote.whenUpdatingProductVariation(siteID: sampleSiteID,
                                    productID: sampleProductID,
                                    productVariationID: productVariationID,
                                    thenReturn: .failure(NSError(domain: "", code: 400, userInfo: nil)))
@@ -363,10 +360,7 @@ final class ProductVariationStoreTests: XCTestCase {
         }
 
         // Then
-        guard case .failure = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
 
         // The existing ProductVariation should not be deleted.
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductVariation.self), 1)


### PR DESCRIPTION
Yosemite/Networking changes for #2085 

## Changes

Note: a bunch of diffs are from JSON and sample `ProductVariation` response!

- Networking layer:
  - Created `ProductVariationMapper` that maps a response to a single `ProductVariation` with unit tests
  - Updated `ProductVariation` to be `Codable` that encodes in a similar way to `Product`
  - In `ProductVariationsRemote`, added `updateProductVariation` for updating a product variation. Also, created a protocol `ProductVariationsRemoteProtocol` that `ProductVariationsRemote` conforms to for unit tests
- Yosemite layer:
  - Added `ProductVariationAction.updateProductVariation`
  - In `ProductVariationStore`, implemented `updateProductVariation`
  - Created `MockProductVariation` and `MockProductVariationsRemote` for unit tests

## Testing

This PR doesn't affect existing behavior, just CI!


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
