### PR TITLE
Add BehaviorSubject observable

### DIFF
--- a/WooCommerce/Classes/Tools/Observables/BehaviorSubject.swift
+++ b/WooCommerce/Classes/Tools/Observables/BehaviorSubject.swift
@@ -1,0 +1,115 @@
+
+import Foundation
+
+/// Emits the current value to observers upon subscription and also when new values arrive.
+///
+/// Acts like `CurrentValueSubject` in Combine and `BehaviorSubject` in ReactiveX.
+///
+/// This observable is a bridge between the imperative and reactive programming paradigms. It
+/// allows consumers to _manually_ emit values using the `send()` method.
+///
+/// Multiple observers are allowed which makes this a possible replacement for
+/// `NSNotificationCenter` observations.
+///
+/// ## Example Usage
+///
+/// In a class that you would like to emit values (or events), add the `BehaviorSubject` defining
+/// the value type:
+///
+/// ```
+/// class ViewModel {
+///     /// Calls observers/subscribers whenever a feature's availability changes.
+///     private let isFeatureAvailable = BehaviorSubject<Bool>()
+/// }
+/// ```
+///
+/// Since `BehaviorSubject` exposes `send()` which makes this a **mutable** Observable, we recommend
+/// exposing only the `Observable<Bool>` interface:
+///
+/// ```
+/// class ViewModel {
+///     private let isFeatureAvailableSubject = BehaviorSubject<Bool>()
+///
+///     /// The public Observable that the ViewController will subscribe to
+///     var isFeatureAvailable: Observable<Bool> {
+///         isFeatureAvailableSubject
+///     }
+/// }
+/// ```
+///
+/// The `ViewController` can then subscribe to the `isFeatureAvailable` Observable:
+///
+/// ```
+/// func viewDidLoad() {
+///     viewModel.isFeatureAvailable.subscribe { isAvailable in
+///         // Present an amazing new UI if the feature is available
+///         self.featureSubview.isHidden = !isAvailable
+///     }
+/// }
+/// ```
+///
+/// Whenever the conditions for the feature's availability changes, like after fetching a setting
+/// from the API, the `ViewModel` can _notify_ the `ViewController` by updating
+/// `isFeatureAvailableSubject`:
+///
+/// ```
+/// fetchFromAPI { isFeatureAvailable
+///     // Notify the observers (e.g. ViewController) that the feature availability has changed.
+///     isFeatureAvailableSubject.send(isFeatureAvailable)
+/// }
+/// ```
+///
+/// ## References
+///
+/// See here for info about similar observables in other frameworks:
+///
+/// - https://developer.apple.com/documentation/combine/currentvaluesubject
+/// - http://reactivex.io/documentation/subject.html
+///
+final class BehaviorSubject<Element>: Observable<Element> {
+
+    private typealias OnCancel = () -> ()
+
+    /// The list of Observers that will be notified when a new value is sent.
+    ///
+    private var observers = [UUID: Observer<Element>]()
+
+    /// The last value that was emitted or the initial value passed in `init()`.
+    ///
+    private(set) var value: Element
+
+    /// Create an instance of `self` and set the initial `value`.
+    init(_ initialValue: Element) {
+        self.value = initialValue
+        super.init()
+    }
+
+    override func subscribe(_ onNext: @escaping OnNext<Element>) -> ObservationToken {
+        let uuid = UUID()
+
+        let observer = Observer(onNext: onNext)
+
+        observers[uuid] = observer
+
+        // Emit the last value
+        observer.send(value)
+
+        let onCancel: OnCancel = { [weak self] in
+            self?.observers.removeValue(forKey: uuid)
+        }
+
+        return ObservationToken(onCancel: onCancel)
+    }
+
+    /// Emit a new value. All observers are immediately called with the given value.
+    ///
+    func send(_ element: Element) {
+
+        // Save as the last value so we can send this to new subscribers.
+        value = element
+
+        observers.values.forEach { observer in
+            observer.send(element)
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -308,10 +308,10 @@
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CAF24CF006A00D570DD /* ProductTagsDataSource.swift */; };
 		450C2CB324D0803000D570DD /* ProductSettingsRowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CB224D0803000D570DD /* ProductSettingsRowsTests.swift */; };
-		450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CB824D3127500D570DD /* ProductReviewsTableViewCell.swift */; };
-		450C2CBB24D3127500D570DD /* ProductReviewsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 450C2CB924D3127500D570DD /* ProductReviewsTableViewCell.xib */; };
 		450C2CB624D1ABB200D570DD /* ProductImagesGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CB424D1ABB100D570DD /* ProductImagesGalleryViewController.swift */; };
 		450C2CB724D1ABB200D570DD /* ProductImagesGalleryViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 450C2CB524D1ABB200D570DD /* ProductImagesGalleryViewController.xib */; };
