### PR TITLE
Add AppSettingsAction for In-app Feedback

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		574B774E24AA883D0042116F /* MockFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774D24AA883D0042116F /* MockFileManager.swift */; };
 		574B775024AA897E0042116F /* FileManager+FileManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */; };
 		575CD4DC24ABE77800755B2B /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575CD4DB24ABE77800755B2B /* Collection+Extensions.swift */; };
+		57A881A024CA396D00AE0943 /* GeneralAppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */; };
 		68BC97FB41770051C287D1A8 /* Pods_StorageTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47556EE256120BEE49FF5FD3 /* Pods_StorageTests.framework */; };
 		7028A41485A08AC748206184 /* Pods_Storage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF3D3B298350F68191CD1DAD /* Pods_Storage.framework */; };
 		7426A05020F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */; };
@@ -192,6 +193,7 @@
 		574B774D24AA883D0042116F /* MockFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileManager.swift; sourceTree = "<group>"; };
 		574B774F24AA897E0042116F /* FileManager+FileManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+FileManagerProtocol.swift"; sourceTree = "<group>"; };
 		575CD4DB24ABE77800755B2B /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
+		57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralAppSettings.swift; sourceTree = "<group>"; };
 		5D12CAE2D0EA6AB66F162FF9 /* Pods-StorageTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StorageTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-StorageTests/Pods-StorageTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74159626224D5644003C21CF /* Model 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 13.xcdatamodel"; sourceTree = "<group>"; };
 		7426A04E20F69D00002A4E07 /* OrderCoupon+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderCoupon+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -378,6 +380,14 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		57A8819E24CA395000AE0943 /* AppSettings */ = {
+			isa = PBXGroup;
+			children = (
+				57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */,
+			);
+			name = AppSettings;
+			sourceTree = "<group>";
+		};
 		7471A518216CF12900219F7E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
@@ -541,6 +551,7 @@
 		B59E11D720A9CFF3004121A4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				57A8819E24CA395000AE0943 /* AppSettings */,
 				025CA2BB238EB86200B05C81 /* ProductShippingClass+CoreDataClass.swift */,
 				025CA2BC238EB86200B05C81 /* ProductShippingClass+CoreDataProperties.swift */,
 				028296EE237D404F00E84012 /* ProductVariation+CoreDataClass.swift */,
@@ -924,6 +935,7 @@
 				CE4FD4482350EB7600A16B31 /* OrderItemRefund+CoreDataProperties.swift in Sources */,
 				D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				B505F6DE20BEEA4F00BB1B69 /* CoreDataManager.swift in Sources */,
+				57A881A024CA396D00AE0943 /* GeneralAppSettings.swift in Sources */,
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
 				45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -1,0 +1,26 @@
