### PR TITLE
Settings → Replace "Feature Request" With "Send Feedback"

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -63,10 +63,6 @@ extension WooConstants {
         ///
         case helpCenter = "https://docs.woocommerce.com/document/woocommerce-ios/"
 
-        /// Feature Request URL
-        ///
-        case featureRequest = "http://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283"
-
         /// URL used for Learn More button in Orders empty state.
         ///
         case blog = "https://woocommerce.com/blog/"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -183,7 +183,7 @@ private extension SettingsViewController {
         case let cell as BasicTableViewCell where row == .betaFeatures:
             configureBetaFeatures(cell: cell)
         case let cell as BasicTableViewCell where row == .sendFeedback:
-            configureFeatureSuggestions(cell: cell)
+            configureSendFeedback(cell: cell)
         case let cell as BasicTableViewCell where row == .about:
             configureAbout(cell: cell)
         case let cell as BasicTableViewCell where row == .licenses:
@@ -232,10 +232,10 @@ private extension SettingsViewController {
         cell.accessibilityIdentifier = "settings-beta-features-button"
     }
 
-    func configureFeatureSuggestions(cell: BasicTableViewCell) {
+    func configureSendFeedback(cell: BasicTableViewCell) {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString("Feature Request", comment: "Navigates to the feature request screen")
+        cell.textLabel?.text = NSLocalizedString("Send Feedback", comment: "Presents a survey to gather feedback from the user.")
     }
 
     func configureAbout(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -145,7 +145,7 @@ private extension SettingsViewController {
             sections = [
                 Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
                 Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
-                Section(title: improveTheAppTitle, rows: [.privacy, .betaFeatures, .featureRequest], footerHeight: UITableView.automaticDimension),
+                Section(title: improveTheAppTitle, rows: [.privacy, .betaFeatures, .sendFeedback], footerHeight: UITableView.automaticDimension),
                 Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
                 otherSection,
                 Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
@@ -154,7 +154,7 @@ private extension SettingsViewController {
             sections = [
                 Section(title: selectedStoreTitle, rows: storeRows, footerHeight: CGFloat.leastNonzeroMagnitude),
                 Section(title: nil, rows: [.support], footerHeight: UITableView.automaticDimension),
-                Section(title: improveTheAppTitle, rows: [.privacy, .featureRequest], footerHeight: UITableView.automaticDimension),
+                Section(title: improveTheAppTitle, rows: [.privacy, .sendFeedback], footerHeight: UITableView.automaticDimension),
                 Section(title: aboutSettingsTitle, rows: [.about, .licenses], footerHeight: UITableView.automaticDimension),
                 otherSection,
                 Section(title: nil, rows: [.logout], footerHeight: CGFloat.leastNonzeroMagnitude)
@@ -182,7 +182,7 @@ private extension SettingsViewController {
             configurePrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .betaFeatures:
             configureBetaFeatures(cell: cell)
-        case let cell as BasicTableViewCell where row == .featureRequest:
+        case let cell as BasicTableViewCell where row == .sendFeedback:
             configureFeatureSuggestions(cell: cell)
         case let cell as BasicTableViewCell where row == .about:
             configureAbout(cell: cell)
@@ -465,7 +465,7 @@ extension SettingsViewController: UITableViewDelegate {
             privacyWasPressed()
         case .betaFeatures:
             betaFeaturesWasPressed()
-        case .featureRequest:
+        case .sendFeedback:
             featureRequestWasPressed()
         case .about:
             aboutWasPressed()
@@ -504,7 +504,7 @@ private enum Row: CaseIterable {
     case logout
     case privacy
     case betaFeatures
-    case featureRequest
+    case sendFeedback
     case about
     case licenses
     case appSettings
@@ -524,7 +524,7 @@ private enum Row: CaseIterable {
             return BasicTableViewCell.self
         case .betaFeatures:
             return BasicTableViewCell.self
-        case .featureRequest:
+        case .sendFeedback:
             return BasicTableViewCell.self
         case .about:
             return BasicTableViewCell.self

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -360,8 +360,8 @@ private extension SettingsViewController {
     }
 
     func presentSurveyForFeedback() {
-        let safariViewController = SFSafariViewController(url: WooConstants.URLs.featureRequest.asURL())
-        present(safariViewController, animated: true, completion: nil)
+        let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
+        present(surveyNavigation, animated: true, completion: nil)
     }
 
     func appSettingsWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -359,7 +359,7 @@ private extension SettingsViewController {
         navigationController?.pushViewController(betaFeaturesViewController, animated: true)
     }
 
-    func featureRequestWasPressed() {
+    func presentSurveyForFeedback() {
         let safariViewController = SFSafariViewController(url: WooConstants.URLs.featureRequest.asURL())
         present(safariViewController, animated: true, completion: nil)
     }
@@ -466,7 +466,7 @@ extension SettingsViewController: UITableViewDelegate {
         case .betaFeatures:
             betaFeaturesWasPressed()
         case .sendFeedback:
-            featureRequestWasPressed()
+            presentSurveyForFeedback()
         case .about:
             aboutWasPressed()
         case .licenses:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -8,7 +8,7 @@ import WordPressAuthenticator
 
 // MARK: - SettingsViewController
 //
-class SettingsViewController: UIViewController {
+final class SettingsViewController: UIViewController {
 
     /// Main TableView
     ///


### PR DESCRIPTION
Closes #2553.

~⚠️ Leaving this as a draft until we have released the In-app Feedback feature (#2554). I found that this is easier to do so I don't have to hide this behind a feature flag. 😅~ 

This replaces the Feature Request button in Settings with Send Feedback. The Send Feedback button displays the survey. 

## Design

Before | After 
--------|-------
![before](https://user-images.githubusercontent.com/198826/90575706-371a8a00-e179-11ea-8e05-1edbc5085a36.gif) | ![after](https://user-images.githubusercontent.com/198826/90575707-397ce400-e179-11ea-88fe-cda69e62ac4a.gif)

## Testing

1. Navigate to Settings.
2. Tap on Send Feedback. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

