### PR TITLE
Add state support to ProductsM3 feedback survey

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -1,5 +1,11 @@
 import Foundation
 
 public enum FeedbackType: String, Codable {
+    /// Identifier for the general inApp feedback survey
+    ///
     case general
+
+    /// identifier for the products m3 beta feedback survey
+    ///
+    case productsM3
 }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -29,11 +29,22 @@ struct InAppFeedbackCardVisibilityUseCase {
         self.calendar = calendar
     }
 
-    /// Returns whether the In-app Feedback Card should be displayed.
+    /// Returns whether the feedback request should be displayed.
     ///
     /// - Parameter currentDate The current date. This is only used for consistency in unit tests.
     ///
     func shouldBeVisible(currentDate: Date = Date()) throws -> Bool {
+        switch feedbackType {
+        case .general:
+            return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
+        case .productsM3:
+            return shouldProductsFeedbackBeVisible()
+        }
+    }
+
+    /// Returns whether the In-app Feedback Card should be displayed.
+    ///
+    private func shouldGeneralFeedbackBeVisible(currentDate: Date) throws -> Bool {
         guard let installationDate = inferInstallationDate() else {
             throw InferenceError.failedToInferInstallationDate
         }
@@ -51,6 +62,12 @@ struct InAppFeedbackCardVisibilityUseCase {
         }
 
         return true
+    }
+
+    /// Returns whether the productsM3 feedback request should be displayed
+    ///
+    private func shouldProductsFeedbackBeVisible() -> Bool {
+        return settings.feedbackStatus(of: feedbackType) == .pending
     }
 
     /// Returns the total number of days between `from` and `to`.

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import Yosemite
 import struct Storage.GeneralAppSettings
 import struct Storage.FeedbackSettings
+import enum Storage.FeedbackType
 
 private typealias InferenceError = InAppFeedbackCardVisibilityUseCase.InferenceError
 
@@ -36,7 +37,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .pending)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -53,7 +54,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .pending)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -71,7 +72,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
+        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .given(lastFeedbackDate))
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -89,7 +90,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .given(lastFeedbackDate))
+        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .given(lastFeedbackDate))
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -107,7 +108,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let settings = createAppSetting(instalationDate: nil, feedbackSatus: .pending)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .general, feedbackSatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -127,7 +128,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path,
                                                    thenReturn: [.creationDate: documentDirCreationDate])
 
-        let settings = createAppSetting(instalationDate: installationDate, feedbackSatus: .pending)
+        let settings = createAppSetting(instalationDate: installationDate, feedbackType: .general, feedbackSatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -141,7 +142,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Given
         fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
 
-        let settings = createAppSetting(instalationDate: nil, feedbackSatus: .pending)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .general, feedbackSatus: .pending)
         let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .general, fileManager: fileManager, calendar: calendar)
 
         // When
@@ -152,6 +153,54 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertEqual(error as? InferenceError, .failedToInferInstallationDate)
+    }
+
+    func test_shouldBeVisible_for_productM3_is_true_if_no_settings_are_found() throws {
+        // Given
+        let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:])
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible()
+
+        // Then
+        XCTAssertTrue(shouldBeVisible)
+    }
+
+    func test_shouldBeVisible_for_productM3_is_true_if_feedback_has_pending_status() throws {
+        // Given
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM3, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible()
+
+        // Then
+        XCTAssertTrue(shouldBeVisible)
+    }
+
+    func test_shouldBeVisible_for_productM3_is_false_if_feedback_has_dismissed_status() throws {
+        // Given
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM3, feedbackSatus: .dismissed)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible()
+
+        // Then
+        XCTAssertFalse(shouldBeVisible)
+    }
+
+    func test_shouldBeVisible_for_productM3_is_false_if_feedback_has_given_status() throws {
+        // Given
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM3, feedbackSatus: .given(Date()))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible()
+
+        // Then
+        XCTAssertFalse(shouldBeVisible)
     }
 }
 
@@ -166,8 +215,8 @@ private extension InAppFeedbackCardVisibilityUseCaseTests {
         try XCTUnwrap(FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last)
     }
 
-    func createAppSetting(instalationDate: Date?, feedbackSatus: FeedbackSettings.Status) -> GeneralAppSettings {
-        let feedback = FeedbackSettings(name: .general, status: feedbackSatus)
+    func createAppSetting(instalationDate: Date?, feedbackType: FeedbackType, feedbackSatus: FeedbackSettings.Status) -> GeneralAppSettings {
+        let feedback = FeedbackSettings(name: feedbackType, status: feedbackSatus)
         let settings = GeneralAppSettings(installationDate: instalationDate, feedbacks: [feedback.name: feedback])
         return settings
     }

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -351,6 +351,66 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).isSuccess)
         XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).get())
     }
+
+    func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_pending() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .pending) { _ in }
+        subject?.onAction(updateAction)
+
+        // When
+        var visibilityResult: Result<Bool, Error>?
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { result in
+            visibilityResult = result
+        }
+        subject?.onAction(queryAction)
+
+        // Then
+        let result = try XCTUnwrap(visibilityResult)
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertTrue(try result.get())
+
+    }
+
+    func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_dismissed() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .dismissed) { _ in }
+        subject?.onAction(updateAction)
+
+        // When
+        var visibilityResult: Result<Bool, Error>?
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { result in
+            visibilityResult = result
+        }
+        subject?.onAction(queryAction)
+
+        // Then
+        let result = try XCTUnwrap(visibilityResult)
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertFalse(try result.get())
+
+    }
+
+    func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_given() throws {
+        // Given
+        try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .given(Date())) { _ in }
+        subject?.onAction(updateAction)
+
+        // When
+        var visibilityResult: Result<Bool, Error>?
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { result in
+            visibilityResult = result
+        }
+        subject?.onAction(queryAction)
+
+        // Then
+        let result = try XCTUnwrap(visibilityResult)
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertFalse(try result.get())
+
+    }
 }
 
 // MARK: - Utils

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -352,7 +352,7 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).get())
     }
 
-    func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_pending() throws {
+    func test_loadFeedbackVisibility_for_productsM3_returns_true_after_marking_it_as_pending() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .pending) { _ in }


### PR DESCRIPTION
closes https://github.com/woocommerce/woocommerce-ios/issues/2647

# Why 

Prior to this PR, there was no way to reference any other feedback than the general one. This PR adds support to productsM3 feedback.

# How
- Add `productsM3` case to `FeedbackType` enum
- Update `InAppFeedbackCardVisibilityUseCase` to differentiate for feedback type when computing the `shouldBeVisible` method.
- Updates and adds tests.

# Testing Steps
This PR does not involve any user-facing changes. So running the tests should be enough 😇 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
