### PR TITLE
Product Variation > Inventory: hide stock status row when stock management is disabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -321,14 +321,7 @@ private extension ProductInventorySettingsViewController {
     func configureStockStatus(cell: SettingTitleAndValueTableViewCell) {
         let title = NSLocalizedString("Stock status", comment: "Title of the cell in Product Inventory Settings > Stock status")
         cell.updateUI(title: title, value: viewModel.stockStatus?.description)
-
-        // Stock status is only editable for `Product`.
-        if viewModel.isStockStatusEnabled {
-            cell.accessoryType = .disclosureIndicator
-        } else {
-            cell.accessoryType = .none
-            cell.selectionStyle = .none
-        }
+        cell.accessoryType = .disclosureIndicator
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -218,8 +218,10 @@ private extension ProductInventorySettingsViewModel {
             let stockSection: Section
             if manageStockEnabled {
                 stockSection = Section(rows: [.manageStock, .stockQuantity, .backorders])
-            } else {
+            } else if isStockStatusEnabled {
                 stockSection = Section(rows: [.manageStock, .stockStatus])
+            } else {
+                stockSection = Section(rows: [.manageStock])
             }
 
             switch productModel {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductInventorySettingsViewModel+VariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductInventorySettingsViewModel+VariationTests.swift
@@ -59,7 +59,7 @@ final class ProductInventorySettingsViewModel_VariationTests: XCTestCase {
         // Assert
         let expectedSections: [Section] = [
             .init(rows: [.sku]),
-            .init(rows: [.manageStock, .stockStatus])
+            .init(rows: [.manageStock])
         ]
         XCTAssertEqual(sections, expectedSections)
         XCTAssertEqual(viewModel.sku, sku)


### PR DESCRIPTION
Fixes #2596 

## Changes

More context for the change in #2596 (there's a p2 link).

- In `ProductInventorySettingsViewController`, removed the `viewModel.isStockStatusEnabled` condition to configure the stock status cell's accessory type differently now that the cell is only shown when `viewModel.isStockStatusEnabled` is `true`
- In `ProductInventorySettingsViewModel`'s sections setup, updated to hide the stock status row when `isStockStatusEnabled` is `false` (if the model is a variation)
- Updated a test case on a variation's inventory settings section

## Testing

### Variation inventory

- Go to the Products tab
- Tap on a variable product
- Tap on the variations row
- Tap on a variation
- Tap on the inventory row (or from the bottom sheet)
- Turn off the "Manage stock" switch --> the stock status row should not be visible

### Product inventory

- Go to the Products tab
- Tap on a simple product
- Tap on the inventory row (or from the bottom sheet)
- Turn off the "Manage stock" switch --> the stock status row should be visible and editable

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-08-07 at 09 47 28](https://user-images.githubusercontent.com/1945542/89599782-0d1cba00-d893-11ea-90a1-d8dcf5ca42fb.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-07 at 09 46 42](https://user-images.githubusercontent.com/1945542/89599780-0aba6000-d893-11ea-9bf6-3b89670aa537.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
