### PR TITLE
Add a warning banner on top of the variation list when any variations are missing a price

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,8 @@
 4.9
 -----
+- [**] In Settings > Experimental Features, a Products switch is now available for turning Products M3 features on and off for core products (default off for beta testing). Products M3 features: edit grouped, external and variable products, enable/disable reviews, change product type and update categories and tags.
 - [*] Edit Products: the update action now shows up on the product details after updating just the sale price.
 - [*] Variable product > variation list: a warning banner is shown if any variations do not have a price, and warning text is shown on these variation rows.
-- [**] In Settings > Experimental Features, a Products switch is now available for turning Products M3 features on and off for core products (default off for beta testing). Products M3 features: edit grouped, external and variable products, enable/disable reviews, change product type and update categories and tag.
  
 4.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 4.9
 -----
 - [*] Edit Products: the update action now shows up on the product details after updating just the sale price.
+- [*] Variable product > variation list: a warning banner is shown if any variations do not have a price, and warning text is shown on these variation rows.
  
 4.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsTopBannerFactory.swift
@@ -4,8 +4,8 @@ import UIKit
 ///
 final class ProductVariationsTopBannerFactory {
     static func missingPricesTopBannerView() -> TopBannerView {
-        let viewModel = TopBannerViewModel(title: Constants.title,
-                                           infoText: Constants.info,
+        let viewModel = TopBannerViewModel(title: Localization.title,
+                                           infoText: Localization.info,
                                            icon: Constants.icon,
                                            isExpanded: true,
                                            topButton: .none,
@@ -16,10 +16,13 @@ final class ProductVariationsTopBannerFactory {
 
 private extension ProductVariationsTopBannerFactory {
     enum Constants {
+        static let icon = UIImage.infoOutlineImage
+    }
+
+    enum Localization {
         static let title = NSLocalizedString("Some variations do not have prices",
                                              comment: "Banner title in product variation list top banner when some variations do not have a price")
         static let info = NSLocalizedString("Variations without price will not be shown in your store.",
                                             comment: "Banner caption in my store when the stats will be deprecated")
-        static let icon = UIImage.infoOutlineImage
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsTopBannerFactory.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+/// Generates top banner view that is shown at the top of variation list screen when at least one variation is missing a price.
+///
+final class ProductVariationsTopBannerFactory {
+    static func missingPricesTopBannerView() -> TopBannerView {
+        let viewModel = TopBannerViewModel(title: Constants.title,
+                                           infoText: Constants.info,
+                                           icon: Constants.icon,
+                                           isExpanded: true,
+                                           topButton: .none,
+                                           type: .warning)
+        return TopBannerView(viewModel: viewModel)
+    }
+}
+
+private extension ProductVariationsTopBannerFactory {
+    enum Constants {
+        static let title = NSLocalizedString("Some variations do not have prices",
+                                             comment: "Banner title in product variation list top banner when some variations do not have a price")
+        static let info = NSLocalizedString("Variations without price will not be shown in your store.",
+                                            comment: "Banner caption in my store when the stats will be deprecated")
+        static let icon = UIImage.infoOutlineImage
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -185,7 +185,6 @@ private extension ProductVariationsViewController {
     func updateTopBannerView() {
         let hasVariationsMissingPrice = resultsController.fetchedObjects.contains { $0.price.isEmpty }
         topBannerView.isHidden = hasVariationsMissingPrice == false
-        tableView.layoutIfNeeded()
         tableView.updateHeaderHeight()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -340,21 +340,21 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
 
         let action = ProductVariationAction
             .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] error in
-                                    guard let self = self else {
-                                        return
-                                    }
+                guard let self = self else {
+                    return
+                }
 
-                                    if let error = error {
-                                        ServiceLocator.analytics.track(.productVariationListLoadError, withError: error)
+                if let error = error {
+                    ServiceLocator.analytics.track(.productVariationListLoadError, withError: error)
 
-                                        DDLogError("⛔️ Error synchronizing product variations: \(error)")
-                                        self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
-                                    } else {
-                                        ServiceLocator.analytics.track(.productVariationListLoaded)
-                                    }
+                    DDLogError("⛔️ Error synchronizing product variations: \(error)")
+                    self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
+                } else {
+                    ServiceLocator.analytics.track(.productVariationListLoaded)
+                }
 
-                                    self.transitionToResultsUpdatedState()
-                                    onCompletion?(error == nil)
+                self.transitionToResultsUpdatedState()
+                onCompletion?(error == nil)
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -69,13 +69,9 @@ final class TopBannerView: UIView {
 
 private extension TopBannerView {
     func configureSubviews(with viewModel: TopBannerViewModel) {
-        configureBackground()
-
         let mainStackView = createMainStackView(with: viewModel)
         addSubview(mainStackView)
         pinSubviewToAllEdges(mainStackView)
-
-        iconImageView.tintColor = .textSubtle
 
         titleLabel.applyHeadlineStyle()
         titleLabel.numberOfLines = 0
@@ -89,6 +85,7 @@ private extension TopBannerView {
         }
 
         renderContent(of: viewModel)
+        configureBannerType(type: viewModel.type)
     }
 
     func renderContent(of viewModel: TopBannerViewModel) {
@@ -125,11 +122,9 @@ private extension TopBannerView {
             dismissButton.setImage(UIImage.gridicon(.cross, size: CGSize(width: 24, height: 24)), for: .normal)
             dismissButton.tintColor = .textSubtle
             dismissButton.addTarget(self, action: #selector(onDismissButtonTapped), for: .touchUpInside)
+        case .none:
+            break
         }
-    }
-
-    func configureBackground() {
-        backgroundColor = .systemColor(.secondarySystemGroupedBackground)
     }
 
     func createMainStackView(with viewModel: TopBannerViewModel) -> UIStackView {
@@ -161,7 +156,7 @@ private extension TopBannerView {
 
     func createInformationStackView(with viewModel: TopBannerViewModel) -> UIStackView {
         let topActionButton = topButton(for: viewModel.topButton)
-        let titleStackView = UIStackView(arrangedSubviews: [titleLabel, topActionButton])
+        let titleStackView = UIStackView(arrangedSubviews: [titleLabel, topActionButton].compactMap { $0 })
         titleStackView.axis = .horizontal
         titleStackView.spacing = 16
 
@@ -189,12 +184,25 @@ private extension TopBannerView {
         return UIView.createBorderView()
     }
 
-    func topButton(for buttonType: TopBannerViewModel.TopButtonType) -> UIButton {
+    func topButton(for buttonType: TopBannerViewModel.TopButtonType) -> UIButton? {
         switch buttonType {
         case .chevron:
             return expandCollapseButton
         case .dismiss:
             return dismissButton
+        case .none:
+            return nil
+        }
+    }
+
+    func configureBannerType(type: TopBannerViewModel.BannerType) {
+        switch type {
+        case .normal:
+            iconImageView.tintColor = .textSubtle
+            backgroundColor = .systemColor(.secondarySystemGroupedBackground)
+        case .warning:
+            iconImageView.tintColor = .warning
+            backgroundColor = .warningBackground
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -7,13 +7,21 @@ struct TopBannerViewModel {
     enum TopButtonType {
         case chevron(handler: (() -> Void)?)
         case dismiss(handler: (() -> Void)?)
+        case none
 
         var handler: (() -> Void)? {
             switch self {
             case let .chevron(handler), let .dismiss(handler):
                 return handler
+            case .none:
+                return nil
             }
         }
+    }
+
+    enum BannerType {
+        case normal
+        case warning
     }
 
     let title: String?
@@ -23,6 +31,7 @@ struct TopBannerViewModel {
     let isExpanded: Bool
     let actionHandler: (() -> Void)?
     let topButton: TopButtonType
+    let type: BannerType
 
     /// Used when the top banner is not actionable.
     ///
@@ -30,7 +39,8 @@ struct TopBannerViewModel {
          infoText: String?,
          icon: UIImage?,
          isExpanded: Bool,
-         topButton: TopButtonType) {
+         topButton: TopButtonType,
+         type: BannerType = .normal) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
@@ -38,6 +48,7 @@ struct TopBannerViewModel {
         self.actionButtonTitle = nil
         self.actionHandler = nil
         self.topButton = topButton
+        self.type = type
     }
 
     /// Used when the top banner is actionable.
@@ -48,7 +59,8 @@ struct TopBannerViewModel {
          actionButtonTitle: String,
          isExpanded: Bool = true,
          actionHandler: @escaping () -> Void,
-         topButton: TopButtonType) {
+         topButton: TopButtonType,
+         type: BannerType = .normal) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
@@ -56,5 +68,6 @@ struct TopBannerViewModel {
         self.isExpanded = isExpanded
         self.actionHandler = actionHandler
         self.topButton = topButton
+        self.type = type
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
+		02CB9BE424E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CB9BE324E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift */; };
 		02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */; };
 		02CEBB8224C98861002EDF35 /* ProductFormDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */; };
 		02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */; };
@@ -1187,6 +1188,7 @@
 		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
+		02CB9BE324E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationsTopBannerFactory.swift; sourceTree = "<group>"; };
 		02CEBB7F24C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormActionsFactoryProtocol.swift; sourceTree = "<group>"; };
 		02CEBB8124C98861002EDF35 /* ProductFormDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormDataModel.swift; sourceTree = "<group>"; };
 		02CEBB8324C99A10002EDF35 /* Product+ShippingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ShippingTests.swift"; sourceTree = "<group>"; };
@@ -2265,6 +2267,7 @@
 				026CF638237E9ABE009563D4 /* ProductVariationsViewController.swift */,
 				026CF639237E9ABE009563D4 /* ProductVariationsViewController.xib */,
 				0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */,
+				02CB9BE324E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift */,
 			);
 			path = Variations;
 			sourceTree = "<group>";
@@ -5102,6 +5105,7 @@
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				748C7780211E18A600814F2C /* OrderStats+Woo.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
+				02CB9BE424E78EF4004170E9 /* ProductVariationsTopBannerFactory.swift in Sources */,
 				024A543422BA6F8F00F4F38E /* DeveloperEmailChecker.swift in Sources */,
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
 				0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */,


### PR DESCRIPTION
Fixes #2594 

## Changes

- Created `ProductVariationsTopBannerFactory` that generates the top banner view when some variations are missing a price, the copy mostly following the [Android PR](https://github.com/woocommerce/woocommerce-android/pull/2717)
- Updated `TopBannerView` and `TopBannerViewModel` to allow no top button and support normal/warning banner type
- In `ProductVariationsViewController`, showed/hid the warning top banner based on whether the latest variations have any missing a price.
  - Showing/hiding the top banner dynamically took me 2ish hours 😰 I've tried setting `tableView.tableHeaderView` to `nil`/`topBannerView` whenever the variations change, but it either leaves a gap after hiding the banner or covering the top cells after showing the banner. I also tried showing the banner as the section header and that also had weird UI issue after showing/hiding the banner dynamically. Eventually, I got it working by making `tableView.tableHeaderView` a frame-based container view that contains a stack view that contains the top banner then showing/hiding the banner by setting its `isHidden` property. If you think I might have missed something with the previous approaches or know of other ways to show/hide a table header view dynamically, please lemme know!
  - The callback when the variation results change in storage layer is moved to a separate function `transitionToResultsUpdatedState`, because after transitioning from ghost view to normal results we have to set up the results controller forwarding to table view again to include updating the top banner visibility (right now we don't). the top banner visibility also needs to be updated in `transitionToResultsUpdatedState` since the table view doesn't receive the results controller change events in ghost view state (animated placeholder state).

## Testing

- Go to the Products tab
- Tap on a variable product where all the variations have a price
- Tap on the variations row --> there should be no warning banner on top of the list
- Tap on a variation, remove the price, and tap "Update" to save remotely
- Go back to the variations screen --> a warning banner should show up
- Tap on the variation whose price was removed, set a price again, and tap "Update" to save remotely
- Go back to the variations screen --> a warning banner should disappear

## Example screenshots

![simulator](https://user-images.githubusercontent.com/1945542/90378006-682c8900-e0ab-11ea-9992-e1e04d362ee1.gif)

light | dark
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-08-17 at 17 02 57](https://user-images.githubusercontent.com/1945542/90378154-9316dd00-e0ab-11ea-8c8b-ad0b28e8c06e.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-17 at 17 03 15](https://user-images.githubusercontent.com/1945542/90378170-9742fa80-e0ab-11ea-8672-6fbc0195c82a.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
