### PR TITLE
Save the Installation Date 

### DIFF
--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -16,6 +16,16 @@ extension NSNotification.Name {
 }
 
 final class MainTabViewModel {
+
+    private let storesManager: StoresManager
+    private let featureFlagService: FeatureFlagService
+
+    init(storesManager: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.storesManager = storesManager
+        self.featureFlagService = featureFlagService
+    }
+
     /// Callback to be executed when this view model receives new data
     /// passing the string to be presented in the badge as a parameter
     ///

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -72,7 +72,7 @@ private extension MainTabViewModel {
         onBadgeReload?(NumberFormatter.localizedOrNinetyNinePlus(processingCount))
     }
 
-    private func observeBadgeRefreshNotifications() {
+    func observeBadgeRefreshNotifications() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(requestBadgeCount),
                                                name: .ordersBadgeReloadRequired,

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -44,7 +44,7 @@ final class MainTabViewModel {
 
 private extension MainTabViewModel {
     @objc func requestBadgeCount() {
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+        guard let siteID = storesManager.sessionManager.defaultStoreID else {
             DDLogError("# Error: Cannot fetch order count")
             return
         }
@@ -57,7 +57,7 @@ private extension MainTabViewModel {
             self?.processBadgeCount(orderCount)
         }
 
-        ServiceLocator.stores.dispatch(action)
+        storesManager.dispatch(action)
     }
 
     func processBadgeCount(_ orderCount: OrderCount?) {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -139,6 +139,12 @@ final class MainTabBarController: UITabBarController {
         startListeningToOrdersBadge()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        viewModel.onViewDidAppear()
+    }
+
     override func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
         let currentlySelectedTab = WooTab(visibleIndex: selectedIndex)
         guard let userSelectedIndex = tabBar.items?.firstIndex(of: item) else {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 		5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */; };
 		5778E00E24DB2BA200B65CBF /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */; };
 		578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578187B12481D9290063B46B /* XCTestCase+Assertions.swift */; };
+		5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FB4124EC834300117FD6 /* MainTabViewModelTests.swift */; };
 		5795F22C23E26A8D00F6707C /* OrderSearchStarterViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */; };
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
@@ -1363,6 +1364,7 @@
 		5778E00924DB1D8600B65CBF /* BehaviorSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubjectTests.swift; sourceTree = "<group>"; };
 		5778E00D24DB2BA200B65CBF /* BehaviorSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BehaviorSubject.swift; sourceTree = "<group>"; };
 		578187B12481D9290063B46B /* XCTestCase+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Assertions.swift"; sourceTree = "<group>"; };
+		5791FB4124EC834300117FD6 /* MainTabViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabViewModelTests.swift; sourceTree = "<group>"; };
 		5795F22B23E26A8D00F6707C /* OrderSearchStarterViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderSearchStarterViewController.xib; sourceTree = "<group>"; };
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
@@ -2846,6 +2848,14 @@
 			path = "Stats V4";
 			sourceTree = "<group>";
 		};
+		5791FB4024EC833200117FD6 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				5791FB4124EC834300117FD6 /* MainTabViewModelTests.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		5798191124526FC7000817F8 /* Observables */ = {
 			isa = PBXGroup;
 			children = (
@@ -3264,6 +3274,7 @@
 		B56DB3E02049BFAA00D4AA8E /* WooCommerceTests */ = {
 			isa = PBXGroup;
 			children = (
+				5791FB4024EC833200117FD6 /* ViewModels */,
 				57C2F6E324C27B0C00131012 /* Authentication */,
 				CCDC49F1240060F3003166BA /* UnitTests.xctestplan */,
 				D816DDBA22265D8000903E59 /* ViewRelated */,
@@ -5499,6 +5510,7 @@
 				45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */,
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
+				5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */,
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,
 				02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */,
 				571E4674249D1615002ADCB8 /* XCTestCase+Wait.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -13,6 +13,16 @@ extension SessionManager {
         return SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
     }
 
+    /// Create an instance of unit testing.
+    ///
+    static func makeForTesting(authenticated: Bool = false) -> SessionManager {
+        var manager = SessionManager.testingInstance
+        // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
+        // will be removed.
+        manager.defaultCredentials = authenticated ? SessionSettings.credentials : nil
+        return manager
+    }
+
     func setStoreId(_ id: Int?) {
         UserDefaults(suiteName: "storesManagerTests")!.set(id, forKey: .defaultStoreID)
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+@testable import WooCommerce
+
+import Yosemite
+
+/// Test cases for `MainTabViewModel`.
+final class MainTabViewModelTests: XCTestCase {
+
+    private var storesManager: MockupStoresManager!
+    private var featureFlagService: MockFeatureFlagService!
+
+    override func setUp() {
+        super.setUp()
+
+        var sessionManager = SessionManager.testingInstance
+        sessionManager.defaultCredentials = Credentials(authToken: "")
+
+        storesManager = MockupStoresManager(sessionManager: sessionManager)
+        featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
+    }
+
+    override func tearDown() {
+        featureFlagService = nil
+        storesManager = nil
+        super.tearDown()
+    }
+
+    func test_onViewDidAppear_will_save_the_installation_date() throws {
+        // Given
+        let viewModel = MainTabViewModel(storesManager: storesManager, featureFlagService: featureFlagService)
+
+        assertEmpty(storesManager.receivedActions)
+
+        // When
+        viewModel.onViewDidAppear()
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 1)
+
+        let action = try XCTUnwrap(storesManager.receivedActions.first as? AppSettingsAction)
+        switch action {
+        case let .setInstallationDateIfNecessary(date, _):
+            let interval = abs(date.timeIntervalSince(Date()))
+            XCTAssertLessThanOrEqual(interval, 100)
+        default:
+            XCTFail("Expected action to be .setInstallationDateIfNecessary")
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
@@ -7,27 +7,23 @@ import Yosemite
 /// Test cases for `MainTabViewModel`.
 final class MainTabViewModelTests: XCTestCase {
 
-    private var storesManager: MockupStoresManager!
     private var featureFlagService: MockFeatureFlagService!
 
     override func setUp() {
         super.setUp()
-
-        var sessionManager = SessionManager.testingInstance
-        sessionManager.defaultCredentials = Credentials(authToken: "")
-
-        storesManager = MockupStoresManager(sessionManager: sessionManager)
         featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
     }
 
     override func tearDown() {
         featureFlagService = nil
-        storesManager = nil
         super.tearDown()
     }
 
     func test_onViewDidAppear_will_save_the_installation_date() throws {
         // Given
+        let storesManager = MockupStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        storesManager.reset()
+
         let viewModel = MainTabViewModel(storesManager: storesManager, featureFlagService: featureFlagService)
 
         assertEmpty(storesManager.receivedActions)
@@ -46,5 +42,21 @@ final class MainTabViewModelTests: XCTestCase {
         default:
             XCTFail("Expected action to be .setInstallationDateIfNecessary")
         }
+    }
+
+    func test_when_user_is_not_logged_in_then_onViewDidAppear_will_not_save_the_installation_date() throws {
+        // Given
+        let storesManager = MockupStoresManager(sessionManager: .makeForTesting(authenticated: false))
+        storesManager.reset()
+
+        let viewModel = MainTabViewModel(storesManager: storesManager, featureFlagService: featureFlagService)
+
+        assertEmpty(storesManager.receivedActions)
+
+        // When
+        viewModel.onViewDidAppear()
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 0)
     }
 }


### PR DESCRIPTION
Closes #2632. 

## Findings

This got complicated than expected. At first, I thought that I could just simply dispatch the [`AppSettingsAction.setInstallationDateIfNecessary`](https://github.com/woocommerce/woocommerce-ios/blob/74d9f5b92b55fc9fa51336e4d72e1d3c0831bcf7/Yosemite/Yosemite/Actions/AppSettingsAction.swift#L69-L76) in `AppDelegate`. And then I found out that calling that action has no effect if the user is not logged in because `DeauthenticatedState` doesn't handle any actions. 

https://github.com/woocommerce/woocommerce-ios/blob/74d9f5b92b55fc9fa51336e4d72e1d3c0831bcf7/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift#L20-L22

So, I guess we can't really save the installation date until the user is logged in. This is fine because we currently have no need for the installation date to be very accurate. We do use some sort of inference to determine the _oldest_ date that we know:

https://github.com/woocommerce/woocommerce-ios/blob/74d9f5b92b55fc9fa51336e4d72e1d3c0831bcf7/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift#L65-L73

## Solution

With all that said, I opted to call the action in `MainTabBarController` instead of `AppDelegate`:

- Calling it in `AppDelegate` may make us assume that we expect it to be called even for not logged in users. 
- It was easier to have some sort of unit test within `MainTabViewModel`.

## Testing

1. Delete the app from the simulator. 
2. Run and log in.
3. Open the `Documents` directory.
4. Confirm that a file named `general-app-settings.plist` was created. The contents should have an `installationDate` key:

    ```xml
	<?xml version="1.0" encoding="UTF-8"?>
	<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
	<plist version="1.0">
	<dict>
		<key>installationDate</key>
		<date>2020-08-18T22:20:20Z</date>
	</dict>
	</plist>
    ```

5. Forcefully close the app. 
6. Delete the `general-app-settings.plist` file. 
7. Run the app again. 
8. Confirm that a `general-app-settings.plist` was created again. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

 