### PR TITLE
Add In-app Feedback Card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -75,10 +75,15 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         return [storeStatsPeriodViewController, topPerformersPeriodViewController]
     }
 
-    init(timeRange: StatsTimeRangeV4, currentDate: Date) {
+    private let featureFlagService: FeatureFlagService
+
+    init(timeRange: StatsTimeRangeV4,
+         currentDate: Date,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.timeRange = timeRange
         self.granularity = timeRange.intervalGranularity
         self.currentDate = currentDate
+        self.featureFlagService = featureFlagService
         super.init(nibName: nil, bundle: nil)
         configureChildViewControllers()
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -79,12 +79,20 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     private let featureFlagService: FeatureFlagService
 
+    /// If applicable, present the in-app feedback. The in-app feedback may still not be presented
+    /// depending on the constraints. But setting this to `false`, will ensure that it will
+    /// never be presented.
+    ///
+    private let canDisplayInAppFeedback: Bool
+
     init(timeRange: StatsTimeRangeV4,
          currentDate: Date,
+         canDisplayInAppFeedback: Bool,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.timeRange = timeRange
         self.granularity = timeRange.intervalGranularity
         self.currentDate = currentDate
+        self.canDisplayInAppFeedback = canDisplayInAppFeedback
         self.featureFlagService = featureFlagService
         super.init(nibName: nil, bundle: nil)
         configureChildViewControllers()
@@ -225,7 +233,8 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
     /// - Returns: The views or empty array if we do not need in-app feedback from the user.
     ///
     func createInAppFeedbackCardViewsForStackView() -> [UIView] {
-        guard featureFlagService.isFeatureFlagEnabled(.inAppFeedback),
+        guard canDisplayInAppFeedback,
+            featureFlagService.isFeatureFlagEnabled(.inAppFeedback),
             let cardView = inAppFeedbackCardViewController.view else {
             return []
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -65,6 +65,8 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         return StoreStatsV4PeriodViewController(timeRange: timeRange, currentDate: currentDate)
     }()
 
+    private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()
+
     private lazy var topPerformersPeriodViewController: TopPerformerDataViewController = {
         return TopPerformerDataViewController(granularity: timeRange.topEarnerStatsGranularity)
     }()
@@ -72,7 +74,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     // MARK: Internal Properties
 
     private var childViewContrllers: [UIViewController] {
-        return [storeStatsPeriodViewController, topPerformersPeriodViewController]
+        return [storeStatsPeriodViewController, inAppFeedbackCardViewController, topPerformersPeriodViewController]
     }
 
     private let featureFlagService: FeatureFlagService
@@ -168,6 +170,12 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             storeStatsPeriodView.heightAnchor.constraint(equalToConstant: 380),
             ])
 
+        // In-app Feedback Card
+        let inAppFeedbackCardViews = createInAppFeedbackCardViewsForStackView()
+        inAppFeedbackCardViews.forEach {
+            stackView.addArrangedSubview($0)
+        }
+
         // Top performers header.
         let topPerformersHeaderView = TopPerformersSectionHeaderView(title:
             NSLocalizedString("Top Performers",
@@ -207,6 +215,31 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         childViewContrllers.forEach { childViewController in
             childViewController.didMove(toParent: self)
         }
+    }
+
+    /// Create in-app feedback views to be added to the main `stackView`.
+    ///
+    /// The views created are an empty space and the `inAppFeedbackCardViewController.view`.
+    ///
+    /// - SeeAlso: configureSubviews
+    /// - Returns: The views or empty array if we do not need in-app feedback from the user.
+    ///
+    func createInAppFeedbackCardViewsForStackView() -> [UIView] {
+        guard featureFlagService.isFeatureFlagEnabled(.inAppFeedback),
+            let cardView = inAppFeedbackCardViewController.view else {
+            return []
+        }
+
+        let emptySpaceView: UIView = {
+            let view = UIView(frame: .zero)
+            view.backgroundColor = nil
+            NSLayoutConstraint.activate([
+                view.heightAnchor.constraint(equalToConstant: 8)
+            ])
+            return view
+        }()
+
+        return [emptySpaceView, cardView]
     }
 
     func createBorderView() -> UIView {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -7,7 +7,7 @@ import Yosemite
 /// - Top performers header view (`TopPerformersSectionHeaderView`)
 /// - Top performers data view (managed by child view controller `TopPerformerDataViewController`)
 ///
-class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
+final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     // MARK: Public Interface
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -85,6 +85,13 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     ///
     private let canDisplayInAppFeedback: Bool
 
+    /// Create an instance of `self`.
+    ///
+    /// - Parameter canDisplayInAppFeedback: If applicable, present the in-app feedback. The in-app
+    ///                                      feedback may still not be presented depending on the
+    ///                                      constraints. But setting this to `false`, will ensure
+    ///                                      that it will never be presented.
+    ///
     init(timeRange: StatsTimeRangeV4,
          currentDate: Date,
          canDisplayInAppFeedback: Bool,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -256,10 +256,10 @@ private extension StoreStatsAndTopPerformersViewController {
 
     func configurePeriodViewControllers() {
         let currentDate = Date()
-        let dayVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .today, currentDate: currentDate)
-        let weekVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisWeek, currentDate: currentDate)
-        let monthVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisMonth, currentDate: currentDate)
-        let yearVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisYear, currentDate: currentDate)
+        let dayVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .today, currentDate: currentDate, canDisplayInAppFeedback: true)
+        let weekVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisWeek, currentDate: currentDate, canDisplayInAppFeedback: false)
+        let monthVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisMonth, currentDate: currentDate, canDisplayInAppFeedback: false)
+        let yearVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisYear, currentDate: currentDate, canDisplayInAppFeedback: false)
 
         periodVCs.append(dayVC)
         periodVCs.append(weekVC)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -5,7 +5,7 @@ import Yosemite
 /// Top-level stats container view controller that consists of a button bar with 4 time ranges.
 /// Each time range tab is managed by a `StoreStatsAndTopPerformersPeriodViewController`.
 ///
