### PR TITLE
Add multiple button support to TopBannerView

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -11,7 +11,7 @@ final class DashboardTopBannerFactory {
                                            isExpanded: true,
                                            topButton: .chevron(handler: nil),
                                            actionButtons: [
-                                              ActionButton(title: DeprecatedStatsConstants.actionTitle, action: actionHandler),
+                                            .init(title: DeprecatedStatsConstants.actionTitle, action: actionHandler),
                                            ])
         return TopBannerView(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardTopBannerFactory.swift
@@ -8,10 +8,11 @@ final class DashboardTopBannerFactory {
         let viewModel = TopBannerViewModel(title: DeprecatedStatsConstants.title,
                                            infoText: DeprecatedStatsConstants.info,
                                            icon: DeprecatedStatsConstants.icon,
-                                           actionButtonTitle: DeprecatedStatsConstants.actionTitle,
                                            isExpanded: true,
-                                           actionHandler: actionHandler,
-                                           topButton: .chevron(handler: nil))
+                                           topButton: .chevron(handler: nil),
+                                           actionButtons: [
+                                              ActionButton(title: DeprecatedStatsConstants.actionTitle, action: actionHandler),
+                                           ])
         return TopBannerView(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -44,7 +44,13 @@ final class TopBannerView: UIView {
         return button
     }()
 
-    private lazy var actionStackView = createActionStackView()
+    private lazy var actionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    private let actionButtons: [UIButton]
 
     private let isActionEnabled: Bool
 
@@ -58,6 +64,7 @@ final class TopBannerView: UIView {
         isExpanded = viewModel.isExpanded
         onAction = viewModel.actionHandler
         onTopButtonTapped = viewModel.topButton.handler
+        actionButtons = viewModel.actionButtons.map { _ in UIButton() }
         super.init(frame: .zero)
         configureSubviews(with: viewModel)
     }
@@ -109,6 +116,10 @@ private extension TopBannerView {
         iconImageView.image = viewModel.icon
 
         actionButton.setTitle(viewModel.actionButtonTitle, for: .normal)
+        zip(viewModel.actionButtons, actionButtons).forEach { buttonInfo, button in
+            button.setTitle(buttonInfo.title, for: .normal)
+            button.on(.touchUpInside, call: { _ in buttonInfo.action() })
+        }
     }
 
     func configureTopButton(viewModel: TopBannerViewModel, onContentView contentView: UIView) {
@@ -136,6 +147,7 @@ private extension TopBannerView {
         let iconInformationStackView = createIconInformationStackView(with: viewModel)
         let mainStackView = UIStackView(arrangedSubviews: [iconInformationStackView, createBorderView()])
         if isActionEnabled {
+            configureActionStackView()
             mainStackView.addArrangedSubview(actionStackView)
         }
 
@@ -177,6 +189,36 @@ private extension TopBannerView {
         expandCollapseButton.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         return informationStackView
+    }
+
+    func configureActionStackView() {
+        // StackView to hold the action buttons
+        let buttonsStackView = UIStackView()
+        buttonsStackView.distribution = .fillEqually
+        buttonsStackView.spacing = 0.5
+
+        // Background to simulate a separator by giving the buttons some spacing
+        let separatorBackground = createButtonsBackgroundView()
+        buttonsStackView.addSubview(separatorBackground)
+        buttonsStackView.pinSubviewToAllEdges(separatorBackground)
+
+        // Style buttons
+        buttonsStackView.addArrangedSubviews(actionButtons)
+        actionButtons.forEach { button in
+            button.applyLinkButtonStyle()
+            button.backgroundColor = backgroundColor
+            buttonsStackView.addArrangedSubview(button)
+        }
+
+        // Bundle everything with a vertical separator
+        actionStackView.addArrangedSubviews([buttonsStackView, createBorderView()])
+    }
+
+    func createButtonsBackgroundView() -> UIView {
+        let separatorBackground = UIView()
+        separatorBackground.translatesAutoresizingMaskIntoConstraints = false
+        separatorBackground.backgroundColor = .systemColor(.separator)
+        return separatorBackground
     }
 
     func createActionStackView() -> UIStackView {

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -38,12 +38,6 @@ final class TopBannerView: UIView {
         return button
     }()
 
-    private lazy var actionButton: UIButton = {
-        let button = UIButton(frame: .zero)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-
     private lazy var actionStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -57,12 +51,10 @@ final class TopBannerView: UIView {
     private(set) var isExpanded: Bool
 
     private let onTopButtonTapped: (() -> Void)?
-    private let onAction: (() -> Void)?
 
     init(viewModel: TopBannerViewModel) {
-        isActionEnabled = viewModel.actionHandler != nil
+        isActionEnabled = viewModel.actionButtons.isNotEmpty
         isExpanded = viewModel.isExpanded
-        onAction = viewModel.actionHandler
         onTopButtonTapped = viewModel.topButton.handler
         actionButtons = viewModel.actionButtons.map { _ in UIButton() }
         super.init(frame: .zero)
@@ -90,11 +82,6 @@ private extension TopBannerView {
         infoLabel.applyBodyStyle()
         infoLabel.numberOfLines = 0
 
-        if isActionEnabled {
-            actionButton.applyLinkButtonStyle()
-            actionButton.addTarget(self, action: #selector(onActionButtonTapped), for: .touchUpInside)
-        }
-
         renderContent(of: viewModel)
     }
 
@@ -115,7 +102,6 @@ private extension TopBannerView {
 
         iconImageView.image = viewModel.icon
 
-        actionButton.setTitle(viewModel.actionButtonTitle, for: .normal)
         zip(viewModel.actionButtons, actionButtons).forEach { buttonInfo, button in
             button.setTitle(buttonInfo.title, for: .normal)
             button.on(.touchUpInside, call: { _ in buttonInfo.action() })
@@ -221,12 +207,6 @@ private extension TopBannerView {
         return separatorBackground
     }
 
-    func createActionStackView() -> UIStackView {
-        let stackView = UIStackView(arrangedSubviews: [actionButton, createBorderView()])
-        stackView.axis = .vertical
-        return stackView
-    }
-
     func createBorderView() -> UIView {
         return UIView.createBorderView()
     }
@@ -244,10 +224,6 @@ private extension TopBannerView {
 private extension TopBannerView {
     @objc func onDismissButtonTapped() {
         onTopButtonTapped?()
-    }
-
-    @objc func onActionButtonTapped() {
-        onAction?()
     }
 
     @objc func onExpandCollapseButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -38,7 +38,7 @@ final class TopBannerView: UIView {
         return button
     }()
 
-    private lazy var actionStackView: UIStackView = {
+    private let actionStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         return stackView

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -24,6 +24,8 @@ struct TopBannerViewModel {
     let actionHandler: (() -> Void)?
     let topButton: TopButtonType
 
+    let actionButtons: [ActionButton]
+
     /// Used when the top banner is not actionable.
     ///
     init(title: String?,
@@ -38,6 +40,7 @@ struct TopBannerViewModel {
         self.actionButtonTitle = nil
         self.actionHandler = nil
         self.topButton = topButton
+        self.actionButtons = []
     }
 
     /// Used when the top banner is actionable.
@@ -48,7 +51,8 @@ struct TopBannerViewModel {
          actionButtonTitle: String,
          isExpanded: Bool = true,
          actionHandler: @escaping () -> Void,
-         topButton: TopButtonType) {
+         topButton: TopButtonType,
+         actionButtons: [ActionButton]) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
@@ -56,5 +60,11 @@ struct TopBannerViewModel {
         self.isExpanded = isExpanded
         self.actionHandler = actionHandler
         self.topButton = topButton
+        self.actionButtons = actionButtons
     }
+}
+
+struct ActionButton {
+    let title: String
+    let action: () -> Void
 }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -19,46 +19,21 @@ struct TopBannerViewModel {
     let title: String?
     let infoText: String?
     let icon: UIImage?
-    let actionButtonTitle: String?
     let isExpanded: Bool
-    let actionHandler: (() -> Void)?
     let topButton: TopButtonType
 
     let actionButtons: [ActionButton]
 
-    /// Used when the top banner is not actionable.
-    ///
     init(title: String?,
          infoText: String?,
          icon: UIImage?,
-         isExpanded: Bool,
-         topButton: TopButtonType) {
-        self.title = title
-        self.infoText = infoText
-        self.icon = icon
-        self.isExpanded = isExpanded
-        self.actionButtonTitle = nil
-        self.actionHandler = nil
-        self.topButton = topButton
-        self.actionButtons = []
-    }
-
-    /// Used when the top banner is actionable.
-    ///
-    init(title: String?,
-         infoText: String?,
-         icon: UIImage?,
-         actionButtonTitle: String,
          isExpanded: Bool = true,
-         actionHandler: @escaping () -> Void,
          topButton: TopButtonType,
-         actionButtons: [ActionButton]) {
+         actionButtons: [ActionButton] = []) {
         self.title = title
         self.infoText = infoText
         self.icon = icon
-        self.actionButtonTitle = actionButtonTitle
         self.isExpanded = isExpanded
-        self.actionHandler = actionHandler
         self.topButton = topButton
         self.actionButtons = actionButtons
     }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerViewModel.swift
@@ -16,6 +16,13 @@ struct TopBannerViewModel {
         }
     }
 
+    /// Represents an actionable button with a title and an action
+    ///
+    struct ActionButton {
+        let title: String
+        let action: () -> Void
+    }
+
     let title: String?
     let infoText: String?
     let icon: UIImage?
@@ -37,9 +44,4 @@ struct TopBannerViewModel {
         self.topButton = topButton
         self.actionButtons = actionButtons
     }
-}
-
-struct ActionButton {
-    let title: String
-    let action: () -> Void
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
+		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */; };
 		265BCA052430E611004E53EE /* ProductCategoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */; };
 		265BCA072430E62E004E53EE /* ProductCategoryListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */; };
@@ -1230,6 +1231,7 @@
 		02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeatureFlagService.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
+		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
 		265BCA042430E611004E53EE /* ProductCategoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewController.swift; sourceTree = "<group>"; };
 		265BCA062430E62E004E53EE /* ProductCategoryListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryListViewController.xib; sourceTree = "<group>"; };
@@ -2552,6 +2554,14 @@
 				267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */,
 			);
 			path = Categories;
+			sourceTree = "<group>";
+		};
+		2614EB1A24EB60DB00968D4B /* TopBanner */ = {
+			isa = PBXGroup;
+			children = (
+				2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */,
+			);
+			path = TopBanner;
 			sourceTree = "<group>";
 		};
 		265BCA032430E5EA004E53EE /* Edit Categories */ = {
@@ -4228,6 +4238,7 @@
 				0269177E23260090002AFC20 /* Products */,
 				573D0ACC2458665C004DE614 /* Search */,
 				26B119BC24D0C5AB00FED5C7 /* Survey */,
+				2614EB1A24EB60DB00968D4B /* TopBanner */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
 				45C8B25A231521510002FA77 /* CustomerNoteTableViewCellTests.swift */,
@@ -5588,6 +5599,7 @@
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,
 				D83A6A7A23792B2400419D48 /* UIColor+Muriel-Tests.swift in Sources */,
+				2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
@@ -18,8 +18,8 @@ final class TopBannerViewTests: XCTestCase {
 
     func test_it_shows_actionStackView_if_actionButtons_are_provided() throws {
         // Given
-        let actionButton = ActionButton(title: "Button", action: {})
-        let actionButton2 = ActionButton(title: "Button2", action: {})
+        let actionButton = TopBannerViewModel.ActionButton(title: "Button", action: {})
+        let actionButton2 = TopBannerViewModel.ActionButton(title: "Button2", action: {})
         let viewModel = createViewModel(with: [actionButton, actionButton2])
         let topBannerView = TopBannerView(viewModel: viewModel)
 
@@ -34,7 +34,7 @@ final class TopBannerViewTests: XCTestCase {
     func test_it_forwards_actionButtons_actions_correctly() throws {
         // Given
         var actionInvoked = false
-        let actionButton = ActionButton(title: "Button", action: {
+        let actionButton = TopBannerViewModel.ActionButton(title: "Button", action: {
             actionInvoked = true
         })
         let viewModel = createViewModel(with: [actionButton])
@@ -50,7 +50,7 @@ final class TopBannerViewTests: XCTestCase {
 }
 
 private extension TopBannerViewTests {
-    func createViewModel(with actionButtons: [ActionButton]) -> TopBannerViewModel {
+    func createViewModel(with actionButtons: [TopBannerViewModel.ActionButton]) -> TopBannerViewModel {
         TopBannerViewModel(title: "", infoText: "", icon: nil, isExpanded: true, topButton: .chevron(handler: nil), actionButtons: actionButtons)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import WooCommerce
+
+final class TopBannerViewTests: XCTestCase {
+
+    func test_it_hides_actionStackView_if_no_actionButtons_are_provided() throws {
+        // Given
+        let viewModel = createViewModel(with: [])
+        let topBannerView = TopBannerView(viewModel: viewModel)
+
+        // When
+        let mirrorView = try mirror(of: topBannerView)
+
+        // Then
+        XCTAssertTrue(mirrorView.actionButtons.isEmpty)
+        XCTAssertNil(mirrorView.actionStackView.superview)
+    }
+
+    func test_it_shows_actionStackView_if_actionButtons_are_provided() throws {
+        // Given
+        let actionButton = ActionButton(title: "Button", action: {})
+        let actionButton2 = ActionButton(title: "Button2", action: {})
+        let viewModel = createViewModel(with: [actionButton, actionButton2])
+        let topBannerView = TopBannerView(viewModel: viewModel)
+
+        // When
+        let mirrorView = try mirror(of: topBannerView)
+
+        // Then
+        XCTAssertEqual(mirrorView.actionButtons.count, 2)
+        XCTAssertNotNil(mirrorView.actionStackView.superview)
+    }
+
+    func test_it_forwards_actionButtons_actions_correctly() throws {
+        // Given
+        var actionInvoked = false
+        let actionButton = ActionButton(title: "Button", action: {
+            actionInvoked = true
+        })
+        let viewModel = createViewModel(with: [actionButton])
+        let topBannerView = TopBannerView(viewModel: viewModel)
+
+        // When
+        let mirrorView = try mirror(of: topBannerView)
+        mirrorView.actionButtons[0].sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertTrue(actionInvoked)
+    }
+}
+
+private extension TopBannerViewTests {
+    func createViewModel(with actionButtons: [ActionButton]) -> TopBannerViewModel {
+        TopBannerViewModel(title: "", infoText: "", icon: nil, isExpanded: true, topButton: .chevron(handler: nil), actionButtons: actionButtons)
+    }
+}
+
+
+// MARK: - Mirroring
+
+private extension TopBannerViewTests {
+    struct TopBannerViewMirror {
+        let actionStackView: UIStackView
+        let actionButtons: [UIButton]
+    }
+
+    func mirror(of view: TopBannerView) throws -> TopBannerViewMirror {
+        let mirror = Mirror(reflecting: view)
+        return TopBannerViewMirror(
+            actionStackView: try XCTUnwrap(mirror.descendant("actionStackView") as? UIStackView),
+            actionButtons: try XCTUnwrap(mirror.descendant("actionButtons") as? [UIButton])
+        )
+    }
+}


### PR DESCRIPTION
closes #2646 

# Why
For the new products feedback survey, we need to modify the products top banner. Prior this PR the `TopBannerView` class only supported one action button.

# How
- Adds a new `ActionButton` struct inside `TopBannerViewModel` that will represent an action button.
- Update `TopBannerView` to build its view hierarchy based on the new `actionButtons` property from `TopBannerViewModel`.
- Adds some tests.

# Screenshot
This is not in the app, but is only to show you how it would look.
<img width="395" alt="mutile-layout-button" src="https://user-images.githubusercontent.com/562080/90651589-cd46c280-e202-11ea-8090-5e1f45820f1c.png">

# Testing Steps
Make sure that the current banners(Products and Stats) keep looking as they used to.
* To show the stats banner you may need to replace line 45 of `StatsVersionCoordinator` with
```swift
let nextVersion: StatsVersion = .v3
```

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