+		450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450C2CB824D3127500D570DD /* ProductReviewsTableViewCell.swift */; };
+		450C2CBB24D3127500D570DD /* ProductReviewsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 450C2CB924D3127500D570DD /* ProductReviewsTableViewCell.xib */; };
 		4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512054E2464741B005D68DE /* ProductVisibility.swift */; };
 		4512055224655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512055024655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift */; };
 		4512055324655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4512055124655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib */; };
@@ -406,6 +406,7 @@
 		57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */; };
 		5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */; };
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
+		5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */; };
 		578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578187B12481D9290063B46B /* XCTestCase+Assertions.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
@@ -1226,10 +1227,10 @@
 		4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductVisibilityViewController.xib; sourceTree = "<group>"; };
 		450C2CAF24CF006A00D570DD /* ProductTagsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsDataSource.swift; sourceTree = "<group>"; };
 		450C2CB224D0803000D570DD /* ProductSettingsRowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSettingsRowsTests.swift; sourceTree = "<group>"; };
-		450C2CB824D3127500D570DD /* ProductReviewsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewsTableViewCell.swift; sourceTree = "<group>"; };
-		450C2CB924D3127500D570DD /* ProductReviewsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductReviewsTableViewCell.xib; sourceTree = "<group>"; };
 		450C2CB424D1ABB100D570DD /* ProductImagesGalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesGalleryViewController.swift; sourceTree = "<group>"; };
 		450C2CB524D1ABB200D570DD /* ProductImagesGalleryViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductImagesGalleryViewController.xib; sourceTree = "<group>"; };
+		450C2CB824D3127500D570DD /* ProductReviewsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewsTableViewCell.swift; sourceTree = "<group>"; };
+		450C2CB924D3127500D570DD /* ProductReviewsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductReviewsTableViewCell.xib; sourceTree = "<group>"; };
 		4512054E2464741B005D68DE /* ProductVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVisibility.swift; sourceTree = "<group>"; };
 		4512055024655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndTextFieldWithImageTableViewCell.swift; sourceTree = "<group>"; };
 		4512055124655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndTextFieldWithImageTableViewCell.xib; sourceTree = "<group>"; };
@@ -1324,6 +1325,7 @@
 		57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlus.swift"; sourceTree = "<group>"; };
 		5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlusTests.swift"; sourceTree = "<group>"; };
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
+		5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubjectTests.swift; sourceTree = "<group>"; };
 		578187B12481D9290063B46B /* XCTestCase+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Assertions.swift"; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
@@ -2772,6 +2774,7 @@
 			isa = PBXGroup;
 			children = (
 				5798191224526FE8000817F8 /* PublishSubjectTests.swift */,
+				5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */,
 			);
 			path = Observables;
 			sourceTree = "<group>";
@@ -5484,6 +5487,7 @@
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */,
+				5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 		5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */; };
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
 		5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */; };
