### PR TITLE
Unit tests for ProductSettingsRows

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CAF24CF006A00D570DD /* ProductTagsDataSource.swift */; };
+		450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CB224D0803000D570DD /* ProductSettingsRowsTests.swift */; };
 		4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512054E2464741B005D68DE /* ProductVisibility.swift */; };
 		4512055224655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512055024655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift */; };
 		4512055324655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4512055124655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib */; };
@@ -1182,6 +1183,7 @@
 		4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibilityViewController.swift; sourceTree = "<group>"; };
 		4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVisibilityViewController.xib; sourceTree = "<group>"; };
 		450C2CAF24CF006A00D570DD /* ProductTagsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsDataSource.swift; sourceTree = "<group>"; };
+		450C2CB224D0803000D570DD /* ProductSettingsRowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsRowsTests.swift; sourceTree = "<group>"; };
 		4512054E2464741B005D68DE /* ProductVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibility.swift; sourceTree = "<group>"; };
 		4512055024655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndTextFieldWithImageTableViewCell.swift; sourceTree = "<group>"; };
 		4512055124655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndTextFieldWithImageTableViewCell.xib; sourceTree = "<group>"; };
@@ -2512,6 +2514,7 @@
 			children = (
 				453770D02431FF4700AC718D /* ProductSettingsViewModelTests.swift */,
 				455800CB24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift */,
+				450C2CB224D0803000D570DD /* ProductSettingsRowsTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -5227,6 +5230,7 @@
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
+				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */,
 				B555531321B57E8800449E71 /* MockupUserNotificationsCenterAdapter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+/// Test cases for `ProductSettingsRows`.
+///
+final class ProductSettingsRowsTests: XCTestCase {
+
+    var settings = ProductSettings(status: .draft,
+                                   featured: false,
+                                   password: nil,
+                                   catalogVisibility: .catalog,
+                                   virtual: false,
+                                   reviewsAllowed: false,
+                                   slug: "slug",
+                                   purchaseNote: nil,
+                                   menuOrder: 0)
+
+    override func setUp() {
+        super.setUp()
+
+        // Given
+        settings = ProductSettings(status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testVirtualProductRowChangedWhenUpdated() {
+        // Given
+        let virtualProduct = ProductSettingsRows.VirtualProduct(settings)
+
+        let cell = SwitchTableViewCell()
+        virtualProduct.configure(cell: cell)
+
+        // When
+        cell.onChange?(true)
+
+        // Then
+        XCTAssertEqual(settings.virtual, true)
+    }
+
+    func testReviewsAllowedRowChangedWhenUpdated() {
+        // Given
+        let reviewsAllowed = ProductSettingsRows.ReviewsAllowed(settings)
+
+        let cell = SwitchTableViewCell()
+        reviewsAllowed.configure(cell: cell)
+
+        // When
+        cell.onChange?(true)
+
+        // Then
+        XCTAssertEqual(settings.reviewsAllowed, true)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
@@ -6,21 +6,13 @@ import Yosemite
 ///
 final class ProductSettingsRowsTests: XCTestCase {
 
-    var settings = ProductSettings(status: .draft,
-                                   featured: false,
-                                   password: nil,
-                                   catalogVisibility: .catalog,
-                                   virtual: false,
-                                   reviewsAllowed: false,
-                                   slug: "slug",
-                                   purchaseNote: nil,
-                                   menuOrder: 0)
+    var originalSettings: ProductSettings?
 
     override func setUp() {
         super.setUp()
 
         // Given
-        settings = ProductSettings(status: .draft,
+        originalSettings = ProductSettings(status: .draft,
                                        featured: false,
                                        password: nil,
                                        catalogVisibility: .catalog,
@@ -35,7 +27,9 @@ final class ProductSettingsRowsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testVirtualProductRowChangedWhenUpdated() {
+    func testVirtualProductRowChangedWhenUpdated() throws {
+        let settings = try XCTUnwrap(originalSettings)
+
         // Given
         let virtualProduct = ProductSettingsRows.VirtualProduct(settings)
 
@@ -49,7 +43,9 @@ final class ProductSettingsRowsTests: XCTestCase {
         XCTAssertEqual(settings.virtual, true)
     }
 
-    func testReviewsAllowedRowChangedWhenUpdated() {
+    func testReviewsAllowedRowChangedWhenUpdated() throws {
+        let settings = try XCTUnwrap(originalSettings)
+
         // Given
         let reviewsAllowed = ProductSettingsRows.ReviewsAllowed(settings)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
@@ -6,7 +6,7 @@ import Yosemite
 ///
 final class ProductSettingsRowsTests: XCTestCase {
 
-    var originalSettings: ProductSettings?
+    private var originalSettings: ProductSettings?
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
Fixes #2526 

## Description
I added some unit tests for two specific cases of `ProductSettingsRows`, in particular the one related to VirtualProduct and ReviewsAllowed rows, since only in these two rows we handle the value of settings inside the cell (the value change inside it because we use a `SwitchTableViewCell` that contains a switch). 
The other rows do not seem to need testing, as the updated value always comes from the outside (other view controllers), but if you have any suggestion, feel free to suggest it 😃 

## Testing 
- Look at the code
- CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
