### PR TITLE
Edit Grouped Products: edit linked products (Part 3/3) - search product list selector

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -128,17 +128,24 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///     - keyword: Search string that should be matched by the products - title, excerpt and content (description).
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of products to be retrieved per page.
+    ///     - excludedProductIDs: a list of product IDs to be excluded from the results.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func searchProducts(for siteID: Int64,
                                keyword: String,
                                pageNumber: Int,
                                pageSize: Int,
+                               excludedProductIDs: [Int64] = [],
                                completion: @escaping ([Product]?, Error?) -> Void) {
+        let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ",")
+
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
-            ParameterKey.search: keyword
+            ParameterKey.search: keyword,
+            ParameterKey.exclude: stringOfExcludedProductIDs
         ]
 
         let path = Path.products

--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -44,7 +44,6 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                 excludedProductIDs: [Int64] = [],
                                 completion: @escaping (Result<[Product], Error>) -> Void) {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
-            .filter { !$0.isEmpty }
             .joined(separator: ",")
         let filterParameters = [
             ParameterKey.stockStatus: stockStatus?.rawValue ?? "",
@@ -91,7 +90,6 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         }
 
         let stringOfProductIDs = productIDs.map { String($0) }
-            .filter { !$0.isEmpty }
             .joined(separator: ",")
         let parameters = [
             ParameterKey.include: stringOfProductIDs,
@@ -138,7 +136,6 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                excludedProductIDs: [Int64] = [],
                                completion: @escaping ([Product]?, Error?) -> Void) {
         let stringOfExcludedProductIDs = excludedProductIDs.map { String($0) }
-            .filter { !$0.isEmpty }
             .joined(separator: ",")
 
         let parameters = [

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -143,6 +143,12 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
 
     // MARK: Public functions
 
+    /// Called when the visual data of the data source change outside of selection UX.
+    /// (e.g. receiving selected products from search UI in `ProductListMultiSelectorDataSource`)
+    func reloadData() {
+        tableView.reloadData()
+    }
+
     func updateResultsController() {
         resultsController = dataSource.createResultsController()
         configureResultsController(resultsController) { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorDataSource.swift
@@ -79,6 +79,13 @@ final class ProductListMultiSelectorDataSource: PaginatedListSelectorDataSource 
     }
 }
 
+extension ProductListMultiSelectorDataSource {
+    /// Called when it receives events from adding a list of products (e.g. from search UI).
+    func addProducts(_ productIDs: [Int64]) {
+        selectedProductIDs = (selectedProductIDs + productIDs).removingDuplicates()
+    }
+}
+
 private extension ProductListMultiSelectorDataSource {
     func isProductSelected(_ product: Product) -> Bool {
         return selectedProductIDs.contains(product.productID)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
@@ -1,7 +1,7 @@
 import Yosemite
 
-/// Implementation of `SearchUICommand` for Product search.
-final class ProductSearchUICommand: SearchUICommand {
+/// Implementation of `SearchUICommand` for selecting linked products to a grouped product from search UI.
+final class ProductListMultiSelectorSearchUICommand: SearchUICommand {
     typealias Model = Product
     typealias CellViewModel = ProductsTabProductViewModel
     typealias ResultsControllerModel = StorageProduct
@@ -14,16 +14,22 @@ final class ProductSearchUICommand: SearchUICommand {
 
     private let siteID: Int64
 
-    init(siteID: Int64) {
+    private let excludedProductIDs: [Int64]
+    private var selectedProductIDs: [Int64] = []
+
+    typealias Completion = (_ selectedProductIDs: [Int64]) -> Void
+    private let onCompletion: Completion
+
+    init(siteID: Int64, excludedProductIDs: [Int64], onCompletion: @escaping Completion) {
         self.siteID = siteID
+        self.excludedProductIDs = excludedProductIDs
+        self.onCompletion = onCompletion
     }
 
     func createResultsController() -> ResultsController<ResultsControllerModel> {
         let storageManager = ServiceLocator.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(key: "name", ascending: true)
-
-        return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
+        let predicate = NSPredicate(format: "siteID == %lld AND NOT(productID in %@)", siteID, excludedProductIDs)
+        return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortOrder: .nameAscending)
     }
 
     func createStarterViewController() -> UIViewController? {
@@ -43,8 +49,25 @@ final class ProductSearchUICommand: SearchUICommand {
         viewController.configure(.simple(message: message, image: .emptySearchResultsImage))
     }
 
+    func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void) {
+        let hasUnsavedChanges = selectedProductIDs.isNotEmpty
+        let title = hasUnsavedChanges ? Strings.done: Strings.cancel
+
+        // The button title has to be updated without animation so that the title is not truncated when its width changes.
+        UIView.performWithoutAnimation {
+            button.setTitle(title, for: .normal)
+            button.layoutIfNeeded()
+        }
+        button.on(.touchUpInside) { [weak self] _ in
+            if hasUnsavedChanges {
+                self?.completeSelectingProducts()
+            }
+            onDismiss()
+        }
+    }
+
     func createCellViewModel(model: Product) -> ProductsTabProductViewModel {
-        return ProductsTabProductViewModel(product: model)
+        return ProductsTabProductViewModel(product: model, isSelected: isProductSelected(model))
     }
 
     /// Synchronizes the Products matching a given Keyword
@@ -67,8 +90,36 @@ final class ProductSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        ProductDetailsFactory.productDetails(product: model, presentationStyle: .navigationStack) { [weak viewController] vc in
-            viewController?.navigationController?.pushViewController(vc, animated: true)
+        onProductSelected(model)
+        reloadData()
+        updateActionButton()
+    }
+}
+
+private extension ProductListMultiSelectorSearchUICommand {
+    @objc func completeSelectingProducts() {
+        onCompletion(selectedProductIDs)
+    }
+}
+
+private extension ProductListMultiSelectorSearchUICommand {
+    func isProductSelected(_ product: Product) -> Bool {
+        return selectedProductIDs.contains(product.productID)
+    }
+
+    func onProductSelected(_ product: Product) {
+        if isProductSelected(product) {
+            // Unselects the product if it is currently selected.
+            selectedProductIDs.removeAll { $0 == product.productID }
+        } else {
+            selectedProductIDs.append(product.productID)
         }
+    }
+}
+
+private extension ProductListMultiSelectorSearchUICommand {
+    enum Strings {
+        static let cancel = NSLocalizedString("Cancel", comment: "Action title to cancel selecting products to add to a grouped product from search results")
+        static let done = NSLocalizedString("Done", comment: "Action title to select products to add to a grouped product from search results")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
@@ -76,7 +76,8 @@ final class ProductListMultiSelectorSearchUICommand: SearchUICommand {
         let action = ProductAction.searchProducts(siteID: siteID,
                                                   keyword: keyword,
                                                   pageNumber: pageNumber,
-                                                  pageSize: pageSize) { error in
+                                                  pageSize: pageSize,
+                                                  excludedProductIDs: excludedProductIDs) { error in
                                                     if let error = error {
                                                         DDLogError("☠️ Product Search Failure! \(error)")
                                                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
@@ -83,10 +83,7 @@ final class ProductListMultiSelectorSearchUICommand: SearchUICommand {
 
                                                     onCompletion?(error == nil)
         }
-
         ServiceLocator.stores.dispatch(action)
-
-        ServiceLocator.analytics.track(.productListSearched)
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorSearchUICommand.swift
@@ -41,9 +41,7 @@ final class ProductListMultiSelectorSearchUICommand: SearchUICommand {
         let boldSearchKeyword = NSAttributedString(string: searchKeyword,
                                                    attributes: [.font: EmptyStateViewController.Config.messageFont.bold])
 
-        let format = NSLocalizedString("We're sorry, we couldn't find results for “%@”",
-                                       comment: "Message for empty Products search results. The %@ is a placeholder for the text entered by the user.")
-        let message = NSMutableAttributedString(string: format)
+        let message = NSMutableAttributedString(string: Strings.emptySearchResultsFormat)
         message.replaceFirstOccurrence(of: "%@", with: boldSearchKeyword)
 
         viewController.configure(.simple(message: message, image: .emptySearchResultsImage))
@@ -119,5 +117,8 @@ private extension ProductListMultiSelectorSearchUICommand {
     enum Strings {
         static let cancel = NSLocalizedString("Cancel", comment: "Action title to cancel selecting products to add to a grouped product from search results")
         static let done = NSLocalizedString("Done", comment: "Action title to select products to add to a grouped product from search results")
+        static let emptySearchResultsFormat =
+            NSLocalizedString("We're sorry, we couldn't find results for “%@”",
+                              comment: "Message for empty Products search results. The %@ is a placeholder for the text entered by the user.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListSelectorViewController.swift
@@ -74,7 +74,7 @@ private extension ProductListSelectorViewController {
         let navigationController = WooNavigationController(rootViewController: searchViewController)
         present(navigationController, animated: true, completion: nil)
     }
-    
+
     func didSelectProductsFromSearch(ids: [Int64]) {
         dataSource.addProducts(ids)
         paginatedListSelector.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListSelectorViewController.swift
@@ -63,7 +63,21 @@ private extension ProductListSelectorViewController {
     }
 
     @objc func searchButtonTapped() {
-        // TODO-2199: search products
+        let productIDsToExclude = (excludedProductIDs + productIDs).removingDuplicates()
+        let searchProductsCommand = ProductListMultiSelectorSearchUICommand(siteID: siteID,
+                                                                            excludedProductIDs: productIDsToExclude) { [weak self] productIDs in
+                                                                                self?.didSelectProductsFromSearch(ids: productIDs)
+        }
+        let searchViewController = SearchViewController(storeID: siteID,
+                                                        command: searchProductsCommand,
+                                                        cellType: ProductsTabProductTableViewCell.self)
+        let navigationController = WooNavigationController(rootViewController: searchViewController)
+        present(navigationController, animated: true, completion: nil)
+    }
+    
+    func didSelectProductsFromSearch(ids: [Int64]) {
+        dataSource.addProducts(ids)
+        paginatedListSelector.reloadData()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -71,7 +71,7 @@ final class OrderSearchUICommand: SearchUICommand {
         ServiceLocator.analytics.track(.ordersListFilterOrSearch, withProperties: ["filter": "", "search": "\(keyword)"])
     }
 
-    func didSelectSearchResult(model: Order, from viewController: UIViewController) {
+    func didSelectSearchResult(model: Order, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
         guard let detailsViewController = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
             fatalError()
         }

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -51,6 +51,10 @@ protocol SearchUICommand {
     func configureEmptyStateViewControllerBeforeDisplay(viewController: EmptyStateViewControllerType,
                                                         searchKeyword: String)
 
+    /// Optionally configures the action button that dismisses the search UI.
+    /// - Parameters:
+    ///   - button: the button in the navigation bar that dismisses the search UI. Shows "Cancel" by default.
+    ///   - onDismiss: called when it is ready to dismiss the search UI.
     func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void)
 
     /// Creates a view model for the search result cell.

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -51,6 +51,8 @@ protocol SearchUICommand {
     func configureEmptyStateViewControllerBeforeDisplay(viewController: EmptyStateViewControllerType,
                                                         searchKeyword: String)
 
+    func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void)
+
     /// Creates a view model for the search result cell.
     ///
     /// - Parameter model: search result model.
@@ -69,13 +71,20 @@ protocol SearchUICommand {
     /// - Parameters:
     ///   - model: search result model.
     ///   - viewController: view controller where the user selects the search result.
-    func didSelectSearchResult(model: Model, from viewController: UIViewController)
+    func didSelectSearchResult(model: Model, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void)
 
     /// The Accessibility Identifier for the search bar
     var searchBarAccessibilityIdentifier: String { get }
 
     /// The Accessibility Identifier for the cancel button
     var cancelButtonAccessibilityIdentifier: String { get }
+}
+
+// MARK: - Default implementation
+extension SearchUICommand {
+    func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void) {
+        // If not implemented, keeps the default cancel UI/UX
+    }
 }
 
 // MARK: - SearchUICommand using EmptySearchResultsViewController

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -71,6 +71,8 @@ protocol SearchUICommand {
     /// - Parameters:
     ///   - model: search result model.
     ///   - viewController: view controller where the user selects the search result.
+    ///   - reloadData: called when UI reload is necessary.
+    ///   - updateActionButton: called when action button update is necessary.
     func didSelectSearchResult(model: Model, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void)
 
     /// The Accessibility Identifier for the search bar

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -469,7 +469,7 @@ private extension SearchViewController {
             childView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
             childView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
             childView.topAnchor.constraint(equalTo: searchBar.bottomAnchor),
-            childView.bottomAnchor.constraint(equalTo: tableView.bottomAnchor)
+            childView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
         childController.didMove(toParent: self)

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -186,13 +186,13 @@ where Cell.SearchModel == Command.CellViewModel {
         let model = resultsController.object(at: indexPath)
         searchUICommand.didSelectSearchResult(model: model, from: self, reloadData: { [weak self] in
             self?.tableView.reloadData()
-            }, updateActionButton: { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                self.searchUICommand.configureActionButton(self.cancelButton, onDismiss: { [weak self] in
-                    self?.dismissWasPressed()
-                })
+        }, updateActionButton: { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.searchUICommand.configureActionButton(self.cancelButton, onDismiss: { [weak self] in
+                self?.dismissWasPressed()
+            })
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -37,6 +37,10 @@ where Cell.SearchModel == Command.CellViewModel {
     ///
     private let resultsController: ResultsController<Command.ResultsControllerModel>
 
+    /// Predicate for the results controller from the command.
+    ///
+    private let resultsPredicate: NSPredicate?
+
     /// The controller of the view to show if there is no search `keyword` entered.
     ///
     /// If `nil`, the `tableView` will be shown instead.
@@ -96,6 +100,7 @@ where Cell.SearchModel == Command.CellViewModel {
          command: Command,
          cellType: Cell.Type) {
         self.resultsController = command.createResultsController()
+        self.resultsPredicate = resultsController.predicate
         self.searchUICommand = command
         self.storeID = storeID
         super.init(nibName: "SearchViewController", bundle: nil)
@@ -179,7 +184,16 @@ where Cell.SearchModel == Command.CellViewModel {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let model = resultsController.object(at: indexPath)
-        searchUICommand.didSelectSearchResult(model: model, from: self)
+        searchUICommand.didSelectSearchResult(model: model, from: self, reloadData: { [weak self] in
+            self?.tableView.reloadData()
+            }, updateActionButton: { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                self.searchUICommand.configureActionButton(self.cancelButton, onDismiss: { [weak self] in
+                    self?.dismissWasPressed()
+                })
+        })
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -373,7 +387,10 @@ private extension SearchViewController {
     /// Updates the Predicate + Triggers a Sync Event
     ///
     func synchronizeSearchResults(with keyword: String) {
-        resultsController.predicate = NSPredicate(format: "ANY searchResults.keyword = %@", keyword)
+        // When the search query changes, also includes the original results predicate in addition to the search keyword.
+        let searchResultsPredicate = NSPredicate(format: "ANY searchResults.keyword = %@", keyword)
+        let subpredicates = [resultsPredicate].compactMap { $0 } + [searchResultsPredicate]
+        resultsController.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
 
         tableView.setContentOffset(.zero, animated: false)
         tableView.reloadData()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77223B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift */; };
 		020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77423B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift */; };
 		020BE77723B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020BE77623B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift */; };
+		020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020C908324C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift */; };
 		020DD48A23229495005822B1 /* ProductsTabProductTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */; };
 		020DD48D2322A617005822B1 /* ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */; };
 		020DD48F232392C9005822B1 /* UIViewController+AppReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */; };
@@ -924,6 +925,7 @@
 		020BE77223B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecInsertMoreFormatBarCommandTests.swift; sourceTree = "<group>"; };
 		020BE77423B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecSourceCodeFormatBarCommandTests.swift; sourceTree = "<group>"; };
 		020BE77623B4A9D9007FE54C /* AztecLinkFormatBarCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecLinkFormatBarCommandTests.swift; sourceTree = "<group>"; };
+		020C908324C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommandTests.swift; sourceTree = "<group>"; };
 		020DD48923229495005822B1 /* ProductsTabProductTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductTableViewCell.swift; sourceTree = "<group>"; };
 		020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTabProductViewModel.swift; sourceTree = "<group>"; };
 		020DD48E232392C9005822B1 /* UIViewController+AppReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AppReview.swift"; sourceTree = "<group>"; };
@@ -1835,6 +1837,14 @@
 			path = Vendors;
 			sourceTree = "<group>";
 		};
+		020C908224C84638001E2BEB /* Product */ = {
+			isa = PBXGroup;
+			children = (
+				020C908324C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift */,
+			);
+			path = Product;
+			sourceTree = "<group>";
+		};
 		020DD48B2322A5F9005822B1 /* View Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -2605,6 +2615,7 @@
 			isa = PBXGroup;
 			children = (
 				573D0ACD2458665C004DE614 /* Order */,
+				020C908224C84638001E2BEB /* Product */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -5254,6 +5265,7 @@
 				02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,
 				453904F523BB8BD5007C4956 /* ProductTaxClassListSelectorDataSourceTests.swift in Sources */,
+				020C908424C84652001E2BEB /* ProductListMultiSelectorSearchUICommandTests.swift in Sources */,
 				746FC23D2200A62B00C3096C /* DateWooTests.swift in Sources */,
 				02F5F80E246102240000613A /* FilterProductListViewModel+numberOfActiveFiltersTests.swift in Sources */,
 				021AEF9C2407B07300029D28 /* ProductImageStatus+HelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */; };
 		021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */; };
 		021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */; };
+		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
 		0225C42824768A4C00C5B4F0 /* FilterProductListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */; };
 		0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */; };
 		0225C42C2477D0D500C5B4F0 /* ProductFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */; };
@@ -105,7 +106,6 @@
 		023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A059824135F2600E3FC99 /* ReviewsViewController.swift */; };
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
-		02404EDA2314C36300FF1170 /* StatsVersionStateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */; };
 		02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404ED92314C36200FF1170 /* StatsVersionCoordinator.swift */; };
 		02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EDF2314FE5900FF1170 /* DashboardUIFactoryTests.swift */; };
 		02404EE2231501E000FF1170 /* StatsVersionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02404EE1231501E000FF1170 /* StatsVersionCoordinatorTests.swift */; };
@@ -956,6 +956,7 @@
 		021E2A1F23AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBackordersSettingListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		021FAFCC2355621E00B99241 /* UIView+SubviewsAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxisTests.swift"; sourceTree = "<group>"; };
 		021FAFCE23556D2B00B99241 /* UIView+SubviewsAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SubviewsAxis.swift"; sourceTree = "<group>"; };
+		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
 		0225C42724768A4C00C5B4F0 /* FilterProductListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelTests.swift; sourceTree = "<group>"; };
 		0225C42924768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProductListViewModelProductListFilterTests.swift; sourceTree = "<group>"; };
 		0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModel.swift; sourceTree = "<group>"; };
@@ -987,7 +988,6 @@
 		023A059824135F2600E3FC99 /* ReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsViewController.swift; sourceTree = "<group>"; };
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
-		02404ED92314C36200FF1170 /* StatsVersionStateCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionStateCoordinator.swift; sourceTree = "<group>"; };
 		02404ED92314C36200FF1170 /* StatsVersionCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsVersionCoordinator.swift; sourceTree = "<group>"; };
 		02404EDF2314FE5900FF1170 /* DashboardUIFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactoryTests.swift; sourceTree = "<group>"; };
 		02404EE1231501E000FF1170 /* StatsVersionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersionCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -1939,6 +1939,7 @@
 			children = (
 				022F7A0124A05F6400012601 /* GroupedProductsViewController.swift */,
 				022F7A0224A05F6400012601 /* GroupedProductsViewController.xib */,
+				021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */,
 				023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */,
 				02B1AFEB24BC5AE5005DB1E3 /* GroupedProductListSelectorDataSource.swift */,
 				0273707F24C0094500167204 /* ProductListMultiSelectorDataSource.swift */,
@@ -5158,6 +5159,7 @@
 				02C88775245036D400E4470F /* FilterProductListViewModel.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				02C8876D24501FAC00E4470F /* FilterListViewController.swift in Sources */,
+				021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */,
 				45D1CF4523BAC2A500945A36 /* ProductTaxClassListSelectorDataSource.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,
 				6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductListMultiSelectorDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ListSelector/ProductListMultiSelectorDataSourceTests.swift
@@ -85,6 +85,26 @@ final class ProductListMultiSelectorDataSourceTests: XCTestCase {
         // Assert - step 2
         XCTAssertFalse(dataSource.isSelected(model: product))
     }
+
+    func testAddingProductsChangesSelectedProductIDsWithoutDuplicates() {
+        // Arrange
+        let siteID: Int64 = 1
+        let dataSource = ProductListMultiSelectorDataSource(siteID: siteID, excludedProductIDs: [])
+        var productsSequence = [[Int64]]()
+        cancellable = dataSource.productIDs.subscribe { productIDs in
+            productsSequence.append(productIDs)
+        }
+
+        // Action
+        dataSource.addProducts([17, 671])
+        dataSource.addProducts([17, 630])
+
+        // Assert
+        XCTAssertEqual(productsSequence, [
+            [17, 671],
+            [17, 671, 630]
+        ])
+    }
 }
 
 private extension ProductListMultiSelectorDataSourceTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductListMultiSelectorSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductListMultiSelectorSearchUICommandTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import Storage
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ProductListMultiSelectorSearchUICommandTests: XCTestCase {
+    private let sampleSiteID: Int64 = 134
+
+    private var storageManager: StorageManagerType {
+        ServiceLocator.storageManager
+    }
+
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    func testCommandCreatesResultsControllerExcludingSpecifiedProductIDs() throws {
+        // Arrange
+        let excludedProductIDs: [Int64] = [17, 630]
+        excludedProductIDs.forEach { productID in
+            insert(Product().copy(siteID: sampleSiteID, productID: productID))
+        }
+
+        let otherProductIDs: [Int64] = [22, 671, 5]
+        otherProductIDs.forEach { productID in
+            insert(Product().copy(siteID: sampleSiteID, productID: productID))
+        }
+
+        let command = ProductListMultiSelectorSearchUICommand(siteID: sampleSiteID,
+                                                              excludedProductIDs: excludedProductIDs) { _ in }
+
+        // Action
+        let resultsController = command.createResultsController()
+        try resultsController.performFetch()
+
+        // Assert
+        XCTAssertEqual(resultsController.fetchedObjects.count, otherProductIDs.count)
+        XCTAssertFalse(resultsController.fetchedObjects.contains(where: { excludedProductIDs.contains($0.productID) }))
+    }
+
+    func testSearchActionButtonIsConfiguredToCancelAfterSelectingAndUnselectingTheSameProduct() throws {
+        // Arrange
+        let command = ProductListMultiSelectorSearchUICommand(siteID: sampleSiteID,
+                                                              excludedProductIDs: []) { _ in }
+
+        // Action
+        let product = Product().copy(siteID: sampleSiteID, productID: 17)
+        command.didSelectSearchResult(model: product, from: UIViewController(), reloadData: {}, updateActionButton: {})
+        command.didSelectSearchResult(model: product, from: UIViewController(), reloadData: {}, updateActionButton: {})
+        let button = UIButton(type: .custom)
+        command.configureActionButton(button, onDismiss: {})
+
+        // Assert
+        XCTAssertEqual(button.titleLabel?.text,
+                       NSLocalizedString("Cancel", comment: "Action title to cancel selecting products to add to a grouped product from search results"))
+    }
+
+    func testSearchActionButtonIsConfiguredToDoneAfterSelectingAProduct() throws {
+        // Arrange
+        let command = ProductListMultiSelectorSearchUICommand(siteID: sampleSiteID,
+                                                              excludedProductIDs: []) { _ in }
+
+        // Action
+        let product = Product().copy(siteID: sampleSiteID, productID: 17)
+        command.didSelectSearchResult(model: product, from: UIViewController(), reloadData: {}, updateActionButton: {})
+        let button = UIButton(type: .custom)
+        command.configureActionButton(button, onDismiss: {})
+
+        // Assert
+        XCTAssertEqual(button.titleLabel?.text, NSLocalizedString("Done",
+                                                                  comment: "Action title to select products to add to a grouped product from search results"))
+    }
+}
+
+private extension ProductListMultiSelectorSearchUICommandTests {
+    func insert(_ readOnlyOrderProduct: Yosemite.Product) {
+        let product = storage.insertNewObject(ofType: StorageProduct.self)
+        product.update(with: readOnlyOrderProduct)
+    }
+}

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -8,7 +8,7 @@ public enum ProductAction: Action {
 
     /// Searches products that contain a given keyword.
     ///
-    case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    case searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludedProductIDs: [Int64] = [], onCompletion: (Error?) -> Void)
 
     /// Synchronizes the Products matching the specified criteria.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -43,8 +43,13 @@ public class ProductStore: Store {
             retrieveProduct(siteID: siteID, productID: productID, onCompletion: onCompletion)
         case .retrieveProducts(let siteID, let productIDs, let pageNumber, let pageSize, let onCompletion):
             retrieveProducts(siteID: siteID, productIDs: productIDs, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
-        case .searchProducts(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
-            searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case .searchProducts(let siteID, let keyword, let pageNumber, let pageSize, let excludedProductIDs, let onCompletion):
+            searchProducts(siteID: siteID,
+                           keyword: keyword,
+                           pageNumber: pageNumber,
+                           pageSize: pageSize,
+                           excludedProductIDs: excludedProductIDs,
+                           onCompletion: onCompletion)
         case .synchronizeProducts(let siteID,
                                   let pageNumber,
                                   let pageSize,
@@ -93,12 +98,13 @@ private extension ProductStore {
 
     /// Searches all of the products that contain a given Keyword.
     ///
-    func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func searchProducts(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, excludedProductIDs: [Int64], onCompletion: @escaping (Error?) -> Void) {
         let remote = ProductsRemote(network: network)
         remote.searchProducts(for: siteID,
                               keyword: keyword,
                               pageNumber: pageNumber,
-                              pageSize: pageSize) { [weak self] (products, error) in
+                              pageSize: pageSize,
+                              excludedProductIDs: excludedProductIDs) { [weak self] (products, error) in
                                 guard let products = products else {
                                     onCompletion(error)
                                     return


### PR DESCRIPTION
Search product list selector for grouped product's linked products #2199

This PR implements the highlighted screen in the flow to search and select linked products for a grouped product:

![search-linked-products](https://user-images.githubusercontent.com/1945542/88175270-3a912300-cc58-11ea-893d-7a43bce8e35b.png)

## Changes

Note: I understand that there are a bunch of changes to make the UI sync with the selected product IDs from multiple sources (search UI and product list selector). Happy to explain any changes further, and feel free to suggest a better way for these UI components to interact with each other!

- In `PaginatedListSelectorViewController` (the child view controller of the screen that presents search UI), added `reloadData` function to allow the paginated list selector to reload data in case of data changes not from selecting from the list
- In `ProductListMultiSelectorDataSource` (the data source for the screen that presents search UI), added `addProducts` function to update the selected product IDs externally
- Changes in `SearchUICommand` protocol:
  - Added `func configureActionButton(_ button: UIButton, onDismiss: @escaping () -> Void)` so that the search UI can display different text on the dismiss CTA ("Done" when there are any selected products, and "Cancel" otherwise) and handle the selected product IDs. Before this PR and use case, the dismiss CTA always shows "Cancel".
  - Added `reloadData: () -> Void` and `updateActionButton: () -> Void` to `func didSelectSearchResult` so that the search UI can reload the search results to reflect the selected/unselected UI change and trigger an update on the action button configuration for different button text via `configureActionButton` above.
- Updated existing `SearchUICommand` implementations (`OrderSearchUICommand` and `ProductSearchUICommand`) based on the protocol changes
- Created `ProductListMultiSelectorSearchUICommand` that implements `SearchUICommand` for selecting multiple products from search UI
- In `ProductListSelectorViewController`, presented `SearchViewController` with `ProductListMultiSelectorSearchUICommand`, updated its data source on any selected product IDs from search and then reloaded the paginated product list
- In `SearchViewController`, updated based on changes in `SearchUICommand` protocol. Additionally, it now keeps track of the command's results controller's `predicate` to be used along with the search query predicate. This is because this product search UI selector has a predicate to exclude certain product IDs, and the view controller used to remove the pre-existing predicate on search query changes.
  - This also fixes an issue in existing product search UI, where the site predicate gets removed whenever the search query changes. I just noticed this bug after switching sites.
- In Yosemite/Networking layers, added `excludedProductIDs` param to `searchProducts`

## Testing

- Go to the Products tab
- Tap on a grouped product
- Tap on the "Grouped products" row
- Tap on the "Add Products" button 
- Tap on the search icon in the navigation bar --> should see a list of products that **do not contain the pre-selected products plus the grouped product itself** (even though it's allowed to select itself in core)
- Select/unselect some products --> the "Cancel" button's text should change to "Done" when at least one product is selected 
- Search for some products --> when there are no results, a placeholder should be shown
- Select some products from the search results or initial screen where the search query is empty
- Tap "Done" --> the selected products should show as selected in the "Grouped Products" list selector with the number of selected products in the navigation bar
- Tap "Done" --> the "Grouped products" row should show the updated total number of linked products
- Tap "Update" --> the linked products for the grouped product should be updated remotely

### Sanity check on affected screens

- Go to the Products tab
- Tap on the search icon and make sure the search works as before
- Go to the Orders tab
- Tap on the search icon and make sure the search works as before

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/88179386-67483900-cc5e-11ea-8871-eeef9b27dc1b.gif)

\ | No results selected | Non-zero results selected
-- | -- | --
Light | ![Simulator Screen Shot - iPhone 11 - 2020-07-22 at 21 00 03](https://user-images.githubusercontent.com/1945542/88179369-60b9c180-cc5e-11ea-86b4-4ba14de01d94.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-22 at 21 00 05](https://user-images.githubusercontent.com/1945542/88179377-657e7580-cc5e-11ea-9f77-1fe01946458e.png)
Dark | ![Simulator Screen Shot - iPhone 11 - 2020-07-22 at 21 00 21](https://user-images.githubusercontent.com/1945542/88179383-66170c00-cc5e-11ea-800d-1b9d529c1f87.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-22 at 21 00 22](https://user-images.githubusercontent.com/1945542/88179385-66afa280-cc5e-11ea-92ec-23b22fe7a7e3.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
