### PR TITLE
Create a product form view model for a product variation 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -1,0 +1,215 @@
+import Yosemite
+
+/// Provides data for product form UI on a `ProductVariation`, and handles product editing actions.
+final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
+    typealias ProductModel = ProductVariation
+
+    /// Emits product variation on change.
+    var observableProduct: Observable<ProductVariation> {
+        productVariationSubject
+    }
+
+    /// The latest product variation including potential edits.
+    var productModel: ProductVariation {
+        productVariation
+    }
+
+    /// Emits a boolean of whether the product variation has unsaved changes for remote update.
+    var isUpdateEnabled: Observable<Bool> {
+        isUpdateEnabledSubject
+    }
+
+    /// Creates actions available on the bottom sheet.
+    private(set) var actionsFactory: ProductFormActionsFactoryProtocol
+
+    /// Not applicable to product variation form
+    private(set) var password: String? = nil
+
+    /// Not applicable to product variation form
+    private(set) var productName: Observable<String>? = nil
+
+    private let productVariationSubject: PublishSubject<ProductVariation> = PublishSubject<ProductVariation>()
+    private let isUpdateEnabledSubject: PublishSubject<Bool>
+
+    /// The product variation before any potential edits; reset after a remote update.
+    private var originalProductVariation: ProductVariation {
+        didSet {
+            productVariation = originalProductVariation
+        }
+    }
+
+    /// The product variation with potential edits; reset after a remote update.
+    private var productVariation: ProductVariation {
+        didSet {
+            guard productVariation != oldValue else {
+                return
+            }
+
+            actionsFactory = ProductVariationFormActionsFactory(productVariation: productVariation)
+            productVariationSubject.send(productVariation)
+            isUpdateEnabledSubject.send(hasUnsavedChanges())
+        }
+    }
+
+    private let productImageActionHandler: ProductImageActionHandler
+    private let storesManager: StoresManager
+    private var cancellable: ObservationToken?
+
+    init(productVariation: ProductVariation,
+         productImageActionHandler: ProductImageActionHandler,
+         storesManager: StoresManager = ServiceLocator.stores) {
+        self.productImageActionHandler = productImageActionHandler
+        self.storesManager = storesManager
+        self.originalProductVariation = productVariation
+        self.productVariation = productVariation
+        self.actionsFactory = ProductVariationFormActionsFactory(productVariation: productVariation)
+        self.isUpdateEnabledSubject = PublishSubject<Bool>()
+        self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
+            if allStatuses.productImageStatuses.hasPendingUpload {
+                self?.isUpdateEnabledSubject.send(true)
+            }
+        }
+    }
+
+    deinit {
+        cancellable?.cancel()
+    }
+
+    func hasUnsavedChanges() -> Bool {
+        return productVariation != originalProductVariation || productImageActionHandler.productImageStatuses.hasPendingUpload
+    }
+
+    func hasProductChanged() -> Bool {
+        return productVariation != originalProductVariation
+    }
+
+    func hasPasswordChanged() -> Bool {
+        // no-op
+        return false
+    }
+}
+
+// MARK: - More menu
+//
+extension ProductVariationFormViewModel {
+    func canEditProductSettings() -> Bool {
+        return false
+    }
+
+    func canViewProductInStore() -> Bool {
+        // no-op
+        return false
+    }
+}
+
+// MARK: Action handling
+//
+extension ProductVariationFormViewModel {
+    func updateName(_ name: String) {
+        // no-op
+    }
+
+    func updateImages(_ images: [ProductImage]) {
+        guard images.count <= 1 else {
+            assertionFailure("Up to 1 image can be attached to a product variation.")
+            return
+        }
+        productVariation = productVariation.copy(image: images.first)
+    }
+
+    func updateDescription(_ newDescription: String) {
+        productVariation = productVariation.copy(description: newDescription)
+    }
+
+    func updatePriceSettings(regularPrice: String?,
+                             salePrice: String?,
+                             dateOnSaleStart: Date?,
+                             dateOnSaleEnd: Date?,
+                             taxStatus: ProductTaxStatus,
+                             taxClass: TaxClass?) {
+        productVariation = productVariation.copy(dateOnSaleStart: dateOnSaleStart,
+                                                 dateOnSaleEnd: dateOnSaleEnd,
+                                                 regularPrice: regularPrice,
+                                                 salePrice: salePrice,
+                                                 taxStatusKey: taxStatus.rawValue,
+                                                 taxClass: taxClass?.slug)
+    }
+
+    func updateInventorySettings(sku: String?,
+                                 manageStock: Bool,
+                                 soldIndividually: Bool?,
+                                 stockQuantity: Int64?,
+                                 backordersSetting: ProductBackordersSetting?,
+                                 stockStatus: ProductStockStatus?) {
+        productVariation = productVariation.copy(sku: sku,
+                                                 manageStock: manageStock,
+                                                 stockQuantity: stockQuantity,
+                                                 stockStatus: stockStatus,
+                                                 backordersKey: backordersSetting?.rawValue)
+    }
+
+    func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: ProductShippingClass?) {
+        productVariation = productVariation.copy(weight: weight,
+                                                 dimensions: dimensions,
+                                                 shippingClass: shippingClass?.slug ?? "",
+                                                 shippingClassID: shippingClass?.shippingClassID ?? 0)
+    }
+
+    func updateProductCategories(_ categories: [ProductCategory]) {
+        // no-op
+    }
+
+    func updateProductTags(_ tags: [ProductTag]) {
+        // no-op
+    }
+
+    func updateBriefDescription(_ briefDescription: String) {
+        // no-op
+    }
+
+    func updateSKU(_ sku: String?) {
+        // no-op
+    }
+
+    func updateGroupedProductIDs(_ groupedProductIDs: [Int64]) {
+        // no-op
+    }
+
+    func updateProductSettings(_ settings: ProductSettings) {
+        // no-op
+    }
+
+    func updateExternalLink(externalURL: String?, buttonText: String) {
+        // no-op
+    }
+}
+
+// MARK: Remote actions
+//
+extension ProductVariationFormViewModel {
+    func updateProductRemotely(onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
+        let updateAction = ProductVariationAction.updateProductVariation(productVariation: productVariation) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let productVariation):
+                self?.resetProductVariation(productVariation)
+                onCompletion(.success(productVariation))
+            }
+        }
+        storesManager.dispatch(updateAction)
+    }
+
+    private func resetProductVariation(_ productVariation: ProductVariation) {
+        originalProductVariation = productVariation
+        isUpdateEnabledSubject.send(hasUnsavedChanges())
+    }
+}
+
+// MARK: Reset actions
+//
+extension ProductVariationFormViewModel {
+    func resetPassword(_ password: String?) {
+        // no-op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -106,7 +106,7 @@ extension ProductVariationFormViewModel {
 //
 extension ProductVariationFormViewModel {
     func updateName(_ name: String) {
-        // no-op
+        // no-op: a variation's name is derived from its attributes and is not editable
     }
 
     func updateImages(_ images: [ProductImage]) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -226,11 +226,16 @@
 		02BA12852461674B008D8325 /* Optional+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA12842461674B008D8325 /* Optional+String.swift */; };
 		02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */; };
 		02BA23C022EE9DAF009539E7 /* AsyncDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */; };
