### PR TITLE
Update product inventory settings to take in `ProductFormDataModel` protocol to allow `Product` and `ProductVariation`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventoryEditableData.swift
@@ -1,34 +1,23 @@
 import Yosemite
 
-/// Contains editable properties of a Product in the inventory settings.
+/// Contains editable properties of a product model in the inventory settings.
 ///
-struct ProductInventoryEditableData {
+struct ProductInventoryEditableData: Equatable {
     let sku: String?
     let manageStock: Bool
-    let soldIndividually: Bool
+    let soldIndividually: Bool?
     let stockQuantity: Int64?
     let backordersSetting: ProductBackordersSetting?
     let stockStatus: ProductStockStatus?
 }
 
 extension ProductInventoryEditableData {
-    init(product: Product) {
-        self.sku = product.sku
-        self.manageStock = product.manageStock
-        self.soldIndividually = product.soldIndividually
-        self.stockQuantity = product.stockQuantity
-        self.backordersSetting = product.backordersSetting
-        self.stockStatus = product.productStockStatus
-    }
-}
-
-extension ProductInventoryEditableData: Equatable {
-    static func == (lhs: ProductInventoryEditableData, rhs: ProductInventoryEditableData) -> Bool {
-        return lhs.sku == rhs.sku &&
-            lhs.manageStock == rhs.manageStock &&
-            lhs.soldIndividually == rhs.soldIndividually &&
-            lhs.stockQuantity == rhs.stockQuantity &&
-            lhs.backordersSetting == rhs.backordersSetting &&
-            lhs.stockStatus == rhs.stockStatus
+    init(productModel: ProductFormDataModel) {
+        self.sku = productModel.sku
+        self.manageStock = productModel.manageStock
+        self.soldIndividually = (productModel as? Product)?.soldIndividually
+        self.stockQuantity = productModel.stockQuantity
+        self.backordersSetting = productModel.backordersSetting
+        self.stockStatus = productModel.stockStatus
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -809,10 +809,6 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func editInventorySettings() {
-        // TODO-2085: Support product variation
-        guard let product = product as? Product else {
-            return
-        }
         let inventorySettingsViewController = ProductInventorySettingsViewController(product: product) { [weak self] data in
             self?.onEditInventorySettingsCompletion(data: data)
         }
@@ -820,14 +816,10 @@ private extension ProductFormViewController {
     }
 
     func onEditInventorySettingsCompletion(data: ProductInventoryEditableData) {
-        // TODO-2085: Support product variation
-        guard let product = product as? Product else {
-            return
-        }
         defer {
             navigationController?.popViewController(animated: true)
         }
-        let originalData = ProductInventoryEditableData(product: product)
+        let originalData = ProductInventoryEditableData(productModel: product)
         let hasChangedData = originalData != data
         ServiceLocator.analytics.track(.productInventorySettingsDoneButtonTapped, withProperties: ["has_changed_data": hasChangedData])
 


### PR DESCRIPTION
Inventory settings for a variation - part of #2085

## Changes

- Updated `ProductInventorySettingsViewController` to take in `ProductFormDataModel` protocol instead of concrete `Product`, so that it works for both `Product` and `ProductVariation`
  - Since `soldIndividually` is only available/editable in `Product`, I had to switch on the product model's type for this field in some instances. If you have better ideas on handling this difference, please lemme know!
  - It'd be nice if this view controller has a view model to be unit tested, but that would involve a bunch of other changes. I reopened this issue https://github.com/woocommerce/woocommerce-ios/issues/1985 to track this since these screens support two data models now.
- Updated `soldIndividually` in `ProductInventoryEditableData` to be optional, and its initializer now takes in `ProductFormDataModel` protocol instead of concrete `Product`
- In `ProductFormViewController`, removed TODOs and `Product` checks for editing inventory settings to allow a product variation

## Testing

No app behavior changes are expected, please sanity check the affected part:

- Go to the Products tab
- Tap on a simple product
- Tap on the inventory row --> make sure the "Limit one per order" (`soldIndividually`) is shown as expected
- Edit the "Limit one per order" and optionally other inventory fields
- Tap "Done"
- Tap "Update" --> the inventory settings should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
