### PR TITLE
Integrate In-app Feedback Card Conditions for Displaying

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -170,9 +170,16 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
                 return
             }
 
-            UIView.animate(withDuration: 0.2) {
-                self.inAppFeedbackCardViewsForStackView.forEach {
-                    $0.isHidden = !isVisible
+            let isHidden = !isVisible
+
+            self.inAppFeedbackCardViewsForStackView.forEach { subView in
+                // Check if the subView will change first. It looks like if we don't do this,
+                // then StackView will not animate the change correctly.
+                if subView.isHidden != isHidden {
+                    UIView.animate(withDuration: 0.2) {
+                        subView.isHidden = isHidden
+                        self.stackView.setNeedsLayout()
+                    }
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -111,6 +111,11 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
         configureSubviews()
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel.onViewDidAppear()
+    }
 }
 
 // MARK: Public Interface

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -66,6 +66,15 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     }()
 
     private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()
+    /// An array of UIViews for the In-app Feedback Card. This will be dynamically shown
+    /// or hidden depending on the configuration.
+    private lazy var inAppFeedbackCardViewsForStackView: [UIView] = {
+        let views = createInAppFeedbackCardViewsForStackView()
+        views.forEach {
+            $0.isHidden = true
+        }
+        return views
+    }()
 
     private lazy var topPerformersPeriodViewController: TopPerformerDataViewController = {
         return TopPerformerDataViewController(granularity: timeRange.topEarnerStatsGranularity)
@@ -186,10 +195,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             ])
 
         // In-app Feedback Card
-        let inAppFeedbackCardViews = createInAppFeedbackCardViewsForStackView()
-        inAppFeedbackCardViews.forEach {
-            stackView.addArrangedSubview($0)
-        }
+        stackView.addArrangedSubviews(inAppFeedbackCardViewsForStackView)
 
         // Top performers header.
         let topPerformersHeaderView = TopPerformersSectionHeaderView(title:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -82,6 +82,9 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     private let viewModel: StoreStatsAndTopPerformersPeriodViewModel
 
+    /// Subscriptions that should be cancelled on `deinit`.
+    private var cancellables = [ObservationToken]()
+
     /// Create an instance of `self`.
     ///
     /// - Parameter canDisplayInAppFeedbackCard: If applicable, present the in-app feedback card.
@@ -104,6 +107,12 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        cancellables.forEach {
+            $0.cancel()
+        }
     }
 
     override func viewDidLoad() {
@@ -170,7 +179,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             return
         }
 
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { [weak self] isVisible in
+        let cancellable = viewModel.isInAppFeedbackCardVisible.subscribe { [weak self] isVisible in
             guard let self = self else {
                 return
             }
@@ -188,6 +197,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
                 }
             }
         }
+        cancellables.append(cancellable)
     }
 
     func configureSubviews() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -159,6 +159,7 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
         }
     }
 
