### PR TITLE
Add XCTest Helpers

### DIFF
--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
@@ -28,4 +28,15 @@ extension XCTestCase {
                       file: file,
                       line: line)
     }
+
+    /// Asserts that `subject`'s type is **exactly** `expectedType`.
+    ///
+    /// If `subject`'s type is just a subclass of `expectedType`, then this will fail.
+    ///
+    func assertThat<T>(_ subject: Any, isAnInstanceOf expectedType: T.Type, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(type(of: subject) == expectedType,
+                      "Expected \(subject) to be an instance of \(expectedType)",
+                      file: file,
+                      line: line)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Assertions.swift
@@ -33,7 +33,14 @@ extension XCTestCase {
     ///
     /// If `subject`'s type is just a subclass of `expectedType`, then this will fail.
     ///
-    func assertThat<T>(_ subject: Any, isAnInstanceOf expectedType: T.Type, file: StaticString = #file, line: UInt = #line) {
+    func assertThat<T>(_ subject: Any?, isAnInstanceOf expectedType: T.Type, file: StaticString = #file, line: UInt = #line) {
+        guard let subject = subject else {
+            XCTFail("Expected nil to be an instance of \(expectedType)",
+                    file: file,
+                    line: line)
+            return
+        }
+
         XCTAssertTrue(type(of: subject) == expectedType,
                       "Expected \(subject) to be an instance of \(expectedType)",
                       file: file,

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Wait.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Wait.swift
@@ -34,13 +34,22 @@ extension XCTestCase {
     /// }
     /// ```
     ///
-    func waitUntil(condition: @escaping () -> Bool, timeout: TimeInterval = Constants.expectationTimeout) {
+    func waitUntil(file: StaticString = #file,
+                   line: UInt = #line,
+                   timeout: TimeInterval = Constants.expectationTimeout,
+                   condition: @escaping (() -> Bool)) {
         let predicate = NSPredicate { _, _ -> Bool in
             return condition()
         }
 
         let exp = expectation(for: predicate, evaluatedWith: nil)
 
-        wait(for: [exp], timeout: timeout)
+        let result = XCTWaiter.wait(for: [exp], timeout: timeout)
+        switch result {
+        case .timedOut:
+            XCTFail("Timed out waiting for condition to return `true`.", file: file, line: line)
+        default:
+            break
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+Wait.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+Wait.swift
@@ -21,4 +21,26 @@ extension XCTestCase {
         block(exp)
         wait(for: [exp], timeout: timeout)
     }
+
+    /// Creates an `XCTestExpectation` and waits until `condition` returns `true`.
+    ///
+    /// Example usage:
+    ///
+    /// ```
+    /// var valueThatIsUpdatedAsynchronously: Int = 0
+    ///
+    /// waitUntil {
+    ///     valueThatIsUpdatedAsynchronously > 5
+    /// }
+    /// ```
+    ///
+    func waitUntil(condition: @escaping () -> Bool, timeout: TimeInterval = Constants.expectationTimeout) {
+        let predicate = NSPredicate { _, _ -> Bool in
+            return condition()
+        }
+
+        let exp = expectation(for: predicate, evaluatedWith: nil)
+
+        wait(for: [exp], timeout: timeout)
+    }
 }


### PR DESCRIPTION
Ref #2254. 

I'm using these as part of the unit tests of #2254 ([WIP branch](https://github.com/woocommerce/woocommerce-ios/compare/develop...issue/2254-fix-review-push-navigation?expand=1)).  But I think these are useful on their own. 

## Changes

This adds `assertThat(isAnInstanceOf:)` and `waitUntil`. Please see the code for their description. 🙂 

## Testing

Add these test to any existing test class in the `WooCommerce` module:

```swift
    func testAssertThatIsAnInstanceOf__Success() {
        class A { }
        class B: A { }

        let b = B()

        assertThat(b, isAnInstanceOf: B.self)
    }

    func testAssertThatIsAnInstanceOf__Failure() {
        class A { }
        class B: A { }

        let b = B()

        assertThat(b, isAnInstanceOf: A.self)
    }

    func testWaitUntil__Success() {
        var counter: Int = 0

        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
            counter += 1
        }

        waitUntil {
            counter > 10
        }
    }

    func testWaitUntil__Failure() {
        var counter: Int = 0

        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
            counter += 1
        }

        waitUntil {
            counter > 10_000_000
        }
    }
```

The tests marked as `__Failure()` should fail. The others should pass. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

