### PR TITLE
Product variations are now editable - description, price, shipping, and inventory

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		02BDB83523EA98C800BCC63E /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
 		02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */; };
 		02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */; };
+		02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */ = {isa = PBXBuildFile; fileRef = 02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */; };
 		02DD6492248A3EC00082523E /* product-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 02DD6491248A3EC00082523E /* product-external.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
@@ -408,6 +409,7 @@
 		02BDB83423EA98C800BCC63E /* String+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLTests.swift"; sourceTree = "<group>"; };
 		02C1CEF324C6A02B00703EBA /* ProductVariationMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationMapper.swift; sourceTree = "<group>"; };
+		02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all-manage-stock-two-states.json"; sourceTree = "<group>"; };
 		02DD6491248A3EC00082523E /* product-external.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-external.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
@@ -1152,6 +1154,7 @@
 				026CF623237D839A009563D4 /* product-variations-load-all.json */,
 				02698CF924C188E8005337C4 /* product-variations-load-all-alternative-types.json */,
 				02698CFB24C1B0CE005337C4 /* product-variations-load-all-first-on-sale-empty-sale-price.json */,
+				02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */,
 				020C907A24C6E108001E2BEB /* product-variation-update.json */,
 				CE0A0F1E223998A00075ED8D /* products-load-all.json */,
 				0282DD90233A120A006A5FDB /* products-search-photo.json */,
@@ -1554,6 +1557,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
 				74A1D263211898F000931DFA /* site-visits-day.json in Resources */,
+				02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */,
 				D823D90722376B4800C90817 /* shipment_tracking_new_custom_provider.json in Resources */,
 				268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */,
 				74A1D264211898F000931DFA /* site-visits-week.json in Resources */,

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -196,7 +196,9 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
                                                             alternativeTypes: [
                                                                 .string(transform: { value in
                                                                     guard value.lowercased() == Values.manageStockParent else {
-                                                                        assertionFailure("Unexpected manage stock value: \(value)")
+                                                                        let message = "Unexpected manage stock value: \(value)"
+                                                                        assertionFailure(message)
+                                                                        DDLogError(message)
                                                                         return false
                                                                     }
                                                                     return false

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -252,7 +252,11 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(image, forKey: .image)
+        // TODO-2576: When the image removal is feasible in the API, let's remove this condition.
+        // Ref: https://github.com/woocommerce/woocommerce/issues/27116
+        if let image = image {
+            try container.encode(image, forKey: .image)
+        }
 
         try container.encode(description, forKey: .description)
 

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -188,14 +188,18 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
 
         // Even though the API docs claim `manageStock` is a bool, it's possible that `"parent"`
         // could be returned as well (typically with variations) — we need to account for this.
-        // A "parent" value means that stock mgmt is turned on + managed at the parent product-level, therefore
-        // we need to set this var as `true` in this situation.
+        // A "parent" value means that stock mgmt is turned off at the product variation and it is managed at the parent product-level.
+        // Therefore, we need to set this var as `false` in this situation.
         // See: https://github.com/woocommerce/woocommerce-ios/issues/884 for more deets
         let manageStock = container.failsafeDecodeIfPresent(targetType: Bool.self,
                                                             forKey: .manageStock,
                                                             alternativeTypes: [
                                                                 .string(transform: { value in
-                                                                    value.lowercased() == Values.manageStockParent ? true : false
+                                                                    guard value.lowercased() == Values.manageStockParent else {
+                                                                        assertionFailure("Unexpected manage stock value: \(value)")
+                                                                        return false
+                                                                    }
+                                                                    return false
                                                                 })
         ]) ?? false
 
@@ -293,7 +297,6 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable {
         try container.encode(manageStock, forKey: .manageStock)
         try container.encode(stockQuantity, forKey: .stockQuantity)
         try container.encode(backordersKey, forKey: .backordersKey)
-        try container.encode(stockStatus.rawValue, forKey: .stockStatusKey)
     }
 }
 

--- a/Networking/NetworkingTests/Mapper/ProductVariationListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationListMapperTests.swift
@@ -74,7 +74,7 @@ final class ProductVariationListMapperTests: XCTestCase {
 
         XCTAssertEqual(productVariation.price, "16")
         XCTAssertEqual(productVariation.salePrice, "12.5")
-        XCTAssertTrue(productVariation.manageStock)
+        XCTAssertFalse(productVariation.manageStock)
     }
 
     /// Verifies that the `salePrice` field of the ProductVariation is parsed to "0" when the product variation is on sale and the sale price is an empty string
@@ -84,6 +84,24 @@ final class ProductVariationListMapperTests: XCTestCase {
 
         XCTAssertEqual(productVariation.salePrice, "0")
         XCTAssertTrue(productVariation.onSale)
+    }
+
+    /// Verifies that the `manageStock` field of the ProductVariation is parsed to `false` when the product variation has the same stock
+    /// management as its parent product (API value for `manage_stock` is `parent`).
+    ///
+    func testThatProductVariationManageStockIsFalseWhenTheAPIValueIsParent() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductVariationListResponseWithTwoManageStockStates()?[1])
+
+        XCTAssertFalse(productVariation.manageStock)
+    }
+
+    /// Verifies that the `manageStock` field of the ProductVariation is parsed to `true` when the product variation's stock management is enabled
+    /// (API value for `manage_stock` is `true`).
+    ///
+    func testThatProductVariationManageStockIsTrueWhenTheAPIValueIsTrue() throws {
+        let productVariation = try XCTUnwrap(mapLoadProductVariationListResponseWithTwoManageStockStates()?.first)
+
+        XCTAssertTrue(productVariation.manageStock)
     }
 }
 