+    /// Observe and react to visibility events for the in-app feedback card.
     func configureInAppFeedbackCardViews() {
         guard viewModel.canDisplayInAppFeedbackCard else {
             return
@@ -169,8 +170,10 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
                 return
             }
 
-            self.inAppFeedbackCardViewsForStackView.forEach {
-                $0.isHidden = !isVisible
+            UIView.animate(withDuration: 0.2) {
+                self.inAppFeedbackCardViewsForStackView.forEach {
+                    $0.isHidden = !isVisible
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -54,7 +54,11 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
             return isInAppFeedbackCardVisibleSubject.send(isEnabled)
         }
 
-        let action = AppSettingsAction.loadInAppFeedbackCardVisibility { result in
+        let action = AppSettingsAction.loadInAppFeedbackCardVisibility { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
             switch result {
             case .success(let shouldBeVisible):
                 self.isInAppFeedbackCardVisibleSubject.send(shouldBeVisible)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -1,5 +1,5 @@
-
-import Foundation
+import Yosemite
+import class AutomatticTracks.CrashLogging
 
 /// ViewModel for `StoreStatsAndTopPerformersPeriodViewController`.
 ///
@@ -17,10 +17,10 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     var isInAppFeedbackCardVisible: Observable<Bool> {
         isInAppFeedbackCardVisibleSubject
     }
-
     private let isInAppFeedbackCardVisibleSubject = BehaviorSubject(false)
 
     private let featureFlagService: FeatureFlagService
+    private let storesManager: StoresManager
 
     /// Create an instance of `self`.
     ///
@@ -29,16 +29,33 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     ///     But setting this to `false`, will ensure that it will never be presented.
     ///
     init(canDisplayInAppFeedbackCard: Bool,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         storesManager: StoresManager = ServiceLocator.stores) {
         self.canDisplayInAppFeedbackCard = canDisplayInAppFeedbackCard
         self.featureFlagService = featureFlagService
+        self.storesManager = storesManager
 
         updateIsInAppFeedbackCardVisibleValue()
     }
 
     /// Calculates and updates the value of `isInAppFeedbackCardVisibleSubject`.
     private func updateIsInAppFeedbackCardVisibleValue() {
-        let isVisible = canDisplayInAppFeedbackCard && featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
-        isInAppFeedbackCardVisibleSubject.send(isVisible)
+        // Abort right away if we don't need to calculate the real value.
+        let isEnabled = canDisplayInAppFeedbackCard && featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
+        if !isEnabled {
+            return isInAppFeedbackCardVisibleSubject.send(isEnabled)
+        }
+
+        let action = AppSettingsAction.loadInAppFeedbackCardVisibility { result in
+            switch result {
+            case .success(let shouldBeVisible):
+                self.isInAppFeedbackCardVisibleSubject.send(shouldBeVisible)
+            case .failure(let error):
+                CrashLogging.logError(error)
+                // We'll just send a `false` value. I think this is the safer bet.
+                self.isInAppFeedbackCardVisibleSubject.send(false)
+            }
+        }
+        storesManager.dispatch(action)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -34,7 +34,15 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
         self.canDisplayInAppFeedbackCard = canDisplayInAppFeedbackCard
         self.featureFlagService = featureFlagService
         self.storesManager = storesManager
+    }
 
+    /// Must be called by the `ViewController` during the `viewDidAppear()` event. This will
+    /// update the visibility of the in-app feedback card.
+    ///
+    /// The visibility is updated on `viewDidAppear()` to consider scenarios when the app is
+    /// never terminated.
+    ///
+    func onViewDidAppear() {
         updateIsInAppFeedbackCardVisibleValue()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -50,7 +50,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     private func updateIsInAppFeedbackCardVisibleValue() {
         // Abort right away if we don't need to calculate the real value.
         let isEnabled = canDisplayInAppFeedbackCard && featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
-        if !isEnabled {
+        guard isEnabled else {
             return isInAppFeedbackCardVisibleSubject.send(isEnabled)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -1,0 +1,44 @@
+
+import Foundation
+
+/// ViewModel for `StoreStatsAndTopPerformersPeriodViewController`.
+///
+/// This was created after `StoreStatsAndTopPerformersPeriodViewController` existed so not
+/// all data-loading are in here.
+///
+final class StoreStatsAndTopPerformersPeriodViewModel {
+
+    /// If applicable, present the in-app feedback card. The in-app feedback card may still not be
+    /// presented depending on the constraints. But setting this to `false`, will ensure that it
+    /// will never be presented.
+    let canDisplayInAppFeedbackCard: Bool
+
+    /// An Observable that informs the UI whether the in-app feedback card should be displayed or not.
+    var isInAppFeedbackCardVisible: Observable<Bool> {
+        isInAppFeedbackCardVisibleSubject
+    }
+
+    private let isInAppFeedbackCardVisibleSubject = BehaviorSubject(false)
+
+    private let featureFlagService: FeatureFlagService
+
+    /// Create an instance of `self`.
+    ///
+    /// - Parameter canDisplayInAppFeedbackCard: If applicable, present the in-app feedback card.
+    ///     The in-app feedback card may still not be presented depending on the constraints.
+    ///     But setting this to `false`, will ensure that it will never be presented.
+    ///
+    init(canDisplayInAppFeedbackCard: Bool,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.canDisplayInAppFeedbackCard = canDisplayInAppFeedbackCard
+        self.featureFlagService = featureFlagService
+
+        updateIsInAppFeedbackCardVisibleValue()
+    }
+
+    /// Calculates and updates the value of `isInAppFeedbackCardVisibleSubject`.
+    private func updateIsInAppFeedbackCardVisibleValue() {
+        let isVisible = canDisplayInAppFeedbackCard && featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
+        isInAppFeedbackCardVisibleSubject.send(isVisible)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -256,10 +256,10 @@ private extension StoreStatsAndTopPerformersViewController {
 
     func configurePeriodViewControllers() {
         let currentDate = Date()
-        let dayVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .today, currentDate: currentDate, canDisplayInAppFeedback: true)
-        let weekVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisWeek, currentDate: currentDate, canDisplayInAppFeedback: false)
-        let monthVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisMonth, currentDate: currentDate, canDisplayInAppFeedback: false)
-        let yearVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisYear, currentDate: currentDate, canDisplayInAppFeedback: false)
+        let dayVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .today, currentDate: currentDate, canDisplayInAppFeedbackCard: true)
+        let weekVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisWeek, currentDate: currentDate, canDisplayInAppFeedbackCard: false)
+        let monthVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisMonth, currentDate: currentDate, canDisplayInAppFeedbackCard: false)
+        let yearVC = StoreStatsAndTopPerformersPeriodViewController(timeRange: .thisYear, currentDate: currentDate, canDisplayInAppFeedbackCard: false)
 
         periodVCs.append(dayVC)
         periodVCs.append(weekVC)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -406,10 +406,11 @@
 		575472812452185300A94C3C /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		57612989245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */; };
 		5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */; };
+		576D9F2924DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576D9F2824DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift */; };
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
+		5778E00624DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */; };
 		5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */; };
 		5778E00E24DB2BA200B65CBF /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */; };
-		5778E00624DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */; };
 		578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578187B12481D9290063B46B /* XCTestCase+Assertions.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
@@ -1328,10 +1329,11 @@
 		575472802452185300A94C3C /* PushNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotification.swift; sourceTree = "<group>"; };
 		57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlus.swift"; sourceTree = "<group>"; };
 		5761298A24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+LocalizedOrNinetyNinePlusTests.swift"; sourceTree = "<group>"; };
+		576D9F2824DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewModelTests.swift; sourceTree = "<group>"; };
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
+		5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewModel.swift; sourceTree = "<group>"; };
 		5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubjectTests.swift; sourceTree = "<group>"; };
 		5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubject.swift; sourceTree = "<group>"; };
-		5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewModel.swift; sourceTree = "<group>"; };
 		578187B12481D9290063B46B /* XCTestCase+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Assertions.swift"; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
@@ -2482,6 +2484,7 @@
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				576D9F2724DB81BF007B48F4 /* Stats V4 */,
 				02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */,
 				0257285B230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift */,
 				02404EDF2314FE5900FF1170 /* DashboardUIFactoryTests.swift */,
