### PR TITLE
Edit Product: the product screen now shows the "Product type" row

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -241,8 +241,6 @@ extension ProductDetailsViewModel {
             configureProductName(cell)
         case let cell as OldProductReviewsTableViewCell:
             configureReviews(cell)
-        case let cell as TitleBodyTableViewCell where row == .productType:
-            configureProductType(cell)
         case let cell as WooBasicTableViewCell where row == .permalink:
             configurePermalink(cell)
         case let cell as WooBasicTableViewCell where row == .affiliateLink:
@@ -301,26 +299,6 @@ extension ProductDetailsViewModel {
         cell.reviewTotalsLabel?.text = ratingCount.humanReadableString()
         let averageRating = Double(product.averageRating)
         cell.starRatingView.rating = CGFloat(averageRating ?? 0)
-    }
-
-    /// Product Type cell.
-    ///
-    func configureProductType(_ cell: TitleBodyTableViewCell) {
-        let title = NSLocalizedString("Product type",
-                                      comment: "Product Details > descriptive label for the Product Type cell.")
-        cell.titleLabel?.text = title
-        if product.productType == .simple {
-            switch product.virtual {
-            case true:
-                cell.bodyLabel?.text = NSLocalizedString("Virtual",
-                                                         comment: "Display label for simple virtual product type.")
-            case false:
-                cell.bodyLabel?.text = NSLocalizedString("Physical",
-                                                         comment: "Display label for simple physical product type.")
-            }
-            return
-        }
-        cell.bodyLabel?.text = product.productType.description
     }
 
     /// Product permalink cell.
@@ -803,7 +781,6 @@ extension ProductDetailsViewModel {
         case productImages
         case productName
         case reviews
-        case productType
         case productVariants
         case permalink
         case affiliateLink
@@ -823,8 +800,6 @@ extension ProductDetailsViewModel {
                 return TitleBodyTableViewCell.reuseIdentifier
             case .reviews:
                 return OldProductReviewsTableViewCell.reuseIdentifier
-            case .productType:
-                return TitleBodyTableViewCell.reuseIdentifier
             case .productVariants:
                 return TitleBodyTableViewCell.reuseIdentifier
             case .permalink:

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -241,6 +241,8 @@ extension ProductDetailsViewModel {
             configureProductName(cell)
         case let cell as OldProductReviewsTableViewCell:
             configureReviews(cell)
+        case let cell as TitleBodyTableViewCell where row == .productType:
+            configureProductType(cell)
         case let cell as WooBasicTableViewCell where row == .permalink:
             configurePermalink(cell)
         case let cell as WooBasicTableViewCell where row == .affiliateLink:
@@ -299,6 +301,26 @@ extension ProductDetailsViewModel {
         cell.reviewTotalsLabel?.text = ratingCount.humanReadableString()
         let averageRating = Double(product.averageRating)
         cell.starRatingView.rating = CGFloat(averageRating ?? 0)
+    }
+
+    /// Product Type cell.
+    ///
+    func configureProductType(_ cell: TitleBodyTableViewCell) {
+        let title = NSLocalizedString("Product type",
+                                      comment: "Product Details > descriptive label for the Product Type cell.")
+        cell.titleLabel?.text = title
+        if product.productType == .simple {
+            switch product.virtual {
+            case true:
+                cell.bodyLabel?.text = NSLocalizedString("Virtual",
+                                                         comment: "Display label for simple virtual product type.")
+            case false:
+                cell.bodyLabel?.text = NSLocalizedString("Physical",
+                                                         comment: "Display label for simple physical product type.")
+            }
+            return
+        }
+        cell.bodyLabel?.text = product.productType.description
     }
 
     /// Product permalink cell.
@@ -781,6 +803,7 @@ extension ProductDetailsViewModel {
         case productImages
         case productName
         case reviews
+        case productType
         case productVariants
         case permalink
         case affiliateLink
@@ -800,6 +823,8 @@ extension ProductDetailsViewModel {
                 return TitleBodyTableViewCell.reuseIdentifier
             case .reviews:
                 return OldProductReviewsTableViewCell.reuseIdentifier
+            case .productType:
+                return TitleBodyTableViewCell.reuseIdentifier
             case .productVariants:
                 return TitleBodyTableViewCell.reuseIdentifier
             case .permalink:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -214,11 +214,9 @@ private extension DefaultProductFormTableViewModel {
         if product.productType == .simple {
             switch product.virtual {
             case true:
-                details = NSLocalizedString("Virtual",
-                                            comment: "Display label for simple virtual product type.")
+                details = Constants.virtualProductType
             case false:
-                details = NSLocalizedString("Physical",
-                                            comment: "Display label for simple physical product type.")
+                details = Constants.physicalProductType
             }
         }
 
@@ -447,6 +445,12 @@ private extension DefaultProductFormTableViewModel {
                                                  comment: "Format of the SKU on the Inventory Settings row")
         static let stockQuantityFormat = NSLocalizedString("Quantity: %ld",
                                                            comment: "Format of the stock quantity on the Inventory Settings row")
+
+        // Product Type
+        static let virtualProductType = NSLocalizedString("Virtual",
+                                                          comment: "Display label for simple virtual product type.")
+        static let physicalProductType = NSLocalizedString("Physical",
+                                                           comment: "Display label for simple physical product type.")
 
         // Shipping
         static let weightFormat = NSLocalizedString("Weight: %1$@%2$@",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -208,7 +208,6 @@ private extension DefaultProductFormTableViewModel {
         let icon = UIImage.productImage
         let title = Constants.productTypeTitle
 
-
         var details = product.productType.description
 
         if product.productType == .simple {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -205,7 +205,7 @@ private extension DefaultProductFormTableViewModel {
     }
 
     func productTypeRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
-        let icon = UIImage.productPlaceholderImage
+        let icon = UIImage.productImage
         let title = Constants.productTypeTitle
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -64,6 +64,8 @@ private extension DefaultProductFormTableViewModel {
                 return .price(viewModel: priceSettingsRow(product: product))
             case .reviews:
                 return .reviews(viewModel: reviewsRow(product: product), ratingCount: product.ratingCount, averageRating: product.averageRating)
+            case .productType:
+                return .productType(viewModel: productTypeRow(product: product))
             case .shippingSettings:
                 return .shipping(viewModel: shippingSettingsRow(product: product))
             case .inventorySettings:
@@ -196,6 +198,30 @@ private extension DefaultProductFormTableViewModel {
         }
 
         let details = inventoryDetails.isEmpty ? nil: inventoryDetails.joined(separator: "\n")
+
+        return ProductFormSection.SettingsRow.ViewModel(icon: icon,
+                                                        title: title,
+                                                        details: details)
+    }
+
+    func productTypeRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
+        let icon = UIImage.productPlaceholderImage
+        let title = Constants.productTypeTitle
+
+
+        var details = product.productType.description
+
+        if product.productType == .simple {
+            switch product.virtual {
+            case true:
+                details = NSLocalizedString("Virtual",
+                                            comment: "Display label for simple virtual product type.")
+            case false:
+                details = NSLocalizedString("Physical",
+                                            comment: "Display label for simple physical product type.")
+            }
+        }
+
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
@@ -373,6 +399,8 @@ private extension DefaultProductFormTableViewModel {
                                                     comment: "Title of the Reviews row on Product main screen")
         static let inventorySettingsTitle = NSLocalizedString("Inventory",
                                                               comment: "Title of the Inventory Settings row on Product main screen")
+        static let productTypeTitle = NSLocalizedString("Product type",
+                                                              comment: "Title of the Product Type row on Product main screen")
         static let shippingSettingsTitle = NSLocalizedString("Shipping",
                                                              comment: "Title of the Shipping Settings row on Product main screen")
         static let categoriesTitle = NSLocalizedString("Categories",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -39,6 +39,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.productStatus
     }
 
+    var virtual: Bool {
+        product.virtual
+    }
+
     var images: [ProductImage] {
         product.images
     }
@@ -73,6 +77,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
 
     var ratingCount: Int {
         product.ratingCount
+    }
+
+    var productType: ProductType {
+        product.productType
     }
 
     var weight: String? {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -63,6 +63,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         productVariation.status
     }
 
+    var virtual: Bool {
+        productVariation.virtual
+    }
+
     var images: [ProductImage] {
         [productVariation.image].compactMap { $0 }
     }
@@ -98,6 +102,11 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
     var ratingCount: Int {
         0
     }
+
+    var productType: ProductType {
+        .variable
+    }
+
     var weight: String? {
         productVariation.weight
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -7,6 +7,7 @@ enum ProductFormEditAction {
     case description
     case priceSettings
     case reviews
+    case productType
     case inventorySettings
     case shippingSettings
     case categories
@@ -87,6 +88,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForSimpleProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
@@ -95,6 +97,7 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
             shouldShowReviewsRow ? .reviews: nil,
+            shouldShowProductTypeRow ? .productType : nil,
             shouldShowShippingSettingsRow ? .shippingSettings: nil,
             .inventorySettings,
             shouldShowCategoriesRow ? .categories: nil,
@@ -106,6 +109,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForAffiliateProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -113,6 +117,7 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
             shouldShowReviewsRow ? .reviews: nil,
+            shouldShowProductTypeRow ? .productType : nil,
             .externalURL,
             .sku,
             shouldShowCategoriesRow ? .categories: nil,
@@ -124,6 +129,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForGroupedProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -131,6 +137,7 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .groupedProducts,
             shouldShowReviewsRow ? .reviews: nil,
+            shouldShowProductTypeRow ? .productType : nil,
             .sku,
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
@@ -141,6 +148,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowBriefDescriptionRow = isEditProductsRelease2Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -148,6 +156,7 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .variations,
             shouldShowReviewsRow ? .reviews: nil,
+            shouldShowProductTypeRow ? .productType : nil,
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
             shouldShowBriefDescriptionRow ? .briefDescription: nil
@@ -168,6 +177,9 @@ private extension ProductFormActionsFactory {
             return true
         case .reviews:
             // The reviews action is always visible in the settings section.
+            return true
+        case .productType:
+            // The product type action is always visible in the settings section.
             return true
         case .inventorySettings:
             let hasStockData = product.manageStock ? product.stockQuantity != nil: true

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -12,6 +12,7 @@ protocol ProductFormDataModel {
     // Settings
     var permalink: String { get }
     var status: ProductStatus { get }
+    var virtual: Bool { get }
 
     // Images
     var images: [ProductImage] { get }
@@ -32,6 +33,9 @@ protocol ProductFormDataModel {
     // Reviews
     var averageRating: String { get }
     var ratingCount: Int { get }
+
+    // Product Type
+    var productType: ProductType { get }
 
     // Shipping
     var weight: String? { get }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -56,7 +56,19 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
 extension ProductFormSection.SettingsRow: ReusableTableRow {
     var cellTypes: [UITableViewCell.Type] {
         switch self {
-        case .price, .inventory, .shipping, .categories, .tags, .briefDescription, .externalURL, .sku, .groupedProducts, .variations, .status, .noPriceWarning:
+        case .price,
+             .productType,
+             .inventory,
+             .shipping,
+             .categories,
+             .tags,
+             .briefDescription,
+             .externalURL,
+             .sku,
+             .groupedProducts,
+             .variations,
+             .status,
+             .noPriceWarning:
             return [ImageAndTitleAndTextTableViewCell.self]
         case .reviews:
             return [ProductReviewsTableViewCell.self]
@@ -69,7 +81,19 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
 
     private var cellType: UITableViewCell.Type {
         switch self {
-        case .price, .inventory, .shipping, .categories, .tags, .briefDescription, .externalURL, .sku, .groupedProducts, .variations, .status, .noPriceWarning:
+        case .price,
+             .productType,
+             .inventory,
+             .shipping,
+             .categories,
+             .tags,
+             .briefDescription,
+             .externalURL,
+             .sku,
+             .groupedProducts,
+             .variations,
+             .status,
+             .noPriceWarning:
             return ImageAndTitleAndTextTableViewCell.self
         case .reviews:
             return ProductReviewsTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -186,6 +186,7 @@ private extension ProductFormTableViewDataSource {
         switch row {
         case .price(let viewModel),
              .inventory(let viewModel),
+             .productType(let viewModel),
              .shipping(let viewModel),
              .categories(let viewModel),
              .tags(let viewModel),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -24,6 +24,7 @@ enum ProductFormSection: Equatable {
     enum SettingsRow: Equatable {
         case price(viewModel: ViewModel)
         case reviews(viewModel: ViewModel, ratingCount: Int, averageRating: String)
+        case productType(viewModel: ViewModel)
         case shipping(viewModel: ViewModel)
         case inventory(viewModel: ViewModel)
         case categories(viewModel: ViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -234,6 +234,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
             case .reviews:
                 // TODO-2509 Edit Product M3 analytics
                 showReviews()
+            case .productType:
+                // TODO-2509 Edit Product M3 analytics
+                editProductType()
             case .shipping:
                 ServiceLocator.analytics.track(.productDetailViewShippingSettingsTapped)
                 editShippingSettings()
@@ -802,6 +805,32 @@ private extension ProductFormViewController {
 
         let productReviewsViewController = ProductReviewsViewController(product: product.product)
         navigationController?.show(productReviewsViewController, sender: self)
+    }
+}
+
+// MARK: Action - Edit Product Type Settings
+//
+private extension ProductFormViewController {
+    func editProductType() {
+        //TODO-2198: present the bottom action sheet
+    }
+
+    func onEditProdyctTypeCompletion(productType: ProductType) {
+
+        defer {
+            navigationController?.popViewController(animated: true)
+        }
+        let hasChangedData: Bool = {
+            productType != self.product.productType
+        }()
+
+        // TODO-2509 Edit Product M3 analytics
+
+        guard hasChangedData else {
+            return
+        }
+        // TODO-2198: update product type in viewModel
+        // viewModel.updateProductType(productType: productType)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -816,12 +816,11 @@ private extension ProductFormViewController {
     }
 
     func onEditProdyctTypeCompletion(productType: ProductType) {
-
         defer {
             navigationController?.popViewController(animated: true)
         }
         let hasChangedData: Bool = {
-            productType != self.product.productType
+            productType != product.productType
         }()
 
         // TODO-2509 Edit Product M3 analytics

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -165,6 +165,10 @@ extension ProductFormViewModel {
         product = EditableProductModel(product: product.product.copy(averageRating: averageRating, ratingCount: ratingCount))
     }
 
+    func updateProductType(productType: ProductType) {
+        product = EditableProductModel(product: product.product.copy(productTypeKey: productType.rawValue))
+    }
+
     func updateInventorySettings(sku: String?,
                                  manageStock: Bool,
                                  soldIndividually: Bool?,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -129,7 +129,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
                                                 isEditProductsRelease3Enabled: true)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editShippingSettings,
@@ -151,7 +151,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
                                                 isEditProductsRelease3Enabled: true)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editBriefDescription]
@@ -169,7 +169,7 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
                                                 isEditProductsRelease3Enabled: true)
 
         // Assert
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editInventorySettings, .editCategories, .editTags, .editBriefDescription]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -23,6 +23,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
                                                                        .reviews,
+                                                                       .productType,
                                                                        .shippingSettings,
                                                                        .inventorySettings,
                                                                        .categories,
@@ -50,6 +51,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
                                                                        .reviews,
+                                                                       .productType,
                                                                        .shippingSettings,
                                                                        .inventorySettings,
                                                                        .categories,
@@ -75,7 +77,13 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .inventorySettings, .categories, .tags, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .reviews,
+                                                                       .productType,
+                                                                       .inventorySettings,
+                                                                       .categories,
+                                                                       .tags,
+                                                                       .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -96,7 +104,13 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .inventorySettings, .categories, .tags, .briefDescription]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .reviews,
+                                                                       .productType,
+                                                                       .inventorySettings,
+                                                                       .categories,
+                                                                       .tags,
+                                                                       .briefDescription]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -117,7 +131,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .externalURL]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType, .externalURL]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editBriefDescription]
@@ -138,7 +152,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts, .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.groupedProducts, .reviews, .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editBriefDescription]
@@ -159,7 +173,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations, .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations, .reviews, .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editBriefDescription]
@@ -180,7 +194,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations, .reviews]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.variations, .reviews, .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editBriefDescription]


### PR DESCRIPTION
Closes #2262 

## Description
In this PR, I handled the logic for showing the Product Type cell in the Edit Product screen.
The Product Type cell can show these Product types:
- Physical (type is simple, the virtual field is off)
- Virtual (type is simple, the virtual field is on)
- Variable (type is variable)
- Grouped (type is grouped)
- External (type is external)
- A custom product type sent through the API (supported as it comes for free, but there doesn't seem to be any way to use a custom product type).

No actions are supported at the moment, will be part of another PR (here the [related issue](https://github.com/woocommerce/woocommerce-ios/issues/2198)).

## Testing
1. Navigate to different products (simple physical, simple virtual, variable, grouped, external).
2. For each product, make sure that the cell "Product type" shows the right value.

## Screenshots
| Product Type row             |  Product Type row (dark mode enabled) |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-08-13 at 17 19 40](https://user-images.githubusercontent.com/495617/90155809-0a86fc80-dd8c-11ea-930d-71ce6798e4fc.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-08-13 at 17 19 49](https://user-images.githubusercontent.com/495617/90155815-0bb82980-dd8c-11ea-9cde-378f38a09079.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
