### PR TITLE
Removes Sign in with Google temporarily until we have SIWA

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -23,7 +23,8 @@ class AuthenticationManager: Authentication {
                                                                 googleLoginClientId: ApiCredentials.googleClientId,
                                                                 googleLoginServerClientId: ApiCredentials.googleServerId,
                                                                 googleLoginScheme: ApiCredentials.googleAuthScheme,
-                                                                userAgent: UserAgent.defaultUserAgent)
+                                                                userAgent: UserAgent.defaultUserAgent,
+                                                                showLoginOptions: true)
 
         let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: .primaryButtonBackground,
                                                 primaryNormalBorderColor: .primaryButtonDownBackground,


### PR DESCRIPTION
This temporarily removes the Sign in with Google option. Users can still log in with their e-mail address using the magic link option until we're ready to deploy Sign in with Apple.

Before this change:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-11 at 12 51 42](https://user-images.githubusercontent.com/373903/89931515-dff14400-dbd1-11ea-9bcc-c060deb819d1.png)

After this change:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-11 at 12 50 57](https://user-images.githubusercontent.com/373903/89931528-e41d6180-dbd1-11ea-872f-aae4c90c32d8.png)

The fix was to add an initialization parameter to the authenticator library, which is kind of a hack. We're using a different prologue which bypasses some of the logic that the boolean being true would trigger. It effectively removes the Google button from our initial screen used in this app.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