+
+import Foundation
+
+/// An encodable/decodable data structure that can be used to save files. This contains
+/// miscellaneous app settings.
+///
+/// Sometimes I wonder if `AppSettingsStore` should just use one plist file. Maybe things will
+/// be simpler?
+///
+public struct GeneralAppSettings: Codable, Equatable {
+    /// The known `Date` that the app was installed.
+    ///
+    /// Note that this is not accurate because this property/setting was created when we have
+    /// thousands of users already.
+    ///
+    public let installationDate: Date?
+
+    /// The last time that the user interacted with the in-app feedback (https://git.io/JJ8i0).
+    ///
+    public let lastFeedbackDate: Date?
+
+    public init(installationDate: Date?, lastFeedbackDate: Date?) {
+        self.installationDate = installationDate
+        self.lastFeedbackDate = lastFeedbackDate
+    }
+}

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -71,4 +71,9 @@ public enum AppSettingsAction: Action {
     /// given `date`.
     ///
     case setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
+
+    /// Saves the `date` as the last known date that the user interacted with the in-app
+    /// feedback prompt (https://git.io/JJ8i0).
+    ///
+    case setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -63,4 +63,12 @@ public enum AppSettingsAction: Action {
     /// Clears all the states related to stats version
     ///
     case resetStatsVersionStates
+
+    // MARK: - General App Settings
+
+    /// Saves the `date` as the last known date that the app was installed. This does not do
+    /// anything if there is a persisted installation date already and it is older than the
+    /// given `date`.
+    ///
+    case setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -70,7 +70,10 @@ public enum AppSettingsAction: Action {
     /// anything if there is a persisted installation date already and it is older than the
     /// given `date`.
     ///
-    case setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
+    /// - Parameter onCompletion: The `Result`'s success value will be `true` if the installation
+    ///                           date was changed and `false` if not.
+    ///
+    case setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Bool, Error>) -> Void))
 
     /// Saves the `date` as the last known date that the user interacted with the in-app
     /// feedback prompt (https://git.io/JJ8i0).

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -131,8 +131,8 @@ private extension AppSettingsStore {
         do {
             let settings = try loadOrCreateGeneralAppSettings()
 
-            let installationDate = settings.installationDate ?? .distantFuture
-            guard date < installationDate else {
+            if let installationDate = settings.installationDate,
+                date > installationDate {
                 return onCompletion(.success(()))
             }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -127,19 +127,22 @@ private extension AppSettingsStore {
     /// Save the `date` in `GeneralAppSettings` but only if the `date` is older than the existing
     /// `GeneralAppSettings.installationDate`.
     ///
-    func setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Void, Error>) -> Void)) {
+    /// - Parameter onCompletion: The `Result`'s success value will be `true` if the installation
+    ///                           date was changed and `false` if not.
+    ///
+    func setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Bool, Error>) -> Void)) {
         do {
             let settings = try loadOrCreateGeneralAppSettings()
 
             if let installationDate = settings.installationDate,
                 date > installationDate {
-                return onCompletion(.success(()))
+                return onCompletion(.success(false))
             }
 
             let settingsToSave = GeneralAppSettings(installationDate: date, lastFeedbackDate: settings.lastFeedbackDate)
             try saveGeneralAppSettings(settingsToSave)
 
-            onCompletion(.success(()))
+            onCompletion(.success(true))
         } catch {
             onCompletion(.failure(error))
         }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -58,6 +58,11 @@ public class AppSettingsStore: Store {
         return documents!.appendingPathComponent(Constants.productsFeatureSwitchFileName)
     }()
 
+    private lazy var generalAppSettingsFileURL: URL = {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        return documents!.appendingPathComponent(Constants.generalAppSettingsFileName)
+    }()
+
     /// Registers for supported Actions.
     ///
     override public func registerSupportedActions(in dispatcher: Dispatcher) {
@@ -108,11 +113,50 @@ public class AppSettingsStore: Store {
             setProductsFeatureSwitch(isEnabled: isEnabled, onCompletion: onCompletion)
         case .resetStatsVersionStates:
             resetStatsVersionStates()
+        case .setInstallationDateIfNecessary(let date, let onCompletion):
+            setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
         }
     }
 }
 
+// MARK: - General App Settings
 
