### PR TITLE
Update product image upload UX to support product variation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -16,6 +16,8 @@ protocol ProductFormDataModel {
 
     // Images
     var images: [ProductImage] { get }
+    /// Whether the product model allows multiple images.
+    func allowsMultipleImages() -> Bool
 
     // Price
     var regularPrice: String? { get }
@@ -78,6 +80,10 @@ extension Product: ProductFormDataModel {
     var stockStatus: ProductStockStatus {
         productStockStatus
     }
+
+    func allowsMultipleImages() -> Bool {
+        true
+    }
 }
 
 extension ProductVariation: ProductFormDataModel {
@@ -91,5 +97,9 @@ extension ProductVariation: ProductFormDataModel {
 
     var images: [ProductImage] {
         [image].compactMap { $0 }
+    }
+
+    func allowsMultipleImages() -> Bool {
+        false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -18,6 +18,9 @@ protocol ProductFormDataModel {
     var images: [ProductImage] { get }
     /// Whether the product model allows multiple images.
     func allowsMultipleImages() -> Bool
+    /// Whether the product model's images can be deleted.
+    /// TODO-2576: always allows image deletion when the API issue is fixed for removing an image from a product variation.
+    func isImageDeletionEnabled() -> Bool
 
     // Price
     var regularPrice: String? { get }
@@ -84,6 +87,10 @@ extension Product: ProductFormDataModel {
     func allowsMultipleImages() -> Bool {
         true
     }
+
+    func isImageDeletionEnabled() -> Bool {
+        true
+    }
 }
 
 extension ProductVariation: ProductFormDataModel {
@@ -100,6 +107,10 @@ extension ProductVariation: ProductFormDataModel {
     }
 
     func allowsMultipleImages() -> Bool {
+        false
+    }
+
+    func isImageDeletionEnabled() -> Bool {
         false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DeviceMediaLibraryPicker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DeviceMediaLibraryPicker.swift
@@ -8,7 +8,10 @@ final class DeviceMediaLibraryPicker: NSObject {
     private let onCompletion: Completion
     private let dataSource = WPPHAssetDataSource()
 
-    init(onCompletion: @escaping Completion) {
+    private let allowsMultipleImages: Bool
+
+    init(allowsMultipleImages: Bool, onCompletion: @escaping Completion) {
+        self.allowsMultipleImages = allowsMultipleImages
         self.onCompletion = onCompletion
     }
 
@@ -20,6 +23,7 @@ final class DeviceMediaLibraryPicker: NSObject {
         options.filter = [.image]
         options.allowCaptureOfMedia = false
         options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.allowMultipleSelection = allowsMultipleImages
 
         let picker = WPNavigationMediaPickerViewController(options: options)
         picker.dataSource = dataSource

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
@@ -8,19 +8,22 @@ final class MediaPickingCoordinator {
     }()
 
     private lazy var deviceMediaLibraryPicker: DeviceMediaLibraryPicker = {
-        return DeviceMediaLibraryPicker(onCompletion: onDeviceMediaLibraryPickerCompletion)
+        return DeviceMediaLibraryPicker(allowsMultipleImages: allowsMultipleImages, onCompletion: onDeviceMediaLibraryPickerCompletion)
     }()
 
     private let siteID: Int64
+    private let allowsMultipleImages: Bool
     private let onCameraCaptureCompletion: CameraCaptureCoordinator.Completion
     private let onDeviceMediaLibraryPickerCompletion: DeviceMediaLibraryPicker.Completion
     private let onWPMediaPickerCompletion: WordPressMediaLibraryImagePickerViewController.Completion
 
     init(siteID: Int64,
+         allowsMultipleImages: Bool,
          onCameraCaptureCompletion: @escaping CameraCaptureCoordinator.Completion,
          onDeviceMediaLibraryPickerCompletion: @escaping DeviceMediaLibraryPicker.Completion,
          onWPMediaPickerCompletion: @escaping WordPressMediaLibraryImagePickerViewController.Completion) {
         self.siteID = siteID
+        self.allowsMultipleImages = allowsMultipleImages
         self.onCameraCaptureCompletion = onCameraCaptureCompletion
         self.onDeviceMediaLibraryPickerCompletion = onDeviceMediaLibraryPickerCompletion
         self.onWPMediaPickerCompletion = onWPMediaPickerCompletion
@@ -97,6 +100,7 @@ private extension MediaPickingCoordinator {
 
     func showSiteMediaPicker(origin: UIViewController) {
         let wordPressMediaPickerViewController = WordPressMediaLibraryImagePickerViewController(siteID: siteID,
+                                                                                                allowsMultipleImages: allowsMultipleImages,
                                                                                                 onCompletion: onWPMediaPickerCompletion)
         origin.present(wordPressMediaPickerViewController, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageViewController.swift
@@ -9,6 +9,7 @@ final class ProductImageViewController: UIViewController {
     @IBOutlet private weak var imageView: UIImageView!
 
     private let productImage: ProductImage
+    private let isDeletionEnabled: Bool
     private let productUIImageLoader: ProductUIImageLoader
     private let onDeletion: Deletion
 
@@ -17,9 +18,11 @@ final class ProductImageViewController: UIViewController {
     private var imageLoaderTask: Cancellable?
 
     init(productImage: ProductImage,
+         isDeletionEnabled: Bool,
          productUIImageLoader: ProductUIImageLoader,
          onDeletion: @escaping Deletion) {
         self.productImage = productImage
+        self.isDeletionEnabled = isDeletionEnabled
         self.productUIImageLoader = productUIImageLoader
         self.onDeletion = onDeletion
         super.init(nibName: nil, bundle: nil)
@@ -59,6 +62,9 @@ private extension ProductImageViewController {
     }
 
     func configureNavigation() {
+        guard isDeletionEnabled else {
+            return
+        }
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: .trashImage,
                                                             style: .plain,
                                                             target: self,

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -8,13 +8,16 @@ final class ProductImagesCollectionViewController: UICollectionViewController {
 
     private var productImageStatuses: [ProductImageStatus]
 
+    private let isDeletionEnabled: Bool
     private let productUIImageLoader: ProductUIImageLoader
     private let onDeletion: ProductImageViewController.Deletion
 
     init(imageStatuses: [ProductImageStatus],
+         isDeletionEnabled: Bool,
          productUIImageLoader: ProductUIImageLoader,
          onDeletion: @escaping ProductImageViewController.Deletion) {
         self.productImageStatuses = imageStatuses
+        self.isDeletionEnabled = isDeletionEnabled
         self.productUIImageLoader = productUIImageLoader
         self.onDeletion = onDeletion
         let columnLayout = ColumnFlowLayout(
@@ -116,6 +119,7 @@ extension ProductImagesCollectionViewController {
         switch status {
         case .remote(let productImage):
             let productImageViewController = ProductImageViewController(productImage: productImage,
+                                                                        isDeletionEnabled: isDeletionEnabled,
                                                                         productUIImageLoader: productUIImageLoader,
                                                                         onDeletion: { [weak self] productImage in
                                                                             self?.onDeletion(productImage)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -32,9 +32,15 @@ final class ProductImagesViewController: UIViewController {
     }
     private var productImageStatusesObservationToken: ObservationToken?
 
+    private var allowsMultipleImages: Bool {
+        product.allowsMultipleImages()
+    }
+
     // Child view controller.
     private lazy var imagesViewController: ProductImagesCollectionViewController = {
+        let isDeletionEnabled = product.isImageDeletionEnabled()
         let viewController = ProductImagesCollectionViewController(imageStatuses: productImageStatuses,
+                                                                   isDeletionEnabled: isDeletionEnabled,
                                                                    productUIImageLoader: productUIImageLoader,
                                                                    onDeletion: { [weak self] productImage in
                                                                     self?.onDeletion(productImage: productImage)
@@ -44,7 +50,7 @@ final class ProductImagesViewController: UIViewController {
 
     private lazy var mediaPickingCoordinator: MediaPickingCoordinator = {
         return MediaPickingCoordinator(siteID: siteID,
-                                       allowsMultipleImages: product.allowsMultipleImages(),
+                                       allowsMultipleImages: allowsMultipleImages,
                                        onCameraCaptureCompletion: { [weak self] asset, error in
                                         self?.onCameraCaptureCompletion(asset: asset, error: error)
             }, onDeviceMediaLibraryPickerCompletion: { [weak self] assets in
@@ -153,7 +159,7 @@ private extension ProductImagesViewController {
 private extension ProductImagesViewController {
     func updateAddButtonTitle(numberOfImages: Int) {
         let title: String
-        if product.allowsMultipleImages() {
+        if allowsMultipleImages {
             title = Localization.addPhotos
         } else {
             title = numberOfImages == 0 ? Localization.addPhoto: Localization.replacePhoto
@@ -176,7 +182,7 @@ private extension ProductImagesViewController {
     }
 
     func deleteExistingImageIfOnlyOneImageIsAllowed() {
-        if product.allowsMultipleImages() == false, let currentImage = product.images.first {
+        if allowsMultipleImages == false, let currentImage = product.images.first {
             productImageActionHandler.deleteProductImage(currentImage)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryImagePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryImagePickerViewController.swift
@@ -17,7 +17,7 @@ final class WordPressMediaLibraryImagePickerViewController: UIViewController {
         options.showSearchBar = false
         options.showActionBar = false
         options.badgedUTTypes = [String(kUTTypeGIF)]
-        options.allowMultipleSelection = true
+        options.allowMultipleSelection = allowsMultipleImages
         return options
     }()
 
@@ -26,9 +26,11 @@ final class WordPressMediaLibraryImagePickerViewController: UIViewController {
     private var mediaPickerNavigationController: WPNavigationMediaPickerViewController!
 
     private let siteID: Int64
+    private let allowsMultipleImages: Bool
 
-    init(siteID: Int64, onCompletion: @escaping Completion) {
+    init(siteID: Int64, allowsMultipleImages: Bool, onCompletion: @escaping Completion) {
         self.siteID = siteID
+        self.allowsMultipleImages = allowsMultipleImages
         self.onCompletion = onCompletion
         super.init(nibName: nil, bundle: nil)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Product+ProductFormTests.swift
@@ -47,6 +47,18 @@ class Product_ProductFormTests: XCTestCase {
         XCTAssertEqual(product.categoriesDescription(using: usLocale), expectedDescription)
     }
 
+    // MARK: image related
+
+    func testProductAllowsMultipleImages() {
+        let product = Product().copy(images: [])
+        XCTAssertTrue(product.allowsMultipleImages())
+    }
+
+    func testProductImageDeletionIsEnabled() {
+        let product = Product().copy(images: [])
+        XCTAssertTrue(product.isImageDeletionEnabled())
+    }
+
     // MARK: `productTaxStatus`
 
     func testProductTaxStatusFromAnUnexpectedRawValueReturnsDefaultTaxable() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductVariation+ProductFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductVariation+ProductFormTests.swift
@@ -41,6 +41,18 @@ final class ProductVariation_ProductFormTests: XCTestCase {
         XCTAssertFalse(productVariation.isShippingEnabled)
     }
 
+    // MARK: image related
+
+    func testProductVariationDoesNotAllowMultipleImages() {
+        let productVariation = MockProductVariation().productVariation().copy(image: nil)
+        XCTAssertFalse(productVariation.allowsMultipleImages())
+    }
+
+    func testProductVariationImageDeletionIsDisabled() {
+        let productVariation = MockProductVariation().productVariation().copy(image: nil)
+        XCTAssertFalse(productVariation.isImageDeletionEnabled())
+    }
+
     // MARK: `productTaxStatus`
 
     func testProductTaxStatusFromAnUnexpectedRawValueReturnsDefaultTaxable() {


### PR DESCRIPTION
Fixes #2085

- [ ] ⚠️ Update PR base to `develop` after https://github.com/woocommerce/woocommerce-ios/pull/2587 is merged ⚠️ 

This completes the last part of #2085, with changes in product images UX since a variation can only have up to one image and there is an API issue #2576 that prevents an image to be removed from a variation. 

## Changes

- Added `allowsMultipleImages() -> Bool` and `isImageDeletionEnabled() -> Bool` to `ProductFormDataModel` protocol, and returned `true` for both of a `Product` and `false` of a `ProductVariation`.
- In `ProductImagesViewController` (top-level view controller that has a child view controller `ProductImagesCollectionViewController`), added `allowsMultipleImages` check for updating the CTA title and passed `allowsMultipleImages` to `MediaPickingCoordinator`. Also, if only one image is allowed, deleted the existing image before committing the image upload action.
- In `ProductImagesViewController`, passed `isImageDeletionEnabled` to `ProductImagesCollectionViewController` and then to `ProductImageViewController` so that the trash/deletion CTA is not shown when deletion is disabled (e.g. for a variation). This is due to the API issue #2576.

## Testing

Please test the flow of editing image(s) for a product and product variation:

### Product Variation

- Go to the Products tab
- Tap on a variable product
- Tap on the variations row
- Tap on a variation without an image
- Tap on the "+" cell in the images header --> the CTA should say "Add Photo"
- Tap "Add Photo"
- Tap on the device option and select an image --> only one image can be added
- Tap "Update" --> the selected image should be added to the variation remotely
- Tap on the "+" cell in the images header --> the CTA should now say "Replace Photo"
- Tap on the image --> there should be no trash icon to delete the image
- Tap "Replace Photo"
- Tap on the WP Media Library option and select an image --> only one image can be added
- Tap "Update" --> the selected image should replace the variation image remotely
- If on a device, feel free to also test the camera option but only one photo can be taken in any case

### Product

- Go to the Products tab
- Tap on any simple/variable/grouped/external product 
- Tap on the "+" cell in the images header --> the CTA should say "Add Photos"
- Tap "Add Photos"
- Tap on the device or WP Media Library option and select some images --> multiple images can be added
- Tap "Update" --> the selected images should be added to the variation remotely
- Tap on the "+" cell in the images header
- Tap on an image --> there should be a trash icon to delete the image
- Tap the trash icon to delete the image
- Go back to the product details screen, and tap "Update" --> the image should be deleted remotely

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/89158587-f2032f00-d5a0-11ea-80cd-88d0d329190c.gif)

variation has no image | variation has an image
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-08-03 at 15 42 58](https://user-images.githubusercontent.com/1945542/89158572-ee6fa800-d5a0-11ea-9b0b-82b6f96d548c.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-03 at 15 43 04](https://user-images.githubusercontent.com/1945542/89158582-f0d20200-d5a0-11ea-8877-bb7e0bf12df3.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
