### PR TITLE
Fix inconsistent failure in SurveyVC tests

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -37,7 +37,7 @@ final class SurveyViewControllerTests: XCTestCase {
         viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
 
         // Then
-        waitUntil(timeout: 1) {
+        waitUntil {
             surveyCompleted
         }
     }
@@ -59,7 +59,7 @@ final class SurveyViewControllerTests: XCTestCase {
         // Fakes a form submission GET navigation
         let navigationAction = FormSubmittedNavigationAction(httpMethod: "GET")
         viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: Constants.expectationTimeout)
 
         // Then
         XCTAssertFalse(surveyCompleted)
@@ -90,8 +90,8 @@ final class SurveyViewControllerTests: XCTestCase {
         viewController.webView(mirror.webView, didFinish: navigation)
 
         // Then
-        waitUntil(timeout: 1) {
-            return mirror.loadingView.isHidden
+        waitUntil {
+            mirror.loadingView.isHidden
         }
     }
 }


### PR DESCRIPTION
# Why

@pmusolino Reported the other day that some tests on about SurveyViewController were randomly failing.
Today I was able to get the failure to happen multiple times and it seems that when the `waitUntil` timeout was `1` sometimes the test failed even when the condition was met on the same run loop(This is my assumption).

# How 

The fix was to increase the timeout to use the default value and tests appear to run normally now.

# Testing Steps
- See that tests pass

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
