### PR TITLE
Updated Wormholy from v1.6.0 to v1.6.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ target 'WooCommerce' do
   pod 'Charts', '~> 3.3.0'
   pod 'ZendeskSupportSDK', '~> 5.0'
   pod 'Kingfisher', '~> 5.11.0'
-  pod 'Wormholy', '~> 1.6.0', :configurations => ['Debug']
+  pod 'Wormholy', '~> 1.6.2', :configurations => ['Debug']
 
   # Unit Tests
   # ==========

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -77,7 +77,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.0)
-  - Wormholy (1.6.0)
+  - Wormholy (1.6.2)
   - WPMediaPicker (1.7.1)
   - wpxmlrpc (0.8.5)
   - XLPagerTabStrip (9.0.0)
@@ -110,7 +110,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (= 1.17.0)
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.7.0)
-  - Wormholy (~> 1.6.0)
+  - Wormholy (~> 1.6.2)
   - WPMediaPicker (~> 1.7.1)
   - XLPagerTabStrip (~> 9.0)
   - ZendeskSupportSDK (~> 5.0)
@@ -186,7 +186,7 @@ SPEC CHECKSUMS:
   WordPressKit: 2e707edd1b28e8dd0f74a40469ca6e7be7b20a70
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
   WordPressUI: 1cf47a3b78154faf69caa18569ee7ece1e510fa0
-  Wormholy: f52cd3c384fb49ae3e8fdb2b1398b66746a65104
+  Wormholy: 5a186f877829e7d488963b09f204e0186b40c9a8
   WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
@@ -198,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 6c91cb329e1c74848b460c1a87cbb6d6f8453c79
+PODFILE CHECKSUM: 9c41af28281863c8e1439fe3229164844da8cc41
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
## Description
This PR updates Wormholy from version 1.6.0 to version 1.6.2.
This last version introduces the dark mode, and the requests body is now present again. It was removed wrongly in release 1.6.0.

## Testing
- Try to open Wormholy from the Settings screen running the app in `debug`.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
