### PR TITLE
Adds SurveyViewController

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -67,6 +67,12 @@ enum WooConstants {
         trustedURL("https://woocommerce.com/blog/")
     }
 
+    /// URL for in-app feedback survey
+    ///
+    static var inAppFeedbackURL: URL {
+        trustedURL("https://automattic.survey.fm/woo-app-general-feedback-user-survey")
+    }
+
     /// Number of section events required before an app review prompt appears
     ///
     static let notificationEventCount = 5

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -70,7 +70,11 @@ enum WooConstants {
     /// URL for in-app feedback survey
     ///
     static var inAppFeedbackURL: URL {
-        trustedURL("https://automattic.survey.fm/woo-app-general-feedback-user-survey")
+        if BuildConfiguration.current == .localDeveloper {
+            return trustedURL("https://wasseryi.survey.fm/woo-mobile-app-test-survey")
+        } else {
+            return trustedURL("https://automattic.survey.fm/woo-app-general-feedback-user-survey")
+        }
     }
 
     /// Number of section events required before an app review prompt appears

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -11,13 +11,13 @@ final class SurveyViewController: UIViewController {
 
     /// Survey configuration provided by the consumer
     ///
-    private let survey: SurveySource
+    private let survey: Source
 
     /// Handler invoked when the survey has been completed
     ///
     private let onCompletion: () -> Void
 
-    init(survey: SurveySource, onCompletion: @escaping () -> Void) {
+    init(survey: Source, onCompletion: @escaping () -> Void) {
         self.survey = survey
         self.onCompletion = onCompletion
         super.init(nibName: Self.nibName, bundle: nil)
@@ -46,7 +46,7 @@ final class SurveyViewController: UIViewController {
 // MARK: Survey Configuration
 //
 extension SurveyViewController {
-    enum SurveySource {
+    enum Source {
         case inAppFeedback
 
         var url: URL {

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -1,0 +1,46 @@
+import UIKit
+import WebKit
+
+final class SurveyViewController: UIViewController {
+    @IBOutlet private weak var webView: WKWebView!
+
+    private let onSurveySubmission: (_ viewController: UIViewController) -> Void
+
+    init(onSurveySubmission: @escaping (_ viewController: UIViewController) -> Void) {
+        self.onSurveySubmission = onSurveySubmission
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // TODO-jc: localization comment
+        title = NSLocalizedString("How can we improve?", comment: "")
+
+        addCloseNavigationBarButton()
+
+        let request = URLRequest(url: URL(string: "https://wasseryi.survey.fm/woo-mobile-app-test-survey")!)
+        webView.load(request)
+        webView.navigationDelegate = self
+    }
+}
+
+extension SurveyViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        switch navigationAction.navigationType {
+        // The condition for the POST HTTP method is necessary, since the `formSubmitted` callback is triggered when showing the Crowdsignal completion screen
+        // (a GET request).
+        case .formSubmitted where navigationAction.request.httpMethod == "POST":
+            decisionHandler(.allow)
+
+            onSurveySubmission(self)
+        default:
+            decisionHandler(.allow)
+            break
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -49,14 +49,14 @@ extension SurveyViewController {
     enum Source {
         case inAppFeedback
 
-        var url: URL {
+        fileprivate var url: URL {
             switch self {
             case .inAppFeedback:
                 return WooConstants.inAppFeedbackURL
             }
         }
 
-        var title: String {
+        fileprivate var title: String {
             switch self {
             case .inAppFeedback:
                 return NSLocalizedString("How can we improve?", comment: "Title on the navigation bar for the in-app feedback survey")

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.xib
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SurveyViewController" customModule="WooCommerce" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uO7-PA-PdE">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <wkWebViewConfiguration key="configuration">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="uO7-PA-PdE" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="E6O-pY-ZOR"/>
+                <constraint firstAttribute="bottom" secondItem="uO7-PA-PdE" secondAttribute="bottom" id="jea-qC-jDW"/>
+                <constraint firstAttribute="trailing" secondItem="uO7-PA-PdE" secondAttribute="trailing" id="lPe-8y-hdL"/>
+                <constraint firstItem="uO7-PA-PdE" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="qaT-y3-RZP"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="131.8840579710145" y="124.55357142857142"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.xib
@@ -8,7 +8,12 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SurveyViewController" customModule="WooCommerce" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SurveyViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="i5M-Pr-FkT" id="mDh-3v-P2c"/>
+                <outlet property="webView" destination="uO7-PA-PdE" id="yf5-RY-PPl"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */; };
+		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -1178,6 +1179,7 @@
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
+		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -2466,6 +2468,7 @@
 		26B119B524D0B36700FED5C7 /* Survey */ = {
 			isa = PBXGroup;
 			children = (
+				26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */,
 				26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */,
 			);
 			path = Survey;
@@ -4979,6 +4982,7 @@
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				74334F36214AB130006D6AC5 /* ProductTableViewCell.swift in Sources */,
 				024DF31B23742E1C006658FE /* FormatBarItemViewProperties.swift in Sources */,
+				26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */,
 				02E8B17C23E2C78A00A43403 /* ProductImageStatus.swift in Sources */,
 				02EA6BFA2435E92600FFF90A /* KingfisherImageDownloader+ImageDownloadable.swift in Sources */,
 				023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */; };
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
+		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -1180,6 +1181,7 @@
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
+		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -2470,6 +2472,14 @@
 			children = (
 				26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */,
 				26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */,
+			);
+			path = Survey;
+			sourceTree = "<group>";
+		};
+		26B119BC24D0C5AB00FED5C7 /* Survey */ = {
+			isa = PBXGroup;
+			children = (
+				26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */,
 			);
 			path = Survey;
 			sourceTree = "<group>";
@@ -4056,6 +4066,7 @@
 				02E4FD7F2306AA770049610C /* Dashboard */,
 				0269177E23260090002AFC20 /* Products */,
 				573D0ACC2458665C004DE614 /* Search */,
+				26B119BC24D0C5AB00FED5C7 /* Survey */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
 				45C8B25A231521510002FA77 /* CustomerNoteTableViewCellTests.swift */,
@@ -5336,6 +5347,7 @@
 				9379E1A6225537D0006A6BE4 /* TestingAppDelegate.swift in Sources */,
 				453904F323BB88B5007C4956 /* ProductTaxStatusListSelectorCommandTests.swift in Sources */,
 				B56C721421B5BBC000E5E85B /* MockupStoresManager.swift in Sources */,
+				26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */,
 				D8AB131E225DC25F002BB5D1 /* MockOrders.swift in Sources */,
 				D85136D5231E40B500DD0539 /* ProductReviewTableViewCellTests.swift in Sources */,
 				45FBDF2B238BF8A300127F77 /* ProductImageCollectionViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		265D909B2446657B00D66F0F /* ProductCategoryViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */; };
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
+		26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -1176,6 +1177,7 @@
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
+		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -2461,6 +2463,14 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		26B119B524D0B36700FED5C7 /* Survey */ = {
+			isa = PBXGroup;
+			children = (
+				26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */,
+			);
+			path = Survey;
+			sourceTree = "<group>";
+		};
 		4506BD6E2461962700FE6377 /* Visibility */ = {
 			isa = PBXGroup;
 			children = (
@@ -3128,6 +3138,7 @@
 				022BF7FA23B9D681000A1DFB /* Progress */,
 				0282DD92233C9397006A5FDB /* Search */,
 				0202B6932387ACE000F3EBE0 /* TabBar */,
+				26B119B524D0B36700FED5C7 /* Survey */,
 				02817B37242B34260050AD8B /* Toolbar */,
 				02404EE52315272C00FF1170 /* Top Banner */,
 				B56DB3CD2049BFAA00D4AA8E /* Main.storyboard */,
@@ -4389,6 +4400,7 @@
 				CE1D5A56228A0AD200DF3715 /* TwoColumnTableViewCell.xib in Resources */,
 				B57C744320F54F1C00EEFC87 /* AccountHeaderView.xib in Resources */,
 				4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */,
+				26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */,
 				D843D5D422485009001BFA55 /* ShipmentProvidersViewController.xib in Resources */,
 				028BAC4522F3AE5C008BB4AF /* StoreStatsV4PeriodViewController.xib in Resources */,
 				CE227099228F180B00C0626C /* WooBasicTableViewCell.xib in Resources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import WebKit
+import XCTest
+
+@testable import WooCommerce
+
+/// Test cases for `SurveyViewController`.
+///
+final class SurveyViewControllerTests: XCTestCase {
+
+    func testItLoadsTheCorrectInAppFeedbackSurvey() throws {
+        // Given
+        let viewController = SurveyViewController(survey: .inAppFeedback)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+
+        // Then
+        XCTAssertTrue(mirror.webView.isLoading)
+        XCTAssertEqual(mirror.webView.url, WooConstants.inAppFeedbackURL)
+    }
+}
+
+// MARK: - Mirroring
+
+private extension SurveyViewControllerTests {
+    struct SurveyViewControllerMirror {
+        let webView: WKWebView
+    }
+
+    func mirror(of viewController: SurveyViewController) throws -> SurveyViewControllerMirror {
+        let mirror = Mirror(reflecting: viewController)
+        return SurveyViewControllerMirror(webView: try XCTUnwrap(mirror.descendant("webView") as? WKWebView))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -21,7 +21,7 @@ final class SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(mirror.webView.url, WooConstants.inAppFeedbackURL)
     }
 
-    func testItCompletesAfterReceivingAFormSubmittedPostCallbackRequest() throws {
+    func testItCompletesAfterReceivingAFormSubmittedPOSTCallbackRequest() throws {
         // Given
         let exp = expectation(description: #function)
         var surveyCompleted = false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -34,6 +34,7 @@ final class SurveyViewControllerTests: XCTestCase {
         _ = try XCTUnwrap(viewController.view)
         let mirror = try self.mirror(of: viewController)
 
+        // Fakes a form submission POST navigation
         let navigationAction = FormSubmittedNavigationAction(httpMethod: "POST")
         viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
         waitForExpectations(timeout: Constants.expectationTimeout)
@@ -56,6 +57,7 @@ final class SurveyViewControllerTests: XCTestCase {
         _ = try XCTUnwrap(viewController.view)
         let mirror = try self.mirror(of: viewController)
 
+        // Fakes a form submission GET navigation
         let navigationAction = FormSubmittedNavigationAction(httpMethod: "GET")
         viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
         waitForExpectations(timeout: 1)


### PR DESCRIPTION
Relates to #2544 

# Why
For the in-app feedback project, we have decided to render the survey in a web view to speed up development times as this module is not a core part of our product.

This PR adapts [part of the work](https://github.com/woocommerce/woocommerce-ios/compare/spike/web-view-survey?expand=1) done by the great @jaclync and introduces `SurveyViewController` into the project, which is configured with a `SurveySource` internal enum.

The idea to have an internal enum rather than exposing a public link is to have total control over what kind of web page/survey we support.

# How

- Added survey URL in `WooConstants.swift`
- Configure view from `SurveySource` enum
- Copy navigation handling work from [spike branch](https://github.com/woocommerce/woocommerce-ios/compare/spike/web-view-survey?expand=1) to know when the survey has been completed.

# GIF
![simple-survey](https://user-images.githubusercontent.com/562080/88746208-999bdf80-d111-11ea-9e7d-72475f9e6085.gif)


# Testing Steps
- Copy following code in `DashboardViewController`

In `ViewDidLoad`
```swift
let leftBarButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(showSurvey))
navigationItem.leftBarButtonItem = leftBarButton
```

Below `ViewDidLoad` 
```swift
@objc private func showSurvey() {
    let surveyVC = SurveyViewController(survey: .inAppFeedback, onCompletion: { [weak self] in
        self?.dismiss(animated: true, completion: nil)
    })
    let navigationController = WooNavigationController(rootViewController: surveyVC)
    present(navigationController, animated: true, completion: nil)
}
```

- Launch the App
- Tap on the "Share" button on the left bar button item
- Fill the survey
- See that the VC is dismissed after completing the survey.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
