### PR TITLE
Product Variation: update a variation's SKU to be nil if it's the same as its parent product to fix variation remote update

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -4,12 +4,16 @@ import Yosemite
 final class EditableProductVariationModel {
     let productVariation: ProductVariation
 
+    // Property that requires other dependencies than `ProductVariation`
+    let sku: String?
+
     private let allAttributes: [ProductAttribute]
     private lazy var variationName: String = generateName(variationAttributes: productVariation.attributes, allAttributes: allAttributes)
 
-    init(productVariation: ProductVariation, allAttributes: [ProductAttribute]) {
-        self.productVariation = productVariation
+    init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?) {
         self.allAttributes = allAttributes
+        self.sku = parentProductSKU == productVariation.sku ? nil: productVariation.sku
+        self.productVariation = productVariation.copy(sku: self.sku)
     }
 }
 
@@ -107,10 +111,6 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
 
     var shippingClassID: Int64 {
         productVariation.shippingClassID
-    }
-
-    var sku: String? {
-        productVariation.sku
     }
 
     var manageStock: Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -4,16 +4,17 @@ import Yosemite
 final class EditableProductVariationModel {
     let productVariation: ProductVariation
 
-    // Property that requires other dependencies than `ProductVariation`
-    let sku: String?
-
     private let allAttributes: [ProductAttribute]
     private lazy var variationName: String = generateName(variationAttributes: productVariation.attributes, allAttributes: allAttributes)
 
     init(productVariation: ProductVariation, allAttributes: [ProductAttribute], parentProductSKU: String?) {
         self.allAttributes = allAttributes
-        self.sku = parentProductSKU == productVariation.sku ? nil: productVariation.sku
-        self.productVariation = productVariation.copy(sku: self.sku)
+
+        // API sets a variation's SKU to be its parent product's SKU by default.
+        // However, variation API update will fail if we send the variation's SKU as its parent product's SKU (duplicate SKU error).
+        // As a workaround, we set a variation's SKU to nil if it has the same SKU as its parent product during initialization.
+        let sku = parentProductSKU == productVariation.sku ? nil: productVariation.sku
+        self.productVariation = productVariation.copy(sku: sku)
     }
 }
 
@@ -111,6 +112,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
 
     var shippingClassID: Int64 {
         productVariation.shippingClassID
+    }
+
+    var sku: String? {
+        productVariation.sku
     }
 
     var manageStock: Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -52,15 +52,18 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     }
 
     private let allAttributes: [ProductAttribute]
+    private let parentProductSKU: String?
     private let productImageActionHandler: ProductImageActionHandler
     private let storesManager: StoresManager
     private var cancellable: ObservationToken?
 
     init(productVariation: EditableProductVariationModel,
          allAttributes: [ProductAttribute],
+         parentProductSKU: String?,
          productImageActionHandler: ProductImageActionHandler,
          storesManager: StoresManager = ServiceLocator.stores) {
         self.allAttributes = allAttributes
+        self.parentProductSKU = parentProductSKU
         self.productImageActionHandler = productImageActionHandler
         self.storesManager = storesManager
         self.originalProductVariation = productVariation
@@ -118,12 +121,14 @@ extension ProductVariationFormViewModel {
             return
         }
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(image: images.first),
-                                                         allAttributes: allAttributes)
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
     }
 
     func updateDescription(_ newDescription: String) {
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(description: newDescription),
-                                                         allAttributes: allAttributes)
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
     }
 
     func updatePriceSettings(regularPrice: String?,
@@ -138,7 +143,8 @@ extension ProductVariationFormViewModel {
                                                                                                                   salePrice: salePrice,
                                                                                                                   taxStatusKey: taxStatus.rawValue,
                                                                                                                   taxClass: taxClass?.slug),
-                                                         allAttributes: allAttributes)
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
     }
 
     func updateInventorySettings(sku: String?,
@@ -152,7 +158,8 @@ extension ProductVariationFormViewModel {
                                                                                                                   stockQuantity: stockQuantity,
                                                                                                                   stockStatus: stockStatus,
                                                                                                                   backordersKey: backordersSetting?.rawValue),
-                                                         allAttributes: allAttributes)
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
     }
 
     func updateShippingSettings(weight: String?, dimensions: ProductDimensions, shippingClass: ProductShippingClass?) {
@@ -160,7 +167,8 @@ extension ProductVariationFormViewModel {
                                                  dimensions: dimensions,
                                                  shippingClass: shippingClass?.slug ?? "",
                                                  shippingClassID: shippingClass?.shippingClassID ?? 0),
-                                                         allAttributes: allAttributes)
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
     }
 
     func updateProductCategories(_ categories: [ProductCategory]) {
@@ -194,7 +202,8 @@ extension ProductVariationFormViewModel {
     func updateStatus(_ isEnabled: Bool) {
         let status: ProductStatus = isEnabled ? .publish: .privateStatus
         productVariation = EditableProductVariationModel(productVariation: productVariation.productVariation.copy(status: status),
-                                                         allAttributes: allAttributes)
+                                                         allAttributes: allAttributes,
+                                                         parentProductSKU: parentProductSKU)
     }
 }
 
