### PR TITLE
Add support for storing multiple feedback states

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		02F25AE024A446E700092B06 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F25ADF24A446E600092B06 /* XCTestCase+Wait.swift */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
 		267439D624E5D45A0090696C /* FeedbackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267439D524E5D45A0090696C /* FeedbackSettings.swift */; };
+		26EA01D124EC3AEA00176A57 /* FeedbackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EA01D024EC3AEA00176A57 /* FeedbackType.swift */; };
 		450106892399AC7400E24722 /* TaxClass+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */; };
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
 		454005AA24AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 454005A924AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel */; };
@@ -180,6 +181,7 @@
 		262CD20224317C2F00932241 /* Model 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 27.xcdatamodel"; sourceTree = "<group>"; };
 		26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV26toV27.xcmappingmodel; sourceTree = "<group>"; };
 		267439D524E5D45A0090696C /* FeedbackSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSettings.swift; sourceTree = "<group>"; };
+		26EA01D024EC3AEA00176A57 /* FeedbackType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackType.swift; sourceTree = "<group>"; };
 		450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		453227B523C4CE9C00D816B3 /* Model 25.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 25.xcdatamodel"; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 			children = (
 				57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */,
 				267439D524E5D45A0090696C /* FeedbackSettings.swift */,
+				26EA01D024EC3AEA00176A57 /* FeedbackType.swift */,
 			);
 			name = AppSettings;
 			sourceTree = "<group>";
@@ -887,6 +890,7 @@
 				028296F5237D404F00E84012 /* Attribute+CoreDataProperties.swift in Sources */,
 				454005AA24AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel in Sources */,
 				7471A517216CF0FE00219F7E /* SiteVisitStats+CoreDataProperties.swift in Sources */,
+				26EA01D124EC3AEA00176A57 /* FeedbackType.swift in Sources */,
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
 				028296F4237D404F00E84012 /* Attribute+CoreDataClass.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
 		267439D624E5D45A0090696C /* FeedbackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267439D524E5D45A0090696C /* FeedbackSettings.swift */; };
 		26EA01D124EC3AEA00176A57 /* FeedbackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EA01D024EC3AEA00176A57 /* FeedbackType.swift */; };
+		26EA01D524EC44B300176A57 /* GeneralAppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EA01D424EC44B300176A57 /* GeneralAppSettingsTests.swift */; };
 		450106892399AC7400E24722 /* TaxClass+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */; };
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
 		454005AA24AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 454005A924AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel */; };
@@ -182,6 +183,7 @@
 		26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV26toV27.xcmappingmodel; sourceTree = "<group>"; };
 		267439D524E5D45A0090696C /* FeedbackSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSettings.swift; sourceTree = "<group>"; };
 		26EA01D024EC3AEA00176A57 /* FeedbackType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackType.swift; sourceTree = "<group>"; };
+		26EA01D424EC44B300176A57 /* GeneralAppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralAppSettingsTests.swift; sourceTree = "<group>"; };
 		450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		453227B523C4CE9C00D816B3 /* Model 25.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 25.xcdatamodel"; sourceTree = "<group>"; };
@@ -371,6 +373,22 @@
 			path = Testing;
 			sourceTree = "<group>";
 		};
+		26EA01D224EC449C00176A57 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				26EA01D324EC449C00176A57 /* AppSettings */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		26EA01D324EC449C00176A57 /* AppSettings */ = {
+			isa = PBXGroup;
+			children = (
+				26EA01D424EC44B300176A57 /* GeneralAppSettingsTests.swift */,
+			);
+			path = AppSettings;
+			sourceTree = "<group>";
+		};
 		4DD3D0BDDE216A90FC1335D7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -514,6 +532,7 @@
 			children = (
 				D87F61582265AED70031A13B /* Mock data */,
 				02A098252480D155002F8C7A /* Mocks */,
+				26EA01D224EC449C00176A57 /* Model */,
 				B54CA5C520A4BFC800F38CD1 /* Tools */,
 				B52B0F7D20AA2F1200477698 /* Extensions */,
 				B59E11DC20A9F1E6004121A4 /* CoreData */,
@@ -974,6 +993,7 @@
 				5736879024AABE4D00B528FE /* ManagedObjectModelsInventoryTests.swift in Sources */,
 				D87F61572265AD980031A13B /* FileStorageTests.swift in Sources */,
 				B59E11DE20A9F1FB004121A4 /* CoreDataManagerTests.swift in Sources */,
+				26EA01D524EC44B300176A57 /* GeneralAppSettingsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		02EAB6D72480A86D00FD873C /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAB6D62480A86D00FD873C /* CrashLogger.swift */; };
 		02F25AE024A446E700092B06 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F25ADF24A446E600092B06 /* XCTestCase+Wait.swift */; };
 		26577519243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */; };
+		267439D624E5D45A0090696C /* FeedbackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267439D524E5D45A0090696C /* FeedbackSettings.swift */; };
 		450106892399AC7400E24722 /* TaxClass+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */; };
 		4501068B2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */; };
 		454005AA24AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 454005A924AE4D350087FDD1 /* WooCommerceModelV28toV29.xcmappingmodel */; };