+		5778E00E24DB2BA200B65CBF /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */; };
 		578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578187B12481D9290063B46B /* XCTestCase+Assertions.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
@@ -1326,6 +1327,7 @@
 		5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlusTests.swift"; sourceTree = "<group>"; };
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
 		5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubjectTests.swift; sourceTree = "<group>"; };
+		5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubject.swift; sourceTree = "<group>"; };
 		578187B12481D9290063B46B /* XCTestCase+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Assertions.swift"; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
@@ -2766,6 +2768,7 @@
 				5754727A2451F14600A94C3C /* Observable.swift */,
 				5754727C2451F1D800A94C3C /* PublishSubject.swift */,
 				5754727E24520B2A00A94C3C /* Observer.swift */,
+				5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */,
 			);
 			path = Observables;
 			sourceTree = "<group>";
@@ -5089,6 +5092,7 @@
 				02564A8C246CE38E00D6DB2A /* SwappableSubviewContainerView.swift in Sources */,
 				024DF31223742B18006658FE /* AztecItalicFormatBarCommand.swift in Sources */,
 				02EAB6D92480AA4900FD873C /* SentryCrashLogger.swift in Sources */,
+				5778E00E24DB2BA200B65CBF /* BehaviorSubject.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,
 				027D67D1245ADDF40036B8DB /* FilterTypeViewModel+Helpers.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
@@ -140,6 +140,54 @@ final class BehaviorSubjectTests: XCTestCase {
 
     // MARK: - Proof of Compatibility with Combine's PassthroughSubject
 
+    func test_Combine_CurrentValueSubject_will_emit_the_initial_value_to_an_observer() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = CurrentValueSubject<String, Error>("dolorem")
+        var disposeBag = Set<AnyCancellable>()
+
+        // When
+        var emittedValues = [String]()
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dolorem"])
+    }
+
+    func test_Combine_CurrentValueSubject_will_emit_the_last_value_before_the_subscription() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = CurrentValueSubject<String, Error>("dolorem")
+        var disposeBag = Set<AnyCancellable>()
+
+        // This will be emitted instead of "dolorem" when the subscription happens below
+        // because it's the last value.
+        subject.send("recusandae")
+
+        // When
+        var emittedValues = [String]()
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // Then
+        XCTAssertEqual(emittedValues, ["recusandae"])
+    }
+
     func test_Combine_PassthroughSubject_emits_values_to_an_observer() throws {
         guard #available(iOS 13.0, *) else {
             try XCTSkipIf(true, "This test is for iOS 13.0+ only")

--- a/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
@@ -138,7 +138,7 @@ final class BehaviorSubjectTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["dicta"])
     }
 
-    // MARK: - Proof of Compatibility with Combine's PassthroughSubject
+    // MARK: - Proof of Compatibility with Combine's CurrentValueSubject
 
     func test_Combine_CurrentValueSubject_will_emit_the_initial_value_to_an_observer() throws {
         guard #available(iOS 13.0, *) else {
@@ -188,14 +188,14 @@ final class BehaviorSubjectTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["recusandae"])
     }
 
-    func test_Combine_PassthroughSubject_emits_values_to_an_observer() throws {
+    func test_Combine_CurrentValueSubject_emits_values_to_an_observer() throws {
         guard #available(iOS 13.0, *) else {
             try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
         // Given
-        let subject = PassthroughSubject<String, Error>()
+        let subject = CurrentValueSubject<String, Error>("consequatur")
         var disposeBag = Set<AnyCancellable>()
 
         var emittedValues = [String]()
@@ -209,17 +209,17 @@ final class BehaviorSubjectTests: XCTestCase {
         subject.send("dicta")
 
         // Then
-        XCTAssertEqual(emittedValues, ["dicta"])
+        XCTAssertEqual(emittedValues, ["consequatur", "dicta"])
     }
 
-    func test_Combine_PassthroughSubject_continuously_emits_values_to_an_observer() throws {
+    func test_Combine_CurrentValueSubject_continuously_emits_values_to_an_observer() throws {
         guard #available(iOS 13.0, *) else {
             try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
         // Given
-        let subject = PassthroughSubject<String, Error>()
+        let subject = CurrentValueSubject<String, Error>("exercitationem")
         var disposeBag = Set<AnyCancellable>()
 
         var emittedValues = [String]()
@@ -235,48 +235,17 @@ final class BehaviorSubjectTests: XCTestCase {
         subject.send("dolor")
 
         // Then
-        XCTAssertEqual(emittedValues, ["dicta", "amet", "dolor"])
+        XCTAssertEqual(emittedValues, ["exercitationem", "dicta", "amet", "dolor"])
     }
 
-    func test_Combine_PassthroughSubject_does_not_emit_values_before_the_subscription() throws {
+    func test_Combine_CurrentValueSubject_emits_values_to_all_observers() throws {
         guard #available(iOS 13.0, *) else {
             try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
         // Given
-        let subject = PassthroughSubject<String, Error>()
-        var disposeBag = Set<AnyCancellable>()
-
-        var emittedValues = [String]()
-
-        // When
-        // These are not emitted because there's no observer yet
-        subject.send("dicta")
-        subject.send("amet")
-
-        // Add the observer
-        subject.sink(receiveCompletion: { _ in
-            // noop
-        }) { value in
-            emittedValues.append(value)
-        }.store(in: &disposeBag)
-
-        // This will be emitted to the observer
-        subject.send("dolor")
-
-        // Then
-        XCTAssertEqual(emittedValues, ["dolor"])
-    }
-
-    func test_Combine_PassthroughSubject_emits_values_to_all_observers() throws {
-        guard #available(iOS 13.0, *) else {
-            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
-            return
-        }
-
-        // Given
-        let subject = PassthroughSubject<String, Error>()
+        let subject = CurrentValueSubject<String, Error>("provident")
         var disposeBag = Set<AnyCancellable>()
 
         var emittedValues = [String]()
@@ -301,17 +270,18 @@ final class BehaviorSubjectTests: XCTestCase {
 
         // Then
         // We'll receive two values for each observer
-        XCTAssertEqual(emittedValues, ["dicta", "dicta", "amet", "amet"])
+        XCTAssertEqual(emittedValues, ["provident", "provident", "dicta", "dicta", "amet", "amet"])
     }
 
-    func test_Combine_PassthroughSubject_does_not_emit_values_to_cancelled_observers() throws {
+    func test_Combine_CurrentValueSubject_does_not_emit_values_to_cancelled_observers() throws {
         guard #available(iOS 13.0, *) else {
             try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
         // Given
-        let subject = PassthroughSubject<String, Error>()
+        // "dicta" will be emitted because it is the initial value
+        let subject = CurrentValueSubject<String, Error>("dicta")
 
         var emittedValues = [String]()
         let cancellable = subject.sink(receiveCompletion: { _ in
@@ -319,9 +289,6 @@ final class BehaviorSubjectTests: XCTestCase {
         }) { value in
             emittedValues.append(value)
         }
-
-        // This will be emitted because the observer is active
-        subject.send("dicta")
 
         // When
         // Cancel the observer

--- a/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
@@ -9,9 +9,50 @@ import Combine
 ///
 final class BehaviorSubjectTests: XCTestCase {
 
+    func test_it_will_emit_the_initial_value_to_an_observer() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        #warning("replace with initial value call")
+        subject.send("dolorem")
+
+        // When
+        var emittedValues = [String]()
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dolorem"])
+    }
+
+    func test_it_will_emit_the_last_value_before_the_subscription() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        #warning("replace with initial value call")
+        subject.send("dolorem")
+
+        // This will be emitted instead of "dolorem" when the subscription happens below
+        // because it's the last value.
+        subject.send("recusandae")
+
+        // When
+        var emittedValues = [String]()
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // Then
+        XCTAssertEqual(emittedValues, ["recusandae"])
+    }
+
     func test_it_will_emit_values_to_an_observer() {
         // Given
         let subject = PublishSubject<String>()
+
+        #warning("replace with initial value call")
+        subject.send("consequatur")
 
         var emittedValues = [String]()
         _ = subject.subscribe { value in
@@ -22,13 +63,16 @@ final class BehaviorSubjectTests: XCTestCase {
         subject.send("dicta")
 
         // Then
-        XCTAssertEqual(emittedValues, ["dicta"])
+        XCTAssertEqual(emittedValues, ["consequatur", "dicta"])
     }
 
     func test_it_will_continuously_emit_values_to_an_observer() {
         // Given
         let subject = PublishSubject<String>()
 
+        #warning("replace with initial value call")
+        subject.send("exercitationem")
+
         var emittedValues = [String]()
         _ = subject.subscribe { value in
             emittedValues.append(value)
@@ -40,35 +84,15 @@ final class BehaviorSubjectTests: XCTestCase {
         subject.send("dolor")
 
         // Then
-        XCTAssertEqual(emittedValues, ["dicta", "amet", "dolor"])
-    }
-
-    func test_it_will_not_emit_values_before_the_subscription() {
-        // Given
-        let subject = PublishSubject<String>()
-
-        var emittedValues = [String]()
-
-        // When
-        // These are not emitted because there's no observer yet
-        subject.send("dicta")
-        subject.send("amet")
-
-        // Add the observer
-        _ = subject.subscribe { value in
-            emittedValues.append(value)
-        }
-
-        // This will be emitted to the observer
-        subject.send("dolor")
-
-        // Then
-        XCTAssertEqual(emittedValues, ["dolor"])
+        XCTAssertEqual(emittedValues, ["exercitationem", "dicta", "amet", "dolor"])
     }
 
     func test_it_will_emit_values_to_all_observers() {
         // Given
         let subject = PublishSubject<String>()
+
+        #warning("replace with initial value call")
+        subject.send("provident")
 
         var emittedValues = [String]()
 
@@ -87,20 +111,21 @@ final class BehaviorSubjectTests: XCTestCase {
 
         // Then
         // We'll receive two values for each observer
-        XCTAssertEqual(emittedValues, ["dicta", "dicta", "amet", "amet"])
+        XCTAssertEqual(emittedValues, ["provident", "provident", "dicta", "dicta", "amet", "amet"])
     }
 
     func test_it_will_not_emit_values_to_cancelled_observers() {
         // Given
         let subject = PublishSubject<String>()
 
+        #warning("replace with initial value call")
+        // "dicta" will be emitted because it is the initial value
+        subject.send("dicta")
+
         var emittedValues = [String]()
         let observationToken = subject.subscribe { value in
             emittedValues.append(value)
         }
-
-        // This will be emitted because the observer is active
-        subject.send("dicta")
 
         // When
         // Cancel the observer

--- a/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
@@ -1,0 +1,263 @@
+
+import XCTest
+import Foundation
+@testable import WooCommerce
+
+import Combine
+
+/// Tests cases for `BehaviorSubject`
+///
+final class BehaviorSubjectTests: XCTestCase {
+
+    func test_it_will_emit_values_to_an_observer() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        var emittedValues = [String]()
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // When
+        subject.send("dicta")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dicta"])
+    }
+
+    func test_it_will_continuously_emit_values_to_an_observer() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        var emittedValues = [String]()
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // When
+        subject.send("dicta")
+        subject.send("amet")
+        subject.send("dolor")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dicta", "amet", "dolor"])
+    }
+
+    func test_it_will_not_emit_values_before_the_subscription() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        var emittedValues = [String]()
+
+        // When
+        // These are not emitted because there's no observer yet
+        subject.send("dicta")
+        subject.send("amet")
+
+        // Add the observer
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // This will be emitted to the observer
+        subject.send("dolor")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dolor"])
+    }
+
+    func test_it_will_emit_values_to_all_observers() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        var emittedValues = [String]()
+
+        // First observer
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+        // Second observer
+        _ = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // When
+        subject.send("dicta")
+        subject.send("amet")
+
+        // Then
+        // We'll receive two values for each observer
+        XCTAssertEqual(emittedValues, ["dicta", "dicta", "amet", "amet"])
+    }
+
+    func test_it_will_not_emit_values_to_cancelled_observers() {
+        // Given
+        let subject = PublishSubject<String>()
+
+        var emittedValues = [String]()
+        let observationToken = subject.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // This will be emitted because the observer is active
+        subject.send("dicta")
+
+        // When
+        // Cancel the observer
+        observationToken.cancel()
+
+        // This will not be emitted anymore
+        subject.send("amet")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dicta"])
+    }
+
+    // MARK: - Proof of Compatibility with Combine's PassthroughSubject
+
+    func test_Combine_PassthroughSubject_emits_values_to_an_observer() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = PassthroughSubject<String, Error>()
+        var disposeBag = Set<AnyCancellable>()
+
+        var emittedValues = [String]()
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // When
+        subject.send("dicta")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dicta"])
+    }
+
+    func test_Combine_PassthroughSubject_continuously_emits_values_to_an_observer() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = PassthroughSubject<String, Error>()
+        var disposeBag = Set<AnyCancellable>()
+
+        var emittedValues = [String]()
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // When
+        subject.send("dicta")
+        subject.send("amet")
+        subject.send("dolor")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dicta", "amet", "dolor"])
+    }
+
+    func test_Combine_PassthroughSubject_does_not_emit_values_before_the_subscription() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = PassthroughSubject<String, Error>()
+        var disposeBag = Set<AnyCancellable>()
+
+        var emittedValues = [String]()
+
+        // When
+        // These are not emitted because there's no observer yet
+        subject.send("dicta")
+        subject.send("amet")
+
+        // Add the observer
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // This will be emitted to the observer
+        subject.send("dolor")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dolor"])
+    }
+
+    func test_Combine_PassthroughSubject_emits_values_to_all_observers() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = PassthroughSubject<String, Error>()
+        var disposeBag = Set<AnyCancellable>()
+
+        var emittedValues = [String]()
+
+        // First observer
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // Second observer
+        subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }.store(in: &disposeBag)
+
+        // When
+        subject.send("dicta")
+        subject.send("amet")
+
+        // Then
+        // We'll receive two values for each observer
+        XCTAssertEqual(emittedValues, ["dicta", "dicta", "amet", "amet"])
+    }
+
+    func test_Combine_PassthroughSubject_does_not_emit_values_to_cancelled_observers() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = PassthroughSubject<String, Error>()
+
+        var emittedValues = [String]()
+        let cancellable = subject.sink(receiveCompletion: { _ in
+            // noop
+        }) { value in
+            emittedValues.append(value)
+        }
+
+        // This will be emitted because the observer is active
+        subject.send("dicta")
+
+        // When
+        // Cancel the observer
+        cancellable.cancel()
+
+        // This will not be emitted anymore
+        subject.send("amet")
+
+        // Then
+        XCTAssertEqual(emittedValues, ["dicta"])
+    }
+}

--- a/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
@@ -9,6 +9,23 @@ import Combine
 ///
 final class BehaviorSubjectTests: XCTestCase {
 
+    func test_it_keeps_the_initial_value() {
+        let subject = BehaviorSubject("dolorem")
+
+        XCTAssertEqual(subject.value, "dolorem")
+    }
+
+    func test_it_keeps_the_last_emitted_value() {
+        // Given
+        let subject = BehaviorSubject("dolorem")
+
+        // When
+        subject.send("autem")
+
+        // Then
+        XCTAssertEqual(subject.value, "autem")
+    }
+
     func test_it_will_emit_the_initial_value_to_an_observer() {
         // Given
         let subject = BehaviorSubject("dolorem")
@@ -121,6 +138,33 @@ final class BehaviorSubjectTests: XCTestCase {
     }
 
     // MARK: - Proof of Compatibility with Combine's CurrentValueSubject
+
+    func test_Combine_CurrentValueSubject_keeps_the_initial_value() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        let subject = CurrentValueSubject<String, Error>("dolorem")
+
+        XCTAssertEqual(subject.value, "dolorem")
+    }
+
+    func test_Combine_CurrentValueSubject_keeps_the_last_emitted_value() throws {
+        guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
+            return
+        }
+
+        // Given
+        let subject = CurrentValueSubject<String, Error>("dolorem")
+
+        // When
+        subject.send("autem")
+
+        // Then
+        XCTAssertEqual(subject.value, "autem")
+    }
 
     func test_Combine_CurrentValueSubject_will_emit_the_initial_value_to_an_observer() throws {
         guard #available(iOS 13.0, *) else {

--- a/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift
@@ -11,10 +11,7 @@ final class BehaviorSubjectTests: XCTestCase {
 
     func test_it_will_emit_the_initial_value_to_an_observer() {
         // Given
-        let subject = PublishSubject<String>()
-
-        #warning("replace with initial value call")
-        subject.send("dolorem")
+        let subject = BehaviorSubject("dolorem")
 
         // When
         var emittedValues = [String]()
@@ -28,10 +25,7 @@ final class BehaviorSubjectTests: XCTestCase {
 
     func test_it_will_emit_the_last_value_before_the_subscription() {
         // Given
-        let subject = PublishSubject<String>()
-
-        #warning("replace with initial value call")
-        subject.send("dolorem")
+        let subject = BehaviorSubject("dolorem")
 
         // This will be emitted instead of "dolorem" when the subscription happens below
         // because it's the last value.
@@ -49,10 +43,7 @@ final class BehaviorSubjectTests: XCTestCase {
 
     func test_it_will_emit_values_to_an_observer() {
         // Given
-        let subject = PublishSubject<String>()
-
-        #warning("replace with initial value call")
-        subject.send("consequatur")
+        let subject = BehaviorSubject("consequatur")
 
         var emittedValues = [String]()
         _ = subject.subscribe { value in
@@ -68,10 +59,7 @@ final class BehaviorSubjectTests: XCTestCase {
 
     func test_it_will_continuously_emit_values_to_an_observer() {
         // Given
-        let subject = PublishSubject<String>()
-
-        #warning("replace with initial value call")
-        subject.send("exercitationem")
+        let subject = BehaviorSubject("exercitationem")
 
         var emittedValues = [String]()
         _ = subject.subscribe { value in
@@ -89,10 +77,7 @@ final class BehaviorSubjectTests: XCTestCase {
 
     func test_it_will_emit_values_to_all_observers() {
         // Given
-        let subject = PublishSubject<String>()
-
-        #warning("replace with initial value call")
-        subject.send("provident")
+        let subject = BehaviorSubject("provident")
 
         var emittedValues = [String]()
 
@@ -116,11 +101,8 @@ final class BehaviorSubjectTests: XCTestCase {
 
     func test_it_will_not_emit_values_to_cancelled_observers() {
         // Given
-        let subject = PublishSubject<String>()
-
-        #warning("replace with initial value call")
         // "dicta" will be emitted because it is the initial value
-        subject.send("dicta")
+        let subject = BehaviorSubject("dicta")
 
         var emittedValues = [String]()
         let observationToken = subject.subscribe { value in

--- a/WooCommerce/WooCommerceTests/Tools/Observables/PublishSubjectTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Observables/PublishSubjectTests.swift
@@ -115,8 +115,9 @@ final class PublishSubjectTests: XCTestCase {
 
     // MARK: - Proof of Compatibility with Combine's PassthroughSubject
 
-    func testCombinePassthroughSubjectEmitsValuesToAnObserver() {
+    func testCombinePassthroughSubjectEmitsValuesToAnObserver() throws {
         guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
@@ -138,8 +139,9 @@ final class PublishSubjectTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["dicta"])
     }
 
-    func testCombinePassthroughSubjectContinuouslyEmitsValuesToAnObserver() {
+    func testCombinePassthroughSubjectContinuouslyEmitsValuesToAnObserver() throws {
         guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
@@ -163,8 +165,9 @@ final class PublishSubjectTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["dicta", "amet", "dolor"])
     }
 
-    func testCombinePassthroughSubjectDoesNotEmitValuesBeforeTheSubscription() {
+    func testCombinePassthroughSubjectDoesNotEmitValuesBeforeTheSubscription() throws {
         guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
@@ -193,8 +196,9 @@ final class PublishSubjectTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["dolor"])
     }
 
-    func testCombinePassthroughSubjectEmitsValuesToAllObservers() {
+    func testCombinePassthroughSubjectEmitsValuesToAllObservers() throws {
         guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 
@@ -227,8 +231,9 @@ final class PublishSubjectTests: XCTestCase {
         XCTAssertEqual(emittedValues, ["dicta", "dicta", "amet", "amet"])
     }
 
-    func testCombinePassthroughSubjectDoesNotEmitValuesToCancelledObservers() {
+    func testCombinePassthroughSubjectDoesNotEmitValuesToCancelledObservers() throws {
         guard #available(iOS 13.0, *) else {
+            try XCTSkipIf(true, "This test is for iOS 13.0+ only")
             return
         }
 


### PR DESCRIPTION
## Premise

I'm hoping to use this when implementing #2537. I could not use [`PublishSubject`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/Tools/Observables/PublishSubject.swift) because I needed this behavior provided by Combine's [`CurrentValueSubject`](https://developer.apple.com/documentation/combine/currentvaluesubject) or ReactiveX's [`BehaviorSubject`](http://reactivex.io/documentation/subject.html):

> maintains a buffer of the most recently published element.

## BehaviorSubject

This PR only adds [`BehaviorSubject`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2537-add-behavior-subject/WooCommerce/Classes/Tools/Observables/BehaviorSubject.swift). It is a simple version of one of the Observables/Publishers that Combine supports — [`CurrentValueSubject`](https://developer.apple.com/documentation/combine/currentvaluesubject). I named it as `BehaviorSubject` to avoid conflicts and to also match the similarly featured ReactiveX Observable [with the same name](http://reactivex.io/documentation/subject.html). 

### Example Usage

In a class that you would like to emit values (or events), add the `BehaviorSubject` defining the value type:

```swift
class ViewModel {
    /// Calls observers/subscribers whenever a feature's availability changes.
    private let isFeatureAvailable = BehaviorSubject<Bool>()
}
```

Since `BehaviorSubject` exposes `send()` which makes this a **mutable** Observable, we recommend exposing only the `Observable<Bool>` interface:

```swift
class ViewModel {
    private let isFeatureAvailableSubject = BehaviorSubject<Bool>()

    /// The public Observable that the ViewController will subscribe to
    var isFeatureAvailable: Observable<Bool> {
        isFeatureAvailableSubject
    }
}
```

The `ViewController` can then subscribe to the `isFeatureAvailable` Observable:

```swift
func viewDidLoad() {
    viewModel.isFeatureAvailable.subscribe { isAvailable in
        // Present an amazing new UI if the feature is available
        self.featureSubview.isHidden = !isAvailable
    }
}
```

Whenever the conditions for the feature's availability changes, like after fetching a setting from the API, the `ViewModel` can _notify_ the `ViewController` by updating `isFeatureAvailableSubject`:

```swift
fetchFromAPI { isFeatureAvailable
    // Notify the observers (e.g. ViewController) that the feature availability has changed.
    isFeatureAvailableSubject.send(isFeatureAvailable)
}
```

### Compatibility with Combine

I made sure to implement this in a way that we can replace this with `CurrentValueSubject` later. The [`BehaviorSubjectTests`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2537-add-behavior-subject/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift) are grouped into two sections:

1. The [tests for `BehaviorSubject`](https://github.com/woocommerce/woocommerce-ios/blob/afbeddb22beb8d6e0c817548cd63720d105ba954/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift#L12-L138).
2. [Similar feature tests but using Combine's `CurrentValueSubject`](https://github.com/woocommerce/woocommerce-ios/blob/afbeddb22beb8d6e0c817548cd63720d105ba954/WooCommerce/WooCommerceTests/Tools/Observables/BehaviorSubjectTests.swift#L140-L328).

In the tests, you can also see that their usages are quite similar. 

## Testing

The changes are currently unused. Please review the unit tests instead. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