@@ -2777,6 +2780,14 @@
 				5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */,
 			);
 			path = Observables;
+			sourceTree = "<group>";
+		};
+		576D9F2724DB81BF007B48F4 /* Stats V4 */ = {
+			isa = PBXGroup;
+			children = (
+				576D9F2824DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift */,
+			);
+			path = "Stats V4";
 			sourceTree = "<group>";
 		};
 		5798191124526FC7000817F8 /* Observables */ = {
@@ -5450,6 +5461,7 @@
 				0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,
+				576D9F2924DB81D3007B48F4 /* StoreStatsAndTopPerformersPeriodViewModelTests.swift in Sources */,
 				9379E1A6225537D0006A6BE4 /* TestingAppDelegate.swift in Sources */,
 				453904F323BB88B5007C4956 /* ProductTaxStatusListSelectorCommandTests.swift in Sources */,
 				02BAB02124D0235F00F8B06E /* ProductPriceSettingsViewModel+ProductVariationTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		576F92222423C3C0003E5FEF /* OrdersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F92212423C3C0003E5FEF /* OrdersViewModel.swift */; };
 		5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */; };
 		5778E00E24DB2BA200B65CBF /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */; };
+		5778E00624DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */; };
 		578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578187B12481D9290063B46B /* XCTestCase+Assertions.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
@@ -1330,6 +1331,7 @@
 		576F92212423C3C0003E5FEF /* OrdersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModel.swift; sourceTree = "<group>"; };
 		5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubjectTests.swift; sourceTree = "<group>"; };
 		5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubject.swift; sourceTree = "<group>"; };
+		5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersPeriodViewModel.swift; sourceTree = "<group>"; };
 		578187B12481D9290063B46B /* XCTestCase+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Assertions.swift"; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
@@ -2329,6 +2331,7 @@
 				02E4FD7B2306A04C0049610C /* StatsTimeRangeBarView.swift */,
 				02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */,
 				0240B3AB230A910C000A866C /* StoreStatsV4ChartAxisHelper.swift */,
+				5778E00524DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -4917,6 +4920,7 @@
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
 				B57C743D20F5493300EEFC87 /* AccountHeaderView.swift in Sources */,
 				D8C251D2230CA90200F49782 /* StoresManager.swift in Sources */,
