### PR TITLE
Fix wrong parameter in leaderboards remote when requesting weekly leaderboards

### DIFF
--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -51,6 +51,20 @@ extension StatsTimeRangeV4 {
         }
     }
 
+    /// Represents the period unit of the leaderboards v4 API  given a time range.
+    public var leaderboardsGranularity: StatsGranularityV4 {
+        switch self {
+        case .today:
+            return .daily
+        case .thisWeek:
+            return .weekly
+        case .thisMonth:
+            return .monthly
+        case .thisYear:
+            return .yearly
+        }
+    }
+
     /// The number of intervals for site visit stats to fetch given a time range.
     /// The interval unit is in `siteVisitStatsGranularity`.
     func siteVisitStatsQuantity(date: Date, siteTimezone: TimeZone) -> Int {

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -143,7 +143,7 @@ public extension StatsStoreV4 {
         let remote = LeaderboardsRemote(network: network)
 
         remote.loadLeaderboards(for: siteID,
-                                unit: timeRange.intervalGranularity,
+                                unit: timeRange.leaderboardsGranularity,
                                 earliestDateToInclude: earliestDate,
                                 latestDateToInclude: latestDate,
                                 quantity: Constants.defaultTopEarnerStatsLimit) { [weak self] result in


### PR DESCRIPTION
# Why
[An error was reported](https://github.com/woocommerce/woocommerce-ios/issues/2583) where stats were not being properly rendered on the weekly leaderboard in contrast with that is shown on the web dashboard.

I couldn't reproduce the reported bug but after comparing the URLs requested by the web-dashboard and by the WC-app I noticed that we were sending the wrong "unit" parameter. We were sending `day` instead of `week`.

# How
- Added a new `leaderboardsGranularity` method to return the correct `StatsGranularityV4` for the leaderboards API.

# Testing Steps
- Make sure you have some orders this week at your store.
- On the web, go to your store's WooCommerce > Dashboard (wc-admin).
- Under "Date Range" select "Week to Date" and then "Update." 
- Notice the data displayed under "Top Products - Items Sold" on that page.
- Open the My store tab in the app.
- Select the "This Week" tab.
- Scroll down to Top Performers.
- Compare the data to the data on the web.

Note: The order of the products may not be the same as we sort them by total spend on the app and web sorts them by item count.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