-		02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */; };
-		02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */; };
 		02BAB01F24D0232800F8B06E /* MockProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB01E24D0232800F8B06E /* MockProductVariation.swift */; };
 		02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02024D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift */; };
 		02BAB02324D0250300F8B06E /* ProductVariation+ProductFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */; };
+		02BAB02724D13A6400F8B06E /* ProductVariationFormActionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */; };
+		02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */; };
+		02BC5AA024D27D8E00C43326 /* ProductVariationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5A9F24D27D8E00C43326 /* ProductVariationFormViewModel.swift */; };
+		02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA124D27F8800C43326 /* ProductVariationFormViewModel+ObservablesTests.swift */; };
+		02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */; };
+		02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA324D27F8800C43326 /* ProductVariationFormViewModel+ChangesTests.swift */; };
+		02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */; };
 		02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2923B5BB1C00F880B1 /* ImageService.swift */; };
 		02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */; };
 		02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */; };
@@ -1128,11 +1133,16 @@
 		02BA12842461674B008D8325 /* Optional+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+String.swift"; sourceTree = "<group>"; };
 		02BA128A24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+VisibilityTests.swift"; sourceTree = "<group>"; };
 		02BA23BF22EE9DAF009539E7 /* AsyncDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionaryTests.swift; sourceTree = "<group>"; };
-		02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactory.swift; sourceTree = "<group>"; };
-		02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactoryTests.swift; sourceTree = "<group>"; };
 		02BAB01E24D0232800F8B06E /* MockProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductVariation.swift; sourceTree = "<group>"; };
 		02BAB02024D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductPriceSettingsViewModel+ProductVariationTests.swift"; sourceTree = "<group>"; };
 		02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductVariation+ProductFormTests.swift"; sourceTree = "<group>"; };
+		02BAB02624D13A6400F8B06E /* ProductVariationFormActionsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactory.swift; sourceTree = "<group>"; };
+		02BAB02824D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormActionsFactoryTests.swift; sourceTree = "<group>"; };
+		02BC5A9F24D27D8E00C43326 /* ProductVariationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationFormViewModel.swift; sourceTree = "<group>"; };
+		02BC5AA124D27F8800C43326 /* ProductVariationFormViewModel+ObservablesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+ObservablesTests.swift"; sourceTree = "<group>"; };
+		02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+UpdatesTests.swift"; sourceTree = "<group>"; };
+		02BC5AA324D27F8800C43326 /* ProductVariationFormViewModel+ChangesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ProductVariationFormViewModel+ChangesTests.swift"; sourceTree = "<group>"; };
+		02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductVariationStoresManager.swift; sourceTree = "<group>"; };
 		02C0CD2923B5BB1C00F880B1 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		02C0CD2B23B5BC9600F880B1 /* DefaultImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageService.swift; sourceTree = "<group>"; };
 		02C0CD2D23B5E3AE00F880B1 /* DefaultImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageServiceTests.swift; sourceTree = "<group>"; };
@@ -1866,6 +1876,9 @@
 				025A1245247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift */,
 				025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */,
 				02AC822B2498BC9700A615FB /* ProductFormViewModel+UpdatesTests.swift */,
