### PR TITLE
Fix updating a price with only sale price change doesn't trigger update

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents a Product Entity.
 ///
-public struct Product: Codable, GeneratedCopiable {
+public struct Product: Codable, GeneratedCopiable, Equatable {
     public let siteID: Int64
     public let productID: Int64
     public let name: String
@@ -573,73 +573,6 @@ private extension Product {
 // MARK: - Comparable Conformance
 //
 extension Product: Comparable {
-    public static func == (lhs: Product, rhs: Product) -> Bool {
-        return lhs.siteID == rhs.siteID &&
-            lhs.productID == rhs.productID &&
-            lhs.name == rhs.name &&
-            lhs.slug == rhs.slug &&
-            lhs.permalink == rhs.permalink &&
-            lhs.dateCreated == rhs.dateCreated &&
-            lhs.dateModified == rhs.dateModified &&
-            lhs.dateOnSaleStart == rhs.dateOnSaleStart &&
-            lhs.dateOnSaleEnd == rhs.dateOnSaleEnd &&
-            lhs.productTypeKey == rhs.productTypeKey &&
-            lhs.statusKey == rhs.statusKey &&
-            lhs.featured == rhs.featured &&
-            lhs.catalogVisibilityKey == rhs.catalogVisibilityKey &&
-            lhs.fullDescription == rhs.fullDescription &&
-            lhs.briefDescription == rhs.briefDescription &&
-            lhs.sku == rhs.sku &&
-            // lhs.price == rhs.price &&    // can't compare because object type unknown
-            lhs.regularPrice == rhs.regularPrice &&
-            // lhs.salePrice == rhs.salePrice && // can't compare because object type unknown
-            lhs.onSale == rhs.onSale &&
-            lhs.purchasable == rhs.purchasable &&
-            lhs.totalSales == rhs.totalSales &&
-            lhs.virtual == rhs.virtual &&
-            lhs.downloadable == rhs.downloadable &&
-            lhs.downloadLimit == rhs.downloadLimit &&
-            lhs.downloadExpiry == rhs.downloadExpiry &&
-            lhs.buttonText == rhs.buttonText &&
-            lhs.externalURL == rhs.externalURL &&
-            lhs.taxStatusKey == rhs.taxStatusKey &&
-            lhs.taxClass == rhs.taxClass &&
-            lhs.manageStock == rhs.manageStock &&
-            lhs.stockQuantity == rhs.stockQuantity &&
-            lhs.stockStatusKey == rhs.stockStatusKey &&
-            lhs.backordersKey == rhs.backordersKey &&
-            lhs.backordersAllowed == rhs.backordersAllowed &&
-            lhs.backordered == rhs.backordered &&
-            lhs.soldIndividually == rhs.soldIndividually &&
-            lhs.weight == rhs.weight &&
-            lhs.dimensions == rhs.dimensions &&
-            lhs.shippingRequired == rhs.shippingRequired &&
-            lhs.shippingTaxable == rhs.shippingTaxable &&
-            lhs.shippingClass == rhs.shippingClass &&
-            lhs.shippingClassID == rhs.shippingClassID &&
-            lhs.productShippingClass == rhs.productShippingClass &&
-            lhs.reviewsAllowed == rhs.reviewsAllowed &&
-            lhs.averageRating == rhs.averageRating &&
-            lhs.ratingCount == rhs.ratingCount &&
-            lhs.relatedIDs == rhs.relatedIDs &&
-            lhs.upsellIDs == rhs.upsellIDs &&
-            lhs.parentID == rhs.parentID &&
-            lhs.purchaseNote == rhs.purchaseNote &&
-            lhs.categories.count == rhs.categories.count &&
-            lhs.categories.sorted() == rhs.categories.sorted() &&
-            lhs.tags.count == rhs.tags.count &&
-            lhs.tags.sorted() == rhs.tags.sorted() &&
-            lhs.images.count == rhs.images.count &&
-            lhs.images.sorted() == rhs.images.sorted() &&
-            lhs.attributes.count == rhs.attributes.count &&
-            lhs.attributes.sorted() == rhs.attributes.sorted() &&
-            lhs.defaultAttributes.count == rhs.defaultAttributes.count &&
-            lhs.defaultAttributes.sorted() == rhs.defaultAttributes.sorted() &&
-            lhs.variations == rhs.variations &&
-            lhs.groupedProducts == rhs.groupedProducts &&
-            lhs.menuOrder == rhs.menuOrder
-    }
-
     public static func < (lhs: Product, rhs: Product) -> Bool {
         /// Note: stockQuantity can be `null` in the API,
         /// which is why we are unable to sort by it here.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 4.9
 -----
+- [*] Edit Products: the update action now shows up on the product details after updating just the sale price.
  
 4.8
 -----

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1314,7 +1314,7 @@ private extension ProductStoreTests {
                        totalSales: 66,
                        virtual: false,
                        downloadable: true,
-                       downloads: sampleDownloads(),
+                       downloads: [],
                        downloadLimit: 1,
                        downloadExpiry: 1,
                        buttonText: "",


### PR DESCRIPTION
Fixes #2637 

## Changes

- Removed custom `Equatable` implementation in `Product` and used the default one so that we don't skip the `salePrice`
  - it was intentionally skipped before, but I don't think the alternative types matter when comparing two `Product`s with fixed types https://github.com/woocommerce/woocommerce-ios/blob/faee100732aeb94752aa66e8f06fd786042cd336/Networking/Networking/Model/Product/Product.swift#L595

## Testing

1. Edit a simple product
2. Navigate to Price
3. Change the Sale Price only
4. Tap Done --> "Update" CTA should be shown and the sale price in the product details should be the one entered previously
5. Tap Update --> the sale price of the product should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