@@ -178,6 +179,7 @@
 		02F25ADF24A446E600092B06 /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		262CD20224317C2F00932241 /* Model 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 27.xcdatamodel"; sourceTree = "<group>"; };
 		26577518243D808B003168A5 /* WooCommerceModelV26toV27.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = WooCommerceModelV26toV27.xcmappingmodel; sourceTree = "<group>"; };
+		267439D524E5D45A0090696C /* FeedbackSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackSettings.swift; sourceTree = "<group>"; };
 		450106882399AC7400E24722 /* TaxClass+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4501068A2399AC9B00E24722 /* TaxClass+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TaxClass+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		453227B523C4CE9C00D816B3 /* Model 25.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 25.xcdatamodel"; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 			isa = PBXGroup;
 			children = (
 				57A8819F24CA396D00AE0943 /* GeneralAppSettings.swift */,
+				267439D524E5D45A0090696C /* FeedbackSettings.swift */,
 			);
 			name = AppSettings;
 			sourceTree = "<group>";
@@ -849,6 +852,7 @@
 				7474539C2242C85E00E0B5EE /* ProductDimensions+CoreDataProperties.swift in Sources */,
 				74938ECB216FA9B200540BA1 /* OrderStats+CoreDataProperties.swift in Sources */,
 				7426A05120F69D00002A4E07 /* OrderCoupon+CoreDataProperties.swift in Sources */,
+				267439D624E5D45A0090696C /* FeedbackSettings.swift in Sources */,
 				CE4FD4472350EB7600A16B31 /* OrderItemRefund+CoreDataClass.swift in Sources */,
 				747453A12242C85E00E0B5EE /* ProductCategory+CoreDataClass.swift in Sources */,
 				D87F61552265AA900031A13B /* PListFileStorage.swift in Sources */,

