### PR TITLE
Edit Product: open "Photos" when tapping on Product image

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -108,8 +108,9 @@ private extension ProductFormTableViewDataSource {
             cell.configure(with: productImageStatuses, config: .extendedAddImages, productUIImageLoader: productUIImageLoader)
         }
 
-        cell.onImageSelected = { (productImage, indexPath) in
-            // TODO: open image detail
+        cell.onImageSelected = { [weak self] (productImage, indexPath) in
+            ServiceLocator.analytics.track(.productDetailAddImageTapped)
+            self?.onAddImage?()
         }
         cell.onAddImage = { [weak self] in
             ServiceLocator.analytics.track(.productDetailAddImageTapped)


### PR DESCRIPTION
Fixes #2402

## Description
When clicking on a product image on the product details screen, now we open the "Photos" screen, like in Android. I fire also the event `product_detail_add_image_tapped` since the behavior is the same of adding a new photo.

## Testing
1. Open a Product with some images.
2. Tap an image.
3. The "Photos" screen will be presented.
4. Try to upload a photo, press done, and while is uploading, try to tap the image. In this case, nothing has to happen.

<img src="https://user-images.githubusercontent.com/495617/88688342-841abb80-d0f9-11ea-9ff7-9681798aa77b.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
