### PR TITLE
Handle General inApp Feedback Survey Errors

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -74,7 +74,7 @@ extension WooConstants {
         /// URL for in-app feedback survey
         ///
 #if DEBUG
-        case inAppFeedback = "https://wasseryi.survey.fm/woo-mobile-app-test-survey"
+        case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-test-survey"
 #else
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -47,7 +47,7 @@ private extension SurveyCoordinatingController {
         }, onBackToStoreAction: { [weak self] in
             self?.finishSurveyNavigation()
         })
-        show(completionViewController, sender: self)
+        setViewControllers([completionViewController], animated: true)
     }
 
     /// Dismisses the flow modally

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -110,11 +110,11 @@ extension SurveyViewController: WKNavigationDelegate {
         guard case .formSubmitted = navigationAction.navigationType,
             let url = navigationAction.request.url,
             let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
-            let surveyMessageTag = queryItems.first(where: { $0.name == Constants.surveyMessageTagKey })?.value else {
+            let surveyMessageValue = queryItems.first(where: { $0.name == Constants.surveyMessageParameterKey })?.value else {
                 return
         }
 
-        if surveyMessageTag == Constants.surveyCompletionTagValue {
+        if surveyMessageValue == Constants.surveyCompletionParameterValue {
             onCompletion()
         }
     }
@@ -128,7 +128,7 @@ extension SurveyViewController: WKNavigationDelegate {
 //
 private extension SurveyViewController {
     enum Constants {
-        static let surveyMessageTagKey = "msg"
-        static let surveyCompletionTagValue = "done"
+        static let surveyMessageParameterKey = "msg"
+        static let surveyCompletionParameterValue = "done"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -99,16 +99,36 @@ extension SurveyViewController {
 extension SurveyViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
 
-        // The condition for the POST HTTP method is necessary, since the `formSubmitted` callback is triggered when showing the Crowdsignal completion screen
-        // (a GET request).
-        if case .formSubmitted = navigationAction.navigationType, navigationAction.request.httpMethod == "POST" {
-            onCompletion()
+        defer {
+            decisionHandler(.allow)
         }
 
-        decisionHandler(.allow)
+        // To consider the survey as completed, the following conditions need to occur:
+        // - Survey Form is submitted.
+        // - The request URL contains a `msg` parameter key with `done` as it's value
+        //
+        guard case .formSubmitted = navigationAction.navigationType,
+            let url = navigationAction.request.url,
+            let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            let surveyMessageTag = queryItems.first(where: { $0.name == Constants.surveyMessageTagKey })?.value else {
+                return
+        }
+
+        if surveyMessageTag == Constants.surveyCompletionTagValue {
+            onCompletion()
+        }
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation) {
         removeLoadingView()
+    }
+}
+
+// MARK: Constants
+//
+private extension SurveyViewController {
+    enum Constants {
+        static let surveyMessageTagKey = "msg"
+        static let surveyCompletionTagValue = "done"
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
@@ -30,9 +30,8 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
 
         // Then
         waitUntil {
-            coordinator.viewControllers.count > 1
+            coordinator.topViewController is SurveySubmittedViewControllerOutputs
         }
-        XCTAssertTrue(coordinator.topViewController is SurveySubmittedViewControllerOutputs)
     }
 
     func test_it_gets_dismissed_on_backToStore_action() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -44,12 +44,9 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_does_not_complete_after_receiving_a_form_submitted_non_completed_callback_request() throws {
         // Given
-        let exp = expectation(description: #function)
-        exp.isInverted = true
         var surveyCompleted = false
         let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
             surveyCompleted = true
-            exp.fulfill()
         })
 
         // When
@@ -57,9 +54,12 @@ final class SurveyViewControllerTests: XCTestCase {
         let mirror = try self.mirror(of: viewController)
 
         // Fakes a form submission GET navigation
-        let navigationAction = FormSubmittedNavigationAction.nonCompletedAction
-        viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
-        waitForExpectations(timeout: Constants.expectationTimeout)
+        waitForExpectation { exp in
+            let navigationAction = FormSubmittedNavigationAction.nonCompletedAction
+            viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in
+                exp.fulfill()
+            })
+        }
 
         // Then
         XCTAssertFalse(surveyCompleted)
@@ -67,12 +67,9 @@ final class SurveyViewControllerTests: XCTestCase {
 
     func test_it_does_not_complete_after_receiving_a_form_submitted_empty_callback_request() throws {
         // Given
-        let exp = expectation(description: #function)
-        exp.isInverted = true
         var surveyCompleted = false
         let viewController = SurveyViewController(survey: .inAppFeedback, onCompletion: {
             surveyCompleted = true
-            exp.fulfill()
         })
 
         // When
@@ -80,9 +77,12 @@ final class SurveyViewControllerTests: XCTestCase {
         let mirror = try self.mirror(of: viewController)
 
         // Fakes a form submission GET navigation
-        let navigationAction = FormSubmittedNavigationAction.emptyAction
-        viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in })
-        waitForExpectations(timeout: Constants.expectationTimeout)
+        waitForExpectation { exp in
+            let navigationAction = FormSubmittedNavigationAction.emptyAction
+            viewController.webView(mirror.webView, decidePolicyFor: navigationAction, decisionHandler: { _ in
+                exp.fulfill()
+            })
+        }
 
         // Then
         XCTAssertFalse(surveyCompleted)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -169,8 +169,7 @@ private extension SurveyViewControllerTests {
                 urlComponents.queryItems = [item]
             }
 
-            let finalURL = (try? urlComponents.asURL()) ?? WooConstants.URLs.inAppFeedback.asURL()
-            return URLRequest(url: finalURL)
+            return URLRequest(url: try! urlComponents.asURL())
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -142,20 +142,20 @@ private extension SurveyViewControllerTests {
     final class FormSubmittedNavigationAction: WKNavigationAction {
 
         static var emptyAction: FormSubmittedNavigationAction {
-            return FormSubmittedNavigationAction(messageTag: nil)
+            return FormSubmittedNavigationAction(messageParameterValue: nil)
         }
 
         static var nonCompletedAction: FormSubmittedNavigationAction {
-            return FormSubmittedNavigationAction(messageTag: "other")
+            return FormSubmittedNavigationAction(messageParameterValue: "other")
         }
 
         static var completedAction: FormSubmittedNavigationAction {
-            return FormSubmittedNavigationAction(messageTag: "done")
+            return FormSubmittedNavigationAction(messageParameterValue: "done")
         }
 
-        private let messageTag: String?
-        private init(messageTag: String?) {
-            self.messageTag = messageTag
+        private let messageParameterValue: String?
+        private init(messageParameterValue: String?) {
+            self.messageParameterValue = messageParameterValue
         }
 
         override var navigationType: WKNavigationType {
@@ -164,8 +164,8 @@ private extension SurveyViewControllerTests {
 
         override var request: URLRequest {
             var urlComponents = URLComponents(url: WooConstants.URLs.inAppFeedback.asURL(), resolvingAgainstBaseURL: false) ?? URLComponents()
-            if let messageTag = messageTag {
-                let item = URLQueryItem(name: "msg", value: messageTag)
+            if let messageParameterValue = messageParameterValue {
+                let item = URLQueryItem(name: "msg", value: messageParameterValue)
                 urlComponents.queryItems = [item]
             }
 


### PR DESCRIPTION
fixes #2655 

# Why
Prior to this PR the `SurveyViewController` didn't take survey errors into consideration before navigating the user to the survey completion screen.

# How
After looking at how the survey behaves I came to the conclusion the at the user is redirected to the survey URL with a special parameter(`msg=done`) when the user has successfully completed a survey. I couldn't find official documentation for this but it was confirmed in p1597419047017800-slack-crowdsignal

# GIF
![survey](https://user-images.githubusercontent.com/562080/90275448-f395e800-de27-11ea-9204-4d175c4c9d3d.gif)


# Testing Steps
- Add the following code in `DashboardViewController`
```swift
let button = UIBarButtonItem(image: .productReviewsImage, style: .plain, target: self, action: #selector(showSurvey))
navigationItem.setLeftBarButton(button, animated: false)

@objc private func showSurvey() {
    let coordinator = SurveyCoordinatingController(survey: .inAppFeedback)
    present(coordinator, animated: true, completion: nil)
}
```
- Launch the app and tap on the left bar button item
- Tap on finish survey without filling it
- See that the errors are rendered on screen
- Fill the survey
- Tap on finish
- See that you are redirected to the survey completion screen

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
