### PR TITLE
RetrieveProductReviewFromNoteUseCase: Use Storage if Possible

### DIFF
--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -11,7 +11,8 @@ public struct ProductReviewFromNoteParcel {
     public let product: Product
 }
 
-/// Fetches the `Note`, `ProductReview`, and `Product` in sequence from the API using a `noteID`.
+/// Fetches the `Note`, `ProductReview`, and `Product` in sequence from the Storage and/or API
+/// using a `noteID`.
 ///
 /// This can be used to present a view when a push notification is received. This should only
 /// be used as part of `ProductReviewStore`.
@@ -103,11 +104,15 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
-    /// Fetch the Note from the API.
+    /// Fetch the `Note` from storage, or from the API if it is not available in storage.
     ///
     private func fetchNote(noteID: Int64,
                            abort: @escaping AbortBlock,
                            next: @escaping (Note) -> Void) {
+        if let noteInStorage = derivedStorage?.loadNotification(noteID: noteID) {
+            return next(noteInStorage.toReadOnly())
+        }
+
         notificationsRemote.loadNotes(noteIDs: [noteID], pageSize: nil) { result in
             switch result {
             case .failure(let error):
@@ -160,12 +165,16 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
-    /// Fetch the `Product` from the API.
+    /// Fetch the `Product` from storage, or from the API if it is not available in storage.
     ///
     private func fetchProduct(siteID: Int64,
                               productID: Int64,
                               abort: @escaping AbortBlock,
                               next: @escaping (Product) -> Void) {
+        if let productInStorage = derivedStorage?.loadProduct(siteID: siteID, productID: productID) {
+            return next(productInStorage.toReadOnly())
+        }
+
         productsRemote.loadProduct(for: siteID, productID: productID) { result in
             switch result {
             case .failure(let error):

--- a/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -127,7 +127,7 @@ final class RetrieveProductReviewFromNoteUseCase {
         }
     }
 
-    /// Fetch the ProductReview based on the given Note from the API.
+    /// Fetch the `ProductReview` from storage, or from the API if it is not available in storage.
     ///
     private func fetchProductReview(from note: Note,
                                     abort: @escaping AbortBlock,
@@ -135,6 +135,10 @@ final class RetrieveProductReviewFromNoteUseCase {
         guard let siteID = note.meta.identifier(forKey: .site),
             let reviewID = note.meta.identifier(forKey: .comment) else {
                 return abort(ProductReviewFromNoteRetrieveError.reviewNotFound)
+        }
+
+        if let productReviewInStorage = derivedStorage?.loadProductReview(siteID: Int64(siteID), reviewID: Int64(reviewID)) {
+            return next(productReviewInStorage.toReadOnly())
         }
 
         productReviewsRemote.loadProductReview(for: Int64(siteID), reviewID: Int64(reviewID)) { result in

--- a/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductReview/RetrieveProductReviewFromNoteUseCaseTests.swift
@@ -38,7 +38,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         super.tearDown()
     }
 
-    func testItFetchesAllEntitiesAndReturnsTheParcel() throws {
+    func test_it_fetches_all_entities_and_returns_the_Parcel() throws {
         // Given
         let useCase = makeUseCase()
         let note = TestData.note
@@ -121,7 +121,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertEqual(parcel.product, product)
     }
 
-    func testWhenSuccessfulThenItSavesTheProductReviewToStorage() throws {
+    func test_when_successful_then_it_saves_the_ProductReview_to_Storage() throws {
         // Given
         let useCase = makeUseCase()
 
@@ -153,7 +153,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
     /// Simulate a scenario where the StorageType is no longer available, which may happen
     /// if the owning `ProductReviewStore` is deallocated during user log out.
     ///
-    func testWhenSuccessfulButStorageIsNoLongerAvailableThenItReturnsAFailure() throws {
+    func test_when_successful_but_Storage_is_no_longer_available_then_it_returns_a_failure() throws {
         // Given
         let useCase = makeUseCase()
 
@@ -183,7 +183,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertEqual(productsRemote.invocationCountOfLoadProduct, 0)
     }
 
-    func testWhenNoteFetchFailsThenAllOtherFetchesAreAborted() throws {
+    func test_when_Note_fetch_fails_then_all_other_fetches_are_aborted() throws {
         // Given
         let useCase = makeUseCase()
 
@@ -203,7 +203,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertEqual(productsRemote.invocationCountOfLoadProduct, 0)
     }
 
-    func testWhenProductReviewFetchFailsThenAllOtherFetchesAreAborted() throws {
+    func test_when_ProductReview_fetch_fails_then_all_other_fetches_are_aborted() throws {
         // Given
         let useCase = makeUseCase()
 
@@ -227,7 +227,7 @@ final class RetrieveProductReviewFromNoteUseCaseTests: XCTestCase {
         XCTAssertEqual(productsRemote.invocationCountOfLoadProduct, 0)
     }
 
-    func testWhenNoteHasMissingMetaThenItReturnsAFailure() throws {
+    func test_when_Note_has_missing_meta_then_it_returns_a_failure() throws {
         // Given
         let useCase = makeUseCase()
 


### PR DESCRIPTION
Ref #2254. 

## Findings

I'm almost done with fixing #2254. I found that handling push notifications using [`RetrieveProductReviewFromNoteUseCase`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift) can be slow. It would take a while for the Review Details ViewController to be presented. The current implementation makes use of existing records in Core Data so I copied the same strategy here. 

## Solution

The `RetrieveProductReviewFromNoteUseCase` will now use any existing `Note`, `ProductReview`, or `Product` in Core Data and will only fetch them if they do not exist locally yet. 

https://github.com/woocommerce/woocommerce-ios/blob/d1e95de346c6d50287985feeccabfa00ce2795d4/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift#L107-L114

https://github.com/woocommerce/woocommerce-ios/blob/d1e95de346c6d50287985feeccabfa00ce2795d4/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift#L168-L176

https://github.com/woocommerce/woocommerce-ios/blob/105c9c946c56e6cd383c7ff87f968cec1c2110ab/Yosemite/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift#L130-L142

## Testing

This `UseCase` is not currently used. Please review the unit test instead. 🙂 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

