### PR TITLE
Edit Products M3: analytics (part 1/2)

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -301,6 +301,10 @@ public enum WooAnalyticsStat: String {
     case productReviewListLoaded = "product_reviews_loaded"
     case productReviewListLoadFailed = "product_reviews_load_failed"
 
+    // Product Type Event
+    //
+    case productTypeChanged = "product_type_change_tapped"
+
     // Product More Menu
     //
     case productDetailViewProductButtonTapped = "product_detail_view_external_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -261,6 +261,14 @@ public enum WooAnalyticsStat: String {
     case productDetailViewPriceSettingsTapped   = "product_detail_view_price_settings_tapped"
     case productDetailViewShippingSettingsTapped = "product_detail_view_shipping_settings_tapped"
     case productDetailViewInventorySettingsTapped = "product_detail_view_inventory_settings_tapped"
+    case productDetailViewCategoriesTapped = "product_detail_view_categories_tapped"
+    case productDetailViewTagsTapped = "product_detail_view_tags_tapped"
+    case productDetailViewReviewsTapped = "product_detail_view_product_reviews_tapped"
+    case productDetailViewProductTypeTapped = "product_detail_view_product_type_tapped"
+    case productDetailViewGroupedProductsTapped = "product_detail_view_grouped_products_tapped"
+    case productDetailViewExternalProductLinkTapped = "product_detail_view_external_product_link_tapped"
+    case productDetailViewSKUTapped = "product_detail_view_sku_tapped"
+    case productDetailViewVariationsTapped = "product_detail_view_product_variants_tapped"
     case productDescriptionDoneButtonTapped     = "product_description_done_button_tapped"
     case productPriceSettingsDoneButtonTapped   = "product_price_settings_done_button_tapped"
     case productShippingSettingsDoneButtonTapped = "product_shipping_settings_done_button_tapped"
@@ -303,7 +311,6 @@ public enum WooAnalyticsStat: String {
 
     // Readonly Product Variations Events
     //
-    case productDetailsProductVariantsTapped    = "product_detail_view_product_variants_tapped"
     case productVariationListLoaded             = "product_variants_loaded"
     case productVariationListLoadError          = "product_variants_load_error"
     case productVariationListPulledToRefresh    = "product_variants_pulled_to_refresh"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -333,6 +333,8 @@ public enum WooAnalyticsStat: String {
     case productSettingsSlugTapped = "product_settings_slug_tapped"
     case productSettingsPurchaseNoteTapped = "product_settings_purchase_note_tapped"
     case productSettingsMenuOrderTapped = "product_settings_menu_order_tapped"
+    case productSettingsVirtualToggled = "product_settings_virtual_toggled"
+    case productSettingsReviewsToggled = "product_settings_reviews_toggled"
 
     // Product List Sorting/Filtering
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -296,6 +296,11 @@ public enum WooAnalyticsStat: String {
     case productTagListLoadFailed = "product_tags_load_failed"
     case productTagSettingsDoneButtonTapped = "product_tag_settings_done_button_tapped"
 
+    // Product Reviews Events
+    //
+    case productReviewListLoaded = "product_reviews_loaded"
+    case productReviewListLoadFailed = "product_reviews_load_failed"
+
     // Product More Menu
     //
     case productDetailViewProductButtonTapped = "product_detail_view_external_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -303,10 +303,10 @@ public enum WooAnalyticsStat: String {
 
     // Edit Grouped Product Events
     //
-    case groupdProductLinkedProductsDeleteButtonTapped = "grouped_product_linked_products_delete_tapped"
-    case groupdProductLinkedProductsAddButtonTapped = "grouped_product_linked_products_add_tapped"
-    case groupdProductLinkedProductsAdded = "grouped_product_linked_products_added"
-    case groupdProductLinkedProductsDoneButtonTapped = "grouped_product_linked_products_done_button_tapped"
+    case groupedProductLinkedProductsDeleteButtonTapped = "grouped_product_linked_products_delete_tapped"
+    case groupedProductLinkedProductsAddButtonTapped = "grouped_product_linked_products_add_tapped"
+    case groupedProductLinkedProductsAdded = "grouped_product_linked_products_added"
+    case groupedProductLinkedProductsDoneButtonTapped = "grouped_product_linked_products_done_button_tapped"
 
     // Edit External/Affiliate Product Event
     //

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -312,6 +312,10 @@ public enum WooAnalyticsStat: String {
     //
     case externalProductLinkSettingsDoneButtonTapped = "external_product_link_settings_done_button_tapped"
 
+    // Edit Product SKU Events
+    //
+    case productSKUDoneButtonTapped = "product_sku_done_button_tapped"
+
     // Product Type Event
     //
     case productTypeChanged = "product_type_change_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -301,6 +301,13 @@ public enum WooAnalyticsStat: String {
     case productReviewListLoaded = "product_reviews_loaded"
     case productReviewListLoadFailed = "product_reviews_load_failed"
 
+    // Edit Grouped Product Events
+    //
+    case groupdProductLinkedProductsDeleteButtonTapped = "grouped_product_linked_products_delete_tapped"
+    case groupdProductLinkedProductsAddButtonTapped = "grouped_product_linked_products_add_tapped"
+    case groupdProductLinkedProductsAdded = "grouped_product_linked_products_added"
+    case groupdProductLinkedProductsDoneButtonTapped = "grouped_product_linked_products_done_button_tapped"
+
     // Product Type Event
     //
     case productTypeChanged = "product_type_change_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -308,6 +308,10 @@ public enum WooAnalyticsStat: String {
     case groupdProductLinkedProductsAdded = "grouped_product_linked_products_added"
     case groupdProductLinkedProductsDoneButtonTapped = "grouped_product_linked_products_done_button_tapped"
 
+    // Edit External/Affiliate Product Event
+    //
+    case externalProductLinkSettingsDoneButtonTapped = "external_product_link_settings_done_button_tapped"
+
     // Product Type Event
     //
     case productTypeChanged = "product_type_change_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -282,6 +282,14 @@ public enum WooAnalyticsStat: String {
     case productImageSettingsAddImagesSourceTapped = "product_image_settings_add_images_source_tapped"
     case productImageSettingsDeleteImageButtonTapped = "product_image_settings_delete_image_button_tapped"
 
+    // Product Categories Events
+    //
+    case productCategoriyListLoaded = "product_categories_loaded"
+    case productCategoriyListLoadFailed = "product_categories_load_failed"
+    case productCategorySettingsDoneButtonTapped = "product_category_settings_done_button_tapped"
+    case productCategorySettingsAddButtonTapped = "product_category_settings_add_button_tapped"
+    case productCategorySettingsSaveNewCategoryTapped = "add_product_category_save_tapped"
+
     // Product More Menu
     //
     case productDetailViewProductButtonTapped = "product_detail_view_external_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -290,6 +290,12 @@ public enum WooAnalyticsStat: String {
     case productCategorySettingsAddButtonTapped = "product_category_settings_add_button_tapped"
     case productCategorySettingsSaveNewCategoryTapped = "add_product_category_save_tapped"
 
+    // Product Tags Events
+    //
+    case productTagListLoaded = "product_tags_loaded"
+    case productTagListLoadFailed = "product_tags_load_failed"
+    case productTagSettingsDoneButtonTapped = "product_tag_settings_done_button_tapped"
+
     // Product More Menu
     //
     case productDetailViewProductButtonTapped = "product_detail_view_external_tapped"

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -708,7 +708,7 @@ extension ProductDetailsViewModel {
         case .affiliateLink:
             WebviewHelper.launch(product.externalURL, with: sender)
         case .productVariants:
-            ServiceLocator.analytics.track(.productDetailsProductVariantsTapped)
+            ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
             let variationsViewController = ProductVariationsViewController(product: product,
                                                                            isEditProductsRelease3Enabled: false)
             sender.navigationController?.pushViewController(variationsViewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -118,6 +118,8 @@ private extension AddProductCategoryViewController {
 extension AddProductCategoryViewController {
 
     @objc private func saveNewCategory() {
+        ServiceLocator.analytics.track(.productCategorySettingsSaveNewCategoryTapped)
+
         titleCategoryTextFieldResignFirstResponder()
         configureRightButtonItemAsSpinner()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -137,10 +137,12 @@ extension ProductCategoryListViewController {
     }
 
     @objc private func doneButtonTapped() {
+        ServiceLocator.analytics.track(.productCategorySettingsDoneButtonTapped)
         onCompletion(viewModel.selectedCategories)
     }
 
     @objc private func addButtonTapped() {
+        ServiceLocator.analytics.track(.productCategorySettingsAddButtonTapped)
         let addCategoryViewController = AddProductCategoryViewController(siteID: siteID) { [weak self] (newCategory) in
             defer {
                 self?.dismiss(animated: true, completion: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
@@ -128,7 +128,7 @@ private extension ProductCategoryListViewModel {
             self?.updateViewModelsArray()
 
             if let error = error {
-                ServiceLocator.analytics.track(.productCategoriyListLoadFailed)
+                ServiceLocator.analytics.track(.productCategoriyListLoadFailed, withError: error)
                 self?.handleSychronizeAllCategoriesError(error)
             } else {
                 ServiceLocator.analytics.track(.productCategoriyListLoaded)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewModel.swift
@@ -128,8 +128,10 @@ private extension ProductCategoryListViewModel {
             self?.updateViewModelsArray()
 
             if let error = error {
+                ServiceLocator.analytics.track(.productCategoriyListLoadFailed)
                 self?.handleSychronizeAllCategoriesError(error)
             } else {
+                ServiceLocator.analytics.track(.productCategoriyListLoaded)
                 self?.syncCategoriesState = .synced
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -68,6 +68,9 @@ extension ProductExternalLinkViewController {
     }
 
     @objc private func completeEditing() {
+        ServiceLocator.analytics.track(.externalProductLinkSettingsDoneButtonTapped, withProperties: [
+            "has_changed_data": hasUnsavedChanges()
+        ])
         onCompletion(externalURL, buttonText)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductListSelectorDataSource.swift
@@ -70,7 +70,7 @@ final class GroupedProductListSelectorDataSource: PaginatedListSelectorDataSourc
         cell.update(viewModel: viewModel, imageService: imageService)
 
         cell.configureAccessoryDeleteButton { [weak self] in
-            ServiceLocator.analytics.track(.groupdProductLinkedProductsDeleteButtonTapped)
+            ServiceLocator.analytics.track(.groupedProductLinkedProductsDeleteButtonTapped)
             self?.deleteProduct(model)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductListSelectorDataSource.swift
@@ -70,6 +70,7 @@ final class GroupedProductListSelectorDataSource: PaginatedListSelectorDataSourc
         cell.update(viewModel: viewModel, imageService: imageService)
 
         cell.configureAccessoryDeleteButton { [weak self] in
+            ServiceLocator.analytics.track(.groupdProductLinkedProductsDeleteButtonTapped)
             self?.deleteProduct(model)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductsViewController.swift
@@ -64,9 +64,14 @@ final class GroupedProductsViewController: UIViewController {
 //
 private extension GroupedProductsViewController {
     @objc func addTapped() {
+        ServiceLocator.analytics.track(.groupdProductLinkedProductsAddButtonTapped)
+
         let excludedProductIDs = dataSource.groupedProductIDs + [productID]
         let listSelector = ProductListSelectorViewController(excludedProductIDs: excludedProductIDs,
                                                              siteID: siteID) { [weak self] selectedProductIDs in
+                                                                if selectedProductIDs.isNotEmpty {
+                                                                    ServiceLocator.analytics.track(.groupdProductLinkedProductsAdded)
+                                                                }
                                                                 self?.dataSource.addProducts(selectedProductIDs)
                                                                 self?.navigationController?.popViewController(animated: true)
         }
@@ -74,6 +79,11 @@ private extension GroupedProductsViewController {
     }
 
     @objc func doneButtonTapped() {
+        let hasChangedData = dataSource.hasUnsavedChanges()
+        ServiceLocator.analytics.track(.groupdProductLinkedProductsDoneButtonTapped, withProperties: [
+            "has_changed_data": hasChangedData
+        ])
+
         completeUpdating()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/GroupedProductsViewController.swift
@@ -64,13 +64,13 @@ final class GroupedProductsViewController: UIViewController {
 //
 private extension GroupedProductsViewController {
     @objc func addTapped() {
-        ServiceLocator.analytics.track(.groupdProductLinkedProductsAddButtonTapped)
+        ServiceLocator.analytics.track(.groupedProductLinkedProductsAddButtonTapped)
 
         let excludedProductIDs = dataSource.groupedProductIDs + [productID]
         let listSelector = ProductListSelectorViewController(excludedProductIDs: excludedProductIDs,
                                                              siteID: siteID) { [weak self] selectedProductIDs in
                                                                 if selectedProductIDs.isNotEmpty {
-                                                                    ServiceLocator.analytics.track(.groupdProductLinkedProductsAdded)
+                                                                    ServiceLocator.analytics.track(.groupedProductLinkedProductsAdded)
                                                                 }
                                                                 self?.dataSource.addProducts(selectedProductIDs)
                                                                 self?.navigationController?.popViewController(animated: true)
@@ -80,7 +80,7 @@ private extension GroupedProductsViewController {
 
     @objc func doneButtonTapped() {
         let hasChangedData = dataSource.hasUnsavedChanges()
-        ServiceLocator.analytics.track(.groupdProductLinkedProductsDoneButtonTapped, withProperties: [
+        ServiceLocator.analytics.track(.groupedProductLinkedProductsDoneButtonTapped, withProperties: [
             "has_changed_data": hasChangedData
         ])
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -208,9 +208,12 @@ private extension ProductTagsViewController {
 
         let action = ProductTagAction.synchronizeAllProductTags(siteID: product.siteID) { [weak self] error in
             guard error == nil else {
+                ServiceLocator.analytics.track(.productTagListLoadFailed)
                 self?.tagsFailedLoading()
                 return
             }
+
+            ServiceLocator.analytics.track(.productTagListLoaded)
 
             if let tagNames = self?.fetchedTags.map({ $0.name }) {
                 self?.tagsLoaded(tags: tagNames)
@@ -226,6 +229,8 @@ private extension ProductTagsViewController {
     }
 
     @objc func addTagsRemotely() {
+        ServiceLocator.analytics.track(.productTagSettingsDoneButtonTapped)
+
         textView.resignFirstResponder()
         configureRightBarButtonItemAsSpinner()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -229,7 +229,9 @@ private extension ProductTagsViewController {
     }
 
     @objc func addTagsRemotely() {
-        ServiceLocator.analytics.track(.productTagSettingsDoneButtonTapped)
+        ServiceLocator.analytics.track(.productTagSettingsDoneButtonTapped, withProperties: [
+            "has_changed_data": hasUnsavedChanges()
+        ])
 
         textView.resignFirstResponder()
         configureRightBarButtonItemAsSpinner()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -207,8 +207,8 @@ private extension ProductTagsViewController {
         dataSource = LoadingDataSource()
 
         let action = ProductTagAction.synchronizeAllProductTags(siteID: product.siteID) { [weak self] error in
-            guard error == nil else {
-                ServiceLocator.analytics.track(.productTagListLoadFailed)
+            if let error = error {
+                ServiceLocator.analytics.track(.productTagListLoadFailed, withError: error)
                 self?.tagsFailedLoading()
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -171,7 +171,7 @@ enum ProductSettingsRows {
             cell.title = title
             cell.isOn = settings.virtual
             cell.onChange = { newValue in
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productSettingsVirtualToggled)
                 self.settings.virtual = newValue
             }
         }
@@ -202,7 +202,7 @@ enum ProductSettingsRows {
             cell.title = title
             cell.isOn = settings.reviewsAllowed
             cell.onChange = { newValue in
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productSettingsReviewsToggled)
                 self.settings.reviewsAllowed = newValue
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -259,10 +259,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 ServiceLocator.analytics.track(.productDetailViewPriceSettingsTapped)
                 editPriceSettings()
             case .reviews:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
             case .productType:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewProductTypeTapped)
                 let cell = tableView.cellForRow(at: indexPath)
                 editProductType(cell: cell)
             case .shipping:
@@ -272,27 +272,28 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 ServiceLocator.analytics.track(.productDetailViewInventorySettingsTapped)
                 editInventorySettings()
             case .categories:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewCategoriesTapped)
                 editCategories()
             case .tags:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewTagsTapped)
                 editTags()
             case .briefDescription:
                 ServiceLocator.analytics.track(.productDetailViewShortDescriptionTapped)
                 editShortDescription()
             case .externalURL:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewExternalProductLinkTapped)
                 editExternalLink()
                 break
             case .sku:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewSKUTapped)
                 editSKU()
                 break
             case .groupedProducts:
+                ServiceLocator.analytics.track(.productDetailViewGroupedProductsTapped)
                 editGroupedProducts()
                 break
             case .variations:
-                // TODO-2509 Edit Product M3 analytics
+                ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
                 guard let product = product as? EditableProductModel, product.product.variations.isNotEmpty else {
                     return
                 }
@@ -475,16 +476,22 @@ private extension ProductFormViewController {
                                                                     self?.dismiss(animated: true) { [weak self] in
                                                                         switch action {
                                                                         case .editInventorySettings:
+                                                                            ServiceLocator.analytics.track(.productDetailViewInventorySettingsTapped)
                                                                             self?.editInventorySettings()
                                                                         case .editShippingSettings:
+                                                                            ServiceLocator.analytics.track(.productDetailViewShippingSettingsTapped)
                                                                             self?.editShippingSettings()
                                                                         case .editCategories:
+                                                                            ServiceLocator.analytics.track(.productDetailViewCategoriesTapped)
                                                                             self?.editCategories()
                                                                         case .editTags:
+                                                                            ServiceLocator.analytics.track(.productDetailViewTagsTapped)
                                                                             self?.editTags()
                                                                         case .editBriefDescription:
+                                                                            ServiceLocator.analytics.track(.productDetailViewShortDescriptionTapped)
                                                                             self?.editShortDescription()
                                                                         case .editSKU:
+                                                                            ServiceLocator.analytics.track(.productDetailViewSKUTapped)
                                                                             self?.editSKU()
                                                                             break
                                                                         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -982,7 +982,6 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-        //TODO: Edit Product M3 analytics
         let hasChangedData = categories.sorted() != product.product.categories.sorted()
         guard hasChangedData else {
             return
@@ -1014,7 +1013,6 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-        // TODO-2509: Edit Product M3 analytics
         let hasChangedData = tags.sorted() != product.product.tags.sorted()
         guard hasChangedData else {
             return
@@ -1041,8 +1039,8 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-        // TODO-2509: Edit Product M3 analytics
         let hasChangedData = sku != product.sku
+        ServiceLocator.analytics.track(.productSKUDoneButtonTapped, withProperties: ["has_changed_data": hasChangedData])
         guard hasChangedData else {
             return
         }
@@ -1072,7 +1070,6 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-        // TODO-2000: Edit Product M3 analytics
         let hasChangedData = groupedProductIDs != product.product.groupedProducts
         guard hasChangedData else {
             return
@@ -1103,7 +1100,6 @@ private extension ProductFormViewController {
         defer {
             navigationController?.popViewController(animated: true)
         }
-        // TODO-2000: Edit Product M3 analytics
         let hasChangedData = externalURL != product.product.externalURL || buttonText != product.product.buttonText
         guard hasChangedData else {
             return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -856,10 +856,12 @@ private extension ProductFormViewController {
         let command = ProductTypeBottomSheetListSelectorCommand(selected: viewModel.productModel.productType) { [weak self] (selectedProductType) in
             self?.dismiss(animated: true, completion: nil)
 
-            // TODO-2509 Edit Product M3 analytics
-            //  let hasChangedData: Bool = {
-            //      self?.product.productType != selectedProductType
-            //  }()
+            if let originalProductType = self?.product.productType {
+                ServiceLocator.analytics.track(.productTypeChanged, withProperties: [
+                    "from": originalProductType.rawValue,
+                    "to": selectedProductType.rawValue
+                ])
+            }
             self?.presentProductTypeChangeAlert(completion: { (change) in
                 guard change == true else {
                     return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -92,9 +92,9 @@ extension ProductReviewsViewModel {
                                                                    status: .approved) { error in
                                                                     if let error = error {
             DDLogError("⛔️ Error synchronizing reviews for product ID :\(productID). Error: \(error)")
-                                                                        // TODO: Analytics Products M3. Failed
+                                                                        ServiceLocator.analytics.track(.productReviewListLoadFailed)
                                                                     } else {
-                                                                        // TODO: Analytics Products M3. Loading more
+                                                                        ServiceLocator.analytics.track(.productReviewListLoaded)
                                                                     }
 
                                                                     onCompletion?()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -92,7 +92,7 @@ extension ProductReviewsViewModel {
                                                                    status: .approved) { error in
                                                                     if let error = error {
             DDLogError("⛔️ Error synchronizing reviews for product ID :\(productID). Error: \(error)")
-                                                                        ServiceLocator.analytics.track(.productReviewListLoadFailed)
+                                                                        ServiceLocator.analytics.track(.productReviewListLoadFailed, withError: error)
                                                                     } else {
                                                                         ServiceLocator.analytics.track(.productReviewListLoaded)
                                                                     }

--- a/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductCategoryAction.swift
@@ -19,7 +19,7 @@ public enum ProductCategoryAction: Action {
 
 /// Defines all errors that a `ProductCategoryAction` can return
 ///
-public enum ProductCategoryActionError {
+public enum ProductCategoryActionError: Error {
     /// Represents a product category synchronization failed state
     ///
     case categoriesSynchronization(pageNumber: Int, rawError: Error)

--- a/Yosemite/Yosemite/Actions/ProductTagAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductTagAction.swift
@@ -26,7 +26,7 @@ public enum ProductTagAction: Action {
 
 /// Defines all errors that a `ProductTagAction` can return
 ///
-public enum ProductTagActionError {
+public enum ProductTagActionError: Error {
     /// Represents a product tag synchronization failed state
     ///
     case tagsSynchronization(pageNumber: Int, rawError: Error)


### PR DESCRIPTION
Part 1/2 of #2509 

Since the variation events are a bit more involved, I grouped the more straightforward events in this PR and the next PR would include the events for editing a product variation.

## Changes

- Added 26 new events to `WooAnalyticsStat`
- Implemented logging for the 26 new events - for "done" events from product tags/categories, I started logging in the view controllers instead of the already giant `ProductFormViewController` like price/inventory/shipping settings. also, I noticed that we weren't logging tap events from product form bottom sheet so I added logging for all actions including some of the new events.

## Testing

### Product categories

- Go to the Products tab
- Tap on any core product
- Tap on the categories row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_categories_tapped` in the console. once the list is loaded, should see `🔵 Tracked product_categories_loaded`
- Tap "Add Category" CTA --> should see `🔵 Tracked product_category_settings_add_button_tapped`
- Enter a new category name, and tap "Save" --> should see `🔵 Tracked add_product_category_save_tapped`
- Tap "Done" to finish editing categories --> should see `🔵 Tracked product_category_settings_done_button_tapped`

### Product tags

- Go to the Products tab
- Tap on any core product
- Tap on the categories row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_tags_tapped` in the console. once the list is loaded, should see `🔵 Tracked product_tags_loaded`
- Tap "Save" --> should see `🔵 Tracked product_tag_settings_done_button_tapped` in the console with property `"has_changed_data": false`

### Product reviews

- Go to the Products tab
- Tap on any core product with at least one review --> should see `🔵 Tracked product_detail_view_product_reviews_tapped` in the console. once the list is loaded, should see `🔵 Tracked product_reviews_loaded`

### Product type

- Go to the Products tab
- Tap on any core product
- Tap on the product type row --> should see `🔵 Tracked product_detail_view_product_type_tapped` in the console
- Tap on a product type --> should see `🔵 Tracked product_type_change_tapped` in the console with properties "from" and "to" with the from/to product type

### Grouped product

- Go to the Products tab
- Tap on a grouped product 
- Tap on the grouped products row --> should see `🔵 Tracked product_detail_view_grouped_products_tapped` in the console
- Tap "Add Products" CTA --> should see `🔵 Tracked grouped_product_linked_products_add_tapped` in the console
- Select at least one product from the product list or search results --> should see `🔵 Tracked grouped_product_linked_products_added` in the console
- Tap "X" to delete a linked product --> should see `🔵 Tracked grouped_product_linked_products_delete_tapped` in the console
- Tap "Done" --> should see `🔵 Tracked grouped_product_linked_products_done_button_tapped` in the console with property `"has_changed_data": true`
- Tap on the SKU row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_sku_tapped` in the console
- Tap "Done" --> should see `🔵 Tracked product_sku_done_button_tapped` with property `"has_changed_data": false`

### External/affiliate product

- Go to the Products tab
- Tap on an external/affiliate product 
- Tap on the product link row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_external_product_link_tapped` in the console
- Tap "Done" --> should see `🔵 Tracked external_product_link_settings_done_button_tapped` with property `"has_changed_data": false`

### Product settings

- Go to the Products tab
- Tap on a simple product 
- Tap on "..." then "Product Settings"
- Toggle the "Virtual Product" switch --> should see `🔵 Tracked product_settings_virtual_toggled`
- Toggle the "Enable Reviews" switch --> should see `🔵 Tracked product_settings_reviews_toggled`

### Error loading error scenario

This might be easier on a device:
- Turn on airplane mode so that there's no network connection
- Go to the Products tab
- Tap on any core product
- Tap on the categories row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_categories_tapped` in the console. once the list is loaded, should see `🔵 Tracked product_categories_load_failed` with the error
- Go back to product details
- Tap on the tags row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_tags_tapped ` in the console. once the list is loaded, should see `🔵 Tracked product_categories_load_failed` with the error
- Go back to product details
- Tap on the reviews row or from the bottom sheet --> should see `🔵 Tracked product_detail_view_product_reviews_tapped ` in the console. once the list is loaded, should see `🔵 Tracked product_reviews_load_failed` with the error

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
