### PR TITLE
Hide inApp feedback card after CTAs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -66,6 +66,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     }()
 
     private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()
+
     /// An array of UIViews for the In-app Feedback Card. This will be dynamically shown
     /// or hidden depending on the configuration.
     private lazy var inAppFeedbackCardViewsForStackView: [UIView] = createInAppFeedbackCardViewsForStackView()
@@ -103,6 +104,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
         configureInAppFeedbackCardViews()
         configureChildViewControllers()
+        configureInAppFeedbackViewControllerAction()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -302,6 +304,12 @@ private extension StoreStatsAndTopPerformersPeriodViewController {
             view.heightAnchor.constraint(equalToConstant: 0.5)
             ])
         return view
+    }
+
+    func configureInAppFeedbackViewControllerAction() {
+        inAppFeedbackCardViewController.onFeedbackGiven = { [weak self] in
+            self?.viewModel.onInAppFeedbackCardAction()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -46,6 +46,23 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
         updateIsInAppFeedbackCardVisibleValue()
     }
 
+    /// Updates the card visibility state stored in `isInAppFeedbackCardVisibleSubject` by updating the app last feedback date.
+    ///
+    func onInAppFeedbackCardAction() {
+        let action = AppSettingsAction.setLastFeedbackDate(date: Date()) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
+            if let error = result.failure {
+                CrashLogging.logError(error)
+            }
+
+            self.updateIsInAppFeedbackCardVisibleValue()
+        }
+        storesManager.dispatch(action)
+    }
+
     /// Calculates and updates the value of `isInAppFeedbackCardVisibleSubject`.
     private func updateIsInAppFeedbackCardVisibleValue() {
         // Abort right away if we don't need to calculate the real value.

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -20,6 +20,9 @@ final class InAppFeedbackCardViewController: UIViewController {
     @IBOutlet private var didNotLikeButton: UIButton!
     @IBOutlet private var likeButton: UIButton!
 
+    /// Closure invoked after the user has choose what kind feedback to give.
+    var onFeedbackGiven: (() -> Void)?
+
     /// The stackview containing the `titleLabel` and the horizontal view for the buttons.
     @IBOutlet private var verticalStackView: UIStackView!
 
@@ -68,6 +71,7 @@ private extension InAppFeedbackCardViewController {
         didNotLikeButton.on(.touchUpInside) { [weak self] _ in
             let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
             self?.present(surveyNavigation, animated: true, completion: nil)
+            self?.onFeedbackGiven?()
         }
     }
 
@@ -76,6 +80,7 @@ private extension InAppFeedbackCardViewController {
         likeButton.setTitle(Localization.iLikeIt, for: .normal)
         likeButton.on(.touchUpInside) { [weak self] _ in
             self?.storeReviewControllerType.requestReview()
+            self?.onFeedbackGiven?()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -20,7 +20,7 @@ final class InAppFeedbackCardViewController: UIViewController {
     @IBOutlet private var didNotLikeButton: UIButton!
     @IBOutlet private var likeButton: UIButton!
 
-    /// Closure invoked after the user has choose what kind feedback to give.
+    /// Closure invoked after the user has chosen what kind feedback to give.
     var onFeedbackGiven: (() -> Void)?
 
     /// The stackview containing the `titleLabel` and the horizontal view for the buttons.

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -15,7 +15,7 @@ final class SurveyCoordinatingController: WooNavigationController {
          viewControllersFactory: SurveyViewControllersFactoryProtocol = SurveyViewControllersFactory()) {
         self.zendeskManager = zendeskManager
         self.viewControllersFactory = viewControllersFactory
-        super.init(navigationBarClass: nil, toolbarClass: nil)
+        super.init(nibName: nil, bundle: nil)
         startSurveyNavigation(survey: survey)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/inAppFeedback/InAppFeedbackCardViewControllerTests.swift
@@ -34,6 +34,46 @@ final class InAppFeedbackCardViewControllerTests: XCTestCase {
         // Then
         XCTAssertFalse(MockStoreReviewController.requestReviewInvoked)
     }
+
+    func test_feedbackGiven_closure_is_invoked_when_tapping_like_button() throws {
+        // Given
+        let viewController = InAppFeedbackCardViewController()
+
+        // When
+        var feedbackGivenInvoked = false
+        viewController.onFeedbackGiven = {
+            feedbackGivenInvoked = true
+        }
+
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+        mirror.likeButton.sendActions(for: .touchUpInside)
+
+        // Then
+        waitUntil {
+            feedbackGivenInvoked == true
+        }
+    }
+
+    func test_feedbackGiven_closure_is_invoked_when_tapping_didNotLike_button() throws {
+        // Given
+        let viewController = InAppFeedbackCardViewController()
+
+        // When
+        var feedbackGivenInvoked = false
+        viewController.onFeedbackGiven = {
+            feedbackGivenInvoked = true
+        }
+
+        _ = try XCTUnwrap(viewController.view)
+        let mirror = try self.mirror(of: viewController)
+        mirror.didNotLikeButton.sendActions(for: .touchUpInside)
+
+        // Then
+        waitUntil {
+            feedbackGivenInvoked == true
+        }
+    }
 }
 
 // MARK: - Mirroring


### PR DESCRIPTION
closes #2629

# Why
This PR hides the in-App feedback card in the dashboard after the user taps on any call to action. Which could be the "I like it" button which will trigger the app store review or the "Could be Better" button which will trigger the survey flow.

# How

- Expose closure on `InAppFeedbackCardViewController` to inform it's parent controller when the feedback has been given.
- Adds a new method `onInAppFeedbackCardAction` on `StoreStatsAndTopPerformersPeriodViewModel` which sets the `lastFeedbackDate` and recalculates the `inAppFeedbackCard` visibility.

# Gifs

![dismiss-card](https://user-images.githubusercontent.com/562080/89925865-a3214f00-dbc9-11ea-84bf-2c3fa18828a6.gif)


# Testing Steps
- Delete the app on the device.
- Run the app and log in.
- Time travel to at least 90 days from now.
- Navigate to the Orders tab and navigate back to My Store.
- Confirm that the in-app feedback card is now visible.
- Tap on any call to action.
- See that the CTA happened and the card was dismissed
Note: In-app review won't show if the system is date is altered

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
