### PR TITLE
Add PushNotesManager.inactiveNotifications Observable

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -23,7 +23,8 @@ final class PushNotificationsManager: PushNotesManager {
     /// Mutable reference to `foregroundNotifications`.
     private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
 
-    /// An observable that emits values when the app is activated due to a Remote Notification.
+    /// An observable that emits values when a Remote Notification is received while the app is
+    /// in inactive.
     ///
     var inactiveNotifications: Observable<PushNotification> {
         inactiveNotificationsSubject

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -24,7 +24,6 @@ final class PushNotificationsManager: PushNotesManager {
     private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
 
     /// An observable that emits values when the app is activated due to a Remote Notification.
-    /// The Remote Notification is emitted.
     ///
     var inactiveNotifications: Observable<PushNotification> {
         inactiveNotificationsSubject

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -29,7 +29,7 @@ final class PushNotificationsManager: PushNotesManager {
         inactiveNotificationsSubject
     }
 
-    /// Mutable reference to `backgroundNotifications`
+    /// Mutable reference to `inactiveNotifications`
     private let inactiveNotificationsSubject = PublishSubject<PushNotification>()
 
     /// Returns the current Application's State

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -9,6 +9,11 @@ protocol PushNotesManager {
     ///
     var foregroundNotifications: Observable<PushNotification> { get }
 
+    /// An observable that emits values when the app is activated due to a Remote Notification.
+    /// The Remote Notification is emitted.
+    ///
+    var inactiveNotifications: Observable<PushNotification> { get }
+
     /// Resets the Badge Count.
     ///
     func resetBadgeCount(type: Note.Kind)

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -10,7 +10,6 @@ protocol PushNotesManager {
     var foregroundNotifications: Observable<PushNotification> { get }
 
     /// An observable that emits values when the app is activated due to a Remote Notification.
-    /// The Remote Notification is emitted.
     ///
     var inactiveNotifications: Observable<PushNotification> { get }
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -9,7 +9,8 @@ protocol PushNotesManager {
     ///
     var foregroundNotifications: Observable<PushNotification> { get }
 
-    /// An observable that emits values when the app is activated due to a Remote Notification.
+    /// An observable that emits values when a Remote Notification is received while the app is
+    /// in inactive.
     ///
     var inactiveNotifications: Observable<PushNotification> { get }
 

--- a/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
@@ -64,4 +64,11 @@ extension MockPushNotificationsManager {
     func sendForegroundNotification(_ notification: PushNotification) {
         foregroundNotificationsSubject.send(notification)
     }
+
+    /// Send a `PushNotification` that will be emitted by the `inactiveNotifications`
+    /// observable.
+    ///
+    func sendInactiveNotification(_ notification: PushNotification) {
+        inactiveNotificationsSubject.send(notification)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockPushNotificationsManager.swift
@@ -12,6 +12,12 @@ final class MockPushNotificationsManager: PushNotesManager {
 
     private let foregroundNotificationsSubject = PublishSubject<PushNotification>()
 
+    var inactiveNotifications: Observable<PushNotification> {
+        inactiveNotificationsSubject
+    }
+
+    private let inactiveNotificationsSubject = PublishSubject<PushNotification>()
+
     func resetBadgeCount(type: Note.Kind) {
 
     }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -432,6 +432,31 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(emittedNotifications.isEmpty)
     }
+
+    func testItEmitsInactiveNotificationsWhenItReceivesANotificationWhileTheAppIsNotActive() throws {
+        // Given
+        application.applicationState = .inactive
+
+        var emittedNotifications = [PushNotification]()
+        _ = manager.inactiveNotifications.subscribe { notification in
+            emittedNotifications.append(notification)
+        }
+
+        let userinfo = notificationPayload(noteID: 9_981, type: .storeOrder)
+
+        // When
+        manager.handleNotification(userinfo, onBadgeUpdateCompletion: {}) { _ in
+            // noop
+        }
+
+        // Then
+        XCTAssertEqual(emittedNotifications.count, 1)
+
+        let emittedNotification = try XCTUnwrap(emittedNotifications.first)
+        XCTAssertEqual(emittedNotification.kind, .storeOrder)
+        XCTAssertEqual(emittedNotification.noteID, 9_981)
+        XCTAssertEqual(emittedNotification.message, Sample.defaultMessage)
+    }
 }
 
 


### PR DESCRIPTION
Ref #2254. 

This will be used as part of #2254. I'm submitting it earlier since the [WIP branch](https://github.com/woocommerce/woocommerce-ios/compare/develop...issue/2254-fix-review-push-navigation?expand=1) is almost 500 lines and I have not even removed the old code yet. 😱 

## Changes

This adds a new `inactiveNotifications` `Observable`, similar to the existing `foregroundNotifications`.

https://github.com/woocommerce/woocommerce-ios/blob/98f4369f151c3154eb282b88c79870312491e609/WooCommerce/Classes/Notifications/PushNotificationsManager.swift#L26-L33

## Testing for Regression

Please test that you can still receive new order push notifications and tapping on them will open the order details.

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