-class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripViewController {
+final class StoreStatsAndTopPerformersViewController: ButtonBarPagerTabStripViewController {
 
     // MARK: - DashboardUI protocol
 

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -75,13 +75,12 @@ struct InAppFeedbackCardViewController_Previews: PreviewProvider {
         VStack {
             InAppFeedbackCardViewControllerRepresentable()
         }
-        .background(Color(UIColor.listBackground))
     }
 
     static var previews: some View {
         Group {
             makeStack()
-                .previewLayout(.fixed(width: 375, height: 128))
+                .previewLayout(.fixed(width: 320, height: 128))
                 .previewDisplayName("Light")
 
             makeStack()
@@ -90,9 +89,14 @@ struct InAppFeedbackCardViewController_Previews: PreviewProvider {
                 .previewDisplayName("Dark")
 
             makeStack()
-                .previewLayout(.fixed(width: 375, height: 528))
+                .previewLayout(.fixed(width: 414, height: 528))
                 .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
                 .previewDisplayName("Large Font")
+
+            makeStack()
+                .previewLayout(.fixed(width: 896, height: 128))
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Large Width - Dark")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -15,6 +15,8 @@ final class InAppFeedbackCardViewController: UIViewController {
         configureTitleLabel()
         configureDidNotLikeButton()
         configureLikeButton()
+
+        view.backgroundColor = .listForeground
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -9,9 +9,13 @@ final class InAppFeedbackCardViewController: UIViewController {
     @IBOutlet private var didNotLikeButton: UIButton!
     @IBOutlet private var likeButton: UIButton!
 
+    /// The stackview containing the `titleLabel` and the horizontal view for the buttons.
+    @IBOutlet private var verticalStackView: UIStackView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        configureVerticalStackView()
         configureTitleLabel()
         configureDidNotLikeButton()
         configureLikeButton()
@@ -23,6 +27,12 @@ final class InAppFeedbackCardViewController: UIViewController {
 // MARK: - Provisioning
 
 private extension InAppFeedbackCardViewController {
+
+    func configureVerticalStackView() {
+        verticalStackView.isLayoutMarginsRelativeArrangement = true
+        verticalStackView.layoutMargins = .init(top: 0, left: 16, bottom: 0, right: 16)
+    }
+
     func configureTitleLabel() {
         titleLabel.applyBodyStyle()
         titleLabel.numberOfLines = 0

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -5,6 +5,50 @@ import UIKit
 ///
 final class InAppFeedbackCardViewController: UIViewController {
 
+    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var didNotLikeButton: UIButton!
+    @IBOutlet private var likeButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTitleLabel()
+        configureDidNotLikeButton()
+        configureLikeButton()
+    }
+}
+
+// MARK: - Provisioning
+
+private extension InAppFeedbackCardViewController {
+    func configureTitleLabel() {
+        titleLabel.applyBodyStyle()
+        titleLabel.numberOfLines = 0
+        titleLabel.text = Localization.enjoyingTheWooCommerceApp
+    }
+
+    func configureDidNotLikeButton() {
+        didNotLikeButton.applySecondaryButtonStyle()
+        didNotLikeButton.setTitle(Localization.couldBeBetter, for: .normal)
+    }
+
+    func configureLikeButton() {
+        likeButton.applyPrimaryButtonStyle()
+        likeButton.setTitle(Localization.iLikeIt, for: .normal)
+    }
+}
+
+// MARK: - Constants
+
+private extension InAppFeedbackCardViewController {
+    enum Localization {
+        static let enjoyingTheWooCommerceApp = NSLocalizedString("Enjoying the WooCommerce app?",
+                                                                 comment: "The title used when asking the user for feedback for the app.")
+        static let couldBeBetter = NSLocalizedString("Could Be Better",
+                                                     comment: "The title of the button for giving a negative feedback for the app.")
+        static let iLikeIt = NSLocalizedString("I Like It",
+                                               comment: "The title of the button for giving a positive feedback for the app.")
+    }
 }
 
 // MARK: - Previews
@@ -46,7 +90,7 @@ struct InAppFeedbackCardViewController_Previews: PreviewProvider {
                 .previewDisplayName("Dark")
 
             makeStack()
-                .previewLayout(.fixed(width: 375, height: 128))
+                .previewLayout(.fixed(width: 375, height: 528))
                 .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
                 .previewDisplayName("Large Font")
         }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -1,0 +1,56 @@
+
+import UIKit
+
+/// Displays a small view asking the user to provide a feedback for the app.
+///
+final class InAppFeedbackCardViewController: UIViewController {
+
+}
+
+// MARK: - Previews
+
+#if canImport(SwiftUI) && DEBUG
+
+import SwiftUI
+
+private struct InAppFeedbackCardViewControllerRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let viewController = InAppFeedbackCardViewController()
+        return viewController.view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        // noop
+    }
+}
+
+@available(iOS 13.0, *)
+struct InAppFeedbackCardViewController_Previews: PreviewProvider {
+
+    private static func makeStack() -> some View {
+        VStack {
+            InAppFeedbackCardViewControllerRepresentable()
+        }
+        .background(Color(UIColor.listBackground))
+    }
+
+    static var previews: some View {
+        Group {
+            makeStack()
+                .previewLayout(.fixed(width: 375, height: 128))
+                .previewDisplayName("Light")
+
+            makeStack()
+                .previewLayout(.fixed(width: 375, height: 128))
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark")
+
+            makeStack()
+                .previewLayout(.fixed(width: 375, height: 128))
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .previewDisplayName("Large Font")
+        }
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -82,7 +82,7 @@ struct InAppFeedbackCardViewController_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             makeStack()
-                .previewLayout(.fixed(width: 320, height: 128))
+                .previewLayout(.fixed(width: 320, height: 148))
                 .previewDisplayName("Light")
 
             makeStack()

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
@@ -21,50 +21,42 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Asl-4X-QmQ" userLabel="ContainerView">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
+                <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf" userLabel="VerticalStackView">
+                    <rect key="frame" x="15" y="16" width="290.5" height="108"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf" userLabel="VerticalStackView">
-                            <rect key="frame" x="16" y="16" width="288" height="108"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
+                            <rect key="frame" x="16" y="0.0" width="258.5" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="nuf-l1-QC2" userLabel="ButtonsStackView">
+                            <rect key="frame" x="16" y="40.5" width="258.5" height="67.5"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
-                                    <rect key="frame" x="0.0" y="0.0" width="288" height="20.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="nuf-l1-QC2" userLabel="ButtonsStackView">
-                                    <rect key="frame" x="0.0" y="40.5" width="288" height="67.5"/>
-                                    <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fwj-Sy-QD3">
-                                            <rect key="frame" x="0.0" y="0.0" width="136.5" height="67.5"/>
-                                            <state key="normal" title="Could Be Better"/>
-                                        </button>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sgc-1W-ZK6">
-                                            <rect key="frame" x="151.5" y="0.0" width="136.5" height="67.5"/>
-                                            <state key="normal" title="I Like It"/>
-                                        </button>
-                                    </subviews>
-                                </stackView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fwj-Sy-QD3">
+                                    <rect key="frame" x="0.0" y="0.0" width="121.5" height="67.5"/>
+                                    <state key="normal" title="Could Be Better"/>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sgc-1W-ZK6">
+                                    <rect key="frame" x="136.5" y="0.0" width="122" height="67.5"/>
+                                    <state key="normal" title="I Like It"/>
+                                </button>
                             </subviews>
                         </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="ffG-Ca-TIf" secondAttribute="trailing" constant="16" id="BKG-rz-CsH"/>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="320" id="J4L-rz-0aV"/>
-                        <constraint firstAttribute="bottom" secondItem="ffG-Ca-TIf" secondAttribute="bottom" constant="16" id="K1I-cL-mig"/>
-                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="414" id="Rra-Ce-xpI"/>
-                        <constraint firstItem="ffG-Ca-TIf" firstAttribute="top" secondItem="Asl-4X-QmQ" secondAttribute="top" constant="16" id="qLb-cQ-MOr"/>
-                        <constraint firstItem="ffG-Ca-TIf" firstAttribute="leading" secondItem="Asl-4X-QmQ" secondAttribute="leading" constant="16" id="uJh-9r-7n9"/>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="414" id="vf1-wt-Fs4"/>
                     </constraints>
-                </view>
+                    <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
+                </stackView>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="Asl-4X-QmQ" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="APR-1a-jpq"/>
-                <constraint firstAttribute="top" secondItem="Asl-4X-QmQ" secondAttribute="top" id="Ibo-uC-Sbw"/>
-                <constraint firstItem="Asl-4X-QmQ" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" id="MbE-G4-ZaM"/>
-                <constraint firstItem="Asl-4X-QmQ" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" priority="750" id="XUM-hY-coZ"/>
+                <constraint firstItem="ffG-Ca-TIf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vUN-kp-3ea" secondAttribute="leading" id="HI7-Gz-sqF"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ffG-Ca-TIf" secondAttribute="trailing" id="KGT-7l-Gal"/>
+                <constraint firstItem="ffG-Ca-TIf" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="OfF-He-JOA"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="ffG-Ca-TIf" secondAttribute="bottom" constant="16" id="VdC-Gq-cXg"/>
+                <constraint firstAttribute="top" secondItem="ffG-Ca-TIf" secondAttribute="top" constant="-16" id="dqn-7D-6sl"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
@@ -18,44 +18,58 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="140"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf">
-                    <rect key="frame" x="16" y="16" width="382" height="108"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Asl-4X-QmQ" userLabel="ContainerView">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
-                            <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="nuf-l1-QC2">
-                            <rect key="frame" x="0.0" y="40.5" width="382" height="67.5"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf" userLabel="VerticalStackView">
+                            <rect key="frame" x="16" y="16" width="288" height="108"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fwj-Sy-QD3">
-                                    <rect key="frame" x="0.0" y="0.0" width="183.5" height="67.5"/>
-                                    <state key="normal" title="Could Be Better"/>
-                                </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sgc-1W-ZK6">
-                                    <rect key="frame" x="198.5" y="0.0" width="183.5" height="67.5"/>
-                                    <state key="normal" title="I Like It"/>
-                                </button>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
+                                    <rect key="frame" x="0.0" y="0.0" width="288" height="20.5"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="nuf-l1-QC2" userLabel="ButtonsStackView">
+                                    <rect key="frame" x="0.0" y="40.5" width="288" height="67.5"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fwj-Sy-QD3">
+                                            <rect key="frame" x="0.0" y="0.0" width="136.5" height="67.5"/>
+                                            <state key="normal" title="Could Be Better"/>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sgc-1W-ZK6">
+                                            <rect key="frame" x="151.5" y="0.0" width="136.5" height="67.5"/>
+                                            <state key="normal" title="I Like It"/>
+                                        </button>
+                                    </subviews>
+                                </stackView>
                             </subviews>
                         </stackView>
                     </subviews>
-                </stackView>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="ffG-Ca-TIf" secondAttribute="trailing" constant="16" id="BKG-rz-CsH"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="320" id="J4L-rz-0aV"/>
+                        <constraint firstAttribute="bottom" secondItem="ffG-Ca-TIf" secondAttribute="bottom" constant="16" id="K1I-cL-mig"/>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="414" id="Rra-Ce-xpI"/>
+                        <constraint firstItem="ffG-Ca-TIf" firstAttribute="top" secondItem="Asl-4X-QmQ" secondAttribute="top" constant="16" id="qLb-cQ-MOr"/>
+                        <constraint firstItem="ffG-Ca-TIf" firstAttribute="leading" secondItem="Asl-4X-QmQ" secondAttribute="leading" constant="16" id="uJh-9r-7n9"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="ffG-Ca-TIf" secondAttribute="bottom" constant="16" id="2XZ-pu-IqB"/>
-                <constraint firstAttribute="top" secondItem="ffG-Ca-TIf" secondAttribute="top" constant="-16" id="60C-sl-8B2"/>
-                <constraint firstItem="ffG-Ca-TIf" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="BEG-3z-meN"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="ffG-Ca-TIf" secondAttribute="trailing" constant="16" id="p6T-5h-EAY"/>
+                <constraint firstItem="Asl-4X-QmQ" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="APR-1a-jpq"/>
+                <constraint firstAttribute="top" secondItem="Asl-4X-QmQ" secondAttribute="top" id="Ibo-uC-Sbw"/>
+                <constraint firstItem="Asl-4X-QmQ" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" id="MbE-G4-ZaM"/>
+                <constraint firstItem="Asl-4X-QmQ" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" priority="750" id="XUM-hY-coZ"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="137.68115942028987" y="-100.44642857142857"/>
+            <point key="canvasLocation" x="69.565217391304358" y="-100.44642857142857"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
@@ -13,6 +13,7 @@
                 <outlet property="didNotLikeButton" destination="fwj-Sy-QD3" id="lHh-PH-TAX"/>
                 <outlet property="likeButton" destination="Sgc-1W-ZK6" id="qRZ-w4-Hw2"/>
                 <outlet property="titleLabel" destination="knB-Iy-ibQ" id="mYE-x1-nqG"/>
+                <outlet property="verticalStackView" destination="ffG-Ca-TIf" id="Yfy-BA-qN8"/>
                 <outlet property="view" destination="iN0-l3-epB" id="NfP-gC-jAJ"/>
             </connections>
         </placeholder>
@@ -22,16 +23,16 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf" userLabel="VerticalStackView">
-                    <rect key="frame" x="15" y="16" width="290.5" height="108"/>
+                    <rect key="frame" x="31" y="16" width="258.5" height="108"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
-                            <rect key="frame" x="16" y="0.0" width="258.5" height="20.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="258.5" height="20.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="nuf-l1-QC2" userLabel="ButtonsStackView">
-                            <rect key="frame" x="16" y="40.5" width="258.5" height="67.5"/>
+                            <rect key="frame" x="0.0" y="40.5" width="258.5" height="67.5"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fwj-Sy-QD3">
                                     <rect key="frame" x="0.0" y="0.0" width="121.5" height="67.5"/>
@@ -47,7 +48,6 @@
                     <constraints>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="414" id="vf1-wt-Fs4"/>
                     </constraints>
-                    <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                 </stackView>
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InAppFeedbackCardViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="NfP-gC-jAJ"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="140"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf">
+                    <rect key="frame" x="16" y="16" width="382" height="108"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
+                            <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="nuf-l1-QC2">
+                            <rect key="frame" x="0.0" y="40.5" width="382" height="67.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fwj-Sy-QD3">
+                                    <rect key="frame" x="0.0" y="0.0" width="183.5" height="67.5"/>
+                                    <state key="normal" title="Could Be Better"/>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sgc-1W-ZK6">
+                                    <rect key="frame" x="198.5" y="0.0" width="183.5" height="67.5"/>
+                                    <state key="normal" title="I Like It"/>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="ffG-Ca-TIf" secondAttribute="bottom" constant="16" id="2XZ-pu-IqB"/>
+                <constraint firstAttribute="top" secondItem="ffG-Ca-TIf" secondAttribute="top" constant="-16" id="60C-sl-8B2"/>
+                <constraint firstItem="ffG-Ca-TIf" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="BEG-3z-meN"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="ffG-Ca-TIf" secondAttribute="trailing" constant="16" id="p6T-5h-EAY"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="137.68115942028987" y="-100.44642857142857"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
@@ -10,6 +10,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InAppFeedbackCardViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
+                <outlet property="didNotLikeButton" destination="fwj-Sy-QD3" id="lHh-PH-TAX"/>
+                <outlet property="likeButton" destination="Sgc-1W-ZK6" id="qRZ-w4-Hw2"/>
+                <outlet property="titleLabel" destination="knB-Iy-ibQ" id="mYE-x1-nqG"/>
                 <outlet property="view" destination="iN0-l3-epB" id="NfP-gC-jAJ"/>
             </connections>
         </placeholder>
@@ -21,7 +24,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ffG-Ca-TIf">
                     <rect key="frame" x="16" y="16" width="382" height="108"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enjoying the WooCommerce app?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="knB-Iy-ibQ">
                             <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <nil key="textColor"/>

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.xib
@@ -49,7 +49,6 @@
                             </subviews>
                         </stackView>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="ffG-Ca-TIf" secondAttribute="trailing" constant="16" id="BKG-rz-CsH"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="320" id="J4L-rz-0aV"/>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -361,6 +361,8 @@
 		45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF35238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.swift */; };
 		45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */; };
 		570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */; };
+		571B850224CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571B850124CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift */; };
+		571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */; };
 		571E4674249D1615002ADCB8 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */; };
 		571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */; };
 		573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */; };
