### PR TITLE
Add AppSettingsAction.loadInAppFeedbackCardVisibility

### DIFF
--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */; };
 		572F2B8D247312E4005A5F74 /* StorageManagerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */; };
 		573B448B2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */; };
+		5758EB3024DC7791009ED8A6 /* InAppFeedbackCardVisibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5758EB2F24DC7791009ED8A6 /* InAppFeedbackCardVisibilityUseCase.swift */; };
+		5758EB3324DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5758EB3224DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift */; };
 		578CE7882475D70F00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7872475D70E00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift */; };
 		578CE78C2475E7A500492EBF /* MockNotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */; };
 		578CE7902475EBAB00492EBF /* MockProductReviewsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */; };
@@ -340,6 +342,8 @@
 		570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCase.swift; sourceTree = "<group>"; };
 		572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManagerConcurrencyTests.swift; sourceTree = "<group>"; };
 		573B448A2424082B00E71ADC /* OrderStoreTests+FetchFilteredAndAllOrders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStoreTests+FetchFilteredAndAllOrders.swift"; sourceTree = "<group>"; };
+		5758EB2F24DC7791009ED8A6 /* InAppFeedbackCardVisibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardVisibilityUseCase.swift; sourceTree = "<group>"; };
+		5758EB3224DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardVisibilityUseCaseTests.swift; sourceTree = "<group>"; };
 		578CE7872475D70E00492EBF /* RetrieveProductReviewFromNoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCaseTests.swift; sourceTree = "<group>"; };
 		578CE78B2475E7A500492EBF /* MockNotificationsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationsRemote.swift; sourceTree = "<group>"; };
 		578CE78F2475EBAB00492EBF /* MockProductReviewsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductReviewsRemote.swift; sourceTree = "<group>"; };
@@ -692,6 +696,22 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
+		5758EB2E24DC7777009ED8A6 /* AppSettings */ = {
+			isa = PBXGroup;
+			children = (
+				5758EB2F24DC7791009ED8A6 /* InAppFeedbackCardVisibilityUseCase.swift */,
+			);
+			path = AppSettings;
+			sourceTree = "<group>";
+		};
+		5758EB3124DC961E009ED8A6 /* AppSettings */ = {
+			isa = PBXGroup;
+			children = (
+				5758EB3224DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift */,
+			);
+			path = AppSettings;
+			sourceTree = "<group>";
+		};
 		578CE7862475D6FA00492EBF /* ProductReview */ = {
 			isa = PBXGroup;
 			children = (
@@ -851,6 +871,7 @@
 		B5BC736320D1A98500B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				5758EB2E24DC7777009ED8A6 /* AppSettings */,
 				570B05CD246B6A2F00C186AE /* ProductReview */,
 				0212AC5F242C680800C51F6C /* Enums */,
 				B5BC736420D1A98500B5B6FA /* AccountStore.swift */,
@@ -883,6 +904,7 @@
 		B5BC736620D1AA8F00B5B6FA /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				5758EB3124DC961E009ED8A6 /* AppSettings */,
 				578CE7862475D6FA00492EBF /* ProductReview */,
 				D87F615D2265B1BC0031A13B /* AppSettingsStoreTests.swift */,
 				0202B6982387B01500F3EBE0 /* AppSettingsStoreTests+ProductsFeatureSwitch.swift */,
@@ -1305,6 +1327,7 @@
 				CE3B7AD72225ECA90050FE4B /* OrderStatusStore.swift in Sources */,
 				B5631ECD2114DF8C008D3535 /* EntityListener.swift in Sources */,
 				D80F758A223F72AA002F4A3B /* ShipmentTrackingProviderGroup+ReadOnlyConvertible.swift in Sources */,
+				5758EB3024DC7791009ED8A6 /* InAppFeedbackCardVisibilityUseCase.swift in Sources */,
 				7471401321877A8B009A11CC /* NotificationStore.swift in Sources */,
 				74D42DBA221C978D00B4977D /* ShipmentTracking+ReadOnlyType.swift in Sources */,
 				B5DC3CB120D1B8720063AC41 /* AccountAction.swift in Sources */,
@@ -1492,6 +1515,7 @@
 				02BA23C622EEF092009539E7 /* StatsV4AvailabilityStoreTests.swift in Sources */,
 				0202B6972387AFBF00F3EBE0 /* MockInMemoryStorage.swift in Sources */,
 				028BCE2422DE22BB00056966 /* SiteVisitStatsStoreErrorTests.swift in Sources */,
+				5758EB3324DC9631009ED8A6 /* InAppFeedbackCardVisibilityUseCaseTests.swift in Sources */,
 				B5F2AE9520EBAD6000FEDC59 /* ResultsControllerTests.swift in Sources */,
 				B5BC736E20D1AB3600B5B6FA /* Constants.swift in Sources */,
 				02FF055D23D9846A0058E6E7 /* FileManager+URLTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -79,4 +79,13 @@ public enum AppSettingsAction: Action {
     /// feedback prompt (https://git.io/JJ8i0).
     ///
     case setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
+
+    /// Returns whether the In-app Feedback Card should be shown to the user.
+    ///
+    /// The result is only `true` if these conditions are met:
+    ///
+    /// - The known installation date is more than 3 months ago
+    /// - The user has not given feedback for more than 6 months ago.
+    ///
+    case loadInAppFeedbackCardVisibility(onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -71,18 +71,15 @@ struct InAppFeedbackCardVisibilityUseCase {
     /// consider the users who have already installed before we started tracking that value.
     ///
     private func inferInstallationDate() -> Date? {
-        let documentDirCreationDate = creationDateOfDocumentDir()
-        let savedInstallationDate = settings.installationDate
-
-        if let documentDirCreationDate = documentDirCreationDate,
-            let savedInstallationDate = savedInstallationDate {
-            return min(documentDirCreationDate, savedInstallationDate)
-        } else if documentDirCreationDate != nil {
-            return documentDirCreationDate
-        } else if savedInstallationDate != nil {
-            return savedInstallationDate
-        } else {
-            return nil
+        switch (creationDateOfDocumentDir(), settings.installationDate) {
+            case let (documentDirCreationDate?, savedInstallationDate?):
+                return min(documentDirCreationDate, savedInstallationDate)
+            case let (documentDirCreationDate?, nil):
+                return documentDirCreationDate
+            case let (nil, savedInstallationDate?):
+                return savedInstallationDate
+            default:
+                return nil
         }
     }
 

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -2,7 +2,15 @@ import Foundation
 
 import Storage
 
+/// Calculates whether the app should display the In-app Feedback Card to the user.
+///
+/// The result is only `true` if these conditions are met:
+///
+/// - The known installation date is more than 3 months ago
+/// - The user has not given feedback for more than 6 months ago.
+///
 struct InAppFeedbackCardVisibilityUseCase {
+    /// Errors returned by this UseCase.
     enum InferenceError: Error {
         case failedToInferInstallationDate
         case unexpectedCalendarResult
@@ -19,6 +27,10 @@ struct InAppFeedbackCardVisibilityUseCase {
         self.calendar = calendar
     }
 
+    /// Returns whether the In-app Feedback Card should be displayed.
+    ///
+    /// - Parameter currentDate The current date. This is only used for consistency in unit tests.
+    ///
     func shouldBeVisible(currentDate: Date = Date()) throws -> Bool {
         guard let installationDate = inferInstallationDate() else {
             throw InferenceError.failedToInferInstallationDate
@@ -39,6 +51,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         return true
     }
 
+    /// Returns the total number of days between `from` and `to`.
     private func numberOfDays(from: Date, to: Date) throws -> Int {
         let components = [.day] as Set<Calendar.Component>
         let dateComponents = calendar.dateComponents(components, from: from, to: to)
@@ -49,6 +62,14 @@ struct InAppFeedbackCardVisibilityUseCase {
         return days
     }
 
+    /// Retrieve the installation date.
+    ///
+    /// Checks both the date of `GeneralAppSettings.installationDate` and the creation date of the
+    /// Documents directory. The oldest of the two will be returned.
+    ///
+    /// We could simply just use the `GeneralAppSettings.installationDate` but we also have to
+    /// consider the users who have already installed before we started tracking that value.
+    ///
     private func inferInstallationDate() -> Date? {
         let documentDirCreationDate = creationDateOfDocumentDir()
         let savedInstallationDate = settings.installationDate
@@ -65,6 +86,11 @@ struct InAppFeedbackCardVisibilityUseCase {
         }
     }
 
+    /// Retrieve the date that the app's Documents directory was created.
+    ///
+    /// This value is used as a way to determine when the app was installed. There doesn't seem
+    /// to be an API to check the true installation date.
+    ///
     private func creationDateOfDocumentDir() -> Date? {
         guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).last,
             let attributes = try? fileManager.attributesOfItem(atPath: documentsURL.path) else {
@@ -79,7 +105,11 @@ struct InAppFeedbackCardVisibilityUseCase {
 
 private extension InAppFeedbackCardVisibilityUseCase {
     enum Constants {
+        /// The mininum number of days after the user has installed the app before we should
+        /// ask for feedback.
         static let minimumInstallAgeInDays = 3 * 30
+        /// The minimum number of days after the user's last feedback before we should ask
+        /// for another feedback.
         static let feedbackFrequencyInDays = 6 * 30
     }
 }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+import Storage
+
+struct InAppFeedbackCardVisibilityUseCase {
+    enum InferenceError: Error {
+        case failedToInferInstallationDate
+        case unexpectedCalendarResult
+    }
+
+    private let fileManager: FileManager
+    private let calendar: Calendar
+
+    private let settings: GeneralAppSettings
+
+    init(settings: GeneralAppSettings, fileManager: FileManager = FileManager.default, calendar: Calendar = .current) {
+        self.settings = settings
+        self.fileManager = fileManager
+        self.calendar = calendar
+    }
+
+    func shouldBeVisible(currentDate: Date = Date()) throws -> Bool {
+        guard let installationDate = inferInstallationDate() else {
+            throw InferenceError.failedToInferInstallationDate
+        }
+
+        if try numberOfDays(from: installationDate, to: currentDate) < Constants.minimumInstallAgeInDays {
+            return false
+        }
+
+        guard let lastFeedbackDate = settings.lastFeedbackDate else {
+            return true
+        }
+
+        if try numberOfDays(from: lastFeedbackDate, to: currentDate) < Constants.feedbackFrequencyInDays {
+            return false
+        }
+
+        return true
+    }
+
+    private func numberOfDays(from: Date, to: Date) throws -> Int {
+        let components = [.day] as Set<Calendar.Component>
+        let dateComponents = calendar.dateComponents(components, from: from, to: to)
+        guard let days = dateComponents.day else {
+            throw InferenceError.unexpectedCalendarResult
+        }
+
+        return days
+    }
+
+    private func inferInstallationDate() -> Date? {
+        let documentDirCreationDate = creationDateOfDocumentDir()
+        let savedInstallationDate = settings.installationDate
+
+        if let documentDirCreationDate = documentDirCreationDate,
+            let savedInstallationDate = savedInstallationDate {
+            return min(documentDirCreationDate, savedInstallationDate)
+        } else if documentDirCreationDate != nil {
+            return documentDirCreationDate
+        } else if savedInstallationDate != nil {
+            return savedInstallationDate
+        } else {
+            return nil
+        }
+    }
+
+    private func creationDateOfDocumentDir() -> Date? {
+        guard let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).last,
+            let attributes = try? fileManager.attributesOfItem(atPath: documentsURL.path) else {
+                return nil
+        }
+
+        return attributes[.creationDate] as? Date
+    }
+}
+
+// MARK: - Constants
+
+private extension InAppFeedbackCardVisibilityUseCase {
+    enum Constants {
+        static let minimumInstallAgeInDays = 3 * 30
+        static let feedbackFrequencyInDays = 6 * 30
+    }
+}

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -132,7 +132,7 @@ private extension AppSettingsStore {
     ///
     func setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Bool, Error>) -> Void)) {
         do {
-            let settings = try loadOrCreateGeneralAppSettings()
+            let settings = loadOrCreateGeneralAppSettings()
 
             if let installationDate = settings.installationDate,
                 date > installationDate {
@@ -152,7 +152,7 @@ private extension AppSettingsStore {
     ///
     func setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void)) {
         do {
-            let settings = try loadOrCreateGeneralAppSettings()
+            let settings = loadOrCreateGeneralAppSettings()
 
             let settingsToSave = GeneralAppSettings(installationDate: settings.installationDate, lastFeedbackDate: date)
             try saveGeneralAppSettings(settingsToSave)
@@ -164,8 +164,8 @@ private extension AppSettingsStore {
     }
 
     /// Load the `GeneralAppSettings` from file or create an empty one if it doesn't exist.
-    func loadOrCreateGeneralAppSettings() throws -> GeneralAppSettings {
-        guard let settings: GeneralAppSettings = try fileStorage.data(for: generalAppSettingsFileURL) else {
+    func loadOrCreateGeneralAppSettings() -> GeneralAppSettings {
+        guard let settings: GeneralAppSettings = try? fileStorage.data(for: generalAppSettingsFileURL) else {
             return GeneralAppSettings(installationDate: nil, lastFeedbackDate: nil)
         }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -117,6 +117,8 @@ public class AppSettingsStore: Store {
             setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
         case .setLastFeedbackDate(let date, let onCompletion):
             setLastFeedbackDate(date: date, onCompletion: onCompletion)
+        case .loadInAppFeedbackCardVisibility(let onCompletion):
+            loadInAppFeedbackCardVisibility(onCompletion: onCompletion)
         }
     }
 }
@@ -161,6 +163,15 @@ private extension AppSettingsStore {
         } catch {
             onCompletion(.failure(error))
         }
+    }
+
+    func loadInAppFeedbackCardVisibility(onCompletion: (Result<Bool, Error>) -> Void) {
+        let settings = loadOrCreateGeneralAppSettings()
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings)
+
+        onCompletion(Result {
+            try useCase.shouldBeVisible()
+        })
     }
 
     /// Load the `GeneralAppSettings` from file or create an empty one if it doesn't exist.

--- a/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
@@ -6,6 +6,7 @@ import XCTest
 final class MockupFileManager: FileManager {
     var dataByFilePath: [String: Data] = [:]
 
+    /// The mocked results for the `attributesOfItem(atPath:)`.
     private var attributesOfItemResults = [String: [FileAttributeKey: Any]]()
 
     override func fileExists(atPath path: String) -> Bool {
@@ -34,6 +35,7 @@ final class MockupFileManager: FileManager {
 // MARK: - Mocking
 
 extension MockupFileManager {
+    /// Sets the return value when `attributesOfItem(atPath:)` is called.
     func whenRetrievingAttributesOfItem(atPath path: String, thenReturn: [FileAttributeKey: Any]) {
         attributesOfItemResults[path] = thenReturn
     }

--- a/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockupFileManager.swift
@@ -1,9 +1,12 @@
 import Foundation
+import XCTest
 
 /// A subclass of `FileManager` where the file existence is based on a dictionary whose key is the file path.
 ///
 final class MockupFileManager: FileManager {
     var dataByFilePath: [String: Data] = [:]
+
+    private var attributesOfItemResults = [String: [FileAttributeKey: Any]]()
 
     override func fileExists(atPath path: String) -> Bool {
         return dataByFilePath[path] != nil
@@ -16,5 +19,22 @@ final class MockupFileManager: FileManager {
 
     override func removeItem(at URL: URL) throws {
         dataByFilePath.removeValue(forKey: URL.path)
+    }
+
+    override func attributesOfItem(atPath path: String) throws -> [FileAttributeKey: Any] {
+        guard let attributes = attributesOfItemResults[path] else {
+            XCTFail("No mocked attributes for path \(path)")
+            return [:]
+        }
+
+        return attributes
+    }
+}
+
+// MARK: - Mocking
+
+extension MockupFileManager {
+    func whenRetrievingAttributesOfItem(atPath path: String, thenReturn: [FileAttributeKey: Any]) {
+        attributesOfItemResults[path] = thenReturn
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import Yosemite
+import struct Storage.GeneralAppSettings
+
+final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
+
+    private var dateFormatter: DateFormatter!
+    private var calendar: Calendar!
+    private var fileManager: MockupFileManager!
+
+    override func setUp() {
+        super.setUp()
+        dateFormatter = DateFormatter.Defaults.iso8601
+        calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = dateFormatter.timeZone
+        fileManager = MockupFileManager()
+    }
+
+    override func tearDown() {
+        fileManager = MockupFileManager()
+        calendar = nil
+        dateFormatter = nil
+        super.tearDown()
+    }
+
+    func test_shouldBeVisible_is_false_if_installationDate_is_less_than_90_days_ago() throws {
+        // Given
+        let installationDate = try date(from: "2020-08-08T00:00:00Z")
+        let currentDate = try date(from: "2020-11-05T23:59:59Z")
+        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: nil)
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertFalse(shouldBeVisible)
+    }
+
+    func test_shouldBeVisible_is_false_if_lastFeedback_is_less_than_180_days_ago() throws {
+        // Given
+        let installationDate = try date(from: "2020-08-08T00:00:00Z")
+        let lastFeedbackDate = try date(from: "2020-11-06T00:00:00Z")
+        let currentDate = try date(from: "2021-05-04T23:59:59Z")
+        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: lastFeedbackDate)
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertFalse(shouldBeVisible)
+    }
+
+    func test_shouldBeVisible_is_true_if_lastFeedback_is_more_than_or_equal_to_180_days_ago() throws {
+        // Given
+        let installationDate = try date(from: "2020-08-08T00:00:00Z")
+        let lastFeedbackDate = try date(from: "2020-11-06T00:00:00Z")
+        let currentDate = try date(from: "2021-05-05T00:00:00Z")
+        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: lastFeedbackDate)
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertTrue(shouldBeVisible)
+    }
+}
+
+// MARK: - Utils
+
+private extension InAppFeedbackCardVisibilityUseCaseTests {
+    func date(from iso8601Date: String) throws -> Date {
+        try XCTUnwrap(dateFormatter.date(from: iso8601Date))
+    }
+
+    func documentDirectoryURL() throws -> URL {
+        try XCTUnwrap(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last)
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -5,6 +5,8 @@ import struct Storage.GeneralAppSettings
 
 private typealias InferenceError = InAppFeedbackCardVisibilityUseCase.InferenceError
 
+/// Test cases for InAppFeedbackCardVisibilityUseCase.
+///
 final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     private var dateFormatter: DateFormatter!

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -324,6 +324,31 @@ final class AppSettingsStoreTests: XCTestCase {
         // The other properties should be kept
         XCTAssertEqual(savedSettings.installationDate, existingSettings.installationDate)
     }
+
+    /// This is more like a simple integration test because most of the logic is tested by
+    /// `InAppFeedbackCardVisibilityUseCase`.
+    ///
+    func test_loadInAppFeedbackCardVisibility_returns_true_if_installationDate_is_more_than_90_days_ago() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+
+        // Set the installation date. We'll set a very old one to make sure that it's older than the
+        // Documents directory which is also considered as an "installation date".
+        subject?.onAction(AppSettingsAction.setInstallationDateIfNecessary(date: Date.distantPast, onCompletion: { _ in
+            // noop
+        }))
+
+        // When
+        var shouldBeVisibleResult: Result<Bool, Error>?
+        let action = AppSettingsAction.loadInAppFeedbackCardVisibility { result in
+            shouldBeVisibleResult = result
+        }
+        subject?.onAction(action)
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).isSuccess)
+        XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).get())
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
Ref #2537

This adds `AppSettingsAction.loadInAppFeedbackCardVisibility`, which determines whether the in-app feedback card should be displayed to the user. 

The result is only `true` if these conditions are met:

- The known installation date is more than 3 months ago
- The user has not given feedback for more than 6 months ago.

These values are based on the actions created in https://github.com/woocommerce/woocommerce-ios/pull/2556. 

## Installation Date

In https://github.com/woocommerce/woocommerce-ios/pull/2556, we added actions to set the `GeneralAppSettings.installationDate`. However, if we simply just use this value, then that will mean that even old users will not be able to see the in-app feedback card **until 3 months** after we've released the in-app feedback feature. 

So we can show the in-app feedback card early to existing users, I added another "installation date" to consider by checking the creation date of the Documents directory:

https://github.com/woocommerce/woocommerce-ios/blob/2f05e04ba3d6af11aebb09f338a53005f78f6dfa/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift#L65-L87

The oldest of the two dates (`GeneralAppSettings.installationDate` and Documents creation date) will be used as the final installation date. 

## Small Fix

While working on this, I found that I made a mistake in `loadOrCreateGeneralAppSettings `:

https://github.com/woocommerce/woocommerce-ios/blob/8c2b080fad70acf91105c3a0bad7bf138b0259b6/Yosemite/Yosemite/Stores/AppSettingsStore.swift#L166-L173

I meant that to auto-recover and create a new `GeneralAppSettings` instance if the file does not exist. I didn't realize that the `fileStorage.data(for:)` fails if the file does not exist. 🙈 I didn't see it initially because I was using a mocked `FileStorage` which behaved a bit differently. 

I fixed this in eea3f95 and ec58890. 

## Testing

The action is currently not used. The follow-up PR should use this. Please review the unit test for now. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

