### PR TITLE
Adds in-app Survey loading view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyLoadingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyLoadingView.swift
@@ -1,0 +1,76 @@
+import Foundation
+import UIKit
+
+/// Loading view to show while the survey is loading
+///
+final class SurveyLoadingView: UIView {
+
+    /// Main stack view to hold UI components vertically
+    ///
+    private let mainStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = Layout.stackViewSpacing
+        return stackView
+    }()
+
+    /// Label to indicate the user to wait
+    ///
+    private let waitLabel: UILabel = {
+        let label = UILabel()
+        label.text = Localization.wait
+        return label
+    }()
+
+    /// Extra Large and purple loading indicator
+    ///
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .gray)
+        indicator.transform = CGAffineTransform(scaleX: Layout.indicatorScaleFactor, y: Layout.indicatorScaleFactor)
+        indicator.startAnimating()
+        return indicator
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addComponents()
+        styleComponents()
+    }
+
+    /// Adds and layouts components in the main view
+    ///
+    private func addComponents() {
+        addSubview(mainStackView)
+        mainStackView.addArrangedSubviews([waitLabel, loadingIndicator])
+        pinSubviewToAllEdges(mainStackView, insets: Layout.stackViewEdges)
+    }
+
+    /// Applies custom styles to components
+    ///
+    private func styleComponents() {
+        backgroundColor = .listBackground
+        layer.cornerRadius = Layout.corderRadius
+        waitLabel.applyHeadlineStyle()
+        loadingIndicator.color = .primary
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Not supported")
+    }
+}
+
+// MARK: Constants
+private extension SurveyLoadingView {
+    enum Localization {
+        static let wait = NSLocalizedString("Please wait", comment: "Text on the loading view of the survey screen indicating the user to wait")
+    }
+
+    enum Layout {
+        static let stackViewEdges = UIEdgeInsets(top: 38, left: 54, bottom: 48, right: 54)
+        static let stackViewSpacing = CGFloat(40)
+        static let indicatorScaleFactor = CGFloat(2.5)
+        static let corderRadius = CGFloat(14.5)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyLoadingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyLoadingView.swift
@@ -51,7 +51,7 @@ final class SurveyLoadingView: UIView {
     ///
     private func styleComponents() {
         backgroundColor = .listBackground
-        layer.cornerRadius = Layout.corderRadius
+        layer.cornerRadius = Layout.cornerRadius
         waitLabel.applyHeadlineStyle()
         loadingIndicator.color = .primary
     }
@@ -71,6 +71,6 @@ private extension SurveyLoadingView {
         static let stackViewEdges = UIEdgeInsets(top: 38, left: 54, bottom: 48, right: 54)
         static let stackViewSpacing = CGFloat(40)
         static let indicatorScaleFactor = CGFloat(2.5)
-        static let corderRadius = CGFloat(14.5)
+        static let cornerRadius = CGFloat(14.5)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -17,6 +17,10 @@ final class SurveyViewController: UIViewController {
     ///
     private let onCompletion: () -> Void
 
+    /// Loading view displayed while the survey loads
+    ///
+    private let loadingView = SurveyLoadingView()
+
     init(survey: Source, onCompletion: @escaping () -> Void) {
         self.survey = survey
         self.onCompletion = onCompletion
@@ -31,6 +35,7 @@ final class SurveyViewController: UIViewController {
         super.viewDidLoad()
 
         addCloseNavigationBarButton()
+        addLoadingView()
         configureAndLoadSurvey()
     }
 
@@ -40,6 +45,20 @@ final class SurveyViewController: UIViewController {
         let request = URLRequest(url: survey.url)
         webView.load(request)
         webView.navigationDelegate = self
+    }
+
+    /// Adds a loading view to the screen pinned at the center
+    ///
+    private func addLoadingView() {
+        loadingView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(loadingView)
+        view.pinSubviewAtCenter(loadingView)
+    }
+
+    /// Removes the loading view from the screen with a fade out animaition
+    ///
+    private func removeLoadingView() {
+        loadingView.fadeOut()
     }
 }
 
@@ -77,5 +96,9 @@ extension SurveyViewController: WKNavigationDelegate {
         }
 
         decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation) {
+        removeLoadingView()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -58,7 +58,9 @@ final class SurveyViewController: UIViewController {
     /// Removes the loading view from the screen with a fade out animaition
     ///
     private func removeLoadingView() {
-        loadingView.fadeOut()
+        loadingView.fadeOut { [weak self] _ in
+            self?.loadingView.removeFromSuperview()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.xib
@@ -21,7 +21,6 @@
             <subviews>
                 <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uO7-PA-PdE">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                    <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <wkWebViewConfiguration key="configuration">
                         <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                         <wkPreferences key="preferences"/>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
+		26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -1213,6 +1214,7 @@
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
+		26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyLoadingView.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -2517,6 +2519,7 @@
 			children = (
 				26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */,
 				26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */,
+				26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */,
 				2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */,
 				2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */,
 			);
@@ -5218,6 +5221,7 @@
 				0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				CEEC9B5C21E79B3E0055EEF0 /* FeatureFlag.swift in Sources */,
+				26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */,
 				457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */,
 				02F49ADA23BF356E00FA0BFA /* TitleAndTextFieldTableViewCell.ViewModel+State.swift in Sources */,
 				74036CC0211B882100E462C2 /* PeriodDataViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -42,7 +42,7 @@ final class SurveyViewControllerTests: XCTestCase {
         }
     }
 
-    func test_it_does_not_completes_after_receiving_a_form_submitted_GET_callback_request() throws {
+    func test_it_does_not_complete_after_receiving_a_form_submitted_GET_callback_request() throws {
         // Given
         let exp = expectation(description: #function)
         exp.isInverted = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -23,11 +23,9 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func testItCompletesAfterReceivingAFormSubmittedPOSTCallbackRequest() throws {
         // Given
-        let exp = expectation(description: #function)
         var surveyCompleted = false
         let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
             surveyCompleted = true
-            exp.fulfill()
         })
 
         // When
@@ -37,10 +35,11 @@ final class SurveyViewControllerTests: XCTestCase {
         // Fakes a form submission POST navigation
         let navigationAction = FormSubmittedNavigationAction(httpMethod: "POST")
         viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
-        waitForExpectations(timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertTrue(surveyCompleted)
+        waitUntil(timeout: 1) {
+            surveyCompleted
+        }
     }
 
     func testItDoesNotCompletesAfterReceivingAFormSubmittedGETCallbackRequest() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -65,6 +65,36 @@ final class SurveyViewControllerTests: XCTestCase {
         // Then
         XCTAssertFalse(surveyCompleted)
     }
+
+    func test_it_shows_the_loading_view_when_loading_a_survey() throws {
+        // Given
+        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {})
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+
+        // Then
+        XCTAssertFalse(mirror.loadingView.isHidden)
+    }
+
+    func test_it_hides_the_loading_view_after_loading_a_survey() throws {
+        // Given
+        let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {})
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+
+        // Fakes a web view loading completion
+        let navigation = try XCTUnwrap(mirror.webView.reload())
+        viewController.webView(mirror.webView, didFinish: navigation)
+
+        // Then
+        waitUntil(timeout: 1) {
+            return mirror.loadingView.isHidden
+        }
+    }
 }
 
 // MARK: - Mirroring
@@ -72,11 +102,15 @@ final class SurveyViewControllerTests: XCTestCase {
 private extension SurveyViewControllerTests {
     struct SurveyViewControllerMirror {
         let webView: WKWebView
+        let loadingView: SurveyLoadingView
     }
 
     func mirror(of viewController: SurveyViewController) throws -> SurveyViewControllerMirror {
         let mirror = Mirror(reflecting: viewController)
-        return SurveyViewControllerMirror(webView: try XCTUnwrap(mirror.descendant("webView") as? WKWebView))
+        return SurveyViewControllerMirror(
+            webView: try XCTUnwrap(mirror.descendant("webView") as? WKWebView),
+            loadingView: try XCTUnwrap(mirror.descendant("loadingView") as? SurveyLoadingView)
+        )
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 ///
 final class SurveyViewControllerTests: XCTestCase {
 
-    func testItLoadsTheCorrectInAppFeedbackSurvey() throws {
+    func test_it_loads_the_correct_inApp_feedback_survey() throws {
         // Given
         let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {})
 
@@ -21,7 +21,7 @@ final class SurveyViewControllerTests: XCTestCase {
         XCTAssertEqual(mirror.webView.url, WooConstants.URLs.inAppFeedback.asURL())
     }
 
-    func testItCompletesAfterReceivingAFormSubmittedPOSTCallbackRequest() throws {
+    func test_it_completes_after_receiving_a_form_submitted_POST_callback_request() throws {
         // Given
         var surveyCompleted = false
         let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
@@ -42,7 +42,7 @@ final class SurveyViewControllerTests: XCTestCase {
         }
     }
 
-    func testItDoesNotCompletesAfterReceivingAFormSubmittedGETCallbackRequest() throws {
+    func test_it_does_not_completes_after_receiving_a_form_submitted_GET_callback_request() throws {
         // Given
         let exp = expectation(description: #function)
         exp.isInverted = true


### PR DESCRIPTION
fixes #2571 

# Why

Prior to this PR, the user was left staring at an empty screen while the in-app survey loads. Since the survey can take a couple of seconds to load, we have decided to add a loading indicator view.

# How

- Creates a new `SuveryLoadingView` to hold the loading indicator
- Present the loading view when the request to load the survey is fired
- Hide the loading view when the survey has finished loading

PS: I've also updated some tests to use the new method name case.

# GIF

![Survey-loading-view](https://user-images.githubusercontent.com/562080/89419475-02c5b900-d6f7-11ea-9d26-2a40c4b15cc2.gif)


# Testing Steps

- Add the following code in `InAppFeedbackCardViewController`, `configureDidNotLikeButton()` method
```swift
didNotLikeButton.on(.touchUpInside) { [weak self] _  in
    let vc = SurveyViewController(survey: .inAppFeedback, onCompletion: { })
    let nav = WooNavigationController(rootViewController: vc)
    self?.present(nav, animated: true)
}
```
- Tap on the "Could be better" button in the feedback card on the dashboard
- See that the loading spinner is present while the survey loads.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
