### PR TITLE
Shows in-app review from Feedback card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -74,8 +74,8 @@ private extension InAppFeedbackCardViewController {
     func configureLikeButton() {
         likeButton.applyPrimaryButtonStyle()
         likeButton.setTitle(Localization.iLikeIt, for: .normal)
-        likeButton.on(.touchUpInside) { _ in
-            self.storeReviewControllerType.requestReview()
+        likeButton.on(.touchUpInside) { [weak self] _ in
+            self?.storeReviewControllerType.requestReview()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -1,5 +1,16 @@
 
 import UIKit
+import StoreKit
+
+/// Defines methods for presenting the in-app app store review form.
+///
+protocol SKStoreReviewControllerProtocol {
+    /// Displays the in app app store review alert.
+    ///
+    static func requestReview()
+}
+
+extension SKStoreReviewController: SKStoreReviewControllerProtocol { }
 
 /// Displays a small view asking the user to provide a feedback for the app.
 ///
@@ -11,6 +22,18 @@ final class InAppFeedbackCardViewController: UIViewController {
 
     /// The stackview containing the `titleLabel` and the horizontal view for the buttons.
     @IBOutlet private var verticalStackView: UIStackView!
+
+    /// SKStoreReviewController type wrapper. Needed for testing
+    private let storeReviewControllerType: SKStoreReviewControllerProtocol.Type
+
+    init(storeReviewControllerType: SKStoreReviewControllerProtocol.Type = SKStoreReviewController.self) {
+        self.storeReviewControllerType = storeReviewControllerType
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,6 +74,9 @@ private extension InAppFeedbackCardViewController {
     func configureLikeButton() {
         likeButton.applyPrimaryButtonStyle()
         likeButton.setTitle(Localization.iLikeIt, for: .normal)
+        likeButton.on(.touchUpInside) { _ in
+            self.storeReviewControllerType.requestReview()
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
+		26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */; };
 		26FF455F24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
@@ -1225,6 +1226,7 @@
 		26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyLoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
+		26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewControllerTests.swift; sourceTree = "<group>"; };
 		26FF455E24BE49EE00B3B2F4 /* DeprecatedStatsDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedStatsDashboardViewController.swift; sourceTree = "<group>"; };
 		2719B6FD1E6FE78A76B6AC74 /* Pods-WooCommerceTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		33035144757869DE5E4DC88A /* Pods-WooCommerce.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release.xcconfig"; sourceTree = "<group>"; };
@@ -2551,6 +2553,14 @@
 				26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */,
 			);
 			path = Survey;
+			sourceTree = "<group>";
+		};
+		26FE09E224DCFE4000B9BDF5 /* inAppFeedback */ = {
+			isa = PBXGroup;
+			children = (
+				26FE09E324DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift */,
+			);
+			path = inAppFeedback;
 			sourceTree = "<group>";
 		};
 		4506BD6E2461962700FE6377 /* Visibility */ = {
@@ -4141,6 +4151,7 @@
 		D816DDBA22265D8000903E59 /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				26FE09E224DCFE4000B9BDF5 /* inAppFeedback */,
 				57B374B3245B32EE00D58BE0 /* ReusableViews */,
 				57F34A9F2423D44000E38AFB /* Orders */,
 				0290E27C238E5B4A00B5C466 /* ListSelector */,
@@ -5405,6 +5416,7 @@
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
 				02564A88246C047C00D6DB2A /* Optional+StringTests.swift in Sources */,
 				0269576D23726401001BA0BF /* KeyboardFrameObserverTests.swift in Sources */,
+				26FE09E424DCFE5200B9BDF5 /* InAppFeedbackCardViewControllerTests.swift in Sources */,
 				0215320D2423309B003F2BBD /* UIStackView+SubviewsTests.swift in Sources */,
 				027B8BBD23FE0DE10040944E /* ProductImageActionHandlerTests.swift in Sources */,
 				B5980A6521AC905C00EBF596 /* UIDeviceWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import WooCommerce
 
-class InAppFeedbackCardViewControllerTests: XCTestCase {
+final class InAppFeedbackCardViewControllerTests: XCTestCase {
 
     override class func setUp() {
         super.setUp()

--- a/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+
+@testable import WooCommerce
+
+class InAppFeedbackCardViewControllerTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        MockStoreReviewController.resetInvocationState()
+    }
+
+    func test_it_presents_appStore_review_form_when_tapping_like_button() throws {
+        // Given
+        let viewController = InAppFeedbackCardViewController(storeReviewControllerType: MockStoreReviewController.self)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+        mirror.likeButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertTrue(MockStoreReviewController.requestReviewInvoked)
+    }
+
+    func test_it_doesnt_presents_appStore_review_form_when_tapping_didNotlike_button() throws {
+        // Given
+        let viewController = InAppFeedbackCardViewController(storeReviewControllerType: MockStoreReviewController.self)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+        mirror.didNotLikeButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertFalse(MockStoreReviewController.requestReviewInvoked)
+    }
+}
+
+// MARK: - Mirroring
+private extension InAppFeedbackCardViewControllerTests {
+    struct InAppFeedbackCardViewControllerMirror {
+        let likeButton: UIButton
+        let didNotLikeButton: UIButton
+    }
+
+    func mirror(of viewController: InAppFeedbackCardViewController) throws -> InAppFeedbackCardViewControllerMirror {
+        let mirror = Mirror(reflecting: viewController)
+        return InAppFeedbackCardViewControllerMirror(
+            likeButton: try XCTUnwrap(mirror.descendant("likeButton") as? UIButton),
+            didNotLikeButton: try XCTUnwrap(mirror.descendant("didNotLikeButton") as? UIButton)
+        )
+    }
+}
+
+private class MockStoreReviewController: SKStoreReviewControllerProtocol {
+
+    private(set) static var requestReviewInvoked = false
+
+    static func requestReview() {
+        requestReviewInvoked = true
+    }
+
+    static func resetInvocationState() {
+        requestReviewInvoked = false
+    }
+}


### PR DESCRIPTION
closes #2543 

# Why
This is a simple PR that presents the system in-app store review form.

# How

- Call `SKStoreReviewController.requestReview()` method to present the in-app review form.
- Hide `SKStoreReviewController.requestReview()`behind a protocol so we can mock it and add tests to this.

# Gif
![in-app-review](https://user-images.githubusercontent.com/562080/89606682-3d823b00-d836-11ea-83d9-22a59d95cd96.gif)

# Testing Steps
- Launch the app and take on the "I Like it" button from the in-app feedback card.
- See that the in-app store review form appears.
**Note that in debug builds you won't be able to submit the review**

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