--- a/Storage/Storage/Model/FeedbackSettings.swift
+++ b/Storage/Storage/Model/FeedbackSettings.swift
@@ -13,13 +13,13 @@ public struct FeedbackSettings: Codable, Equatable {
 
     /// Name of the feedback, for identity purposes
     ///
-    public let name: String
+    public let name: FeedbackType
 
     /// State of the feedback
     ///
     public let status: Status
 
-    public init(name: String, status: Status) {
+    public init(name: FeedbackType, status: Status) {
         self.name = name
         self.status = status
     }

--- a/Storage/Storage/Model/FeedbackSettings.swift
+++ b/Storage/Storage/Model/FeedbackSettings.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// An encodable/decodable data structure used to save the state of a feedback the app requests
+///
+public struct FeedbackSettings: Codable, Equatable {
+    /// Lists all the possible scenarios that a feedback could be in
+    ///
+    public enum Status: Equatable {
+        case pending
+        case dismissed
+        case given(Date)
+    }
+
+    /// Name of the feedback, for identity purposes
+    ///
+    public let name: String
+
+    /// State of the feedback
+    ///
+    public let status: Status
+
+}
+
+// MARK: Codable Conformance
+//
+extension FeedbackSettings.Status: Codable {
+
+    /// Should match `FeedbackSettings.Status`
+    ///
+    private enum EnumKey: String, Codable {
+        case pending
+        case dismissed
+        case given
+    }
+
+    private enum CodingKeys: CodingKey {
+        case value
+        case associatedValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawValue = try container.decode(EnumKey.self, forKey: .value)
+        switch rawValue {
+        case .pending:
+            self = .pending
+        case .dismissed:
+            self = .dismissed
+        case .given:
+            let date = try container.decode(Date.self, forKey: .associatedValue)
+            self = .given(date)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .pending:
+            try container.encode(EnumKey.pending, forKey: .value)
+        case .dismissed:
+            try container.encode(EnumKey.dismissed, forKey: .value)
+        case .given(let date):
+            try container.encode(EnumKey.given, forKey: .value)
+            try container.encode(date, forKey: .associatedValue)
+        }
+    }
+}

--- a/Storage/Storage/Model/FeedbackSettings.swift
+++ b/Storage/Storage/Model/FeedbackSettings.swift
@@ -19,6 +19,10 @@ public struct FeedbackSettings: Codable, Equatable {
     ///
     public let status: Status
 
+    public init(name: String, status: Status) {
+        self.name = name
+        self.status = status
+    }
 }
 
 // MARK: Codable Conformance

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum FeedbackType {
+    case general
+}

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public enum FeedbackType {
+public enum FeedbackType: String, Codable {
     case general
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -15,12 +15,13 @@ public struct GeneralAppSettings: Codable, Equatable {
     ///
     public let installationDate: Date?
 
-    /// The last time that the user interacted with the in-app feedback (https://git.io/JJ8i0).
-    ///
-    public let lastFeedbackDate: Date?
+    /// Key/Value type to store feedback settings
+    /// Key: A `String` to identify the feedback
+    /// Value: A `FeedbackSetting` to store the feedback state
+    public let feedbacks: [String: FeedbackSettings]
 
-    public init(installationDate: Date?, lastFeedbackDate: Date?) {
+    public init(installationDate: Date?, feedbacks: [String: FeedbackSettings]) {
         self.installationDate = installationDate
-        self.lastFeedbackDate = lastFeedbackDate
+        self.feedbacks = feedbacks
     }
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -16,11 +16,11 @@ public struct GeneralAppSettings: Codable, Equatable {
     public let installationDate: Date?
 
     /// Key/Value type to store feedback settings
-    /// Key: A `String` to identify the feedback
+    /// Key: A `FeedbackType` to identify the feedback
     /// Value: A `FeedbackSetting` to store the feedback state
-    public let feedbacks: [String: FeedbackSettings]
+    public let feedbacks: [FeedbackType: FeedbackSettings]
 
-    public init(installationDate: Date?, feedbacks: [String: FeedbackSettings]) {
+    public init(installationDate: Date?, feedbacks: [FeedbackType: FeedbackSettings]) {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
     }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -34,4 +34,14 @@ public struct GeneralAppSettings: Codable, Equatable {
 
         return feedbackSeeting.status
     }
+
+    /// Returns a new instance of `GeneralAppSettings` with the provided feedback seetings updated.
+    ///
+    public func replacing(feedback: FeedbackSettings) -> GeneralAppSettings {
+        let updatedFeedbacks = feedbacks.merging([feedback.name: feedback]) {
+            _, new in new
+        }
+
+        return GeneralAppSettings(installationDate: installationDate, feedbacks: updatedFeedbacks)
+    }
 }

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -27,8 +27,8 @@ public struct GeneralAppSettings: Codable, Equatable {
 
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
     ///
-    public func feedbackStatus(of feedbackType: FeedbackType) -> FeedbackSettings.Status {
-        guard let feedbackSeeting = feedbacks[feedbackType] else {
+    public func feedbackStatus(of type: FeedbackType) -> FeedbackSettings.Status {
+        guard let feedbackSeeting = feedbacks[type] else {
             return .pending
         }
 

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -25,7 +25,6 @@ public struct GeneralAppSettings: Codable, Equatable {
         self.feedbacks = feedbacks
     }
 
-    /// TODO: Needs testing
     /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
     ///
     public func feedbackStatus(of feedbackType: FeedbackType) -> FeedbackSettings.Status {

--- a/Storage/Storage/Model/GeneralAppSettings.swift
+++ b/Storage/Storage/Model/GeneralAppSettings.swift
@@ -24,4 +24,15 @@ public struct GeneralAppSettings: Codable, Equatable {
         self.installationDate = installationDate
         self.feedbacks = feedbacks
     }
+
+    /// TODO: Needs testing
+    /// Returns the status of a given feedback type. If the feedback is not stored in the feedback array. it is assumed that it has a pending status.
+    ///
+    public func feedbackStatus(of feedbackType: FeedbackType) -> FeedbackSettings.Status {
+        guard let feedbackSeeting = feedbacks[feedbackType] else {
+            return .pending
+        }
+
+        return feedbackSeeting.status
+    }
 }

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Storage
+
+class GeneralAppSettingsTests: XCTestCase {
+
+    func test_it_returns_the_correct_status_of_a_stored_feedback() {
+        // Given
+        let feedback = FeedbackSettings(name: .general, status: .dismissed)
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [.general: feedback])
+
+        // When
+        let loadedStatus = settings.feedbackStatus(of: .general)
+
+        // Then
+        XCTAssertEqual(feedback.status, loadedStatus)
+    }
+
+    func test_it_returns_pending_status_of_a_non_stored_feedback() {
+        // Given
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:])
+
+        // When
+        let loadedStatus = settings.feedbackStatus(of: .general)
+
+        // Then
+        XCTAssertEqual(loadedStatus, .pending)
+    }
+}

--- a/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralAppSettingsTests.swift
@@ -25,4 +25,29 @@ class GeneralAppSettingsTests: XCTestCase {
         // Then
         XCTAssertEqual(loadedStatus, .pending)
     }
+
+    func test_it_replaces_feedback_when_feedback_exists() {
+        // Given
+        let existingFeedback = FeedbackSettings(name: .general, status: .dismissed)
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [.general: existingFeedback])
+
+        // When
+        let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))
+        let newSettings = settings.replacing(feedback: newFeedback)
+
+        // Then
+        XCTAssertEqual(newSettings.feedbacks[.general], newFeedback)
+    }
+
+    func test_it_adds_new_feedback_when_replacing_empty_feedback_store() {
+        // Given
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:])
+
+        // When
+        let newFeedback = FeedbackSettings(name: .general, status: .given(Date()))
+        let newSettings = settings.replacing(feedback: newFeedback)
+
+        // Then
+        XCTAssertEqual(newSettings.feedbacks[.general], newFeedback)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -49,7 +49,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     /// Updates the card visibility state stored in `isInAppFeedbackCardVisibleSubject` by updating the app last feedback date.
     ///
     func onInAppFeedbackCardAction() {
-        let action = AppSettingsAction.updateFeedbackStatus(feedbackType: .general, feedbackStatus: .given(Date())) { [weak self] result in
+        let action = AppSettingsAction.updateFeedbackStatus(type: .general, status: .given(Date())) { [weak self] result in
             guard let self = self else {
                 return
             }
@@ -71,7 +71,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
             return isInAppFeedbackCardVisibleSubject.send(isEnabled)
         }
 
-        let action = AppSettingsAction.loadFeedbackVisibility(feedbackType: .general) { [weak self] result in
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .general) { [weak self] result in
             guard let self = self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -71,7 +71,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
             return isInAppFeedbackCardVisibleSubject.send(isEnabled)
         }
 
-        let action = AppSettingsAction.loadInAppFeedbackCardVisibility { [weak self] result in
+        let action = AppSettingsAction.loadFeedbackVisibility(feedbackType: .general) { [weak self] result in
             guard let self = self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -49,7 +49,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     /// Updates the card visibility state stored in `isInAppFeedbackCardVisibleSubject` by updating the app last feedback date.
     ///
     func onInAppFeedbackCardAction() {
-        let action = AppSettingsAction.setLastFeedbackDate(date: Date()) { [weak self] result in
+        let action = AppSettingsAction.updateFeedbackStatus(feedbackType: .general, feedbackStatus: .given(Date())) { [weak self] result in
             guard let self = self else {
                 return
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -189,7 +189,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
                 onCompletion(.success(shouldShowFeedbackCard))
             }
 
-            if case let AppSettingsAction.setLastFeedbackDate(_, onCompletion) = action {
+            if case let AppSettingsAction.updateFeedbackStatus(_, _, onCompletion) = action {
                 shouldShowFeedbackCard = false
                 onCompletion(.success(Void()))
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -80,7 +80,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
                                                                   storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+            if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
                 onCompletion(.success(true))
             }
         }
@@ -105,7 +105,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
                                                                   storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+            if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
                 onCompletion(.success(false))
             }
         }
@@ -130,7 +130,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
                                                                   storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+            if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
                 onCompletion(.failure(NSError(domain: "", code: 0, userInfo: nil)))
             }
         }
@@ -155,7 +155,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
                                                                   storesManager: storesManager)
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+            if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
                 onCompletion(.success(true))
             }
         }
@@ -185,7 +185,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         // Default `loadInAppFeedbackCardVisibility` to true until `setLastFeedbackDate` action sets it to `false`
         var shouldShowFeedbackCard = true
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            if case let AppSettingsAction.loadInAppFeedbackCardVisibility(onCompletion) = action {
+            if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
                 onCompletion(.success(shouldShowFeedbackCard))
             }
 

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -77,9 +77,9 @@ public enum AppSettingsAction: Action {
 
     /// Updates or stores a feedback setting with the provided `type` and `status`.
     ///
-    case updateFeedbackStatus(feedbackType: FeedbackType, feedbackStatus: FeedbackSettings.Status, onCompletion: ((Result<Void, Error>) -> Void))
+    case updateFeedbackStatus(type: FeedbackType, status: FeedbackSettings.Status, onCompletion: ((Result<Void, Error>) -> Void))
 
     /// Returns whether a specific feedback request should be shown to the user.
     ///
-    case loadFeedbackVisibility(feedbackType: FeedbackType, onCompletion: (Result<Bool, Error>) -> Void)
+    case loadFeedbackVisibility(type: FeedbackType, onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -75,10 +75,9 @@ public enum AppSettingsAction: Action {
     ///
     case setInstallationDateIfNecessary(date: Date, onCompletion: ((Result<Bool, Error>) -> Void))
 
-    /// Saves the `date` as the last known date that the user interacted with the in-app
-    /// feedback prompt (https://git.io/JJ8i0).
+    /// Updates or stores a feedback setting with the provided `type` and `status`.
     ///
-    case setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
+    case updateFeedbackStatus(feedbackType: FeedbackType, feedbackStatus: FeedbackSettings.Status, onCompletion: ((Result<Void, Error>) -> Void))
 
     /// Returns whether a specific feedback request should be shown to the user.
     ///

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -80,12 +80,7 @@ public enum AppSettingsAction: Action {
     ///
     case setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void))
 
-    /// Returns whether the In-app Feedback Card should be shown to the user.
+    /// Returns whether a specific feedback request should be shown to the user.
     ///
-    /// The result is only `true` if these conditions are met:
-    ///
-    /// - The known installation date is more than 3 months ago
-    /// - The user has not given feedback for more than 6 months ago.
-    ///
-    case loadInAppFeedbackCardVisibility(onCompletion: (Result<Bool, Error>) -> Void)
+    case loadFeedbackVisibility(feedbackType: FeedbackType, onCompletion: (Result<Bool, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -20,9 +20,11 @@ struct InAppFeedbackCardVisibilityUseCase {
     private let calendar: Calendar
 
     private let settings: GeneralAppSettings
+    private let feedbackSettings: FeedbackSettings
 
-    init(settings: GeneralAppSettings, fileManager: FileManager = FileManager.default, calendar: Calendar = .current) {
+    init(settings: GeneralAppSettings, feedbackSettings: FeedbackSettings, fileManager: FileManager = FileManager.default, calendar: Calendar = .current) {
         self.settings = settings
+        self.feedbackSettings = feedbackSettings
         self.fileManager = fileManager
         self.calendar = calendar
     }
@@ -40,7 +42,7 @@ struct InAppFeedbackCardVisibilityUseCase {
             return false
         }
 
-        guard let lastFeedbackDate = settings.lastFeedbackDate else {
+        guard case let .given(lastFeedbackDate) = feedbackSettings.status else {
             return true
         }
 

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -20,11 +20,11 @@ struct InAppFeedbackCardVisibilityUseCase {
     private let calendar: Calendar
 
     private let settings: GeneralAppSettings
-    private let feedbackSettings: FeedbackSettings
+    private let feedbackType: FeedbackType
 
-    init(settings: GeneralAppSettings, feedbackSettings: FeedbackSettings, fileManager: FileManager = FileManager.default, calendar: Calendar = .current) {
+    init(settings: GeneralAppSettings, feedbackType: FeedbackType, fileManager: FileManager = FileManager.default, calendar: Calendar = .current) {
         self.settings = settings
-        self.feedbackSettings = feedbackSettings
+        self.feedbackType = feedbackType
         self.fileManager = fileManager
         self.calendar = calendar
     }
@@ -42,7 +42,7 @@ struct InAppFeedbackCardVisibilityUseCase {
             return false
         }
 
-        guard case let .given(lastFeedbackDate) = feedbackSettings.status else {
+        guard case let .given(lastFeedbackDate) = settings.feedbackStatus(of: feedbackType) else {
             return true
         }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -155,7 +155,8 @@ private extension AppSettingsStore {
     func setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void)) {
         do {
             let settings = loadOrCreateGeneralAppSettings()
-            let settingsToSave = replaceGeneralFeedbackDate(date, on: settings)
+            let newFeedback = FeedbackSettings(name: .general, status: .given(date))
+            let settingsToSave = settings.replacing(feedback: newFeedback)
             try saveGeneralAppSettings(settingsToSave)
 
             onCompletion(.success(()))
@@ -185,24 +186,6 @@ private extension AppSettingsStore {
     /// Save the `GeneralAppSettings` to the appropriate file.
     func saveGeneralAppSettings(_ settings: GeneralAppSettings) throws {
         try fileStorage.write(settings, to: generalAppSettingsFileURL)
-    }
-}
-
-// MARK: - Feedback Settings
-//
-private extension AppSettingsStore {
-    /// Adds or replaces the general feedback given date on the provided `GeneralAppSettings` value type.
-    /// Returns a new `GeneralAppSettings`type with the general feedback data updated.
-    ///
-    func replaceGeneralFeedbackDate(_ date: Date, on appSettings: GeneralAppSettings) -> GeneralAppSettings {
-        // Creates a new general feedback setting
-        let feedback = FeedbackSettings(name: .general, status: .given(date))
-
-        // Merges thew new setting with the existing feedback settings
-        let feedbackStore = appSettings.feedbacks.merging([feedback.name: feedback]) { _, new in new }
-
-        // Returns a new app setting with the updated feedback values
-        return GeneralAppSettings(installationDate: appSettings.installationDate, feedbacks: feedbackStore)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -117,8 +117,8 @@ public class AppSettingsStore: Store {
             setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
         case .setLastFeedbackDate(let date, let onCompletion):
             setLastFeedbackDate(date: date, onCompletion: onCompletion)
-        case .loadInAppFeedbackCardVisibility(let onCompletion):
-            loadInAppFeedbackCardVisibility(onCompletion: onCompletion)
+        case .loadFeedbackVisibility(let feedbackType, let onCompletion):
+            loadFeedbackVisibility(feedbackType: feedbackType, onCompletion: onCompletion)
         }
     }
 }
@@ -164,9 +164,9 @@ private extension AppSettingsStore {
         }
     }
 
-    func loadInAppFeedbackCardVisibility(onCompletion: (Result<Bool, Error>) -> Void) {
+    func loadFeedbackVisibility(feedbackType: FeedbackType, onCompletion: (Result<Bool, Error>) -> Void) {
         let settings = loadOrCreateGeneralAppSettings()
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: feedbackType)
 
         onCompletion(Result {
             try useCase.shouldBeVisible()

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -115,10 +115,10 @@ public class AppSettingsStore: Store {
             resetStatsVersionStates()
         case .setInstallationDateIfNecessary(let date, let onCompletion):
             setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
-        case .updateFeedbackStatus(let feedbackType, let feedbackStatus, let onCompletion):
-            updateFeedbackStatus(feedbackType: feedbackType, feedbackstatus: feedbackStatus, onCompletion: onCompletion)
-        case .loadFeedbackVisibility(let feedbackType, let onCompletion):
-            loadFeedbackVisibility(feedbackType: feedbackType, onCompletion: onCompletion)
+        case .updateFeedbackStatus(let type, let status, let onCompletion):
+            updateFeedbackStatus(type: type, status: status, onCompletion: onCompletion)
+        case .loadFeedbackVisibility(let type, let onCompletion):
+            loadFeedbackVisibility(type: type, onCompletion: onCompletion)
         }
     }
 }
@@ -152,10 +152,10 @@ private extension AppSettingsStore {
 
     /// Updates the feedback store  in `GeneralAppSettings` with the given `type` and `status`.
     ///
-    func updateFeedbackStatus(feedbackType: FeedbackType, feedbackstatus: FeedbackSettings.Status, onCompletion: ((Result<Void, Error>) -> Void)) {
+    func updateFeedbackStatus(type: FeedbackType, status: FeedbackSettings.Status, onCompletion: ((Result<Void, Error>) -> Void)) {
         do {
             let settings = loadOrCreateGeneralAppSettings()
-            let newFeedback = FeedbackSettings(name: feedbackType, status: feedbackstatus)
+            let newFeedback = FeedbackSettings(name: type, status: status)
             let settingsToSave = settings.replacing(feedback: newFeedback)
             try saveGeneralAppSettings(settingsToSave)
 
@@ -165,9 +165,9 @@ private extension AppSettingsStore {
         }
     }
 
-    func loadFeedbackVisibility(feedbackType: FeedbackType, onCompletion: (Result<Bool, Error>) -> Void) {
+    func loadFeedbackVisibility(type: FeedbackType, onCompletion: (Result<Bool, Error>) -> Void) {
         let settings = loadOrCreateGeneralAppSettings()
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: feedbackType)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: type)
 
         onCompletion(Result {
             try useCase.shouldBeVisible()

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -195,8 +195,8 @@ private extension AppSettingsStore {
     /// Load the  general feedback setting  from the provided `appSettings` or create an empty one if it doesn't exist.
     ///
     func loadsOrCreateGeneralFeedbackSetting(from appSettings: GeneralAppSettings) -> FeedbackSettings {
-        guard let feedback = appSettings.feedbacks[Constants.generalFeedbackName] else {
-            return FeedbackSettings(name: Constants.generalFeedbackName, status: .pending)
+        guard let feedback = appSettings.feedbacks[.general] else {
+            return FeedbackSettings(name: .general, status: .pending)
         }
         return feedback
     }
@@ -206,7 +206,7 @@ private extension AppSettingsStore {
     ///
     func replaceGeneralFeedbackDate(_ date: Date, on appSettings: GeneralAppSettings) -> GeneralAppSettings {
         // Creates a new general feedback setting
-        let feedback = FeedbackSettings(name: Constants.generalFeedbackName, status: .given(date))
+        let feedback = FeedbackSettings(name: .general, status: .given(date))
 
         // Merges thew new setting with the existing feedback settings
         let feedbackStore = appSettings.feedbacks.merging([feedback.name: feedback]) { _, new in new }
@@ -497,7 +497,4 @@ private enum Constants {
     static let statsVersionLastShownFileName = "stats-version-last-shown.plist"
     static let productsFeatureSwitchFileName = "products-feature-switch.plist"
     static let generalAppSettingsFileName = "general-app-settings.plist"
-
-    // MARK: Feedback Names
-    static let generalFeedbackName = "general-in-app-feedback"
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -115,8 +115,8 @@ public class AppSettingsStore: Store {
             resetStatsVersionStates()
         case .setInstallationDateIfNecessary(let date, let onCompletion):
             setInstallationDateIfNecessary(date: date, onCompletion: onCompletion)
-        case .setLastFeedbackDate(let date, let onCompletion):
-            setLastFeedbackDate(date: date, onCompletion: onCompletion)
+        case .updateFeedbackStatus(let feedbackType, let feedbackStatus, let onCompletion):
+            updateFeedbackStatus(feedbackType: feedbackType, feedbackstatus: feedbackStatus, onCompletion: onCompletion)
         case .loadFeedbackVisibility(let feedbackType, let onCompletion):
             loadFeedbackVisibility(feedbackType: feedbackType, onCompletion: onCompletion)
         }
@@ -150,12 +150,12 @@ private extension AppSettingsStore {
         }
     }
 
-    /// Save the `date` in `GeneralAppSettings` for the general feedback..
+    /// Updates the feedback store  in `GeneralAppSettings` with the given `type` and `status`.
     ///
-    func setLastFeedbackDate(date: Date, onCompletion: ((Result<Void, Error>) -> Void)) {
+    func updateFeedbackStatus(feedbackType: FeedbackType, feedbackstatus: FeedbackSettings.Status, onCompletion: ((Result<Void, Error>) -> Void)) {
         do {
             let settings = loadOrCreateGeneralAppSettings()
-            let newFeedback = FeedbackSettings(name: .general, status: .given(date))
+            let newFeedback = FeedbackSettings(name: feedbackType, status: feedbackstatus)
             let settingsToSave = settings.replacing(feedback: newFeedback)
             try saveGeneralAppSettings(settingsToSave)
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -166,7 +166,8 @@ private extension AppSettingsStore {
 
     func loadInAppFeedbackCardVisibility(onCompletion: (Result<Bool, Error>) -> Void) {
         let settings = loadOrCreateGeneralAppSettings()
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings)
+        let generalFeedback = loadsOrCreateGeneralFeedbackSetting(from: settings)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: generalFeedback)
 
         onCompletion(Result {
             try useCase.shouldBeVisible()
@@ -191,6 +192,15 @@ private extension AppSettingsStore {
 // MARK: - Feedback Settings
 //
 private extension AppSettingsStore {
+    /// Load the  general feedback setting  from the provided `appSettings` or create an empty one if it doesn't exist.
+    ///
+    func loadsOrCreateGeneralFeedbackSetting(from appSettings: GeneralAppSettings) -> FeedbackSettings {
+        guard let feedback = appSettings.feedbacks[Constants.generalFeedbackName] else {
+            return FeedbackSettings(name: Constants.generalFeedbackName, status: .pending)
+        }
+        return feedback
+    }
+
     /// Adds or replaces the general feedback given date on the provided `GeneralAppSettings` value type.
     /// Returns a new `GeneralAppSettings`type with the general feedback data updated.
     ///

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -166,8 +166,7 @@ private extension AppSettingsStore {
 
     func loadInAppFeedbackCardVisibility(onCompletion: (Result<Bool, Error>) -> Void) {
         let settings = loadOrCreateGeneralAppSettings()
-        let generalFeedback = loadsOrCreateGeneralFeedbackSetting(from: settings)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: generalFeedback)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general)
 
         onCompletion(Result {
             try useCase.shouldBeVisible()
@@ -192,15 +191,6 @@ private extension AppSettingsStore {
 // MARK: - Feedback Settings
 //
 private extension AppSettingsStore {
-    /// Load the  general feedback setting  from the provided `appSettings` or create an empty one if it doesn't exist.
-    ///
-    func loadsOrCreateGeneralFeedbackSetting(from appSettings: GeneralAppSettings) -> FeedbackSettings {
-        guard let feedback = appSettings.feedbacks[.general] else {
-            return FeedbackSettings(name: .general, status: .pending)
-        }
-        return feedback
-    }
-
     /// Adds or replaces the general feedback given date on the provided `GeneralAppSettings` value type.
     /// Returns a new `GeneralAppSettings`type with the general feedback data updated.
     ///

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -36,8 +36,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -53,8 +53,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -71,8 +71,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -89,8 +89,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -107,8 +107,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: nil, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: nil, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -127,8 +127,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -141,8 +141,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Given
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: nil, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
+        let settings = createAppSetting(instalationDate: nil, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
         var error: Error?
@@ -166,9 +166,9 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
         try XCTUnwrap(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last)
     }
 
-    func createAppSettingAndFeedback(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
-        let feedback = FeedbackSettings(name: "general", status: feedbackSatus)
+    func createAppSetting(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> GeneralAppSettings {
+        let feedback = FeedbackSettings(name: .general, status: feedbackSatus)
         let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback])
-        return (settings, feedback)
+        return settings
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 @testable import Yosemite
 import struct Storage.GeneralAppSettings
+import struct Storage.FeedbackSettings
 
 private typealias InferenceError = InAppFeedbackCardVisibilityUseCase.InferenceError
 
@@ -35,8 +36,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: nil)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -52,8 +53,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: nil)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -70,8 +71,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: lastFeedbackDate)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -88,8 +89,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: lastFeedbackDate)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -106,8 +107,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let settings = GeneralAppSettings(installationDate: nil, lastFeedbackDate: nil)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: nil, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -126,8 +127,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let settings = GeneralAppSettings(installationDate: installationDate, lastFeedbackDate: nil)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: installationDate, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
@@ -140,8 +141,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Given
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = GeneralAppSettings(installationDate: nil, lastFeedbackDate: nil)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, fileManager: fileManager, calendar: calendar)
+        let (settings, feedback) = createAppSettingAndFeedback(instalationDate: nil, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackSettings: feedback, fileManager: fileManager, calendar: calendar)
 
         // When
         var error: Error?
@@ -163,5 +164,11 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
 
     func documentDirectoryURL() throws -> URL {
         try XCTUnwrap(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last)
+    }
+
+    func createAppSettingAndFeedback(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
+        let feedback = FeedbackSettings(name: "general", status: feedbackSatus)
+        let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback])
+        return (settings, feedback)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -342,7 +342,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // When
         var shouldBeVisibleResult: Result<Bool, Error>?
-        let action = AppSettingsAction.loadInAppFeedbackCardVisibility { result in
+        let action = AppSettingsAction.loadFeedbackVisibility(feedbackType: .general) { result in
             shouldBeVisibleResult = result
         }
         subject?.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -300,7 +300,7 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(savedSettings.feedbacks.isEmpty)
     }
 
-    func testItCanSaveTheLastFeedbackDate() throws {
+    func test_it_can_update_the_general_feedback_given_date() throws {
         // Given
         let date = Date(timeIntervalSince1970: 300)
 
@@ -311,7 +311,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // When
         var result: Result<Void, Error>?
-        let action = AppSettingsAction.setLastFeedbackDate(date: date) { aResult in
+        let action = AppSettingsAction.updateFeedbackStatus(feedbackType: .general, feedbackStatus: .given(date)) { aResult in
             result = aResult
         }
         subject?.onAction(action)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -192,8 +192,8 @@ final class AppSettingsStoreTests: XCTestCase {
         // Given
         let date = Date(timeIntervalSince1970: 100)
 
-        let existingSettings = GeneralAppSettings(installationDate: Date(timeIntervalSince1970: 4_810),
-                                                  lastFeedbackDate: Date(timeIntervalSince1970: 9_971_311))
+        let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(instalationDate: Date(timeIntervalSince1970: 4_810),
+                                                                              feedbackSatus: .given(Date(timeIntervalSince1970: 9_971_311)))
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
 
         // When
@@ -211,7 +211,7 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(date, savedSettings.installationDate)
 
         // The other properties should be kept
-        XCTAssertEqual(savedSettings.lastFeedbackDate, existingSettings.lastFeedbackDate)
+        XCTAssertEqual(savedSettings.feedbacks[feedback.name], feedback)
     }
 
     /// Test that the installationDate can still be saved even if there is no existing
@@ -297,15 +297,16 @@ final class AppSettingsStoreTests: XCTestCase {
 
         let savedSettings: GeneralAppSettings = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
         XCTAssertEqual(date, savedSettings.installationDate)
-        XCTAssertNil(savedSettings.lastFeedbackDate)
+        XCTAssertTrue(savedSettings.feedbacks.isEmpty)
     }
 
     func testItCanSaveTheLastFeedbackDate() throws {
         // Given
         let date = Date(timeIntervalSince1970: 300)
 
-        let existingSettings = GeneralAppSettings(installationDate: Date(timeIntervalSince1970: 1),
-                                                  lastFeedbackDate: Date(timeIntervalSince1970: 999))
+        let (existingSettings, feedback) = createAppSettingAndGeneralFeedback(instalationDate: Date(timeIntervalSince1970: 1),
+                                                                              feedbackSatus: .given(Date(timeIntervalSince1970: 999)))
+
         try fileStorage?.write(existingSettings, to: expectedGeneralAppSettingsFileURL)
 
         // When
@@ -319,7 +320,8 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(result).isSuccess)
 
         let savedSettings: GeneralAppSettings = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
-        XCTAssertEqual(date, savedSettings.lastFeedbackDate)
+        let savedFeedback = try XCTUnwrap(savedSettings.feedbacks[feedback.name])
+        XCTAssertEqual(.given(date), savedFeedback.status)
 
         // The other properties should be kept
         XCTAssertEqual(savedSettings.installationDate, existingSettings.installationDate)
@@ -357,5 +359,11 @@ private extension AppSettingsStoreTests {
     var expectedGeneralAppSettingsFileURL: URL {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
         return documents!.appendingPathComponent("general-app-settings.plist")
+    }
+
+    func createAppSettingAndGeneralFeedback(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
+        let feedback = FeedbackSettings(name: "general-in-app-feedback", status: feedbackSatus)
+        let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback])
+        return (settings, feedback)
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -362,7 +362,7 @@ private extension AppSettingsStoreTests {
     }
 
     func createAppSettingAndGeneralFeedback(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> (GeneralAppSettings, FeedbackSettings) {
-        let feedback = FeedbackSettings(name: "general-in-app-feedback", status: feedbackSatus)
+        let feedback = FeedbackSettings(name: .general, status: feedbackSatus)
         let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback])
         return (settings, feedback)
     }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -311,7 +311,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // When
         var result: Result<Void, Error>?
-        let action = AppSettingsAction.updateFeedbackStatus(feedbackType: .general, feedbackStatus: .given(date)) { aResult in
+        let action = AppSettingsAction.updateFeedbackStatus(type: .general, status: .given(date)) { aResult in
             result = aResult
         }
         subject?.onAction(action)
@@ -342,7 +342,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
         // When
         var shouldBeVisibleResult: Result<Bool, Error>?
-        let action = AppSettingsAction.loadFeedbackVisibility(feedbackType: .general) { result in
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .general) { result in
             shouldBeVisibleResult = result
         }
         subject?.onAction(action)


### PR DESCRIPTION
relates to https://github.com/woocommerce/woocommerce-ios/issues/2647

# Why

The app should support multiple feedback requests. At the time of this writing, a general feedback is requested and we are close to asking feedback for the [product feature](https://github.com/woocommerce/woocommerce-ios/issues/2648).

This PR aims to extend the `GeneralAppSettings` type to save multiple feedback states, one for each feedback.

# How

- Defined a new `FeedbackSettings` type that stores a particular feedback state. Our current options for that state are `pending`, `dismissed` or `given`.
- Modify `GeneralAppSettings` to include this new feedback type
- Modify `AppSettingsStore` to save the `last feedback date` using the new `FeedbackSettings` type.

# Testing Steps
- See that unit tests pass

And

- Delete the app on the device.
- Run the app and log in.
- Time travel to at least 90 days from now.
- Navigate to the Orders tab and navigate back to My Store.
- Confirm that the in-app feedback card is now visible.
- Tap on any CTA
- See that the in-app feedback is hidden
- Relaunch the app
- See that the in-app feedback remains invisible

# Notes
- The test that is failing should be fixed once https://github.com/woocommerce/woocommerce-ios/pull/2656 is merged

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