+				02BC5AA324D27F8800C43326 /* ProductVariationFormViewModel+ChangesTests.swift */,
+				02BC5AA124D27F8800C43326 /* ProductVariationFormViewModel+ObservablesTests.swift */,
+				02BC5AA224D27F8800C43326 /* ProductVariationFormViewModel+UpdatesTests.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -1931,6 +1944,7 @@
 				0225C42B2477D0D500C5B4F0 /* ProductFormViewModel.swift */,
 				0270F47524D005B00005210A /* ProductFormViewModelProtocol.swift */,
 				0270F47724D006F60005210A /* ProductFormPresentationStyle.swift */,
+				02BC5A9F24D27D8E00C43326 /* ProductVariationFormViewModel.swift */,
 			);
 			path = "Edit Product";
 			sourceTree = "<group>";
@@ -2901,6 +2915,7 @@
 				6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */,
 				0259EF78246BF66000B84FDF /* MockProductsAppSettingsStoresManager.swift */,
 				57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */,
+				02BC5AA724D2802B00C43326 /* MockProductVariationStoresManager.swift */,
 			);
 			path = Mockups;
 			sourceTree = "<group>";
@@ -4899,6 +4914,7 @@
 				D817586222BB64C300289CFE /* OrderDetailsNotices.swift in Sources */,
 				022F7A0324A05F6400012601 /* GroupedProductsViewController.swift in Sources */,
 				456417F4247D5434001203F6 /* UITableView+Helpers.swift in Sources */,
