### PR TITLE
Add tests to WooConstant

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -18,7 +18,7 @@ class AuthenticationManager: Authentication {
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: ApiCredentials.dotcomAuthScheme,
-                                                                wpcomTermsOfServiceURL: WooConstants.termsOfServiceUrl.absoluteString,
+                                                                wpcomTermsOfServiceURL: WooConstants.URLs.termsOfService.rawValue,
                                                                 wpcomAPIBaseURL: Settings.wordpressApiBaseURL,
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -35,7 +35,7 @@ enum WooConstants {
 //
 extension WooConstants {
 
-    /// List of thrusted URLs
+    /// List of trusted URLs
     ///
     enum URLs: String, CaseIterable {
 
@@ -82,14 +82,14 @@ extension WooConstants {
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {
-            WooConstants.trustedURL(self.rawValue)
+            Self.trustedURL(self.rawValue)
         }
     }
 }
 
 // MARK: - Utils
 
-private extension WooConstants {
+private extension WooConstants.URLs {
     /// Convert a `string` to a `URL`. Crash if it is malformed.
     ///
     private static func trustedURL(_ url: String) -> URL {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -87,6 +87,62 @@ enum WooConstants {
     static let systemEventCount = 10
 }
 
+// MARK: URLs
+//
+extension WooConstants {
+
+    /// List of thrusted URls
+    ///
+    enum URLs: String, CaseIterable {
+
+        /// Jetpack Setup URL
+        ///
+        case jetpackSetup = "https://jetpack.com/support/getting-started-with-jetpack/"
+
+        /// Terms of Service Website. Displayed by the Authenticator (when / if needed).
+        ///
+        case termsOfService = "https://wordpress.com/tos/"
+
+        /// Cookie policy URL
+        ///
+        case cookie = "https://automattic.com/cookies/"
+
+        /// Privacy policy URL
+        ///
+        case privacy = "https://automattic.com/privacy/"
+
+        /// Privacy policy for California users URL
+        ///
+        case californiaPrivacy = "https://automattic.com/privacy/#california-consumer-privacy-act-ccpa"
+
+        /// Help Center URL
+        ///
+        case helpCenter = "https://docs.woocommerce.com/document/woocommerce-ios/"
+
+        /// Feature Request URL
+        ///
+        case featureRequestURL = "http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283"
+
+        /// URL used for Learn More button in Orders empty state.
+        ///
+        case blogURL = "https://woocommerce.com/blog/"
+
+        /// URL for in-app feedback survey
+        ///
+        #if DEBUG
+        case inAppFeedbackURL = "https://wasseryi.survey.fm/woo-mobile-app-test-survey"
+        #else
+        case inAppFeedbackURL = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
+        #endif
+
+        /// Returns the URL version of the receiver
+        ///
+        func asURL() -> URL {
+            WooConstants.trustedURL(self.rawValue)
+        }
+    }
+}
+
 // MARK: - Utils
 
 private extension WooConstants {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -21,62 +21,6 @@ enum WooConstants {
     static let pushApplicationID = "com.automattic.woocommerce"
 #endif
 
-    /// Jetpack Setup URL
-    ///
-    static let jetpackSetupUrl = "https://jetpack.com/support/getting-started-with-jetpack/"
-
-    /// Terms of Service Website. Displayed by the Authenticator (when / if needed).
-    ///
-    static var termsOfServiceUrl: URL {
-        trustedURL("https://wordpress.com/tos/")
-    }
-
-    /// Cookie policy URL
-    ///
-    static var cookieURL: URL {
-        trustedURL("https://automattic.com/cookies/")
-    }
-
-    /// Privacy policy URL
-    ///
-    static var privacyURL: URL {
-        trustedURL("https://automattic.com/privacy/")
-    }
-
-    /// Privacy policy for California users URL
-    ///
-    static var californiaPrivacyURL: URL {
-        trustedURL("https://automattic.com/privacy/#california-consumer-privacy-act-ccpa")
-    }
-
-    /// Help Center URL
-    ///
-    static var helpCenterURL: URL {
-        trustedURL("https://docs.woocommerce.com/document/woocommerce-ios/")
-    }
-
-    /// Feature Request URL
-    ///
-    static var featureRequestURL: URL {
-        trustedURL("http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283")
-    }
-
-    /// URL used for Learn More button in Orders empty state.
-    ///
-    static var blogURL: URL {
-        trustedURL("https://woocommerce.com/blog/")
-    }
-
-    /// URL for in-app feedback survey
-    ///
-    static var inAppFeedbackURL: URL {
-        if BuildConfiguration.current == .localDeveloper {
-            return trustedURL("https://wasseryi.survey.fm/woo-mobile-app-test-survey")
-        } else {
-            return trustedURL("https://automattic.survey.fm/woo-app-general-feedback-user-survey")
-        }
-    }
-
     /// Number of section events required before an app review prompt appears
     ///
     static let notificationEventCount = 5
@@ -91,7 +35,7 @@ enum WooConstants {
 //
 extension WooConstants {
 
-    /// List of thrusted URls
+    /// List of thrusted URLs
     ///
     enum URLs: String, CaseIterable {
 
@@ -121,19 +65,19 @@ extension WooConstants {
 
         /// Feature Request URL
         ///
-        case featureRequestURL = "http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283"
+        case featureRequest = "http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283"
 
         /// URL used for Learn More button in Orders empty state.
         ///
-        case blogURL = "https://woocommerce.com/blog/"
+        case blog = "https://woocommerce.com/blog/"
 
         /// URL for in-app feedback survey
         ///
-        #if DEBUG
-        case inAppFeedbackURL = "https://wasseryi.survey.fm/woo-mobile-app-test-survey"
-        #else
-        case inAppFeedbackURL = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
-        #endif
+#if DEBUG
+        case inAppFeedback = "https://wasseryi.survey.fm/woo-mobile-app-test-survey"
+#else
+        case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
+#endif
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -114,7 +114,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
     /// For now, link to the online help documentation
     ///
     func showHelpCenter(from controller: UIViewController) {
-        let safariViewController = SFSafariViewController(url: WooConstants.helpCenterURL)
+        let safariViewController = SFSafariViewController(url: WooConstants.URLs.helpCenter.asURL())
         safariViewController.modalPresentationStyle = .pageSheet
         controller.present(safariViewController, animated: true, completion: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -198,19 +198,19 @@ private extension AboutViewController {
     /// California Privacy Policy action
     ///
     func californiaPrivacyWasPressed() {
-        displayWebView(url: WooConstants.californiaPrivacyURL)
+        displayWebView(url: WooConstants.URLs.californiaPrivacy.asURL())
     }
 
     /// Privacy Policy action
     ///
     func privacyWasPressed() {
-        displayWebView(url: WooConstants.privacyURL)
+        displayWebView(url: WooConstants.URLs.privacy.asURL())
     }
 
     /// Terms of Service action
     ///
     func termsWasPressed() {
-        displayWebView(url: WooConstants.termsOfServiceUrl)
+        displayWebView(url: WooConstants.URLs.termsOfService.asURL())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -289,7 +289,7 @@ private extension PrivacySettingsViewController {
     /// Display Automattic's Cookie Policy web page
     ///
     func presentCookiePolicyWebView() {
-        let safariViewController = SFSafariViewController(url: WooConstants.cookieURL)
+        let safariViewController = SFSafariViewController(url: WooConstants.URLs.cookie.asURL())
         safariViewController.modalPresentationStyle = .pageSheet
         present(safariViewController, animated: true, completion: nil)
     }
@@ -297,7 +297,7 @@ private extension PrivacySettingsViewController {
     /// Display Automattic's Privacy Policy web page
     ///
     func presentPrivacyPolicyWebView() {
-        let safariViewController = SFSafariViewController(url: WooConstants.privacyURL)
+        let safariViewController = SFSafariViewController(url: WooConstants.URLs.privacy.asURL())
         safariViewController.modalPresentationStyle = .pageSheet
         present(safariViewController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -360,7 +360,7 @@ private extension SettingsViewController {
     }
 
     func featureRequestWasPressed() {
-        let safariViewController = SFSafariViewController(url: WooConstants.featureRequestURL)
+        let safariViewController = SFSafariViewController(url: WooConstants.URLs.featureRequest.asURL())
         present(safariViewController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -107,7 +107,7 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
                 details: NSLocalizedString("We'll notify you when you receive a new order. In the meantime, explore how you can increase your store sales.",
                                            comment: "The detailed message shown in the Orders → All Orders tab if the list is empty."),
                 linkTitle: NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty."),
-                linkURL: WooConstants.blogURL
+                linkURL: WooConstants.URLs.blog.asURL()
             )
         )
         allOrdersVC.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -52,7 +52,7 @@ extension SurveyViewController {
         fileprivate var url: URL {
             switch self {
             case .inAppFeedback:
-                return WooConstants.inAppFeedbackURL
+                return WooConstants.URLs.inAppFeedback.asURL()
             }
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */; };
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
+		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -1183,6 +1184,7 @@
 		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
+		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -3003,6 +3005,7 @@
 				934CB124224EAB540005CCB9 /* TestingAppDelegate.swift */,
 				9379E1A22255365F006A6BE4 /* TestingMode.storyboard */,
 				746791622108D7C0007CF1DC /* WooAnalyticsTests.swift */,
+				26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -5257,6 +5260,7 @@
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
+				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,
 				450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */,
 				455A2FDB246B1349000CA72C /* ProductVisibilityTests.swift in Sources */,
 				265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import WooCommerce
+
+final class WooConstantsTests: XCTestCase {
+
+    func testAllThrustedURLsAreValid() {
+        // Given
+        let allTrustedURLPaths = WooConstants.URLs.allCases
+
+        // When
+        let allTrustedURLs = allTrustedURLPaths.map { $0.asURL() }
+
+        // Then
+        zip(allTrustedURLPaths, allTrustedURLs).forEach { (path, url) in
+            XCTAssertEqual(path.rawValue, url.absoluteString)
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class WooConstantsTests: XCTestCase {
 
-    func testAllThrustedURLsAreValid() {
+    func testAllTrustedURLsAreValid() {
         // Given
         let allTrustedURLPaths = WooConstants.URLs.allCases
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewControllerTests.swift
@@ -60,7 +60,7 @@ final class EmptyStateViewControllerTests: XCTestCase {
             image: .appleIcon,
             details: "Dolores eum",
             linkTitle: "Bakero!",
-            linkURL: WooConstants.blogURL
+            linkURL: WooConstants.URLs.blog.asURL()
         ))
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -18,7 +18,7 @@ final class SurveyViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertTrue(mirror.webView.isLoading)
-        XCTAssertEqual(mirror.webView.url, WooConstants.inAppFeedbackURL)
+        XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL())
     }
 
     func testItCompletesAfterReceivingAFormSubmittedPOSTCallbackRequest() throws {
@@ -95,7 +95,7 @@ private extension SurveyViewControllerTests {
         }
 
         override var request: URLRequest {
-            var request = URLRequest(url: WooConstants.inAppFeedbackURL)
+            var request = URLRequest(url: WooConstants.URLs.inAppFeedback.asURL())
             request.httpMethod = httpMethod
             return request
         }


### PR DESCRIPTION
# Why

While working on #2570 I had to add a new URL to `WooConstants. I noticed that we use a function called `trustedURL` to return a non-optional URL. If the URL is malformed the app will crash. While the regular procedure is that we test that the URLs are correctly formed I think there is still a chance(human error) that some error could go unnoticed, especially during PRs with big changes.

To mitigate this I've moved these URLs out to an enum that conforms to `CaseIterable` where we can test that all URLs are correct.

**NOTE:** Feel free to tell me if you think that I may be worrying too much and this is not that necessary.

# Testing Steps
- CI Passes
- Do a quick smoke test in the app to see that the correct URLs are being launched.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