@@ -1248,6 +1250,8 @@
 		45FBDF36238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ExtendedAddProductImageCollectionViewCell.xib; sourceTree = "<group>"; };
 		45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedAddProductImageCollectionViewCellTests.swift; sourceTree = "<group>"; };
 		570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OrderDetailsDataSourceTests.swift; path = "Order Details/OrderDetailsDataSourceTests.swift"; sourceTree = "<group>"; };
+		571B850124CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewController.swift; sourceTree = "<group>"; };
+		571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InAppFeedbackCardViewController.xib; sourceTree = "<group>"; };
 		571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZendeskManager.swift; sourceTree = "<group>"; };
 		573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
@@ -2606,6 +2610,15 @@
 			path = "Collection View Cells";
 			sourceTree = "<group>";
 		};
+		571B850024CF7E1600CF58A7 /* InAppFeedback */ = {
+			isa = PBXGroup;
+			children = (
+				571B850124CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift */,
+				571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */,
+			);
+			path = InAppFeedback;
+			sourceTree = "<group>";
+		};
 		571E5C062489E61A00B71B9F /* Product List Section */ = {
 			isa = PBXGroup;
 			children = (
@@ -3087,6 +3100,7 @@
 		B56DB3EF2049C06D00D4AA8E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				571B850024CF7E1600CF58A7 /* InAppFeedback */,
 				0235594024496414004BE2B8 /* BottomSheet */,
 				02564A8F246CEBCB00D6DB2A /* Containers */,
 				027D67CF245ADDCC0036B8DB /* Filters */,
@@ -4384,6 +4398,7 @@
 				740382DC2267D94100A627F4 /* LargeImageTableViewCell.xib in Resources */,
 				57CFCD2A2488496F003F51EC /* PrimarySectionHeaderView.xib in Resources */,
 				CE22E3FC21714776005A6BEF /* TopLeftImageTableViewCell.xib in Resources */,
+				571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */,
 				B5D1AFB420BC445A00DB0E8C /* Images.xcassets in Resources */,
 				CEE005F62076C4040079161F /* Orders.storyboard in Resources */,
 				CE85FD5C20F7A7740080B73E /* TableFooterView.xib in Resources */,
@@ -4944,6 +4959,7 @@
 				022BF7FD23B9D708000A1DFB /* InProgressViewController.swift in Sources */,
 				45527A412472C6160078D609 /* SwitchStoreUseCase.swift in Sources */,
 				D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */,
+				571B850224CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift in Sources */,
 				7441E1D221503F77004E6ECE /* IntrinsicTableView.swift in Sources */,
 				B517EA1D218B41F200730EC4 /* String+Woo.swift in Sources */,
 				02564A8C246CE38E00D6DB2A /* SwappableSubviewContainerView.swift in Sources */,


### PR DESCRIPTION
Part of #2537. 

This adds the in-app feedback card in the Today tab for Stats V4. The card currently does not do anything. This is mostly just a UI implementation. This should unblock the other In-app Feedback tasks like #2544 and #2543.  

## Design

Large Font | Light  | Dark
--------|-------|-
![Simulator Screen Shot - iPhone 8 (13 6) (Large Font) - 2020-07-28 at 17 37 59](https://user-images.githubusercontent.com/198826/88739968-238b7e80-d0f9-11ea-832d-0d8b5f523b01.png)        |       ![Simulator Screen Shot - iPhone 8 - 2020-07-28 at 17 35 16](https://user-images.githubusercontent.com/198826/88739961-21292480-d0f9-11ea-8a58-678de3b1f078.png) | ![Simulator Screen Shot - iPhone 8 (13 6) (Dark) - 2020-07-28 at 17 36 29](https://user-images.githubusercontent.com/198826/88739964-22f2e800-d0f9-11ea-8f52-36061e477c8e.png)

We'll ask Garance for a design review when she's back. 

## Changes

The card has to be added as a child of `StoreStatsAndTopPerformersPeriodViewController` so I created it as a `UIViewController`, [`InAppFeedbackCardViewController`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2537-add-in-app-feedback-card/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift).

The card is only shown when:

- The `inAppFeedback` feature flag is turned on
- If the [`StoreStatsAndTopPerformersPeriodViewController .canDisplayInAppFeedback`](https://github.com/woocommerce/woocommerce-ios/blob/acbefae18c95b9a7d70f9439d159ad73837cdced/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersPeriodViewController.swift#L82-L86) is `true`. It's `true` for only the Today tab. 

I'll add unit tests in upcoming PRs since I still need to add another condition for when to display the in-app feedback card. 

## Testing

1. Log in to a store with WC > 4.0
2. Navigate to My Store → Today.
3. Confirm the card is there.
4. Confirm that the card is not visible in the other tabs. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

