### PR TITLE
Edit Product: moved the Product Type cell at the bottom of the list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -97,12 +97,12 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
             shouldShowReviewsRow ? .reviews: nil,
-            shouldShowProductTypeRow ? .productType : nil,
             shouldShowShippingSettingsRow ? .shippingSettings: nil,
             .inventorySettings,
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
-            shouldShowBriefDescriptionRow ? .briefDescription: nil
+            shouldShowBriefDescriptionRow ? .briefDescription: nil,
+            shouldShowProductTypeRow ? .productType : nil
         ]
         return actions.compactMap { $0 }
     }
@@ -117,12 +117,12 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
             shouldShowReviewsRow ? .reviews: nil,
-            shouldShowProductTypeRow ? .productType : nil,
             .externalURL,
             .sku,
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
-            shouldShowBriefDescriptionRow ? .briefDescription: nil
+            shouldShowBriefDescriptionRow ? .briefDescription: nil,
+            shouldShowProductTypeRow ? .productType : nil
         ]
         return actions.compactMap { $0 }
     }
@@ -137,11 +137,11 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .groupedProducts,
             shouldShowReviewsRow ? .reviews: nil,
-            shouldShowProductTypeRow ? .productType : nil,
             .sku,
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
-            shouldShowBriefDescriptionRow ? .briefDescription: nil
+            shouldShowBriefDescriptionRow ? .briefDescription: nil,
+            shouldShowProductTypeRow ? .productType : nil
         ]
         return actions.compactMap { $0 }
     }
@@ -156,10 +156,10 @@ private extension ProductFormActionsFactory {
         let actions: [ProductFormEditAction?] = [
             .variations,
             shouldShowReviewsRow ? .reviews: nil,
-            shouldShowProductTypeRow ? .productType : nil,
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
-            shouldShowBriefDescriptionRow ? .briefDescription: nil
+            shouldShowBriefDescriptionRow ? .briefDescription: nil,
+            shouldShowProductTypeRow ? .productType : nil
         ]
         return actions.compactMap { $0 }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -23,12 +23,12 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
                                                                        .reviews,
-                                                                       .productType,
                                                                        .shippingSettings,
                                                                        .inventorySettings,
                                                                        .categories,
                                                                        .tags,
-                                                                       .briefDescription]
+                                                                       .briefDescription,
+                                                                       .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -51,12 +51,12 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
                                                                        .reviews,
-                                                                       .productType,
                                                                        .shippingSettings,
                                                                        .inventorySettings,
                                                                        .categories,
                                                                        .tags,
-                                                                       .briefDescription]
+                                                                       .briefDescription,
+                                                                       .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -79,11 +79,11 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
                                                                        .reviews,
-                                                                       .productType,
                                                                        .inventorySettings,
                                                                        .categories,
                                                                        .tags,
-                                                                       .briefDescription]
+                                                                       .briefDescription,
+                                                                       .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -106,11 +106,11 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
 
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
                                                                        .reviews,
-                                                                       .productType,
                                                                        .inventorySettings,
                                                                        .categories,
                                                                        .tags,
-                                                                       .briefDescription]
+                                                                       .briefDescription,
+                                                                       .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
@@ -131,7 +131,10 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType, .externalURL]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .reviews,
+                                                                       .externalURL,
+                                                                       .productType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editSKU, .editCategories, .editTags, .editBriefDescription]


### PR DESCRIPTION
Fixes #2676 

As part of Milestone 3, as suggested by @Garance91540, I moved the Product Type cell for being the last cell of the list in a Product Detail.

## Testing
1. Open different product types (simple, grouped, external, variable)
2. Make sure that for every product the Product Type cell is the last one in the product detail.

## Screenshot

<img src="https://user-images.githubusercontent.com/495617/90632114-2b37d200-e224-11ea-9f08-998a2e278ee5.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