@@ -117,5 +135,11 @@ private extension ProductVariationListMapperTests {
     ///
     func mapLoadProductVariationOnSaleWithEmptySalePriceResponse() -> [ProductVariation]? {
         return mapProductVariations(from: "product-variations-load-all-first-on-sale-empty-sale-price")
+    }
+
+    /// Returns the ProductVariationListMapper output upon receiving two variations with different `manageStock` states
+    ///
+    func mapLoadProductVariationListResponseWithTwoManageStockStates() -> [ProductVariation]? {
+        return mapProductVariations(from: "product-variations-load-all-manage-stock-two-states")
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductVariationMapperTests.swift
@@ -76,7 +76,7 @@ private extension ProductVariationMapperTests {
                                 downloadExpiry: 0,
                                 taxStatusKey: "taxable",
                                 taxClass: "",
-                                manageStock: true,
+                                manageStock: false,
                                 stockQuantity: 16,
                                 stockStatus: .inStock,
                                 backordersKey: "notify",

--- a/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -198,7 +198,7 @@ private extension ProductVariationsRemoteTests {
                                 downloadExpiry: 0,
                                 taxStatusKey: "taxable",
                                 taxClass: "",
-                                manageStock: true,
+                                manageStock: false,
                                 stockQuantity: 16,
                                 stockStatus: .inStock,
                                 backordersKey: "notify",

--- a/Networking/NetworkingTests/Responses/product-variations-load-all-manage-stock-two-states.json
+++ b/Networking/NetworkingTests/Responses/product-variations-load-all-manage-stock-two-states.json
@@ -1,0 +1,124 @@
+{
+    "data": [
+        {
+            "id": 1274,
+            "date_created": "2019-11-14T20:40:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2020-07-31T13:23:13",
+            "date_modified_gmt": "2020-07-31T05:23:13",
+            "description": "<p>Hi</p>\n",
+            "permalink": "https://example.com/product/chocolate-2/?attribute_darkness=99%25&attribute_flavor=nuts&attribute_shape=brick",
+            "sku": "",
+            "price": "16.2",
+            "regular_price": "16.2",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": true,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "reduced-rate",
+            "manage_stock": true,
+            "stock_quantity": 6,
+            "stock_status": "instock",
+            "backorders": "notify",
+            "backorders_allowed": true,
+            "backordered": false,
+            "weight": "0.02",
+            "dimensions": {
+                "length": "6",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "10-day-shipping",
+            "shipping_class_id": 96987521,
+            "image": null,
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "nuts"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "brick"
+                }
+            ],
+            "menu_order": 8
+        },
+        {
+            "id": 1273,
+            "date_created": "2019-11-14T20:40:55",
+            "date_created_gmt": "2019-11-14T12:40:55",
+            "date_modified": "2020-07-31T13:23:13",
+            "date_modified_gmt": "2020-07-31T05:23:13",
+            "description": "",
+            "permalink": "https://example.com/product/chocolate-2/?attribute_darkness=99%25&attribute_flavor=strawberry&attribute_shape=marble",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "on_sale": false,
+            "status": "publish",
+            "purchasable": false,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "tax_status": "taxable",
+            "tax_class": "reduced-rate",
+            "manage_stock": "parent",
+            "stock_quantity": 1,
+            "stock_status": "instock",
+            "backorders": "notify",
+            "backorders_allowed": true,
+            "backordered": false,
+            "weight": "67",
+            "dimensions": {
+                "length": "6",
+                "width": "",
+                "height": ""
+            },
+            "shipping_class": "10-day-shipping",
+            "shipping_class_id": 96987521,
+            "image": null,
+            "attributes": [
+                {
+                    "id": 0,
+                    "name": "Darkness",
+                    "option": "99%"
+                },
+                {
+                    "id": 0,
+                    "name": "Flavor",
+                    "option": "strawberry"
+                },
+                {
+                    "id": 0,
+                    "name": "Shape",
+                    "option": "marble"
+                }
+            ],
+            "menu_order": 7
+        }
+    ]
+}

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -710,7 +710,8 @@ extension ProductDetailsViewModel {
         case .productVariants:
             ServiceLocator.analytics.track(.productDetailsProductVariantsTapped)
             let variationsViewController = ProductVariationsViewController(siteID: product.siteID,
-                                                                           productID: product.productID)
+                                                                           productID: product.productID,
+                                                                           isEditProductsRelease3Enabled: false)
             sender.navigationController?.pushViewController(variationsViewController, animated: true)
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -48,6 +48,8 @@ private extension DefaultProductFormTableViewModel {
         switch product {
         case let product as Product:
             return settingsRows(product: product, actions: actions)
+        case let product as ProductVariation:
+            return settingsRows(productVariation: product, actions: actions)
         default:
             fatalError("Unexpected product form data model: \(type(of: product))")
         }
@@ -76,6 +78,21 @@ private extension DefaultProductFormTableViewModel {
                 return .groupedProducts(viewModel: groupedProductsRow(product: product))
             case .variations:
                 return .variations(viewModel: variationsRow(product: product))
+            default:
+                fatalError("Unexpected action in the settings section: \(action)")
+            }
+        }
+    }
+
+    func settingsRows(productVariation: ProductVariation, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {
+        return actions.map { action in
+            switch action {
+            case .priceSettings:
+                return .price(viewModel: priceSettingsRow(product: productVariation))
+            case .shippingSettings:
+                return .shipping(viewModel: shippingSettingsRow(product: productVariation))
+            case .inventorySettings:
+                return .inventory(viewModel: inventorySettingsRow(product: productVariation))
             default:
                 fatalError("Unexpected action in the settings section: \(action)")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -35,7 +35,7 @@ private extension DefaultProductFormTableViewModel {
             case .images:
                 return .images
             case .name:
-                return .name(name: product.name)
+                return .name(name: product.name, isEditable: product is Product)
             case .description:
                 return .description(description: product.trimmedFullDescription)
             default:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -56,7 +56,7 @@ private extension DefaultProductFormTableViewModel {
     }
 
     func settingsRows(product: Product, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {
-        return actions.map { action in
+        return actions.compactMap { action in
             switch action {
             case .priceSettings:
                 return .price(viewModel: priceSettingsRow(product: product))
@@ -79,13 +79,14 @@ private extension DefaultProductFormTableViewModel {
             case .variations:
                 return .variations(viewModel: variationsRow(product: product))
             default:
-                fatalError("Unexpected action in the settings section: \(action)")
+                assertionFailure("Unexpected action in the settings section: \(action)")
+                return nil
             }
         }
     }
 
     func settingsRows(productVariation: ProductVariation, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {
-        return actions.map { action in
+        return actions.compactMap { action in
             switch action {
             case .priceSettings:
                 return .price(viewModel: priceSettingsRow(product: productVariation))
@@ -94,7 +95,8 @@ private extension DefaultProductFormTableViewModel {
             case .inventorySettings:
                 return .inventory(viewModel: inventorySettingsRow(product: productVariation))
             default:
-                fatalError("Unexpected action in the settings section: \(action)")
+                assertionFailure("Unexpected action in the settings section: \(action)")
+                return nil
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -379,6 +379,10 @@ extension ProductInventorySettingsViewController: UITableViewDelegate {
 
         switch rowAtIndexPath(indexPath) {
         case .stockStatus:
+            // Stock status is only editable for `Product`.
+            guard product is Product else {
+                return
+            }
             let command = ProductStockStatusListSelectorCommand(selected: stockStatus)
             let listSelectorViewController = ListSelectorViewController(command: command) { [weak self] selected in
                                                                             self?.stockStatus = selected
@@ -503,7 +507,17 @@ private extension ProductInventorySettingsViewController {
     func configureStockStatus(cell: SettingTitleAndValueTableViewCell) {
         let title = NSLocalizedString("Stock status", comment: "Title of the cell in Product Inventory Settings > Stock status")
         cell.updateUI(title: title, value: stockStatus?.description)
-        cell.accessoryType = .disclosureIndicator
+
+        // Stock status is only editable for `Product`.
+        switch product {
+        case is Product:
+            cell.accessoryType = .disclosureIndicator
+        case is ProductVariation:
+            cell.accessoryType = .none
+            cell.selectionStyle = .none
+        default:
+            break
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -41,8 +41,8 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         switch self {
         case .images:
             return ProductImagesHeaderTableViewCell.self
-        case .name:
-            return TextFieldTableViewCell.self
+        case .name(_, let isEditable):
+            return isEditable ? TextFieldTableViewCell.self: BasicTableViewCell.self
         case .description(let description):
             return description?.isEmpty == false ? ImageAndTitleAndTextTableViewCell.self: BasicTableViewCell.self
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -120,29 +120,37 @@ private extension ProductFormTableViewDataSource {
 
     func configureName(cell: UITableViewCell, name: String?, isEditable: Bool) {
         if isEditable {
-            guard let cell = cell as? TextFieldTableViewCell else {
-                fatalError()
-            }
-
-            cell.accessoryType = .none
-
-            let placeholder = NSLocalizedString("Title", comment: "Placeholder in the Product Title row on Product form screen.")
-            let viewModel = TextFieldTableViewCell.ViewModel(text: name, placeholder: placeholder, onTextChange: { [weak self] newName in
-                self?.onNameChange?(newName)
-                }, onTextDidBeginEditing: {
-                    ServiceLocator.analytics.track(.productDetailViewProductNameTapped)
-            }, inputFormatter: nil, keyboardType: .default)
-            cell.configure(viewModel: viewModel)
+            configureEditableName(cell: cell, name: name)
         } else {
-            guard let cell = cell as? BasicTableViewCell else {
-                fatalError()
-            }
-
-            cell.accessoryType = .none
-            cell.textLabel?.text = name
-            cell.textLabel?.applyHeadlineStyle()
-            cell.textLabel?.textColor = .text
+            configureReadonlyName(cell: cell, name: name)
         }
+    }
+
+    func configureEditableName(cell: UITableViewCell, name: String?) {
+        guard let cell = cell as? TextFieldTableViewCell else {
+            fatalError()
+        }
+
+        cell.accessoryType = .none
+
+        let placeholder = NSLocalizedString("Title", comment: "Placeholder in the Product Title row on Product form screen.")
+        let viewModel = TextFieldTableViewCell.ViewModel(text: name, placeholder: placeholder, onTextChange: { [weak self] newName in
+            self?.onNameChange?(newName)
+            }, onTextDidBeginEditing: {
+                ServiceLocator.analytics.track(.productDetailViewProductNameTapped)
+        }, inputFormatter: nil, keyboardType: .default)
+        cell.configure(viewModel: viewModel)
+    }
+
+    func configureReadonlyName(cell: UITableViewCell, name: String?) {
+        guard let cell = cell as? BasicTableViewCell else {
+            fatalError()
+        }
+
+        cell.accessoryType = .none
+        cell.textLabel?.text = name
+        cell.textLabel?.applyHeadlineStyle()
+        cell.textLabel?.textColor = .text
     }
 
     func configureDescription(cell: UITableViewCell, description: String?) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -82,8 +82,8 @@ private extension ProductFormTableViewDataSource {
         switch row {
         case .images:
             configureImages(cell: cell)
-        case .name(let name):
-            configureName(cell: cell, name: name)
+        case .name(let name, let isEditable):
+            configureName(cell: cell, name: name, isEditable: isEditable)
         case .description(let description):
             configureDescription(cell: cell, description: description)
         }
@@ -118,21 +118,31 @@ private extension ProductFormTableViewDataSource {
         }
     }
 
-    func configureName(cell: UITableViewCell, name: String?) {
-        guard let cell = cell as? TextFieldTableViewCell else {
-            fatalError()
+    func configureName(cell: UITableViewCell, name: String?, isEditable: Bool) {
+        if isEditable {
+            guard let cell = cell as? TextFieldTableViewCell else {
+                fatalError()
+            }
+
+            cell.accessoryType = .none
+
+            let placeholder = NSLocalizedString("Title", comment: "Placeholder in the Product Title row on Product form screen.")
+            let viewModel = TextFieldTableViewCell.ViewModel(text: name, placeholder: placeholder, onTextChange: { [weak self] newName in
+                self?.onNameChange?(newName)
+                }, onTextDidBeginEditing: {
+                    ServiceLocator.analytics.track(.productDetailViewProductNameTapped)
+            }, inputFormatter: nil, keyboardType: .default)
+            cell.configure(viewModel: viewModel)
+        } else {
+            guard let cell = cell as? BasicTableViewCell else {
+                fatalError()
+            }
+
+            cell.accessoryType = .none
+            cell.textLabel?.text = name
+            cell.textLabel?.applyHeadlineStyle()
+            cell.textLabel?.textColor = .text
         }
-
-        cell.accessoryType = .none
-
-        let placeholder = NSLocalizedString("Title", comment: "Placeholder in the Product Title row on Product form screen.")
-
-        let viewModel = TextFieldTableViewCell.ViewModel(text: name, placeholder: placeholder, onTextChange: { [weak self] newName in
-            self?.onNameChange?(newName)
-            }, onTextDidBeginEditing: {
-                ServiceLocator.analytics.track(.productDetailViewProductNameTapped)
-        }, inputFormatter: nil, keyboardType: .default)
-        cell.configure(viewModel: viewModel)
     }
 
     func configureDescription(cell: UITableViewCell, description: String?) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Yosemite
 
-enum ProductFormSection {
+enum ProductFormSection: Equatable {
     case primaryFields(rows: [PrimaryFieldRow])
     case settings(rows: [SettingsRow])
 
@@ -14,13 +14,13 @@ enum ProductFormSection {
         }
     }
 
-    enum PrimaryFieldRow {
+    enum PrimaryFieldRow: Equatable {
         case images
         case name(name: String?, isEditable: Bool)
         case description(description: String?)
     }
 
-    enum SettingsRow {
+    enum SettingsRow: Equatable {
         case price(viewModel: ViewModel)
         case shipping(viewModel: ViewModel)
         case inventory(viewModel: ViewModel)
@@ -53,53 +53,6 @@ enum ProductFormSection {
 /// Abstracts the view model used to render the Product form
 protocol ProductFormTableViewModel {
     var sections: [ProductFormSection] { get }
-}
-
-// MARK: Equatable implementations
-
-extension ProductFormSection: Equatable {
-    static func ==(lhs: ProductFormSection, rhs: ProductFormSection) -> Bool {
-        switch (lhs, rhs) {
-        case (let .primaryFields(rows1), let .primaryFields(rows2)):
-            return rows1 == rows2
-        case (let .settings(rows1), let .settings(rows2)):
-            return rows1 == rows2
-        default:
-            return false
-        }
-    }
-}
-
-extension ProductFormSection.PrimaryFieldRow: Equatable {
-    static func ==(lhs: ProductFormSection.PrimaryFieldRow, rhs: ProductFormSection.PrimaryFieldRow) -> Bool {
-        switch (lhs, rhs) {
-        case (.images, .images):
-            return true
-        case (let .name(name1, isEditable1), let .name(name2, isEditable2)):
-            return name1 == name2 && isEditable1 == isEditable2
-        case (let .description(description1), let .description(description2)):
-            return description1 == description2
-        default:
-            return false
-        }
-    }
-}
-
-extension ProductFormSection.SettingsRow: Equatable {
-    static func ==(lhs: ProductFormSection.SettingsRow, rhs: ProductFormSection.SettingsRow) -> Bool {
-        switch (lhs, rhs) {
-        case (let .price(viewModel1), let .price(viewModel2)):
-            return viewModel1 == viewModel2
-        case (let .shipping(viewModel1), let .shipping(viewModel2)):
-            return viewModel1 == viewModel2
-        case (let .inventory(viewModel1), let .inventory(viewModel2)):
-            return viewModel1 == viewModel2
-        case (let .briefDescription(viewModel1), let .briefDescription(viewModel2)):
-            return viewModel1 == viewModel2
-        default:
-            return false
-        }
-    }
 }
 
 extension ProductFormSection.SettingsRow.ViewModel: Equatable {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -16,7 +16,7 @@ enum ProductFormSection {
 
     enum PrimaryFieldRow {
         case images
-        case name(name: String?)
+        case name(name: String?, isEditable: Bool)
         case description(description: String?)
     }
 
@@ -75,8 +75,8 @@ extension ProductFormSection.PrimaryFieldRow: Equatable {
         switch (lhs, rhs) {
         case (.images, .images):
             return true
-        case (let .name(name1), let .name(name2)):
-            return name1 == name2
+        case (let .name(name1, isEditable1), let .name(name2, isEditable2)):
+            return name1 == name2 && isEditable1 == isEditable2
         case (let .description(description1), let .description(description2)):
             return description1 == description2
         default:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -261,7 +261,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                     return
                 }
                 let variationsViewController = ProductVariationsViewController(siteID: product.siteID,
-                                                                               productID: product.productID)
+                                                                               productID: product.productID,
+                                                                               isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
                 show(variationsViewController, sender: self)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -612,7 +612,7 @@ private extension ProductFormViewController {
             rightBarButtonItems.append(createUpdateBarButtonItem())
         }
 
-        if isEditProductsRelease2Enabled {
+        if isEditProductsRelease2Enabled && viewModel.canEditProductSettings() {
             rightBarButtonItems.insert(createMoreOptionsBarButtonItem(), at: 0)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -118,6 +118,14 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     func hasPasswordChanged() -> Bool {
         return password != nil && password != originalPassword
     }
+}
+
+// MARK: - More menu
+//
+extension ProductFormViewModel {
+    func canEditProductSettings() -> Bool {
+        return true
+    }
 
     func canViewProductInStore() -> Bool {
         return originalProduct.productStatus == .publish

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -31,6 +31,10 @@ protocol ProductFormViewModelProtocol {
 
     func hasPasswordChanged() -> Bool
 
+    // More menu
+
+    func canEditProductSettings() -> Bool
+
     func canViewProductInStore() -> Bool
 
     // Update actions

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -43,6 +43,7 @@ final class ProductShippingSettingsViewController: UIViewController {
         self.shippingSettingsService = shippingSettingsService
         self.onCompletion = completion
 
+        // TODO-2580: re-enable shipping class for `ProductVariation` when the API issue is fixed.
         switch product {
         case is Product:
             sections = [

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -27,10 +27,7 @@ final class ProductShippingSettingsViewController: UIViewController {
 
     /// Table Sections to be rendered
     ///
-    private let sections: [Section] = [
-        Section(rows: [.weight, .length, .width, .height]),
-        Section(rows: [.shippingClass])
-    ]
+    private let sections: [Section]
 
     typealias Completion = (_ weight: String?, _ dimensions: ProductDimensions, _ shippingClass: ProductShippingClass?) -> Void
     private let onCompletion: Completion
@@ -45,6 +42,20 @@ final class ProductShippingSettingsViewController: UIViewController {
         self.product = product
         self.shippingSettingsService = shippingSettingsService
         self.onCompletion = completion
+
+        switch product {
+        case is Product:
+            sections = [
+                Section(rows: [.weight, .length, .width, .height]),
+                Section(rows: [.shippingClass])
+            ]
+        case is ProductVariation:
+            sections = [
+                Section(rows: [.weight, .length, .width, .height])
+            ]
+        default:
+            fatalError("Unsupported product type: \(product)")
+        }
 
         self.weight = product.weight
         self.length = product.dimensions.length

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -65,10 +65,12 @@ final class ProductVariationsViewController: UIViewController {
     private let productID: Int64
 
     private let imageService: ImageService = ServiceLocator.imageService
+    private let isEditProductsRelease3Enabled: Bool
 
-    init(siteID: Int64, productID: Int64) {
+    init(siteID: Int64, productID: Int64, isEditProductsRelease3Enabled: Bool) {
         self.siteID = siteID
         self.productID = productID
+        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -86,10 +88,6 @@ final class ProductVariationsViewController: UIViewController {
         configureTableView()
         configureSyncingCoordinator()
         registerTableViewCells()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
 
         syncingCoordinator.synchronizeFirstPage()
     }
@@ -226,6 +224,24 @@ extension ProductVariationsViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+
+        if isEditProductsRelease3Enabled {
+            let productVariation = resultsController.object(at: indexPath)
+
+            let currencyCode = CurrencySettings.shared.currencyCode
+            let currency = CurrencySettings.shared.symbol(from: currencyCode)
+            let productImageActionHandler = ProductImageActionHandler(siteID: productVariation.siteID,
+                                                                      product: productVariation)
+            let viewModel = ProductVariationFormViewModel(productVariation: productVariation,
+                                                          productImageActionHandler: productImageActionHandler)
+            let viewController = ProductFormViewController(viewModel: viewModel,
+                                                           productImageActionHandler: productImageActionHandler,
+                                                           currency: currency,
+                                                           presentationStyle: .navigationStack,
+                                                           isEditProductsRelease2Enabled: true,
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            navigationController?.pushViewController(viewController, animated: true)
+        }
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Variation form - part of #2085 

This PR includes various changes and fixes to make a product variation editable on the basic fields - description, price, shipping, and inventory.

## Changes

Please see the differences between a product and variation form in the description of https://github.com/woocommerce/woocommerce-ios/issues/2085, this PR includes all the changes except for the product images!

- Networking layer - a few fixes were made to `ProductVariation` to allow editing inventory and saving a product variation without an image:
  - Updated the logic on how `manageStock` is decoded from the API response: there are two states, whether a variation has its stock management enabled at variation level (`manage_stock` is `true` in the API) or it follows its parent product's stock status (`manage_stock` is `"parent"` in the API). In the past, we've been considered the latter case as the stock management is enabled at variation level but it's not the case. Therefore, the logic and 2 test cases were added on these 2 states, and `manageStock` was updated in a few unit tests that had the incorrect assumption.
  - It now only encodes its `image` field only when the variation has an image. This is due to an [API issue](https://github.com/woocommerce/woocommerce/issues/27116), and if the `image` field isn't set to a non-nil product image the update request will fail (e.g. when updating a variation without an image).
  - `stockStatusKey` is not encoded anymore. Since stock status is only available when a variation's stock management is set to follow its parent product, it's a readonly value from the parent product and shouldn't be encoded.
- App layer:
  - In `ProductVariationsViewController`, navigated to `ProductFormViewController` with a product variation form view model when the user taps on a variation in the list if M3 flag is enabled. Also, `syncingCoordinator.synchronizeFirstPage()` is now only called once in `viewDidLoad` instead of every time in `viewWillAppear`. Updated `ProductDetailsViewModel` to provide `isEditProductsRelease3Enabled` for `ProductVariationsViewController`.
  - In `ProductShippingSettingsViewController`, the shipping class row is hidden for a variation due to an [API issue](https://github.com/woocommerce/woocommerce/issues/27131) (more details in p91TBi-33Q-p2).
  - In `ProductFormViewModelProtocol`, added a new method `func canEditProductSettings() -> Bool` so that the ellipsis menu that shows the product settings in the navigation bar can be hidden for a variation. `ProductFormViewModel` returns `true` for this method, while `ProductVariationFormViewModel` returns `false`. The value of this method is used to determine whether to show the ellipsis menu in the navigation bar in `ProductFormViewController`.
  - In `ProductInventorySettingsViewController`, updated the stock status row to be readonly for a variation: disabled tap action for a variation, and no disclosure indicator is shown in the cell.
  - In `PrimaryFieldRow.name`, added another parameter `isEditable` to be `PrimaryFieldRow.name(name: String?, isEditable: Bool)` because the name field for a variation is readonly. Updated a bunch of related files, and set the value to `product is Product` in `DefaultProductFormTableViewModel`. If the name row is editable, `TextFieldTableViewCell` is used. Otherwise, `BasicTableViewCell` is used with headline style set in `ProductFormTableViewDataSource`.

## Testing

- Go to the Products tab
- Tap on a variable product with non zero variations --> sanity check that the name field is editable
- Tap on the variations row
- Tap on a variation --> a variation form should be presented, without an ellipsis menu in the navigation bar, and the name row is readonly
- Tap on the description row and edit the text
- Go back to the form and tap on the price row, then edit some fields --> no tax section should be shown on price settings
- Go back to the form and tap on the shipping row, then edit some fields --> the shipping class row should not be shown on the shipping settings
- Go back to the form and tap on the inventory row, then toggle the "Manage stock" switch and edit some fields --> the "Limit one per order" toggle row shouldn't be shown as in a product form, and the stock status row is readonly when "Manage stock" is disabled
- Go back to the form and tap "Update" --> the variation should be updated remotely with the changes above

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/89024477-be819400-d357-11ea-9d39-c46a2a3b04b7.gif)

Dark | Light
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-07-31 at 17 59 53](https://user-images.githubusercontent.com/1945542/89024593-eec93280-d357-11ea-8655-1908e75785d3.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-31 at 18 00 31](https://user-images.githubusercontent.com/1945542/89024599-f2f55000-d357-11ea-92ad-33652734068b.png)

Price | Shipping | Inventory (stock management disabled)
-- | -- | --
![Simulator Screen Shot - iPhone 11 - 2020-07-31 at 18 00 00](https://user-images.githubusercontent.com/1945542/89024669-0e605b00-d358-11ea-93ab-7d9e4815b3b2.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-31 at 18 00 08](https://user-images.githubusercontent.com/1945542/89024674-115b4b80-d358-11ea-94aa-cfc27272fa5f.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-31 at 18 00 12](https://user-images.githubusercontent.com/1945542/89024676-128c7880-d358-11ea-9256-f416fc127aa2.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
