### PR TITLE
Refactoring on price settings: move sections and date picker states from view controller to view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -15,11 +15,6 @@ final class ProductPriceSettingsViewController: UIViewController {
     //
     private let timezoneForScheduleSaleDates = TimeZone.siteTimezone
 
-    // Date Pickers status
-    //
-    private var datePickerSaleFromVisible = false
-    private var datePickerSaleToVisible = false
-
     /// Table Sections to be rendered
     ///
     private var sections: [Section] = []
@@ -219,13 +214,12 @@ extension ProductPriceSettingsViewController: UITableViewDelegate {
 
         switch row {
         case .scheduleSaleFrom:
-            datePickerSaleFromVisible = !datePickerSaleFromVisible
+            viewModel.didTapScheduleSaleFromRow()
             refreshViewContent()
         case .scheduleSaleTo:
-            datePickerSaleToVisible = !datePickerSaleToVisible
+            viewModel.didTapScheduleSaleToRow()
             refreshViewContent()
         case .removeSaleTo:
-            datePickerSaleToVisible = false
             viewModel.handleSaleEndDateChange(nil)
             refreshViewContent()
         case .taxStatus:
@@ -439,34 +433,15 @@ private extension ProductPriceSettingsViewController {
     }
 
     func configureSections() {
-        var saleScheduleRows: [Row] = [.scheduleSale]
-        if viewModel.dateOnSaleStart != nil || viewModel.dateOnSaleEnd != nil {
-            saleScheduleRows.append(contentsOf: [.scheduleSaleFrom])
-            if datePickerSaleFromVisible {
-                saleScheduleRows.append(contentsOf: [.datePickerSaleFrom])
-            }
-            saleScheduleRows.append(contentsOf: [.scheduleSaleTo])
-            if datePickerSaleToVisible {
-                saleScheduleRows.append(contentsOf: [.datePickerSaleTo])
-            }
-            if viewModel.dateOnSaleEnd != nil {
-                saleScheduleRows.append(.removeSaleTo)
-            }
-        }
-
-        sections = [
-        Section(title: NSLocalizedString("Price", comment: "Section header title for product price"), rows: [.price, .salePrice]),
-        Section(title: nil, rows: saleScheduleRows),
-        Section(title: NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings"), rows: [.taxStatus, .taxClass])
-        ]
+        sections = viewModel.sections
     }
 }
 
 // MARK: - Private Types
 //
-private extension ProductPriceSettingsViewController {
+extension ProductPriceSettingsViewController {
 
-    struct Section {
+    struct Section: Equatable {
         let title: String?
         let rows: [Row]
     }
@@ -485,7 +460,7 @@ private extension ProductPriceSettingsViewController {
         case taxStatus
         case taxClass
 
-        var type: UITableViewCell.Type {
+        fileprivate var type: UITableViewCell.Type {
             switch self {
             case .price, .salePrice:
                 return UnitInputTableViewCell.self
@@ -502,7 +477,7 @@ private extension ProductPriceSettingsViewController {
             }
         }
 
-        var reuseIdentifier: String {
+        fileprivate var reuseIdentifier: String {
             return type.reuseIdentifier
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductPriceSettingsViewModelTests.swift
@@ -580,4 +580,114 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         // Assert
         XCTAssertFalse(viewModel.hasUnsavedChanges())
     }
+
+    // MARK: - Sections
+
+    typealias Section = ProductPriceSettingsViewModel.Section
+
+    func testInitialSectionsWithoutSaleDates() {
+        // Arrange
+        let saleStartDate: Date? = nil
+        let saleEndDate: Date? = nil
+        let product = MockProduct().product(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate)
+        let viewModel = ProductPriceSettingsViewModel(product: product)
+
+        // Act
+        let sections = viewModel.sections
+
+        // Assert
+        let initialSections: [Section] = [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ]
+        XCTAssertEqual(sections, initialSections)
+    }
+
+    func testTappingScheduleSaleFromRowTogglesPickerRowInSalesSection() {
+        // Arrange
+        let saleStartDate: Date? = nil
+        let saleEndDate = Date().addingTimeInterval(numberOfSecondsPerDay)
+        let product = MockProduct().product(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate)
+        let viewModel = ProductPriceSettingsViewModel(product: product)
+        let initialSections: [Section] = [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ]
+        XCTAssertEqual(viewModel.sections, initialSections)
+
+        // Act
+        viewModel.didTapScheduleSaleFromRow()
+        let sectionsAfterTheFirstTap = viewModel.sections
+        viewModel.didTapScheduleSaleFromRow()
+        let sectionsAfterTheSecondTap = viewModel.sections
+
+        // Assert
+        XCTAssertEqual(sectionsAfterTheFirstTap, [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .datePickerSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ])
+        XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
+    }
+
+    func testTappingScheduleSaleToRowTogglesPickerRowInSalesSection() {
+        // Arrange
+        let saleStartDate: Date? = nil
+        let saleEndDate = Date().addingTimeInterval(numberOfSecondsPerDay)
+        let product = MockProduct().product(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate)
+        let viewModel = ProductPriceSettingsViewModel(product: product)
+        let initialSections: [Section] = [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ]
+        XCTAssertEqual(viewModel.sections, initialSections)
+
+        // Act
+        viewModel.didTapScheduleSaleToRow()
+        let sectionsAfterTheFirstTap = viewModel.sections
+        viewModel.didTapScheduleSaleToRow()
+        let sectionsAfterTheSecondTap = viewModel.sections
+
+        // Assert
+        XCTAssertEqual(sectionsAfterTheFirstTap, [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ])
+        XCTAssertEqual(sectionsAfterTheSecondTap, initialSections)
+    }
+
+    func testRemovingSaleEndDateDeletesRemoveSaleToRow() {
+        // Arrange
+        let saleStartDate: Date? = nil
+        let saleEndDate = Date().addingTimeInterval(numberOfSecondsPerDay)
+        let product = MockProduct().product(dateOnSaleStart: saleStartDate, dateOnSaleEnd: saleEndDate)
+        let viewModel = ProductPriceSettingsViewModel(product: product)
+        let initialSections: [Section] = [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ]
+        XCTAssertEqual(viewModel.sections, initialSections)
+
+        // Act
+        viewModel.handleSaleEndDateChange(nil)
+
+        // Assert
+        XCTAssertEqual(viewModel.sections, [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ])
+    }
+}
+
+private extension ProductPriceSettingsViewModelTests {
+    enum Strings {
+        static let priceSectionTitle = NSLocalizedString("Price", comment: "Section header title for product price")
+        static let taxSectionTitle = NSLocalizedString("Tax Settings", comment: "Section header title for product tax settings")
+    }
 }


### PR DESCRIPTION
Prerequisite for #2085

As part of the UI differences for editing a product variation in p91TBi-33Q-p2, we want to hide the tax status row in price settings for a product variation. This PR prepares the price settings view controller and view model to allow hiding the tax status row when the price settings supports a product variation (after https://github.com/woocommerce/woocommerce-ios/pull/2552).

## Changes

- Moved `datePickerSaleFromVisible` and `datePickerSaleToVisible` states and handling from `ProductPriceSettingsViewController` to `ProductPriceSettingsViewModel` with these two action functions in `ProductPriceSettingsViewModelOutput` protocol:
  - `func didTapScheduleSaleFromRow()`
  - `func didTapScheduleSaleToRow()`
- Moved the logic to calculate the visible sections from `ProductPriceSettingsViewController` to `ProductPriceSettingsViewModel` with unit tests

## Testing

Please test for regression in product price settings:

- Go to the Products tab
- Tap on a simple product
- Tap on the price row
- Test turning on and off "Schedule sale" --> if on, sale start & end dates should be available for edit. if sale end date is set, a "Remove end date" row should appear for removing the sale end date
- Try editing a few fields in price settings and tap "Done" --> the changes should be reflected on the price row
- Tap "Update" --> the price settings changes should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