@@ -210,7 +219,9 @@ extension ProductVariationFormViewModel {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let productVariation):
-                let model = EditableProductVariationModel(productVariation: productVariation, allAttributes: self.allAttributes)
+                let model = EditableProductVariationModel(productVariation: productVariation,
+                                                          allAttributes: self.allAttributes,
+                                                          parentProductSKU: self.parentProductSKU)
                 self.resetProductVariation(model)
                 onCompletion(.success(model))
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -64,6 +64,7 @@ final class ProductVariationsViewController: UIViewController {
     private let siteID: Int64
     private let productID: Int64
     private let allAttributes: [ProductAttribute]
+    private let parentProductSKU: String?
 
     private let imageService: ImageService = ServiceLocator.imageService
     private let isEditProductsRelease3Enabled: Bool
@@ -72,6 +73,7 @@ final class ProductVariationsViewController: UIViewController {
         self.siteID = product.siteID
         self.productID = product.productID
         self.allAttributes = product.attributes
+        self.parentProductSKU = product.sku
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         super.init(nibName: nil, bundle: nil)
     }
@@ -198,7 +200,9 @@ extension ProductVariationsViewController: UITableViewDataSource {
         }
 
         let productVariation = resultsController.object(at: indexPath)
-        let model = EditableProductVariationModel(productVariation: productVariation, allAttributes: allAttributes)
+        let model = EditableProductVariationModel(productVariation: productVariation,
+                                                  allAttributes: allAttributes,
+                                                  parentProductSKU: parentProductSKU)
 
         let currencyCode = CurrencySettings.shared.currencyCode
         let currency = CurrencySettings.shared.symbol(from: currencyCode)
@@ -230,7 +234,9 @@ extension ProductVariationsViewController: UITableViewDelegate {
 
         if isEditProductsRelease3Enabled {
             let productVariation = resultsController.object(at: indexPath)
-            let model = EditableProductVariationModel(productVariation: productVariation, allAttributes: allAttributes)
+            let model = EditableProductVariationModel(productVariation: productVariation,
+                                                      allAttributes: allAttributes,
+                                                      parentProductSKU: parentProductSKU)
 
             let currencyCode = CurrencySettings.shared.currencyCode
             let currency = CurrencySettings.shared.symbol(from: currencyCode)
@@ -238,6 +244,7 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                                       product: model)
             let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                           allAttributes: allAttributes,
+                                                          parentProductSKU: parentProductSKU,
                                                           productImageActionHandler: productImageActionHandler)
             let viewController = ProductFormViewController(viewModel: viewModel,
                                                            productImageActionHandler: productImageActionHandler,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/EditableProductVariationModelTests.swift
@@ -3,6 +3,9 @@ import XCTest
 @testable import Yosemite
 
 final class EditableProductVariationModelTests: XCTestCase {
+
+    // MARK: - `name`
+
     func test_a_variation_with_any_attribute_has_name_that_consists_of_all_attributes() {
         // Arrange
         let allAttributes: [ProductAttribute] = [
@@ -16,7 +19,7 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = MockProductVariation().productVariation().copy(attributes: variationAttributes)
 
         // Action
-        let name = EditableProductVariationModel(productVariation: variation, allAttributes: allAttributes).name
+        let name = EditableProductVariationModel(productVariation: variation, allAttributes: allAttributes, parentProductSKU: nil).name
 
         // Assert
         let expectedName = [
@@ -40,10 +43,38 @@ final class EditableProductVariationModelTests: XCTestCase {
         let variation = MockProductVariation().productVariation().copy(attributes: variationAttributes)
 
         // Action
-        let name = EditableProductVariationModel(productVariation: variation, allAttributes: allAttributes).name
+        let name = EditableProductVariationModel(productVariation: variation, allAttributes: allAttributes, parentProductSKU: nil).name
 
         // Assert
         let expectedName = ["Orange", "House"].joined(separator: " - ")
         XCTAssertEqual(name, expectedName)
+    }
+
+    // MARK: - `sku`
+
+    func test_a_variation_with_the_same_sku_as_parent_product_has_nil_sku_after_form_model_init() {
+        // Arrange
+        let sku = "orange-pen"
+        let variation = MockProductVariation().productVariation().copy(sku: sku)
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation, allAttributes: [], parentProductSKU: sku)
+
+        // Assert
+        XCTAssertNil(model.sku)
+        XCTAssertNil(model.productVariation.sku)
+    }
+
+    func test_a_variation_with_a_different_sku_from_parent_product_has_the_same_sku_after_form_model_init() {
+        // Arrange
+        let sku = "orange-pen"
+        let variation = MockProductVariation().productVariation().copy(sku: sku)
+
+        // Action
+        let model = EditableProductVariationModel(productVariation: variation, allAttributes: [], parentProductSKU: "")
+
+        // Assert
+        XCTAssertEqual(model.sku, sku)
+        XCTAssertEqual(model.productVariation.sku, sku)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ChangesTests.swift
@@ -151,7 +151,7 @@ final class ProductVariationFormViewModel_ChangesTests: XCTestCase {
 // Helper in unit tests
 extension EditableProductVariationModel {
     convenience init(productVariation: ProductVariation) {
-        self.init(productVariation: productVariation, allAttributes: [])
+        self.init(productVariation: productVariation, allAttributes: [], parentProductSKU: nil)
     }
 }
 
@@ -160,6 +160,10 @@ extension ProductVariationFormViewModel {
     convenience init(productVariation: EditableProductVariationModel,
                      productImageActionHandler: ProductImageActionHandler,
                      storesManager: StoresManager = ServiceLocator.stores) {
-        self.init(productVariation: productVariation, allAttributes: [], productImageActionHandler: productImageActionHandler, storesManager: storesManager)
+        self.init(productVariation: productVariation,
+                  allAttributes: [],
+                  parentProductSKU: nil,
+                  productImageActionHandler: productImageActionHandler,
+                  storesManager: storesManager)
     }
 }


### PR DESCRIPTION
Fixes #2599 

## Changes

Thanks @pmusolino for discovering this issue first! This issue prevents the user from updating a variation if the variation doesn't have its own SKU and its parent product has a non-empty SKU (this could be a pretty common case). I noticed that Android doesn't have this issue, I'm guessing they only encode a property of a model if it's changed in an update request. I haven't thought of an easy way for us to implement this optional encoding yet, so this PR is a workaround and I'll research about the encoding.

- In `EditableProductVariationModel`, passed a variation's parent product's SKU `parentProductSKU: String?` to its initializer and set the variation's SKU to `nil` if it has the same SKU as its parent product.
- DI'ed `parentProductSKU: String?` to `EditableProductVariationModel` in `ProductVariationFormViewModel` and `ProductVariationsViewController`

## Testing

Prerequisite: the site has a variable product with a non-empty SKU, and at least one of its variations doesn't have a custom SKU set

- Go to the Products tab
- Tap on a variable product with a non-empty SKU
- Tap on the variations row
- Tap on a variation that doesn't have a custom SKU set
- Edit any field other than the SKU (e.g. description, enabled switch, price)
- Tap "Update" --> this used to fail due to duplicate SKU error in `develop`, and now the variation should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