+				5778E00624DB0C3900B65CBF /* StoreStatsAndTopPerformersPeriodViewModel.swift in Sources */,
 				02DD81FA242CAA400060E50B /* Media+WPMediaAsset.swift in Sources */,
 				024DF31F23743045006658FE /* Header+AztecFormatting.swift in Sources */,
 				029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
@@ -3,11 +3,14 @@
 struct MockFeatureFlagService: FeatureFlagService {
     private let isEditProductsRelease2On: Bool
     private let isEditProductsRelease3On: Bool
+    private let isInAppFeedbackOn: Bool
 
     init(isEditProductsRelease2On: Bool = false,
-         isEditProductsRelease3On: Bool = false) {
+         isEditProductsRelease3On: Bool = false,
+         isInAppFeedbackOn: Bool = false) {
         self.isEditProductsRelease2On = isEditProductsRelease2On
         self.isEditProductsRelease3On = isEditProductsRelease3On
+        self.isInAppFeedbackOn = isInAppFeedbackOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -16,6 +19,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isEditProductsRelease2On
         case .editProductsRelease3:
             return isEditProductsRelease3On
+        case .inAppFeedback:
+            return isInAppFeedbackOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mockups/MockupStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupStoresManager.swift
@@ -11,6 +11,10 @@ final class MockupStoresManager: DefaultStoresManager {
     ///
     private(set) var receivedActions = [Action]()
 
+    /// Callbacks to be called when a specific `Action` type is dispatched. The `key` is the
+    /// `String` description of `Action.Type`.
+    private var receivedActionCallbacks = [String: (Action) -> Void]()
+
     /// Indicates if the Actions should be dispatched for real (or do nothing!)
     ///
     var shouldDispatchActionsForReal = false
@@ -21,11 +25,13 @@ final class MockupStoresManager: DefaultStoresManager {
     override func dispatch(_ action: Action) {
         receivedActions.append(action)
 
-        guard shouldDispatchActionsForReal else {
-            return
+        if shouldDispatchActionsForReal {
+            super.dispatch(action)
+        } else {
+            if let callback = receivedActionCallbacks[String(describing: type(of: action))] {
+                callback(action)
+            }
         }
-
-        super.dispatch(action)
     }
 
     // MARK: - Public Methods
@@ -34,5 +40,32 @@ final class MockupStoresManager: DefaultStoresManager {
     ///
     func reset() {
         receivedActions = []
+    }
+}
+
+// MARK: - Mocking
+
+extension MockupStoresManager {
+    /// When an action of type `actionType` is received, then call the given `callback`.
+    ///
+    /// Example usage:
+    ///
+    /// ```
+    /// storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+    ///     if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+    ///         onCompletion(.success(true))
+    ///     }
+    /// }
+    /// ```
+    func whenReceivingAction<T: Action>(ofType actionType: T.Type, thenCall callback: @escaping (T) -> Void) {
+        // This is one of those times in my life when I really feel like I don't know what I'm doing.
+        // If there's a better way to do this, please let me know. ^_^x
+        let wrappingCallback: (Action) -> Void = { action in
+            if let typedAction = action as? T {
+                callback(typedAction)
+            }
+        }
+        let key = String(describing: actionType)
+        receivedActionCallbacks[key] = wrappingCallback
     }
 }

--- a/WooCommerce/WooCommerceTests/Mockups/MockupStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockupStoresManager.swift
@@ -5,7 +5,7 @@ import Yosemite
 
 /// MockupStoresManager: MockupStoresManager Mockup!
 ///
-class MockupStoresManager: DefaultStoresManager {
+final class MockupStoresManager: DefaultStoresManager {
 
     /// Contains all of the dispatched Actions
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import WooCommerce
+
+final class StoreStatsAndTopPerformersPeriodViewModelTest: XCTestCase {
+
+    func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService)
+
+        // When
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_true_if_feature_flag_is_on() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService)
+
+        // When
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: false,
+                                                                  featureFlagService: featureFlagService)
+
+        // When
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(isVisible))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -19,7 +19,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_by_default() throws {
+    func test_isInAppFeedbackCardVisible_is_false_by_default() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
 
@@ -27,52 +27,52 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
                                                                   featureFlagService: featureFlagService)
 
-        var isVisible: Bool?
+        var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
+            emittedValues.append(value)
         }
 
         // Then
-        XCTAssertFalse(try XCTUnwrap(isVisible))
+        XCTAssertEqual([false], emittedValues)
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() throws {
+    func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
                                                                   featureFlagService: featureFlagService)
 
-        var isVisible: Bool?
+        var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
+            emittedValues.append(value)
         }
 
         // When
         viewModel.onViewDidAppear()
 
         // Then
-        XCTAssertFalse(try XCTUnwrap(isVisible))
+        XCTAssertEqual([false, false], emittedValues)
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() throws {
+    func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: false,
                                                                   featureFlagService: featureFlagService)
 
-        var isVisible: Bool?
+        var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
+            emittedValues.append(value)
         }
 
         // When
         viewModel.onViewDidAppear()
 
         // Then
-        XCTAssertFalse(try XCTUnwrap(isVisible))
+        XCTAssertEqual([false, false], emittedValues)
     }
 
