### PR TITLE
Create a product form actions factory for a product variation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
@@ -30,7 +30,7 @@ struct ProductVariationFormActionsFactory: ProductFormActionsFactoryProtocol {
 }
 
 private extension ProductVariationFormActionsFactory {
-    /// All the editable actions in the settings section given the product and feature switches.
+    /// All the editable actions in the settings section given the product variation.
     func allSettingsSectionActions() -> [ProductFormEditAction] {
         let shouldShowShippingSettingsRow = productVariation.isShippingEnabled
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/ProductVariationFormActionsFactory.swift
@@ -1,0 +1,66 @@
+import Yosemite
+
+/// Creates actions for different sections/UI on the product variation form.
+struct ProductVariationFormActionsFactory: ProductFormActionsFactoryProtocol {
+    private let productVariation: ProductVariation
+
+    init(productVariation: ProductVariation) {
+        self.productVariation = productVariation
+    }
+
+    /// Returns an array of actions that are visible in the product form primary section.
+    func primarySectionActions() -> [ProductFormEditAction] {
+        return [
+            .images,
+            .name,
+            .description
+        ]
+    }
+
+    /// Returns an array of actions that are visible in the product form settings section.
+    func settingsSectionActions() -> [ProductFormEditAction] {
+        return visibleSettingsSectionActions()
+    }
+
+    /// Returns an array of actions that are visible in the product form bottom sheet.
+    func bottomSheetActions() -> [ProductFormBottomSheetAction] {
+        return allSettingsSectionActions().filter { settingsSectionActions().contains($0) == false }
+            .compactMap { ProductFormBottomSheetAction(productFormAction: $0) }
+    }
+}
+
+private extension ProductVariationFormActionsFactory {
+    /// All the editable actions in the settings section given the product and feature switches.
+    func allSettingsSectionActions() -> [ProductFormEditAction] {
+        let shouldShowShippingSettingsRow = productVariation.isShippingEnabled
+
+        let actions: [ProductFormEditAction?] = [
+            .priceSettings,
+            shouldShowShippingSettingsRow ? .shippingSettings: nil,
+            .inventorySettings,
+        ]
+        return actions.compactMap { $0 }
+    }
+}
+
+private extension ProductVariationFormActionsFactory {
+    func visibleSettingsSectionActions() -> [ProductFormEditAction] {
+        return allSettingsSectionActions().compactMap({ $0 }).filter({ isVisibleInSettingsSection(action: $0) })
+    }
+
+    func isVisibleInSettingsSection(action: ProductFormEditAction) -> Bool {
+        switch action {
+        case .priceSettings:
+            // The price settings action is always visible in the settings section.
+            return true
+        case .inventorySettings:
+            let hasStockData = productVariation.manageStock ? productVariation.stockQuantity != nil: true
+            return productVariation.sku != nil || hasStockData
+        case .shippingSettings:
+            return productVariation.weight.isNilOrEmpty == false ||
+                productVariation.dimensions.height.isNotEmpty || productVariation.dimensions.width.isNotEmpty || productVariation.dimensions.length.isNotEmpty
+        default:
+            return false
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -224,6 +224,8 @@
 		02BA12852461674B008D8325 /* Optional+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA12842461674B008D8325 /* Optional+String.swift */; };
 		02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
+		02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */; };
+		02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */; };
 		02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2923B5BB1C00F880B1 /* ImageService.swift */; };
 		02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */; };
 		02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */; };
@@ -1114,6 +1116,8 @@
 		02BA12842461674B008D8325 /* Optional+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+String.swift"; sourceTree = "<group>"; };
 		02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+VisibilityTests.swift"; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
+		02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactory.swift; sourceTree = "<group>"; };
+		02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		02C0CD2923B5BB1C00F880B1 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageService.swift; sourceTree = "<group>"; };
 		02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageServiceTests.swift; sourceTree = "<group>"; };
@@ -1832,6 +1836,7 @@
 				020B2F9823BDF2E000BD79AD /* ProductFormActionsFactoryTests.swift */,
 				02A275C723FEA102005C560F /* ProductFormActionsFactory+EditProductsM2Tests.swift */,
 				263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */,
+				02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */,
 				02153210242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift */,
 				2611EE57243A46C500A74490 /* Categories */,
 				02C5CBD724A5D16A00860C64 /* Edit Grouped Product */,
@@ -1874,6 +1879,7 @@
 				0212276224498CDC0042161F /* ProductFormBottomSheetAction.swift */,
 				02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */,
 				0235BFD8246E959500778909 /* ProductFormActionsFactory.swift */,
+				02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */,
 			);
 			path = BottomSheetListSelector;
 			sourceTree = "<group>";
@@ -4863,6 +4869,7 @@
 				CE1CCB402056F21C000EE3AC /* Style.swift in Sources */,
 				45EF7984244F26BB00B22BA2 /* Array+IndexPath.swift in Sources */,
 				02E6B97823853D81000A36F0 /* SettingTitleAndValueTableViewCell.swift in Sources */,
