### PR TITLE
Replace concrete usage with protocol: `ProductFormDataModel`, `ProductFormActionsFactoryProtocol`, and `TaxClassRequestable`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/EditorFactory.swift
@@ -11,21 +11,21 @@ final class EditorFactory {
 
     // MARK: - Editor: Instantiation
 
-    func productDescriptionEditor(product: Product,
+    func productDescriptionEditor(product: ProductFormDataModel,
                                   onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
         let navigationTitle = NSLocalizedString("Description", comment: "The navigation bar title of the Aztec editor screen.")
         let viewProperties = EditorViewProperties(navigationTitle: navigationTitle, showSaveChangesActionSheet: true)
-        let editor = AztecEditorViewController(content: product.fullDescription, viewProperties: viewProperties)
+        let editor = AztecEditorViewController(content: product.description, viewProperties: viewProperties)
         editor.onContentSave = onContentSave
         return editor
     }
 
-    func productBriefDescriptionEditor(product: Product,
+    func productBriefDescriptionEditor(product: ProductFormDataModel,
                                        onContentSave: @escaping Editor.OnContentSave) -> Editor & UIViewController {
         let navigationTitle = NSLocalizedString("Short description",
                                                 comment: "The navigation bar title of the edit short description screen.")
         let viewProperties = EditorViewProperties(navigationTitle: navigationTitle, showSaveChangesActionSheet: true)
-        let editor = AztecEditorViewController(content: product.briefDescription, viewProperties: viewProperties)
+        let editor = AztecEditorViewController(content: product.shortDescription, viewProperties: viewProperties)
         editor.onContentSave = onContentSave
         return editor
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactory.swift
@@ -21,7 +21,7 @@ enum ProductFormEditAction {
 }
 
 /// Creates actions for different sections/UI on the product form.
-struct ProductFormActionsFactory {
+struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let product: Product
     private let isEditProductsRelease2Enabled: Bool
     private let isEditProductsRelease3Enabled: Bool

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactoryProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductFormActionsFactoryProtocol.swift
@@ -1,0 +1,11 @@
+/// Creates actions available on various sections of a product form.
+protocol ProductFormActionsFactoryProtocol {
+    /// Returns an array of actions that are visible in the product form primary section.
+    func primarySectionActions() -> [ProductFormEditAction]
+
+    /// Returns an array of actions that are visible in the product form settings section.
+    func settingsSectionActions() -> [ProductFormEditAction]
+
+    /// Returns an array of actions that are visible in the product form bottom sheet.
+    func bottomSheetActions() -> [ProductFormBottomSheetAction]
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -13,7 +13,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
     var siteTimezone: TimeZone = TimeZone.siteTimezone
 
     init(product: Product,
-         actionsFactory: ProductFormActionsFactory,
+         actionsFactory: ProductFormActionsFactoryProtocol,
          currency: String,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter()) {
         self.currency = currency
@@ -23,7 +23,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
 }
 
 private extension DefaultProductFormTableViewModel {
-    mutating func configureSections(product: Product, actionsFactory: ProductFormActionsFactory) {
+    mutating func configureSections(product: Product, actionsFactory: ProductFormActionsFactoryProtocol) {
         sections = [.primaryFields(rows: primaryFieldRows(product: product, actions: actionsFactory.primarySectionActions())),
                     .settings(rows: settingsRows(product: product, actions: actionsFactory.settingsSectionActions()))]
             .filter { $0.isNotEmpty }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -12,7 +12,7 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
     //
     var siteTimezone: TimeZone = TimeZone.siteTimezone
 
-    init(product: Product,
+    init(product: ProductFormDataModel,
          actionsFactory: ProductFormActionsFactoryProtocol,
          currency: String,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter()) {
@@ -23,17 +23,17 @@ struct DefaultProductFormTableViewModel: ProductFormTableViewModel {
 }
 
 private extension DefaultProductFormTableViewModel {
-    mutating func configureSections(product: Product, actionsFactory: ProductFormActionsFactoryProtocol) {
+    mutating func configureSections(product: ProductFormDataModel, actionsFactory: ProductFormActionsFactoryProtocol) {
         sections = [.primaryFields(rows: primaryFieldRows(product: product, actions: actionsFactory.primarySectionActions())),
-                    .settings(rows: settingsRows(product: product, actions: actionsFactory.settingsSectionActions()))]
+                    .settings(rows: settingsRows(productModel: product, actions: actionsFactory.settingsSectionActions()))]
             .filter { $0.isNotEmpty }
     }
 
-    func primaryFieldRows(product: Product, actions: [ProductFormEditAction]) -> [ProductFormSection.PrimaryFieldRow] {
+    func primaryFieldRows(product: ProductFormDataModel, actions: [ProductFormEditAction]) -> [ProductFormSection.PrimaryFieldRow] {
         return actions.map { action in
             switch action {
             case .images:
-                return .images(product: product)
+                return .images
             case .name:
                 return .name(name: product.name)
             case .description:
@@ -41,6 +41,15 @@ private extension DefaultProductFormTableViewModel {
             default:
                 fatalError("Unexpected action in the primary section: \(action)")
             }
+        }
+    }
+
+    func settingsRows(productModel product: ProductFormDataModel, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {
+        switch product {
+        case let product as Product:
+            return settingsRows(product: product, actions: actions)
+        default:
+            fatalError("Unexpected product form data model: \(type(of: product))")
         }
     }
 
@@ -75,7 +84,7 @@ private extension DefaultProductFormTableViewModel {
 }
 
 private extension DefaultProductFormTableViewModel {
-    func priceSettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+    func priceSettingsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.priceImage
 
         var priceDetails = [String]()
@@ -117,7 +126,7 @@ private extension DefaultProductFormTableViewModel {
                                                         details: details)
     }
 
-    func inventorySettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+    func inventorySettingsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.inventoryImage
         let title = Constants.inventorySettingsTitle
 
@@ -130,7 +139,7 @@ private extension DefaultProductFormTableViewModel {
         if let stockQuantity = product.stockQuantity, product.manageStock {
             inventoryDetails.append(String.localizedStringWithFormat(Constants.stockQuantityFormat, stockQuantity))
         } else if product.manageStock == false {
-            let stockStatus = product.productStockStatus
+            let stockStatus = product.stockStatus
             inventoryDetails.append(stockStatus.description)
         }
 
@@ -141,7 +150,7 @@ private extension DefaultProductFormTableViewModel {
                                                         details: details)
     }
 
-    func shippingSettingsRow(product: Product) -> ProductFormSection.SettingsRow.ViewModel {
+    func shippingSettingsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.shippingImage
         let title = Constants.shippingSettingsTitle
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -43,7 +43,7 @@ final class ProductPriceSettingsViewController: UIViewController {
 
     /// Init
     ///
-    init(product: Product, completion: @escaping Completion) {
+    init(product: ProductFormDataModel & TaxClassRequestable, completion: @escaping Completion) {
         siteID = product.siteID
         viewModel = ProductPriceSettingsViewModel(product: product)
         onCompletion = completion

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -41,7 +41,7 @@ enum ProductPriceSetingsError: Error {
 /// Provides view data for price settings, and handles init/UI/navigation actions needed in product price settings.
 ///
 final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
-    private let product: Product
+    private let product: ProductFormDataModel & TaxClassRequestable
 
     // Editable data
     //
@@ -81,7 +81,9 @@ final class ProductPriceSettingsViewModel: ProductPriceSettingsViewModelOutput {
 
     private let currencyFormatter: CurrencyFormatter
 
-    init(product: Product, currencySettings: CurrencySettings = CurrencySettings.shared, timezoneForScheduleSaleDates: TimeZone = TimeZone.siteTimezone) {
+    init(product: ProductFormDataModel & TaxClassRequestable,
+         currencySettings: CurrencySettings = CurrencySettings.shared,
+         timezoneForScheduleSaleDates: TimeZone = TimeZone.siteTimezone) {
         self.product = product
         self.timezoneForScheduleSaleDates = timezoneForScheduleSaleDates
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
@@ -9,7 +9,7 @@ struct PaginatedProductShippingClassListSelectorDataSource: PaginatedListSelecto
 
     private let siteID: Int64
 
-    init(product: Product, selected: ProductShippingClass?) {
+    init(product: ProductFormDataModel, selected: ProductShippingClass?) {
         self.siteID = product.siteID
         self.selected = selected
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product+ProductForm.swift
@@ -1,14 +1,6 @@
 import Yosemite
 
 extension Product {
-    /// Returns the full description without the HTML tags and leading/trailing white spaces and new lines.
-    var trimmedFullDescription: String? {
-        guard let description = fullDescription else {
-            return nil
-        }
-        return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     /// Returns the brief description (short description) without the HTML tags and leading/trailing white spaces and new lines.
     var trimmedBriefDescription: String? {
         guard let description = briefDescription else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -1,0 +1,81 @@
+import Yosemite
+
+/// Describes a data model that contains necessary properties for rendering a product form (`ProductFormViewController`).
+protocol ProductFormDataModel {
+    // General
+    var siteID: Int64 { get }
+    var productID: Int64 { get }
+    var name: String { get }
+    var description: String? { get }
+    var shortDescription: String? { get }
+
+    // Settings
+    var virtual: Bool { get }
+    var downloadable: Bool { get }
+    var permalink: String { get }
+
+    // Images
+    var images: [ProductImage] { get }
+
+    // Price
+    var regularPrice: String? { get }
+    var salePrice: String? { get }
+    var dateOnSaleStart: Date? { get }
+    var dateOnSaleEnd: Date? { get }
+    var taxStatusKey: String { get }
+    var taxClass: String? { get }
+
+    // Shipping
+    var weight: String? { get }
+    var dimensions: ProductDimensions { get }
+    var shippingClass: String? { get }
+    var shippingClassID: Int64 { get }
+
+    // Inventory
+    var sku: String? { get }
+    var manageStock: Bool { get }
+    var stockStatus: ProductStockStatus { get }
+    var stockQuantity: Int64? { get }
+    var backordersKey: String { get }
+}
+
+// MARK: Helpers that can be derived from `ProductFormDataModel`
+//
+extension ProductFormDataModel {
+    /// Returns the full description without the HTML tags and leading/trailing white spaces and new lines.
+    var trimmedFullDescription: String? {
+        guard let description = description else {
+            return nil
+        }
+        return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Whether shipping settings are available for the product.
+    var isShippingEnabled: Bool {
+        return downloadable == false && virtual == false
+    }
+
+    /// Returns `ProductTaxStatus` given the raw value from `taxStatusKey` field.
+    var productTaxStatus: ProductTaxStatus {
+        return ProductTaxStatus(rawValue: taxStatusKey)
+    }
+
+    /// Returns `ProductBackordersSetting` given the raw value from `backordersKey` field.
+    var backordersSetting: ProductBackordersSetting {
+        return ProductBackordersSetting(rawValue: backordersKey)
+    }
+}
+
+extension Product: ProductFormDataModel {
+    var description: String? {
+        fullDescription
+    }
+
+    var shortDescription: String? {
+        briefDescription
+    }
+
+    var stockStatus: ProductStockStatus {
+        productStockStatus
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -52,17 +52,17 @@ extension ProductFormDataModel {
 
     /// Whether shipping settings are available for the product.
     var isShippingEnabled: Bool {
-        return downloadable == false && virtual == false
+        downloadable == false && virtual == false
     }
 
     /// Returns `ProductTaxStatus` given the raw value from `taxStatusKey` field.
     var productTaxStatus: ProductTaxStatus {
-        return ProductTaxStatus(rawValue: taxStatusKey)
+        ProductTaxStatus(rawValue: taxStatusKey)
     }
 
     /// Returns `ProductBackordersSetting` given the raw value from `backordersKey` field.
     var backordersSetting: ProductBackordersSetting {
-        return ProductBackordersSetting(rawValue: backordersKey)
+        ProductBackordersSetting(rawValue: backordersKey)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -80,8 +80,8 @@ private extension ProductFormTableViewDataSource {
 private extension ProductFormTableViewDataSource {
     func configureCellInPrimaryFieldsSection(_ cell: UITableViewCell, row: ProductFormSection.PrimaryFieldRow) {
         switch row {
-        case .images(let product):
-            configureImages(cell: cell, product: product)
+        case .images:
+            configureImages(cell: cell)
         case .name(let name):
             configureName(cell: cell, name: name)
         case .description(let description):
@@ -89,7 +89,7 @@ private extension ProductFormTableViewDataSource {
         }
     }
 
-    func configureImages(cell: UITableViewCell, product: Product) {
+    func configureImages(cell: UITableViewCell) {
         guard let cell = cell as? ProductImagesHeaderTableViewCell else {
             fatalError()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -15,7 +15,7 @@ enum ProductFormSection {
     }
 
     enum PrimaryFieldRow {
-        case images(product: Product)
+        case images
         case name(name: String?)
         case description(description: String?)
     }
@@ -73,8 +73,8 @@ extension ProductFormSection: Equatable {
 extension ProductFormSection.PrimaryFieldRow: Equatable {
     static func ==(lhs: ProductFormSection.PrimaryFieldRow, rhs: ProductFormSection.PrimaryFieldRow) -> Bool {
         switch (lhs, rhs) {
-        case (let .images(product1), let .images(product2)):
-            return product1 == product2
+        case (.images, .images):
+            return true
         case (let .name(name1), let .name(name2)):
             return name1 == name2
         case (let .description(description1), let .description(description2)):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -35,15 +35,14 @@ final class ProductShippingSettingsViewController: UIViewController {
     typealias Completion = (_ weight: String?, _ dimensions: ProductDimensions, _ shippingClass: ProductShippingClass?) -> Void
     private let onCompletion: Completion
 
-    private let product: Product
+    private let product: ProductFormDataModel
     private var originalShippingClass: ProductShippingClass?
     private let shippingSettingsService: ShippingSettingsService
 
-    init(product: Product,
+    init(product: ProductFormDataModel,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService,
          completion: @escaping Completion) {
         self.product = product
-        self.originalShippingClass = product.productShippingClass
         self.shippingSettingsService = shippingSettingsService
         self.onCompletion = completion
 
@@ -51,8 +50,6 @@ final class ProductShippingSettingsViewController: UIViewController {
         self.length = product.dimensions.length
         self.width = product.dimensions.width
         self.height = product.dimensions.height
-
-        self.shippingClass = product.productShippingClass
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/Product+Media.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/Product+Media.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Yosemite
 
-extension Product {
+extension ProductFormDataModel {
     var imageStatuses: [ProductImageStatus] {
         return images.map({ ProductImageStatus.remote(image: $0) })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -40,7 +40,7 @@ final class ProductImageActionHandler {
     ///   - siteID: the ID of a site/store where the product belongs to.
     ///   - product: the product whose image statuses and actions are of concern.
     ///   - queue: the queue where the update callbacks are called on. Default to be the main queue.
-    init(siteID: Int64, product: Product, queue: DispatchQueue = .main) {
+    init(siteID: Int64, product: ProductFormDataModel, queue: DispatchQueue = .main) {
         self.siteID = siteID
         self.productID = product.productID
         self.queue = queue
@@ -200,7 +200,7 @@ final class ProductImageActionHandler {
 
     /// Resets the product images to the ones from the given Product.
     ///
-    func resetProductImages(to product: Product) {
+    func resetProductImages(to product: ProductFormDataModel) {
         allStatuses = (productImageStatuses: product.imageStatuses, error: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -13,7 +13,7 @@ final class ProductImagesViewController: UIViewController {
 
     private let siteID: Int64
     private let productID: Int64
-    private let product: Product
+    private let product: ProductFormDataModel
 
     private let productImageActionHandler: ProductImageActionHandler
     private let productUIImageLoader: ProductUIImageLoader
@@ -57,7 +57,7 @@ final class ProductImagesViewController: UIViewController {
 
     private let onCompletion: Completion
 
-    init(product: Product,
+    init(product: ProductFormDataModel,
          productImageActionHandler: ProductImageActionHandler,
          productUIImageLoader: ProductUIImageLoader,
          completion: @escaping Completion) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
+		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */; };
@@ -1115,6 +1116,7 @@
 		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
+		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -1848,6 +1850,7 @@
 			children = (
 				0212276024498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift */,
 				0212276224498CDC0042161F /* ProductFormBottomSheetAction.swift */,
+				02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */,
 				0235BFD8246E959500778909 /* ProductFormActionsFactory.swift */,
 			);
 			path = BottomSheetListSelector;
@@ -4721,6 +4724,7 @@
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
+				02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */,
 				CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */,
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,
 				B5DB01B52114AB2D00A4F797 /* CrashLogging.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
+		02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */; };
@@ -1119,6 +1120,7 @@
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
+		02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingTests.swift"; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -3204,6 +3206,7 @@
 				5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */,
 				02564A87246C047C00D6DB2A /* Optional+StringTests.swift */,
 				0273707D24C0047800167204 /* SequenceHelpersTests.swift */,
+				02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5273,6 +5276,7 @@
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,
 				02404EE2231501E000FF1170 /* StatsVersionCoordinatorTests.swift in Sources */,
 				02B1AFEE24BC5BA9005DB1E3 /* GroupedProductListSelectorDataSourceTests.swift in Sources */,
+				02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */,
 				D83F5939225B424B00626E75 /* AddManualTrackingViewModelTests.swift in Sources */,
 				0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
+		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
 		02D4564C231D05E2008CF0A9 /* BetaFeaturesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */; };
 		02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */; };
@@ -1117,6 +1118,7 @@
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
+		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
 		02D4564B231D05E1008CF0A9 /* BetaFeaturesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesViewController.swift; sourceTree = "<group>"; };
 		02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -1871,6 +1873,7 @@
 				265BCA032430E5EA004E53EE /* Edit Categories */,
 				02162724237963AF000208D2 /* ProductFormViewController.swift */,
 				02162725237963AF000208D2 /* ProductFormViewController.xib */,
+				02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */,
 				02F5F80F24613C930000613A /* ProductFormViewController+PresentationStyle.swift */,
 				02162728237965E8000208D2 /* ProductFormTableViewModel.swift */,
 				0216272A2379662C000208D2 /* DefaultProductFormTableViewModel.swift */,
@@ -4996,6 +4999,7 @@
 				D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */,
 				0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */,
 				D831E2E0230E0BA7000037D0 /* Logs.swift in Sources */,
+				02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */,
 				CECC759C23D61C1400486676 /* AggregateDataHelper.swift in Sources */,
 				02B296A722FA6DB500FD7A4C /* Date+StartAndEnd.swift in Sources */,
 				D81D9228222E7F0800FFA585 /* OrderStatusListViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/Product+ShippingTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Product+ShippingTests.swift
@@ -1,8 +1,8 @@
 import XCTest
-@testable import Yosemite
+@testable import WooCommerce
 
-/// Tests for `Product+Settings.swift`.
-final class Product_SettingsTests: XCTestCase {
+/// Tests for `Product`'s shipping helper.
+final class Product_ShippingTests: XCTestCase {
     // MARK: - `isShippingEnabled`
 
     func testShippingIsEnabledForAPhysicalProduct() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -46,6 +46,31 @@ class Product_ProductFormTests: XCTestCase {
         let usLocale = Locale(identifier: "en_US")
         XCTAssertEqual(product.categoriesDescription(using: usLocale), expectedDescription)
     }
+
+    // MARK: `productTaxStatus`
+
+    func testProductTaxStatusFromAnUnexpectedRawValueReturnsDefaultTaxable() {
+        let product = Product().copy(taxStatusKey: "unknown tax status")
+        XCTAssertEqual(product.productTaxStatus, .taxable)
+    }
+
+    func testProductTaxStatusFromAValidRawValueReturnsTheCorrespondingCase() {
+        let product = Product().copy(taxStatusKey: ProductTaxStatus.shipping.rawValue)
+        XCTAssertEqual(product.productTaxStatus, .shipping)
+    }
+
+    // MARK: `backordersSetting`
+
+    func testBackordersSettingFromAnUnexpectedRawValueReturnsACustomCase() {
+        let rawValue = "unknown setting"
+        let product = Product().copy(backordersKey: rawValue)
+        XCTAssertEqual(product.backordersSetting, .custom(rawValue))
+    }
+
+    func testBackordersSettingFromAValidRawValueReturnsTheCorrespondingCase() {
+        let product = Product().copy(backordersKey: ProductBackordersSetting.notAllowed.rawValue)
+        XCTAssertEqual(product.backordersSetting, .notAllowed)
+    }
 }
 
 private extension Product_ProductFormTests {

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -55,8 +55,6 @@
 		02E262BD238CE46A00B79588 /* ShippingSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262BC238CE46A00B79588 /* ShippingSettingsService.swift */; };
 		02E262C0238CE80100B79588 /* StorageShippingSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262BF238CE80100B79588 /* StorageShippingSettingsServiceTests.swift */; };
 		02E262C2238CF74D00B79588 /* StorageShippingSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E262C1238CF74D00B79588 /* StorageShippingSettingsService.swift */; };
-		02E493EB245C0DCC000AEA9E /* Product+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EA245C0DCC000AEA9E /* Product+Settings.swift */; };
-		02E493ED245C0EBC000AEA9E /* Product+SettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EC245C0EBC000AEA9E /* Product+SettingsTests.swift */; };
 		02E4F5E423CD5628003B0010 /* NSOrderedSet+Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */; };
 		02F096C4240670A400C0C1D5 /* Media+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F096C3240670A400C0C1D5 /* Media+Equatable.swift */; };
 		02FF054D23D983F30058E6E7 /* MediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FF054523D983F30058E6E7 /* MediaFileManager.swift */; };
@@ -295,8 +293,6 @@
 		02E262BC238CE46A00B79588 /* ShippingSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingSettingsService.swift; sourceTree = "<group>"; };
 		02E262BF238CE80100B79588 /* StorageShippingSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageShippingSettingsServiceTests.swift; sourceTree = "<group>"; };
 		02E262C1238CF74D00B79588 /* StorageShippingSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageShippingSettingsService.swift; sourceTree = "<group>"; };
-		02E493EA245C0DCC000AEA9E /* Product+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+Settings.swift"; sourceTree = "<group>"; };
-		02E493EC245C0EBC000AEA9E /* Product+SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+SettingsTests.swift"; sourceTree = "<group>"; };
 		02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSOrderedSet+Array.swift"; sourceTree = "<group>"; };
 		02F096C3240670A400C0C1D5 /* Media+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+Equatable.swift"; sourceTree = "<group>"; };
 		02FF054523D983F30058E6E7 /* MediaFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaFileManager.swift; sourceTree = "<group>"; };
@@ -555,7 +551,6 @@
 			isa = PBXGroup;
 			children = (
 				0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */,
-				02E493EA245C0DCC000AEA9E /* Product+Settings.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -573,7 +568,6 @@
 			isa = PBXGroup;
 			children = (
 				0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */,
-				02E493EC245C0EBC000AEA9E /* Product+SettingsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1284,7 +1278,6 @@
 				026CF62C237D92DC009563D4 /* ProductVariationAttribute+ReadOnlyConvertible.swift in Sources */,
 				74B7D6B020F910AF002667AC /* OrderNote+ReadOnlyConvertible.swift in Sources */,
 				74B2601F2188A92A0041793A /* Note+ReadOnlyConvertible.swift in Sources */,
-				02E493EB245C0DCC000AEA9E /* Product+Settings.swift in Sources */,
 				CE179D57235F4E7500C24EB3 /* RefundStore.swift in Sources */,
 				0218B4EE242E08B20083A847 /* MediaType.swift in Sources */,
 				CE3B7AD72225ECA90050FE4B /* OrderStatusStore.swift in Sources */,
@@ -1419,7 +1412,6 @@
 				0202B6992387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift in Sources */,
 				02FF055623D984310058E6E7 /* MockupFileManager.swift in Sources */,
 				029B00A7230D64E800B0AE66 /* StatsTimeRangeTests.swift in Sources */,
-				02E493ED245C0EBC000AEA9E /* Product+SettingsTests.swift in Sources */,
 				0248B36924590FC300A271A4 /* ProductStore+FilterProductsTests.swift in Sources */,
 				02A098242480D0D8002F8C7A /* MockCrashLogger.swift in Sources */,
 				02FF055F23D985710058E6E7 /* URL+MediaTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/TaxClassAction.swift
+++ b/Yosemite/Yosemite/Actions/TaxClassAction.swift
@@ -12,5 +12,5 @@ public enum TaxClassAction: Action {
 
     /// Request the Tax Class found in a specified Product.
     ///
-    case requestMissingTaxClasses(for: Product, onCompletion: (TaxClass?, Error?) -> Void)
+    case requestMissingTaxClasses(for: TaxClassRequestable, onCompletion: (TaxClass?, Error?) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Extensions/Product+Settings.swift
+++ b/Yosemite/Yosemite/Model/Extensions/Product+Settings.swift
@@ -1,6 +1,0 @@
-extension Product {
-    /// Whether shipping settings are available for the product.
-    public var isShippingEnabled: Bool {
-        return downloadable == false && virtual == false
-    }
-}


### PR DESCRIPTION
Prerequisite for #2085 

This PR abstracts parts of concrete usage with protocol in the product form and its related classes, so that `ProductVariation` can be supported for these classes in a future subtask. These changes should be pretty straightforward. I left the more complicated protocol that abstracts the current `ProductFormViewModel` for a future subtask. In addition, I left the `Product` protocol replacement in price and inventory settings for later since these 2 screens have UI changes between `Product` and `ProductVariation` (p91TBi-33Q-p2).

## Changes

- Created `ProductFormActionsFactoryProtocol` protocol that the existing `ProductFormActionsFactory` conforms to, and updated its existing usage
- Created `ProductFormDataModel` protocol that abstracts the `Product` usage in product form. It contains all the necessary fields for `ProductFormViewController` and its navigated view controllers. Replaced `Product` with `ProductFormDataModel` in product form related classes where replacement is straightforward
- Created `TaxClassRequestable` protocol that abstracts the `Product` usage in `TaxClassAction.requestMissingTaxClasses` within price settings. Updated existing usage in price settings classes
- Removed unused `product: Product` associated value in `ProductFormSection.PrimaryFieldRow.images` enum case
- Removed redundant extension helper `isShippingEnabled` in Yosemite layer and moved its unit tests from Yosemite to app layer.

## Testing

No changes in app behavior are expected, feel free to test for regression with the following steps:

- Go to the Products tab
- Tap on a simple product
- Tap on the description row, and make sure the editing behavior stays the same
- Go back to the product details
- Tap on the price settings row, and make sure the editing behavior stays the same especially on the tax class selector
- Go back to the product details
- Tap on the shipping settings row, and make sure the editing behavior stays the same especially on the shipping class selector
- Go back to the product details
- Tap on the "+" cell in the images header, and make sure image editing behavior stays the same

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
