### PR TITLE
Docs: Mention rbenv Preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce a common style
 
 If your code has any style violations, you can try to automatically correct them by running:
 
-`rake lint:autocorrect`
+```
+rake lint:autocorrect
+```
 
 Otherwise, you can also fix them manually.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Jetpack-powered companion app for WooCommerce.
 
 1. Download Xcode
 
-    At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 11.2.1 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
+    At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 11.5 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action).
 
 2. Install Ruby. We recommend using [rbenv](https://github.com/rbenv/rbenv) to install it. Please refer to the [`.ruby-version` file](.ruby-version) for the required Ruby version.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ A Jetpack-powered companion app for WooCommerce.
 1. Download Xcode
 
     At the moment *WooCommerce for iOS* uses Swift 5 and requires Xcode 11.2.1 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action)
+
+2. Install Ruby. We recommend using [rbenv](https://github.com/rbenv/rbenv) to install it. Please refer to the [`.ruby-version` file](.ruby-version) for the required Ruby version.
+
+    We use Ruby to manage the third party dependencies and other tools and automation. 
+
 2. Clone project in the folder of your preference
 
     ```bash
@@ -22,9 +27,8 @@ A Jetpack-powered companion app for WooCommerce.
     cd woocommerce-ios
     ```
     
-4. Install the third party dependencies and tools required to run the project
+4. Install the third party dependencies and tools required to run the project.
     
-    We use a few tools to help with development. To install or update the required dependencies, run:
     
     ```bash
     rake dependencies


### PR DESCRIPTION
I promised to do this more than 2 months ago during a discussion with Platform. 😅 It's pretty common to have Ruby issues and the usual solution is to use rbenv. The built-in macOS Ruby is so easy to break. This PR updates the `README.md` to mention that we prefer rbenv when installing Ruby. I also made the Ruby requirement as the second step. 

## Testing

Please view the updated `README.md` [here](https://github.com/woocommerce/woocommerce-ios/blob/update/docs-rbenv/README.md). 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

