### PR TITLE
Edit Product: enhancements to external product URL & link button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -25,7 +25,7 @@ final class ProductExternalLinkViewController: UIViewController {
     init(product: Product, onCompletion: @escaping Completion) {
         self.product = product
         self.externalURL = product.externalURL
-        self.buttonText = product.buttonText
+        self.buttonText = product.buttonText.isNotEmpty ? product.buttonText : Strings.buyProductPlaceholder
         self.onCompletion = onCompletion
 
         super.init(nibName: nil, bundle: nil)
@@ -345,7 +345,7 @@ private extension ProductExternalLinkViewController {
                                                        comment: "Title of the text field for editing the button text for an external/affiliate product")
         static let buttonTextFooter = NSLocalizedString("This text will be shown on the button linking to the external product.",
                                                  comment: "Footer text for editing external product button text")
-        static let buyProductPlaceholder = NSLocalizedString("Buy product",
+        static let buyProductPlaceholder = NSLocalizedString("Buy Product",
         comment: "Placeholder of the text field for editing the button text for an external/affiliate product")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -136,10 +136,9 @@ private extension ProductExternalLinkViewController {
                                                                  textFieldAlignment: .trailing,
                                                                  onTextChange: { [weak self] text in
                                                                     self?.externalURL = text
-                                                                    if text?.isValidURL() == true {
+                                                                    if text?.isValidURL() == true || text?.isEmpty == true {
                                                                         self?.hideError()
-                                                                    }
-                                                                    else {
+                                                                    } else {
                                                                         self?.displayError(error: Strings.errorMalformedURL)
                                                                     }
         })
@@ -164,9 +163,6 @@ private extension ProductExternalLinkViewController {
 // MARK: - UITableViewDelegate Conformance
 //
 extension ProductExternalLinkViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-
-    }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let section = sections[section]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -8,10 +8,12 @@ final class ProductExternalLinkViewController: UIViewController {
     }()
 
     private let product: Product
-    private let sections: [Section]
+    private var sections: [Section] = []
 
     private var externalURL: String?
     private var buttonText: String
+
+    private var error: String?
 
     private lazy var keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
         self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
@@ -26,16 +28,9 @@ final class ProductExternalLinkViewController: UIViewController {
         self.buttonText = product.buttonText
         self.onCompletion = onCompletion
 
-        let externalURLFooter = NSLocalizedString("Enter the external URL to the product.",
-                                                  comment: "Footer text for editing product external URL")
-        let buttonTextFooter = NSLocalizedString("This text will be shown on the button linking to the external product.",
-                                                 comment: "Footer text for editing external product button text")
-        self.sections = [
-            Section(footer: externalURLFooter, rows: [.externalURL]),
-            Section(footer: buttonTextFooter, rows: [.buttonText])
-        ]
-
         super.init(nibName: nil, bundle: nil)
+
+        reloadSections()
     }
 
     required init?(coder: NSCoder) {
@@ -108,6 +103,16 @@ extension ProductExternalLinkViewController: UITableViewDataSource {
 // MARK: - Support for UITableViewDataSource
 //
 private extension ProductExternalLinkViewController {
+    func reloadSections() {
+        sections = [
+            Section(errorTitle: error, footer: Strings.externalURLFooter, rows: [.externalURL]),
+            Section(footer: Strings.buttonTextFooter, rows: [.buttonText])
+        ]
+
+        tableView.reloadData()
+        configureTextFieldFirstResponder()
+    }
+
     /// Configure cellForRowAtIndexPath:
     ///
    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
@@ -122,24 +127,29 @@ private extension ProductExternalLinkViewController {
     }
 
     func configureExternalURL(cell: TitleAndTextFieldTableViewCell) {
-        let title = NSLocalizedString("Product URL", comment: "Title of the text field for editing the external URL for an external/affiliate product")
-        let placeholder = NSLocalizedString("Enter URL",
-                                            comment: "Placeholder of the text field for editing the external URL for an external/affiliate product")
-        let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
+        let title = Strings.productURLTitle
+        let placeholder = Strings.enterURLPlaceholder
+        var viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
                                                                  text: externalURL,
                                                                  placeholder: placeholder,
                                                                  keyboardType: .URL,
                                                                  textFieldAlignment: .trailing,
                                                                  onTextChange: { [weak self] text in
                                                                     self?.externalURL = text
+                                                                    if text?.isValidURL() == true {
+                                                                        self?.hideError()
+                                                                    }
+                                                                    else {
+                                                                        self?.displayError(error: Strings.errorMalformedURL)
+                                                                    }
         })
+        viewModel = viewModel.stateUpdated(state: error == nil ? .normal : .error)
         cell.configure(viewModel: viewModel)
     }
 
     func configureButtonText(cell: TitleAndTextFieldTableViewCell) {
-        let title = NSLocalizedString("Button Text", comment: "Title of the text field for editing the button text for an external/affiliate product")
-        let placeholder = NSLocalizedString("Buy product",
-                                            comment: "Placeholder of the text field for editing the button text for an external/affiliate product")
+        let title = Strings.buttonTextTitle
+        let placeholder = Strings.buyProductPlaceholder
         let viewModel = TitleAndTextFieldTableViewCell.ViewModel(title: title,
                                                                  text: buttonText,
                                                                  placeholder: placeholder,
@@ -151,11 +161,50 @@ private extension ProductExternalLinkViewController {
     }
 }
 
+// MARK: - UITableViewDelegate Conformance
+//
+extension ProductExternalLinkViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let section = sections[section]
+        guard let errorTitle = section.errorTitle else {
+            return nil
+        }
+
+        let headerID = ErrorSectionHeaderView.reuseIdentifier
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: headerID) as? ErrorSectionHeaderView else {
+            fatalError()
+        }
+        headerView.configure(title: errorTitle)
+        UIAccessibility.post(notification: .layoutChanged, argument: headerView)
+        return headerView
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        let section = sections[section]
+        guard let errorTitle = section.errorTitle, errorTitle.isEmpty == false else {
+            return 0
+        }
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        let section = sections[section]
+        guard let errorTitle = section.errorTitle, errorTitle.isEmpty == false else {
+            return 0
+        }
+        return Constants.estimatedSectionHeaderHeight
+    }
+}
+
 // MARK: - View Configuration
 //
 private extension ProductExternalLinkViewController {
     func configureNavigation() {
-        title = NSLocalizedString("Product Link", comment: "Edit Product External Link navigation title")
+        title = Strings.screenTitle
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(completeEditing))
     }
@@ -166,6 +215,7 @@ private extension ProductExternalLinkViewController {
 
     func configureTableView() {
         tableView.dataSource = self
+        tableView.delegate = self
 
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
@@ -176,10 +226,31 @@ private extension ProductExternalLinkViewController {
         view.pinSubviewToSafeArea(tableView)
 
         registerTableViewCells()
+        registerTableViewHeaderFooters()
     }
 
     func registerTableViewCells() {
         tableView.register(TitleAndTextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TitleAndTextFieldTableViewCell.reuseIdentifier)
+    }
+
+    func registerTableViewHeaderFooters() {
+        let headersAndFooters = [ErrorSectionHeaderView.self]
+
+        for kind in headersAndFooters {
+            tableView.register(kind.loadNib(), forHeaderFooterViewReuseIdentifier: kind.reuseIdentifier)
+        }
+    }
+
+    func enableDoneButton(_ enabled: Bool) {
+        navigationItem.rightBarButtonItem?.isEnabled = enabled
+    }
+
+    // Configure the text field as first responder
+    func configureTextFieldFirstResponder() {
+        if let indexPath = sections.indexPathForRow(.externalURL) {
+            let cell = tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell
+            cell?.textFieldBecomeFirstResponder()
+        }
     }
 }
 
@@ -196,6 +267,28 @@ private extension ProductExternalLinkViewController {
 extension ProductExternalLinkViewController: KeyboardScrollable {
     var scrollable: UIScrollView {
         return tableView
+    }
+}
+
+// MARK: - Error handling
+//
+private extension ProductExternalLinkViewController {
+    func displayError(error: String) {
+        // This check is useful so we don't reload while typing each letter in the sections
+        if self.error == nil {
+            self.error = error
+            reloadSections()
+            enableDoneButton(false)
+        }
+    }
+
+    func hideError() {
+        // This check is useful so we don't reload while typing each letter in the sections
+        if error != nil {
+            error = nil
+            reloadSections()
+            enableDoneButton(true)
+        }
     }
 }
 
@@ -220,12 +313,39 @@ private extension ProductExternalLinkViewController {
     /// Table Sections
     ///
     struct Section: RowIterable {
+        let errorTitle: String?
         let footer: String?
         let rows: [Row]
 
-        init(footer: String? = nil, rows: [Row]) {
+        init(errorTitle: String? = nil, footer: String? = nil, rows: [Row]) {
+            self.errorTitle = errorTitle
             self.footer = footer
             self.rows = rows
         }
+    }
+}
+
+private extension ProductExternalLinkViewController {
+    enum Constants {
+        static let estimatedSectionHeaderHeight: CGFloat = 44
+    }
+
+    enum Strings {
+        static let screenTitle = NSLocalizedString("Product Link",
+                                                   comment: "Edit Product External Link navigation title")
+        static let productURLTitle = NSLocalizedString("Product URL",
+                                                       comment: "Title of the text field for editing the external URL for an external/affiliate product")
+        static let enterURLPlaceholder = NSLocalizedString("Enter URL",
+                                         comment: "Placeholder of the text field for editing the external URL for an external/affiliate product")
+        static let errorMalformedURL = NSLocalizedString("Check that the URL entered is valid",
+                                                         comment: "The message of the alert when there is an error in the URL of an external product")
+        static let externalURLFooter = NSLocalizedString("Enter the external URL to the product.",
+                                                  comment: "Footer text for editing product external URL")
+        static let buttonTextTitle = NSLocalizedString("Button Text",
+                                                       comment: "Title of the text field for editing the button text for an external/affiliate product")
+        static let buttonTextFooter = NSLocalizedString("This text will be shown on the button linking to the external product.",
+                                                 comment: "Footer text for editing external product button text")
+        static let buyProductPlaceholder = NSLocalizedString("Buy product",
+        comment: "Placeholder of the text field for editing the button text for an external/affiliate product")
     }
 }


### PR DESCRIPTION
Fixes #2609 

## Description
As part of Milestone 3, in this PR there are two enhancements on External product type. 
In particular:
- Local validation for external URL. If the URL is not valid, an error is shown.
- Auto-fill button text with "Buy product" if the external URL field is empty in the beginning. This will come in handy after that [this PR](https://github.com/woocommerce/woocommerce-ios/pull/2665) will be merged.

## Testing
1. Open an External product.
2. Tap the cell 
3. If the Button Text in the API is empty, "Buy Product" will be shown as text.
4. Try to edit the Product URL adding a non-valid URL. An error will be shown.
5. Try to re-edit the Product URL using a valid URL. The error should disappear. 
 
## Screenshots
| Valid URL             |  Valid URL (dark mode enabled) |  Non-Valid URL |  Non-Valid URL (dark mode enabled) |
:-------------------------:|:-------------------------:|:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-08-17 at 16 51 02](https://user-images.githubusercontent.com/495617/90409933-0fa8bc00-e0aa-11ea-926f-aef836150069.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-08-17 at 16 51 25](https://user-images.githubusercontent.com/495617/90409941-12a3ac80-e0aa-11ea-9bf0-a8c5f06f1b26.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-08-17 at 16 51 00](https://user-images.githubusercontent.com/495617/90409987-1df6d800-e0aa-11ea-9421-b704c919ddc8.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-08-17 at 16 51 23](https://user-images.githubusercontent.com/495617/90410001-20593200-e0aa-11ea-8e81-ee3f78f3422a.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