-    func test_isInAppFeedbackCardVisible_is_true_if_the_AppSettingsAction_returns_true() throws {
+    func test_isInAppFeedbackCardVisible_is_true_if_the_AppSettingsAction_returns_true() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
@@ -85,19 +85,19 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             }
         }
 
-        var isVisible: Bool?
+        var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
+            emittedValues.append(value)
         }
 
         // When
         viewModel.onViewDidAppear()
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(isVisible))
+        XCTAssertEqual([false, true], emittedValues)
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_false() throws {
+    func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_false() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
@@ -110,19 +110,19 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             }
         }
 
-        var isVisible: Bool?
+        var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
+            emittedValues.append(value)
         }
 
         // When
         viewModel.onViewDidAppear()
 
         // Then
-        XCTAssertFalse(try XCTUnwrap(isVisible))
+        XCTAssertEqual([false, false], emittedValues)
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_an_error() throws {
+    func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_an_error() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
@@ -135,16 +135,16 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             }
         }
 
-        var isVisible: Bool?
+        var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
+            emittedValues.append(value)
         }
 
         // When
         viewModel.onViewDidAppear()
 
         // Then
-        XCTAssertFalse(try XCTUnwrap(isVisible))
+        XCTAssertEqual([false, false], emittedValues)
     }
 
     func test_isInAppFeedbackCardVisible_is_recomputed_on_viewDidAppear() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -19,9 +19,9 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() throws {
+    func test_isInAppFeedbackCardVisible_is_false_by_default() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
 
         // When
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
@@ -31,6 +31,24 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
             isVisible = value
         }
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService)
+
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // When
+        viewModel.onViewDidAppear()
 
         // Then
         XCTAssertFalse(try XCTUnwrap(isVisible))
@@ -39,8 +57,6 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-
-        // When
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: false,
                                                                   featureFlagService: featureFlagService)
 
@@ -49,6 +65,9 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             isVisible = value
         }
 
+        // When
+        viewModel.onViewDidAppear()
+
         // Then
         XCTAssertFalse(try XCTUnwrap(isVisible))
     }
@@ -56,6 +75,9 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     func test_isInAppFeedbackCardVisible_is_true_if_the_AppSettingsAction_returns_true() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
@@ -63,15 +85,13 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             }
         }
 
-        // When
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
-
         var isVisible: Bool?
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
             isVisible = value
         }
+
+        // When
+        viewModel.onViewDidAppear()
 
         // Then
         XCTAssertTrue(try XCTUnwrap(isVisible))
@@ -80,6 +100,9 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
@@ -87,15 +110,13 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             }
         }
 
-        // When
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
-
         var isVisible: Bool?
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
             isVisible = value
         }
+
+        // When
+        viewModel.onViewDidAppear()
 
         // Then
         XCTAssertFalse(try XCTUnwrap(isVisible))
@@ -104,6 +125,9 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_an_error() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
@@ -111,17 +135,43 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
             }
         }
 
-        // When
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
-
         var isVisible: Bool?
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
             isVisible = value
         }
 
+        // When
+        viewModel.onViewDidAppear()
+
         // Then
         XCTAssertFalse(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_recomputed_on_viewDidAppear() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+                onCompletion(.success(true))
+            }
+        }
+
+        var emittedValues = [Bool]()
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            emittedValues.append(value)
+        }
+
+        // When
+        viewModel.onViewDidAppear()
+        viewModel.onViewDidAppear()
+
+        // Then
+        // We should receive 3 values. The first is from the first subscription. The rest is
+        // from the `onViewDidAppear()` calls.
+        XCTAssertEqual([false, true, true], emittedValues)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -1,16 +1,30 @@
 import XCTest
 
 @testable import WooCommerce