+				02BC5AA024D27D8E00C43326 /* ProductVariationFormViewModel.swift in Sources */,
 				0282DD94233C9465006A5FDB /* SearchUICommand.swift in Sources */,
 				028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */,
 				024DF32123744798006658FE /* AztecFormatBarCommandCoordinator.swift in Sources */,
@@ -5400,6 +5416,7 @@
 				578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
+				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
 				57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */,
 				020BE77123B4A4C6007FE54C /* AztecHorizontalRulerFormatBarCommandTests.swift in Sources */,
 				B5C6CE612190D28E00515926 /* NSAttributedStringHelperTests.swift in Sources */,
@@ -5413,6 +5430,8 @@
 				020BE76F23B4A468007FE54C /* AztecBlockquoteFormatBarCommandTests.swift in Sources */,
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
 				028AFFB62484EDA000693C09 /* Dictionary+LoggingTests.swift in Sources */,
+				02BC5AA824D2802B00C43326 /* MockProductVariationStoresManager.swift in Sources */,
+				02BC5AA424D27F8900C43326 /* ProductVariationFormViewModel+ObservablesTests.swift in Sources */,
 				02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */,
 				027B8BBF23FE0F850040944E /* MockMediaStoresManager.swift in Sources */,
 				025A1246247CDF55008EA761 /* ProductFormViewModel+ChangesTests.swift in Sources */,
@@ -5443,6 +5462,7 @@
 				D85136DD231E613900DD0539 /* ReviewsViewModelTests.swift in Sources */,
 				02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