+				02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */,
 				45CDAFAE2434CFCA00F83C22 /* ProductCatalogVisibilityViewController.swift in Sources */,
 				D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */,
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
@@ -5268,6 +5275,7 @@
 				D82DFB4C225F303200EFE2CB /* EmptyListMessageWithActionTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
 				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
+				02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockupTableView.swift in Sources */,
 				0259EF79246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift in Sources */,
 				2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactoryTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import Yosemite
 
 final class ProductVariationFormActionsFactoryTests: XCTestCase {
-    func testViewModelForPhysicalSimpleProductWithoutImages() {
+    func testActionsForAPhysicalProductVariationWithoutImages() {
         // Arrange
         let productVariation = Fixtures.physicalProductVariationWithoutImages
 
@@ -24,7 +24,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func testViewModelForPhysicalSimpleProductWithImages() {
+    func testActionsForAPhysicalProductVariationWithImages() {
         // Arrange
         let productVariation = Fixtures.physicalProductVariationWithImages
 
@@ -44,7 +44,26 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func testViewModelForDownloadableSimpleProduct() {
+    func testActionsForAPhysicalProductVariationWithImagesMissingShippingData() {
+        // Arrange
+        let productVariation = Fixtures.physicalProductVariationWithImagesWithoutShipping
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: productVariation)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .inventorySettings]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings]
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func testActionsForADownloadableProductVariation() {
         // Arrange
         let productVariation = Fixtures.downloadableProductVariation
 
@@ -62,7 +81,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func testViewModelForVirtualSimpleProduct() {
+    func testActionsForAVirtualProductVariation() {
         // Arrange
         let productVariation = Fixtures.virtualProductVariation
 
@@ -99,6 +118,10 @@ private extension ProductVariationFormActionsFactoryTests {
             .copy(image: image, sku: "uks", virtual: false, downloadable: false,
                   manageStock: true, stockQuantity: nil,
                   weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+        // downloadable: false, virtual: false, with inventory and without shipping
+        static let physicalProductVariationWithImagesWithoutShipping = MockProductVariation().productVariation()
+            .copy(image: image, sku: "uks", virtual: false, downloadable: false,
+                  manageStock: true, stockQuantity: nil)
         // downloadable: false, virtual: true, with inventory/shipping
         static let virtualProductVariation = MockProductVariation().productVariation()
             .copy(image: nil, sku: "uks", virtual: true, downloadable: false,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactoryTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ProductVariationFormActionsFactoryTests: XCTestCase {
+    func testViewModelForPhysicalSimpleProductWithoutImages() {
+        // Arrange
+        let productVariation = Fixtures.physicalProductVariationWithoutImages
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: productVariation)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .shippingSettings,
+                                                                       .inventorySettings]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func testViewModelForPhysicalSimpleProductWithImages() {
+        // Arrange
+        let productVariation = Fixtures.physicalProductVariationWithImages
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: productVariation)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .shippingSettings,
+                                                                       .inventorySettings]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func testViewModelForDownloadableSimpleProduct() {
+        // Arrange
+        let productVariation = Fixtures.downloadableProductVariation
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: productVariation)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .inventorySettings]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
+    func testViewModelForVirtualSimpleProduct() {
+        // Arrange
+        let productVariation = Fixtures.virtualProductVariation
+
+        // Action
+        let factory = ProductVariationFormActionsFactory(productVariation: productVariation)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .inventorySettings]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+}
+
+private extension ProductVariationFormActionsFactoryTests {
+    enum Fixtures {
+        static let image = ProductImage(imageID: 19,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: "https://photo.jpg",
+                                        name: "Tshirt",
+                                        alt: "")
+        // downloadable: false, virtual: false, with inventory/shipping
+        static let physicalProductVariationWithoutImages = MockProductVariation().productVariation()
+            .copy(image: nil, sku: "uks", virtual: false, downloadable: false,
+                  manageStock: true, stockQuantity: nil,
+                  weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+        // downloadable: false, virtual: false, with inventory/shipping
+        static let physicalProductVariationWithImages = MockProductVariation().productVariation()
+            .copy(image: image, sku: "uks", virtual: false, downloadable: false,
+                  manageStock: true, stockQuantity: nil,
+                  weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+        // downloadable: false, virtual: true, with inventory/shipping
+        static let virtualProductVariation = MockProductVariation().productVariation()
+            .copy(image: nil, sku: "uks", virtual: true, downloadable: false,
+                  manageStock: true, stockQuantity: nil,
+                  weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+        // downloadable: true, virtual: false, missing inventory/shipping
+        static let downloadableProductVariation = MockProductVariation().productVariation()
+            .copy(image: nil, sku: "uks", virtual: false, downloadable: true,
+                  manageStock: true, stockQuantity: nil,
+                  weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactoryTests.swift
@@ -106,8 +106,6 @@ private extension ProductVariationFormActionsFactoryTests {
                   weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
         // downloadable: true, virtual: false, missing inventory/shipping
         static let downloadableProductVariation = MockProductVariation().productVariation()
-            .copy(image: nil, sku: "uks", virtual: false, downloadable: true,
-                  manageStock: true, stockQuantity: nil,
-                  weight: "2", dimensions: ProductDimensions(length: "", width: "", height: ""))
+            .copy(image: nil, sku: "uks", virtual: false, downloadable: true)
     }
 }


### PR DESCRIPTION
Product form actions factory for a variation - part of #2085

## Changes

- Created `ProductVariationFormActionsFactory` that conforms to `ProductFormActionsFactoryProtocol`
- Added tests for `ProductVariationFormActionsFactory`

## Testing

Since the changes don't affect the app behavior yet, just CI!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