+private extension AppSettingsStore {
+    /// Save the `date` in `GeneralAppSettings` but only if the `date` is older than the existing
+    /// `GeneralAppSettings.installationDate`.
+    ///
+    func setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Void, Error>) -> Void)) {
+        do {
+            let settings = try loadOrCreateGeneralAppSettings()
+
+            let installationDate = settings.installationDate ?? .distantFuture
+            guard date < installationDate else {
+                return onCompletion(.success(()))
+            }
+
+            let settingsToSave = GeneralAppSettings(installationDate: date, lastFeedbackDate: settings.lastFeedbackDate)
+            try saveGeneralAppSettings(settingsToSave)
+
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
+    /// Load the `GeneralAppSettings` from file or create an empty one if it doesn't exist.
+    func loadOrCreateGeneralAppSettings() throws -> GeneralAppSettings {
+        guard let settings: GeneralAppSettings = try fileStorage.data(for: generalAppSettingsFileURL) else {
+            return GeneralAppSettings(installationDate: nil, lastFeedbackDate: nil)
+        }
+
+        return settings
+    }
+
+    /// Save the `GeneralAppSettings` to the appropriate file.
+    func saveGeneralAppSettings(_ settings: GeneralAppSettings) throws {
+        try fileStorage.write(settings, to: generalAppSettingsFileURL)
+    }
+}
 // MARK: - Shipment tracking providers!
 //
 private extension AppSettingsStore {
@@ -391,4 +435,5 @@ private enum Constants {
     static let statsVersionBannerVisibilityFileName = "stats-version-banner-visibility.plist"
     static let statsVersionLastShownFileName = "stats-version-last-shown.plist"
     static let productsFeatureSwitchFileName = "products-feature-switch.plist"
+    static let generalAppSettingsFileName = "general-app-settings.plist"
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -115,6 +115,8 @@ public class AppSettingsStore: Store {
             resetStatsVersionStates()
         case .setInstallationDateIfNecessary(let date, let onCompletion):
             setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
+        case .setLastFeedbackDate(let date, let onCompletion):
+            setLastFeedbackDate(date: date, onCompletion: onCompletion)
         }
     }
 }
@@ -135,6 +137,21 @@ private extension AppSettingsStore {
             }
 
             let settingsToSave = GeneralAppSettings(installationDate: date, lastFeedbackDate: settings.lastFeedbackDate)
+            try saveGeneralAppSettings(settingsToSave)
+
+            onCompletion(.success(()))
+        } catch {
+            onCompletion(.failure(error))
+        }
+    }
+
+    /// Save the `date` in `GeneralAppSettings.lastFeedbackDate`.
+    ///
+    func setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void)) {
+        do {
+            let settings = try loadOrCreateGeneralAppSettings()
+
+            let settingsToSave = GeneralAppSettings(installationDate: settings.installationDate, lastFeedbackDate: date)
             try saveGeneralAppSettings(settingsToSave)
 
             onCompletion(.success(()))

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -58,7 +58,7 @@ public class AppSettingsStore: Store {
         return documents!.appendingPathComponent(Constants.productsFeatureSwitchFileName)
     }()
 
-    private lazy var generalAppSettingsFileURL: URL = {
+    private lazy var generalAppSettingsFileURL: URL! = {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
         return documents!.appendingPathComponent(Constants.generalAppSettingsFileName)
     }()

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -197,7 +197,7 @@ final class AppSettingsStoreTests: XCTestCase {
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
 
         // When
-        var result: Result<Void, Error>?
+        var result: Result<Bool, Error>?
         let action = AppSettingsAction.setInstallationDateIfNecessary(date: date) { aResult in
             result = aResult
         }
@@ -205,6 +205,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+        XCTAssertTrue(try XCTUnwrap(result).get())
 
         let savedSettings: GeneralAppSettings = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
         XCTAssertEqual(date, savedSettings.installationDate)
@@ -227,7 +228,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // When
         // Save newerDate. This should be successful but the existingDate should be retained.
-        var result: Result<Void, Error>?
+        var result: Result<Bool, Error>?
         let action = AppSettingsAction.setInstallationDateIfNecessary(date: newerDate) { aResult in
             result = aResult
         }
@@ -235,6 +236,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+        XCTAssertFalse(try XCTUnwrap(result).get())
 
         let savedSettings: GeneralAppSettings = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
         XCTAssertEqual(existingDate, savedSettings.installationDate)
@@ -248,7 +250,7 @@ final class AppSettingsStoreTests: XCTestCase {
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
 
         // When
-        var result: Result<Void, Error>?
+        var result: Result<Bool, Error>?
         let action = AppSettingsAction.setInstallationDateIfNecessary(date: date) { aResult in
             result = aResult
         }
@@ -256,6 +258,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // Then
         XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+        XCTAssertTrue(try XCTUnwrap(result).get())
 
         let savedSettings: GeneralAppSettings = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
         XCTAssertEqual(date, savedSettings.installationDate)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -241,6 +241,27 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertNotEqual(newerDate, savedSettings.installationDate)
     }
 
+    func testGivenNoExistingSettingsThenItCanSaveTheAppInstallationDate() throws {
+        // Given
+        let date = Date(timeIntervalSince1970: 100)
+
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // When
+        var result: Result<Void, Error>?
+        let action = AppSettingsAction.setInstallationDateIfNecessary(date: date) { aResult in
+            result = aResult
+        }
+        subject?.onAction(action)
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+
+        let savedSettings: GeneralAppSettings = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
+        XCTAssertEqual(date, savedSettings.installationDate)
+        XCTAssertNil(savedSettings.lastFeedbackDate)
+    }
+
     func testItCanSaveTheLastFeedbackDate() throws {
         // Given
         let date = Date(timeIntervalSince1970: 300)


### PR DESCRIPTION
Part of #2537. 

This adds `AppSettingsActions` to persist information to support checking the conditions for #2537:

Condition | New `AppSettingAction`
--------|-------
Users who’ve installed the app at least 3 months ago | `setInstallationDateIfNecessary`
Once every 6 months | `setLastFeedbackDate`

As far as I can tell, we do not currently track the _installation date_ but please let me know if we do! 

## Changes

The actions eventually lead to persisting a new `struct`, [`GeneralAppSettings`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2537-add-app-settings/Storage/Storage/Model/GeneralAppSettings.swift). I pondered about this for a while. We save **a lot** of files in `AppSettingsStore`. And I think because of these, we now have so many boilerplate. It felt quite cumbersome to save the `installationDate` and `lastFeedbackDate` into separate structures and separate files. I wish we could have just saved all the settings in one file. But please let me know if I'm misunderstanding the purpose of why we did it this way. 

## Testing

These are currently not used. Please just review. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