+				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockProductVariationStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProductVariationStoresManager.swift
@@ -1,0 +1,29 @@
+@testable import WooCommerce
+@testable import Yosemite
+
+/// Mock Product Variation Store Manager
+///
+final class MockProductVariationStoresManager: DefaultStoresManager {
+    // Allows mocking the result on update
+    private let updateResult: Result<ProductVariation, ProductUpdateError>
+
+    init(updateResult: Result<ProductVariation, ProductUpdateError>) {
+        self.updateResult = updateResult
+        super.init(sessionManager: SessionManager.testingInstance)
+    }
+
+    override func dispatch(_ action: Action) {
+        if let productVariationAction = action as? ProductVariationAction {
+            handleProductVariationAction(productVariationAction)
+        }
+    }
+
+    private func handleProductVariationAction(_ action: ProductVariationAction) {
+        switch action {
+        case let .updateProductVariation(_, onCompletion):
+            onCompletion(updateResult)
+        default:
+            fatalError("Not implemented yet")
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -1,0 +1,142 @@
+import Photos
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+/// Unit tests for unsaved changes (`hasUnsavedChanges`, `hasProductChanged`, `hasPasswordChanged`)
+final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
+    private let defaultSiteID: Int64 = 134
+
+    func testProductVariationHasNoChangesFromEditActionsOfTheSameData() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        viewModel.updateImages(productVariation.images)
+        viewModel.updateDescription(productVariation.description ?? "")
+        viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
+                                      salePrice: productVariation.salePrice,
+                                      dateOnSaleStart: productVariation.dateOnSaleStart,
+                                      dateOnSaleEnd: productVariation.dateOnSaleEnd,
+                                      taxStatus: productVariation.productTaxStatus,
+                                      taxClass: nil)
+        viewModel.updateInventorySettings(sku: productVariation.sku,
+                                          manageStock: productVariation.manageStock,
+                                          soldIndividually: nil,
+                                          stockQuantity: productVariation.stockQuantity,
+                                          backordersSetting: productVariation.backordersSetting,
+                                          stockStatus: productVariation.stockStatus)
+        viewModel.updateShippingSettings(weight: productVariation.weight, dimensions: productVariation.dimensions, shippingClass: nil)
+
+        // Assert
+        XCTAssertFalse(viewModel.hasUnsavedChanges())
+        XCTAssertFalse(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductVariationHasUnsavedChangesFromUploadingAnImage() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        waitForExpectation { expectation in
+            productImageActionHandler.addUpdateObserver(self) { statuses in
+                if statuses.productImageStatuses.isNotEmpty {
+                    expectation.fulfill()
+                }
+            }
+            productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+        }
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertFalse(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductVariationHasUnsavedChangesFromEditingImages() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let productImage = ProductImage(imageID: 6,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: "",
+                                        name: "woo",
+                                        alt: nil)
+        viewModel.updateImages([productImage])
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductVariationHasUnsavedChangesFromEditingDescription() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        viewModel.updateDescription("Another way to describe the product?")
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductVariationHasUnsavedChangesFromEditingPriceSettings() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        viewModel.updatePriceSettings(regularPrice: "999999", salePrice: "888888", dateOnSaleStart: nil, dateOnSaleEnd: nil, taxStatus: .none, taxClass: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductVariationHasUnsavedChangesFromEditingInventorySettings() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        viewModel.updateInventorySettings(sku: "", manageStock: false, soldIndividually: nil, stockQuantity: 888888, backordersSetting: nil, stockStatus: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+
+    func testProductVariationHasUnsavedChangesFromEditingShippingSettings() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        viewModel.updateShippingSettings(weight: "88888", dimensions: productVariation.dimensions, shippingClass: nil)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+        XCTAssertTrue(viewModel.hasProductChanged())
+        XCTAssertFalse(viewModel.hasPasswordChanged())
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -1,0 +1,165 @@
+import Photos
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+/// Unit tests for observables (`observableProduct`, `productName`, `isUpdateEnabled`)
+final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
+    private let defaultSiteID: Int64 = 134
+    private var cancellableProduct: ObservationToken?
+    private var cancellableProductName: ObservationToken?
+    private var cancellableUpdateEnabled: ObservationToken?
+
+    override func tearDown() {
+        [cancellableProduct, cancellableProductName, cancellableUpdateEnabled].forEach { cancellable in
+            cancellable?.cancel()
+        }
+        cancellableProduct = nil
+        cancellableProductName = nil
+        cancellableUpdateEnabled = nil
+
+        super.tearDown()
+    }
+
+    func testProductVariationNameObservableIsNil() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+
+        // Action
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Assert
+        XCTAssertNil(viewModel.productName)
+    }
+
+    func testObservablesAreNotEmittedFromEditActionsOfTheSameData() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+        cancellableProduct = viewModel.observableProduct.subscribe { _ in
+            // Assert
+            XCTFail("Should not be triggered from edit actions of the same data")
+        }
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { _ in
+            // Assert
+            XCTFail("Should not be triggered from edit actions of the same data")
+        }
+
+        // Action
+        viewModel.updateImages(productVariation.images)
+        viewModel.updateDescription(productVariation.description ?? "")
+        viewModel.updatePriceSettings(regularPrice: productVariation.regularPrice,
+                                      salePrice: productVariation.salePrice,
+                                      dateOnSaleStart: productVariation.dateOnSaleStart,
+                                      dateOnSaleEnd: productVariation.dateOnSaleEnd,
+                                      taxStatus: productVariation.productTaxStatus,
+                                      taxClass: nil)
+        viewModel.updateInventorySettings(sku: productVariation.sku,
+                                          manageStock: productVariation.manageStock,
+                                          soldIndividually: nil,
+                                          stockQuantity: productVariation.stockQuantity,
+                                          backordersSetting: productVariation.backordersSetting,
+                                          stockStatus: productVariation.stockStatus)
+        viewModel.updateShippingSettings(weight: productVariation.weight, dimensions: productVariation.dimensions, shippingClass: nil)
+    }
+
+    func testObservablesFromUploadingAnImage() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+        var isProductUpdated: Bool?
+        cancellableProduct = viewModel.observableProduct.subscribe { product in
+            isProductUpdated = true
+        }
+
+        // Action
+        var updatedUpdateEnabled: Bool?
+        waitForExpectation { expectation in
+            cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+                updatedUpdateEnabled = isUpdateEnabled
+                expectation.fulfill()
+            }
+            productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: PHAsset())
+        }
+
+        // Assert
+        XCTAssertNil(isProductUpdated)
+        XCTAssertEqual(updatedUpdateEnabled, true)
+    }
+
+    func testObservablesFromUpdatingAVariationSuccessfully() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let newDescription = "Woo!"
+        let expectedProductVariationAfterUpdate = productVariation.copy(description: newDescription)
+        let mockStoresManager = MockProductVariationStoresManager(updateResult: .success(expectedProductVariationAfterUpdate))
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation,
+                                                      productImageActionHandler: productImageActionHandler,
+                                                      storesManager: mockStoresManager)
+
+        var isProductUpdated: Bool?
+        cancellableProduct = viewModel.observableProduct.subscribe { product in
+            isProductUpdated = true
+        }
+
+        var updatedUpdateEnabled: Bool?
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+            updatedUpdateEnabled = isUpdateEnabled
+        }
+
+        // Action
+        viewModel.updateDescription(newDescription)
+
+        var updateResult: Result<ProductVariation, ProductUpdateError>?
+        viewModel.updateProductRemotely { result in
+            updateResult = result
+        }
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel, expectedProductVariationAfterUpdate)
+        XCTAssertEqual(updateResult, .success(expectedProductVariationAfterUpdate))
+        XCTAssertEqual(isProductUpdated, true)
+        XCTAssertEqual(updatedUpdateEnabled, false)
+    }
+
+    func testObservablesFromUpdatingAVariationWithAnError() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: productVariation)
+        let newDescription = "Woo!"
+        let mockUpdateError = ProductUpdateError.notFoundInStorage
+        let mockStoresManager = MockProductVariationStoresManager(updateResult: .failure(mockUpdateError))
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation,
+                                                      productImageActionHandler: productImageActionHandler,
+                                                      storesManager: mockStoresManager)
+
+        var isProductUpdated: Bool?
+        cancellableProduct = viewModel.observableProduct.subscribe { product in
+            isProductUpdated = true
+        }
+
+        var updatedUpdateEnabled: Bool?
+        cancellableUpdateEnabled = viewModel.isUpdateEnabled.subscribe { isUpdateEnabled in
+            updatedUpdateEnabled = isUpdateEnabled
+        }
+
+        // Action
+        viewModel.updateDescription(newDescription)
+
+        var updateResult: Result<ProductVariation, ProductUpdateError>?
+        viewModel.updateProductRemotely { result in
+            updateResult = result
+        }
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel, productVariation.copy(description: newDescription))
+        XCTAssertEqual(updateResult, .failure(mockUpdateError))
+        XCTAssertEqual(isProductUpdated, true)
+        XCTAssertEqual(updatedUpdateEnabled, true)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+UpdatesTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+/// Unit tests for update functions in `ProductVariationFormViewModel`.
+final class ProductVariationFormViewModel_UpdatesTests: XCTestCase {
+    func testUpdatingDescription() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let newDescription = "<p> cool product </p>"
+        viewModel.updateDescription(newDescription)
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel.description, newDescription)
+    }
+
+    func testUpdatingShippingSettings() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let newWeight = "9999.88"
+        let newDimensions = ProductDimensions(length: "122", width: "333", height: "")
+        let newShippingClass = ProductShippingClass(count: 2020,
+                                                    descriptionHTML: "Arriving in 2 days!",
+                                                    name: "2 Days",
+                                                    shippingClassID: 2022,
+                                                    siteID: productVariation.siteID,
+                                                    slug: "2-days")
+        viewModel.updateShippingSettings(weight: newWeight, dimensions: newDimensions, shippingClass: newShippingClass)
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel.description, productVariation.description)
+        XCTAssertEqual(viewModel.productModel.weight, newWeight)
+        XCTAssertEqual(viewModel.productModel.dimensions, newDimensions)
+        XCTAssertEqual(viewModel.productModel.shippingClass, newShippingClass.slug)
+        XCTAssertEqual(viewModel.productModel.shippingClassID, newShippingClass.shippingClassID)
+        XCTAssertEqual(viewModel.productModel.shippingClass, newShippingClass.slug)
+    }
+
+    func testUpdatingPriceSettings() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let newRegularPrice = "32.45"
+        let newSalePrice = "20.00"
+        let newDateOnSaleStart = Date()
+        let newDateOnSaleEnd = newDateOnSaleStart.addingTimeInterval(86400)
+        let newTaxStatus = ProductTaxStatus.taxable
+        let newTaxClass = TaxClass(siteID: productVariation.siteID, name: "Reduced rate", slug: "reduced-rate")
+        viewModel.updatePriceSettings(regularPrice: newRegularPrice,
+                                      salePrice: newSalePrice,
+                                      dateOnSaleStart: newDateOnSaleStart,
+                                      dateOnSaleEnd: newDateOnSaleEnd,
+                                      taxStatus: newTaxStatus,
+                                      taxClass: newTaxClass)
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel.regularPrice, newRegularPrice)
+        XCTAssertEqual(viewModel.productModel.salePrice, newSalePrice)
+        XCTAssertEqual(viewModel.productModel.dateOnSaleStart, newDateOnSaleStart)
+        XCTAssertEqual(viewModel.productModel.dateOnSaleEnd, newDateOnSaleEnd)
+        XCTAssertEqual(viewModel.productModel.taxStatusKey, newTaxStatus.rawValue)
+        XCTAssertEqual(viewModel.productModel.taxClass, newTaxClass.slug)
+    }
+
+    func testUpdatingInventorySettings() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let newSKU = "94115"
+        let newManageStock = !productVariation.manageStock
+        let newStockQuantity: Int64 = 17
+        let newBackordersSetting = ProductBackordersSetting.allowedAndNotifyCustomer
+        let newStockStatus = ProductStockStatus.onBackOrder
+        viewModel.updateInventorySettings(sku: newSKU,
+                                          manageStock: newManageStock,
+                                          soldIndividually: nil,
+                                          stockQuantity: newStockQuantity,
+                                          backordersSetting: newBackordersSetting,
+                                          stockStatus: newStockStatus)
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel.sku, newSKU)
+        XCTAssertEqual(viewModel.productModel.manageStock, newManageStock)
+        XCTAssertEqual(viewModel.productModel.stockQuantity, newStockQuantity)
+        XCTAssertEqual(viewModel.productModel.backordersSetting, newBackordersSetting)
+        XCTAssertEqual(viewModel.productModel.stockStatus, newStockStatus)
+    }
+
+    func testUpdatingImages() {
+        // Arrange
+        let productVariation = MockProductVariation().productVariation()
+        let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: productVariation)
+        let viewModel = ProductVariationFormViewModel(productVariation: productVariation, productImageActionHandler: productImageActionHandler)
+
+        // Action
+        let newImage = ProductImage(imageID: 17,
+                                    dateCreated: Date(),
+                                    dateModified: Date(),
+                                    src: "https://somewebsite.com/shirt.jpg",
+                                    name: "Tshirt",
+                                    alt: "")
+        let newImages = [newImage]
+        viewModel.updateImages(newImages)
+
+        // Assert
+        XCTAssertEqual(viewModel.productModel.images, newImages)
+    }
+}


### PR DESCRIPTION
Product form view model for a variation - part of #2085

- [x] ⚠️ Make sure https://github.com/woocommerce/woocommerce-ios/pull/2577 is merged first

## Changes

Note: sorry about the PR size, this PR only contains one class (~215 diffs) and the rest of the code are on unit tests with a mock stores manager.

- Created `ProductVariationFormViewModel` that conforms to `ProductFormViewModelProtocol` with unit tests
  - Unfortunately, the difference in the editable fields between `Product` and `ProductVariation` results in a few no-op functions and variables in `ProductVariationFormViewModel`. I'm open to any other ideas to make the form work for both product models that allow customizations in the actions!

## Testing

Since the changes don't affect the app behavior yet, just CI!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