+import Yosemite
 
 final class StoreStatsAndTopPerformersPeriodViewModelTest: XCTestCase {
+
+    private var storesManager: MockupStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        storesManager = MockupStoresManager(sessionManager: SessionManager.testingInstance)
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        super.tearDown()
+    }
 
     func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
+
+        // When
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
                                                                   featureFlagService: featureFlagService)
 
-        // When
         var isVisible: Bool?
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
             isVisible = value
@@ -23,10 +37,83 @@ final class StoreStatsAndTopPerformersPeriodViewModelTest: XCTestCase {
     func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+
+        // When
         let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: false,
                                                                   featureFlagService: featureFlagService)
 
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_true_if_the_AppSettingsAction_returns_true() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+                onCompletion(.success(true))
+            }
+        }
+
         // When
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
+
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_false() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+                onCompletion(.success(false))
+            }
+        }
+
+        // When
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
+
+        var isVisible: Bool?
+        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
+            isVisible = value
+        }
+
+        // Then
+        XCTAssertFalse(try XCTUnwrap(isVisible))
+    }
+
+    func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_an_error() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+                onCompletion(.failure(NSError(domain: "", code: 0, userInfo: nil)))
+            }
+        }
+
+        // When
+        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
+                                                                  featureFlagService: featureFlagService,
+                                                                  storesManager: storesManager)
+
         var isVisible: Bool?
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
             isVisible = value

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -3,7 +3,9 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 
-final class StoreStatsAndTopPerformersPeriodViewModelTest: XCTestCase {
+/// Test cases for StoreStatsAndTopPerformersPeriodViewModel.
+///
+final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     private var storesManager: MockupStoresManager!
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -20,22 +20,6 @@ final class StoreStatsAndTopPerformersPeriodViewModelTest: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(isVisible))
     }
 
-    func test_isInAppFeedbackCardVisible_is_true_if_feature_flag_is_on() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService)
-
-        // When
-        var isVisible: Bool?
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            isVisible = value
-        }
-
-        // Then
-        XCTAssertTrue(try XCTUnwrap(isVisible))
-    }
-
     func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)


### PR DESCRIPTION
Closes #2537. 

This depends on #2623 which has been reviewed and approved but hasn't been merged yet. I'll merge it after the release cut.

This PR integrates the action [`AppSettingsAction.loadInAppFeedbackCardVisibility`](https://github.com/woocommerce/woocommerce-ios/blob/fd208e19dee798df19578b636ba03a4a075dd5a7/Yosemite/Yosemite/Actions/AppSettingsAction.swift#L83-L90) (#2623) to the card UI. The UI will now only show up in these conditions:

1. Users who’ve installed the app at least 3 months ago.
2. Once every 6 months. (this will have to be tested later)

ℹ️  The buttons' functionalities will be integrated later with #2626 and #2605. 

## Changes 

### ViewModel

I moved the `canDisplayInAppFeedbackCard` logic into a new ViewModel, [`StoreStatsAndTopPerformersPeriodViewModel`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2537-in-app-feedback-card-visibility-conditions/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersPeriodViewModel.swift). This ViewModel is responsible for dictating when the in-app feedback card should be shown. 

Later, in #2629, the buttons will also call a function inside here to call [`AppSettingsAction.setLastFeedbackDate`](https://github.com/woocommerce/woocommerce-ios/blob/f0828fe1f156c33d44b37614574f697dedbed35a/Yosemite/Yosemite/Actions/AppSettingsAction.swift#L78-L81). 

### UI

The UI uses the new `isInAppFeedbackCardVisible` `Observable` exposed by the ViewModel to hide or show the in-app feedback card: 

https://github.com/woocommerce/woocommerce-ios/blob/fd208e19dee798df19578b636ba03a4a075dd5a7/WooCommerce/Classes/ViewRelated/Dashboard/Stats%20v4/StoreStatsAndTopPerformersPeriodViewController.swift#L173-L190

## Testing

We can only easily test the condition number 1 for now: "Users who’ve installed the app at least 3 months ago.". The second condition will be tested later after the functionalities of the buttons are integrated.

1. Delete the app on the device. 
2. Run the app and log in. 
3. Time travel to at least 90 days from now. 
4. Navigate to the Orders tab and navigate back to My Store.
5. Confirm that the in-app feedback card is now visible.
6. Time travel back to the present. 
7. Navigate to the Orders tab and navigate back to My Store.
8. Confirm that the in-app feedback card is no longer visible.

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

