### PR TITLE
Statically-Typed Event Properties Convention and In-app Feedback Card Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1,32 +1,33 @@
 import Foundation
 
 /// This struct represents an analytics event.
+///
 /// Declaring this class as final is a design choice to promote a simpler usage and implement events
 /// through parametrization of the `name` and `properties` properties.
 ///
 /// An example of a static event definition (in the client App or Pod):
 ///
 /// ~~~
-/// extension AnalyticsEvent {
-///     static let loginStart = AnalyticsEvent(name: "login", properties: ["step": "start"])
+/// extension WooAnalyticsEvent {
+///     static let loginStart = WooAnalyticsEvent(name: "login", properties: ["step": "start"])
 /// }
 /// ~~~
 ///
 /// An example of a dynamic / parametrized event definition (in the client App or Pod):
 ///
 /// ~~~
-/// extension AnalyticsEvent {
+/// extension WooAnalyticsEvent {
 ///     enum LoginStep: String {
 ///         case start
 ///         case success
 ///     }
 ///
-///     static func login(step: LoginStep) -> AnalyticsEvent {
+///     static func login(step: LoginStep) -> WooAnalyticsEvent {
 ///         let properties = [
 ///             "step": step.rawValue
 ///         ]
 ///
-///         return AnalyticsEvent(name: "login", properties: properties)
+///         return WooAnalyticsEvent(name: "login", properties: properties)
 ///     }
 /// }
 /// ~~~
@@ -38,7 +39,7 @@ import Foundation
 /// WPAnalytics.track(.loginStart)
 /// ~~~
 ///
-public final class AnalyticsEvent {
+public final class WooAnalyticsEvent {
     let name: String
     let properties: [String: String]
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -39,8 +39,8 @@ import Foundation
 /// WPAnalytics.track(.loginStart)
 /// ~~~
 ///
-public final class WooAnalyticsEvent {
     let name: String
+public struct WooAnalyticsEvent {
     let properties: [String: String]
 
     public init(name: String, properties: [String: String]) {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// This struct represents an analytics event.
+/// Declaring this class as final is a design choice to promote a simpler usage and implement events
+/// through parametrization of the `name` and `properties` properties.
+///
+/// An example of a static event definition (in the client App or Pod):
+///
+/// ~~~
+/// extension AnalyticsEvent {
+///     static let loginStart = AnalyticsEvent(name: "login", properties: ["step": "start"])
+/// }
+/// ~~~
+///
+/// An example of a dynamic / parametrized event definition (in the client App or Pod):
+///
+/// ~~~
+/// extension AnalyticsEvent {
+///     enum LoginStep: String {
+///         case start
+///         case success
+///     }
+///
+///     static func login(step: LoginStep) -> AnalyticsEvent {
+///         let properties = [
+///             "step": step.rawValue
+///         ]
+///
+///         return AnalyticsEvent(name: "login", properties: properties)
+///     }
+/// }
+/// ~~~
+///
+/// Examples of tracking calls (in the client App or Pod):
+///
+/// ~~~
+/// WPAnalytics.track(.login(step: .start))
+/// WPAnalytics.track(.loginStart)
+/// ~~~
+///
+public final class AnalyticsEvent {
+    let name: String
+    let properties: [String: String]
+
+    public init(name: String, properties: [String: String]) {
+        self.name = name
+        self.properties = properties
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1,19 +1,9 @@
 import Foundation
 
-/// This struct represents an analytics event.
+/// This struct represents an analytics event. It is a combination of `WooAnalyticsStat` and
+/// its properties.
 ///
-/// Declaring this class as final is a design choice to promote a simpler usage and implement events
-/// through parametrization of the `name` and `properties` properties.
-///
-/// An example of a static event definition (in the client App or Pod):
-///
-/// ~~~
-/// extension WooAnalyticsEvent {
-///     static let loginStart = WooAnalyticsEvent(name: "login", properties: ["step": "start"])
-/// }
-/// ~~~
-///
-/// An example of a dynamic / parametrized event definition (in the client App or Pod):
+/// An example of a dynamic / parameterized event definition:
 ///
 /// ~~~
 /// extension WooAnalyticsEvent {
@@ -35,8 +25,8 @@ import Foundation
 /// Examples of tracking calls (in the client App or Pod):
 ///
 /// ~~~
-/// WPAnalytics.track(.login(step: .start))
-/// WPAnalytics.track(.loginStart)
+/// Analytics.track(.login(step: .start))
+/// Analytics.track(.loginStart)
 /// ~~~
 ///
     let name: String

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -29,8 +29,8 @@ import Foundation
 /// Analytics.track(.loginStart)
 /// ~~~
 ///
-    let name: String
 public struct WooAnalyticsEvent {
+    let statName: WooAnalyticsStat
     let properties: [String: String]
 
     public init(name: String, properties: [String: String]) {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -68,6 +68,7 @@ extension WooAnalyticsEvent {
         case completed
     }
 
+    /// The action performed on "New Features" banners like in Products.
     public enum FeatureFeedbackBannerAction: String {
         case gaveFeedback = "gave_feedback"
         case dismissed

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -70,7 +70,7 @@ extension WooAnalyticsEvent {
 
     public enum FeatureFeedbackBannerAction: String {
         case gaveFeedback = "gave_feedback"
-        case dismissed = "dismissed"
+        case dismissed
     }
 
     static func appFeedbackPrompt(action: AppFeedbackPromptAction) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3,7 +3,15 @@ import Foundation
 /// This struct represents an analytics event. It is a combination of `WooAnalyticsStat` and
 /// its properties.
 ///
-/// An example of a dynamic / parameterized event definition:
+/// This was mostly created to promote static-typing via constructors.
+///
+/// ## Adding New Events
+///
+/// 1. Add the event name (`String`) to `WooAnalyticsStat`.
+/// 2. Create an `extension` of `WooAnalyticsStat` if necessary for grouping.
+/// 3. Add a `static func` constructor.
+///
+/// Here is an example:
 ///
 /// ~~~
 /// extension WooAnalyticsEvent {
@@ -25,8 +33,8 @@ import Foundation
 /// Examples of tracking calls (in the client App or Pod):
 ///
 /// ~~~
-/// Analytics.track(.login(step: .start))
-/// Analytics.track(.loginStart)
+/// Analytics.track(event: .login(step: .start))
+/// Analytics.track(event: .loginStart)
 /// ~~~
 ///
 public struct WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -40,9 +40,48 @@ import Foundation
 public struct WooAnalyticsEvent {
     let statName: WooAnalyticsStat
     let properties: [String: String]
+}
 
-    public init(name: String, properties: [String: String]) {
-        self.name = name
-        self.properties = properties
+// MARK: - In-app Feedback and Survey
+
+extension WooAnalyticsEvent {
+
+    /// The action performed on the In-app Feedback Card.
+    public enum AppFeedbackPromptAction: String {
+        case shown
+        case liked
+        case didntLike = "didnt_like"
+    }
+
+    /// Where the feedback was shown. This is shared by a couple of events.
+    public enum FeedbackContext: String {
+        /// Shown in Stats but is for asking general feedback.
+        case general
+        /// Shown in products banner.
+        case products
+    }
+
+    /// The action performed on the survey screen.
+    public enum SurveyScreenAction: String {
+        case opened
+        case canceled
+        case completed
+    }
+
+    public enum FeatureFeedbackBannerAction: String {
+        case gaveFeedback = "gave_feedback"
+        case dismissed = "dismissed"
+    }
+
+    static func appFeedbackPrompt(action: AppFeedbackPromptAction) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .appFeedbackPrompt, properties: ["action": action.rawValue])
+    }
+
+    static func surveyScreen(context: FeedbackContext, action: SurveyScreenAction) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .surveyScreen, properties: ["context": context.rawValue, "action": action.rawValue])
+    }
+
+    static func featureFeedbackBanner(context: FeedbackContext, action: FeatureFeedbackBannerAction) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .featureFeedbackBanner, properties: ["context": context.rawValue, "action": action.rawValue])
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -9,14 +9,14 @@ import WordPressShared
 ///
 public enum WooAnalyticsStat: String {
 
-    // Application Events
+    // MARK: Application Events
     //
     case applicationInstalled                   = "application_installed"
     case applicationUpgraded                    = "application_upgraded"
     case applicationOpened                      = "application_opened"
     case applicationClosed                      = "application_closed"
 
-    // Authentication Events
+    // MARK: Authentication Events
     //
     case signedIn                               = "signed_in"
     case logout                                 = "account_logout"
@@ -58,7 +58,7 @@ public enum WooAnalyticsStat: String {
     case twoFactorCodeRequested                 = "two_factor_code_requested"
     case twoFactorSentSMS                       = "two_factor_sent_sms"
 
-    // Dashboard View Events
+    // MARK: Dashboard View Events
     //
     case dashboardSelected                      = "main_tab_dashboard_selected"
     case dashboardReselected                    = "main_tab_dashboard_reselected"
@@ -66,7 +66,7 @@ public enum WooAnalyticsStat: String {
     case dashboardNewOrdersButtonTapped         = "dashboard_unfulfilled_orders_button_tapped"
     case dashboardShareStoreButtonTapped        = "dashboard_share_your_store_button_tapped"
 
-    // Dashboard Data/Action Events
+    // MARK: Dashboard Data/Action Events
     //
     case dashboardMainStatsDate                 = "dashboard_main_stats_date"
     case dashboardMainStatsLoaded               = "dashboard_main_stats_loaded"
@@ -74,20 +74,20 @@ public enum WooAnalyticsStat: String {
     case dashboardTopPerformersLoaded           = "dashboard_top_performers_loaded"
     case dashboardUnfulfilledOrdersLoaded       = "dashboard_unfulfilled_orders_loaded"
 
-    // Dashboard Stats v3/v4 Events
+    // MARK: Dashboard Stats v3/v4 Events
     //
     case dashboardNewStatsAvailabilityBannerCancelTapped = "dashboard_new_stats_availability_banner_cancel_tapped"
     case dashboardNewStatsAvailabilityBannerTryTapped = "dashboard_new_stats_availability_banner_try_tapped"
     case dashboardNewStatsRevertedBannerDismissTapped = "dashboard_new_stats_reverted_banner_dismiss_tapped"
     case dashboardNewStatsRevertedBannerLearnMoreTapped = "dashboard_new_stats_reverted_banner_learn_more_tapped"
 
-    // Site picker. Can be triggered by login epilogue or settings.
+    // MARK: Site picker. Can be triggered by login epilogue or settings.
     //
     case sitePickerContinueTapped               = "site_picker_continue_tapped"
     case sitePickerStoresShown                  = "site_picker_stores_shown"
     case sitePickerHelpButtonTapped             = "site_picker_help_button_tapped"
 
-    // Help & Support Events
+    // MARK: Help & Support Events
     //
     case supportHelpCenterViewed                = "support_help_center_viewed"
     case supportNewRequestViewed                = "support_new_request_viewed"
@@ -105,9 +105,7 @@ public enum WooAnalyticsStat: String {
     case supportIdentityFormViewed              = "support_identity_form_viewed"
     case supportIdentitySet                     = "support_identity_set"
 
-
-
-    // Settings View Events
+    // MARK: Settings View Events
     //
     case settingsTapped                         = "main_menu_settings_tapped"
     case settingsSelectedStoreTapped            = "settings_selected_site_tapped"
@@ -129,7 +127,7 @@ public enum WooAnalyticsStat: String {
     case settingsLogoutConfirmation             = "settings_logout_confirmation_dialog_result"
     case settingsWereHiringTapped               = "settings_we_are_hiring_button_tapped"
 
-    // Order View Events
+    // MARK: Order View Events
     //
     case ordersSelected                         = "main_tab_orders_selected"
     case ordersReselected                       = "main_tab_orders_reselected"
@@ -165,7 +163,7 @@ public enum WooAnalyticsStat: String {
     case orderShipmentTrackingCustomProviderSelected = "order_shipment_tracking_custom_provider_selected"
     case orderStatusDialogApplyButtonTapped     = "set_order_status_dialog_apply_button_tapped"
 
-    // Order Data/Action Events
+    // MARK: Order Data/Action Events
     //
     case orderOpen                              = "order_open"
     case orderNotesLoaded                       = "order_notes_loaded"
@@ -188,7 +186,7 @@ public enum WooAnalyticsStat: String {
     case orderTrackingDeleteSuccess             = "order_tracking_delete_success"
     case orderTrackingProvidersLoaded           = "order_tracking_providers_loaded"
 
-    // Push Notifications Events
+    // MARK: Push Notifications Events
     //
     case pushNotificationReceived               = "push_notification_received"
     case pushNotificationAlertPressed           = "push_notification_alert_pressed"
@@ -196,7 +194,7 @@ public enum WooAnalyticsStat: String {
     case pushNotificationOSAlertDenied          = "push_notification_os_alert_denied"
     case pushNotificationOSAlertShown           = "push_notification_os_alert_shown"
 
-    // Notification View Events
+    // MARK: Notification View Events
     //
     case notificationsSelected                  = "main_tab_notifications_selected"
     case notificationsReselected                = "main_tab_notifications_reselected"
@@ -210,13 +208,13 @@ public enum WooAnalyticsStat: String {
     case notificationReviewSpamTapped           = "review_detail_spam_button_tapped"
     case notificationShareStoreButtonTapped     = "notifications_share_your_store_button_tapped"
 
-    // Review View Events
+    // MARK: Review View Events
     //
     case reviewsListPulledToRefresh             = "reviews_list_pulled_to_refresh"
     case reviewsListReadAllTapped               = "reviews_list_menu_mark_read_button_tapped"
     case reviewsShareStoreButtonTapped          = "reviews_share_your_store_button_tapped"
 
-    // Notification Data/Action Events
+    // MARK: Notification Data/Action Events
     //
     case notificationListLoaded                 = "notifications_loaded"
     case notificationsLoadFailed                = "notifications_load_failed"
@@ -226,7 +224,8 @@ public enum WooAnalyticsStat: String {
     case notificationReviewActionFailed         = "review_action_failed"
     case notificationReviewActionUndo           = "review_action_undo"
 
-    // Review Data/Action Events
+    // MARK: Review Data/Action Events
+    //
     case reviewLoaded                           = "review_loaded"
     case reviewLoadFailed                       = "review_load_failed"
     case reviewMarkRead                         = "review_mark_read"
@@ -240,7 +239,7 @@ public enum WooAnalyticsStat: String {
     case reviewsProductsLoaded                  = "reviews_products_loaded"
     case reviewsProductsLoadFailed              = "reviews_products_load_failed"
 
-    // Product List Events
+    // MARK: Product List Events
     //
     case productListSelected                    = "main_tab_products_selected"
     case productListReselected                  = "main_tab_products_reselected"
@@ -251,7 +250,7 @@ public enum WooAnalyticsStat: String {
     case productListSearched                    = "product_list_searched"
     case productListMenuSearchTapped            = "product_list_menu_search_tapped"
 
-    // Edit Product Events
+    // MARK: Edit Product Events
     //
     case productDetailUpdateButtonTapped        = "product_detail_update_button_tapped"
     case productDetailUpdateSuccess             = "product_detail_update_success"
@@ -266,7 +265,7 @@ public enum WooAnalyticsStat: String {
     case productShippingSettingsDoneButtonTapped = "product_shipping_settings_done_button_tapped"
     case productInventorySettingsDoneButtonTapped = "product_inventory_settings_done_button_tapped"
 
-    // Product Images Events
+    // MARK: Product Images Events
     //
     case productImageSettingsDoneButtonTapped = "product_image_settings_done_button_tapped"
     case productDetailAddImageTapped = "product_detail_add_image_tapped"
@@ -274,12 +273,12 @@ public enum WooAnalyticsStat: String {
     case productImageSettingsAddImagesSourceTapped = "product_image_settings_add_images_source_tapped"
     case productImageSettingsDeleteImageButtonTapped = "product_image_settings_delete_image_button_tapped"
 
-    // Product More Menu
+    // MARK: Product More Menu
     //
     case productDetailViewProductButtonTapped = "product_detail_view_external_tapped"
     case productDetailShareButtonTapped = "product_detail_share_button_tapped"
 
-    // Product Settings
+    // MARK: Product Settings
     //
     case productDetailViewSettingsButtonTapped = "product_detail_view_settings_button_tapped"
     case productSettingsDoneButtonTapped = "product_settings_done_button_tapped"
@@ -292,7 +291,7 @@ public enum WooAnalyticsStat: String {
     case productSettingsPurchaseNoteTapped = "product_settings_purchase_note_tapped"
     case productSettingsMenuOrderTapped = "product_settings_menu_order_tapped"
 
-    // Product List Sorting/Filtering
+    // MARK: Product List Sorting/Filtering
     //
     case productListViewSortingOptionsTapped = "product_list_view_sorting_options_tapped"
     case productSortingListOptionSelected = "product_sorting_list_option_selected"
@@ -301,18 +300,18 @@ public enum WooAnalyticsStat: String {
     case productFilterListClearMenuButtonTapped = "product_filter_list_clear_menu_button_tapped"
     case productFilterListDismissButtonTapped = "product_filter_list_dismiss_button_tapped"
 
-    // Readonly Product Variations Events
+    // MARK: Readonly Product Variations Events
     //
     case productDetailsProductVariantsTapped    = "product_detail_view_product_variants_tapped"
     case productVariationListLoaded             = "product_variants_loaded"
     case productVariationListLoadError          = "product_variants_load_error"
     case productVariationListPulledToRefresh    = "product_variants_pulled_to_refresh"
 
-    // Azted editor
+    // MARK: Aztec editor
     //
     case aztecEditorDoneButtonTapped            = "aztec_editor_done_button_tapped"
 
-    // Jetpack Tunnel Events
+    // MARK: Jetpack Tunnel Events
     //
     case jetpackTunnelTimeout                   = "jetpack_tunnel_timeout"
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -314,6 +314,14 @@ public enum WooAnalyticsStat: String {
     // MARK: Jetpack Tunnel Events
     //
     case jetpackTunnelTimeout                   = "jetpack_tunnel_timeout"
+
+    // MARK: In-app Feedback and Survey Events
+    //
+    // (https://git.io/JJpb2)
+    //
+    case appFeedbackPrompt = "app_feedback_prompt"
+    case surveyScreen = "survey_screen"
+    case featureFeedbackBanner = "feature_feedback_banner"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1,8 +1,18 @@
 import WordPressShared
 
-
 /// This enum contains all of the events we track in the app. Please reference the "Woo Mobile Events Draft i2"
 /// spreadsheet for more details.
+///
+/// One of goals of this `enum` is to be able to list all the event names that we use throughout
+/// the app. We can also potentially make a parser to gather all the event names and automatically
+/// compare them with WCAndroid. With that, we can make sure both platforms are tracking the
+/// same events. Right now, we use the spreadsheet. XD
+///
+/// ### Type-Safe Properties
+///
+/// If an event has custom properties, add and use a constructor defined in `WooAnalyticsEvent`.
+///
+/// ### Excluding Site Properties
 ///
 /// Note: If you would like to exclude site properties (e.g. `blog_id`) for a given event, please
 /// add the event to the `WooAnalyticsStat.shouldSendSiteProperties` var.

--- a/WooCommerce/Classes/ServiceLocator/Analytics.swift
+++ b/WooCommerce/Classes/ServiceLocator/Analytics.swift
@@ -49,3 +49,13 @@ protocol Analytics {
     ///
     var analyticsProvider: AnalyticsProvider { get }
 }
+
+extension Analytics {
+    /// Track a specific event.
+    ///
+    /// - Parameter event: The event to track along with its properties.
+    ///
+    func track(event: WooAnalyticsEvent) {
+        track(event.statName, withProperties: event.properties)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -21,6 +21,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
 
     private let featureFlagService: FeatureFlagService
     private let storesManager: StoresManager
+    private let analytics: Analytics
 
     /// Create an instance of `self`.
     ///
@@ -30,10 +31,12 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     ///
     init(canDisplayInAppFeedbackCard: Bool,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         storesManager: StoresManager = ServiceLocator.stores) {
+         storesManager: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.canDisplayInAppFeedbackCard = canDisplayInAppFeedbackCard
         self.featureFlagService = featureFlagService
         self.storesManager = storesManager
+        self.analytics = analytics
     }
 
     /// Must be called by the `ViewController` during the `viewDidAppear()` event. This will

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -46,7 +46,7 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     /// never terminated.
     ///
     func onViewDidAppear() {
-        updateIsInAppFeedbackCardVisibleValue()
+        refreshIsInAppFeedbackCardVisibleValue()
     }
 
     /// Updates the card visibility state stored in `isInAppFeedbackCardVisibleSubject` by updating the app last feedback date.
@@ -61,13 +61,13 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
                 CrashLogging.logError(error)
             }
 
-            self.updateIsInAppFeedbackCardVisibleValue()
+            self.refreshIsInAppFeedbackCardVisibleValue()
         }
         storesManager.dispatch(action)
     }
 
     /// Calculates and updates the value of `isInAppFeedbackCardVisibleSubject`.
-    private func updateIsInAppFeedbackCardVisibleValue() {
+    private func refreshIsInAppFeedbackCardVisibleValue() {
         // Abort right away if we don't need to calculate the real value.
         let isEnabled = canDisplayInAppFeedbackCard && featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
         guard isEnabled else {

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -80,6 +80,7 @@ private extension InAppFeedbackCardViewController {
             let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
             self.present(surveyNavigation, animated: true, completion: nil)
             self.onFeedbackGiven?()
+            self.analytics.track(event: .appFeedbackPrompt(action: .didntLike))
         }
     }
 
@@ -93,6 +94,7 @@ private extension InAppFeedbackCardViewController {
 
             self.storeReviewControllerType.requestReview()
             self.onFeedbackGiven?()
+            self.analytics.track(event: .appFeedbackPrompt(action: .liked))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -69,9 +69,13 @@ private extension InAppFeedbackCardViewController {
         didNotLikeButton.applySecondaryButtonStyle()
         didNotLikeButton.setTitle(Localization.couldBeBetter, for: .normal)
         didNotLikeButton.on(.touchUpInside) { [weak self] _ in
+            guard let self = self else {
+                return
+            }
+
             let surveyNavigation = SurveyCoordinatingController(survey: .inAppFeedback)
-            self?.present(surveyNavigation, animated: true, completion: nil)
-            self?.onFeedbackGiven?()
+            self.present(surveyNavigation, animated: true, completion: nil)
+            self.onFeedbackGiven?()
         }
     }
 
@@ -79,8 +83,12 @@ private extension InAppFeedbackCardViewController {
         likeButton.applyPrimaryButtonStyle()
         likeButton.setTitle(Localization.iLikeIt, for: .normal)
         likeButton.on(.touchUpInside) { [weak self] _ in
-            self?.storeReviewControllerType.requestReview()
-            self?.onFeedbackGiven?()
+            guard let self = self else {
+                return
+            }
+
+            self.storeReviewControllerType.requestReview()
+            self.onFeedbackGiven?()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardViewController.swift
@@ -29,8 +29,12 @@ final class InAppFeedbackCardViewController: UIViewController {
     /// SKStoreReviewController type wrapper. Needed for testing
     private let storeReviewControllerType: SKStoreReviewControllerProtocol.Type
 
-    init(storeReviewControllerType: SKStoreReviewControllerProtocol.Type = SKStoreReviewController.self) {
+    private let analytics: Analytics
+
+    init(storeReviewControllerType: SKStoreReviewControllerProtocol.Type = SKStoreReviewController.self,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.storeReviewControllerType = storeReviewControllerType
+        self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 		57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */; };
 		57CFCD28248845B4003F51EC /* PrimarySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */; };
 		57CFCD2A2488496F003F51EC /* PrimarySectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */; };
+		57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EBC91F24EEE61800C1D45B /* WooAnalyticsEvent.swift */; };
 		57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */; };
 		57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */; };
 		6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */; };
@@ -1391,6 +1392,7 @@
 		57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNoticePresenter.swift; sourceTree = "<group>"; };
 		57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimarySectionHeaderView.swift; sourceTree = "<group>"; };
 		57CFCD292488496F003F51EC /* PrimarySectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrimarySectionHeaderView.xib; sourceTree = "<group>"; };
+		57EBC91F24EEE61800C1D45B /* WooAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalyticsEvent.swift; sourceTree = "<group>"; };
 		57F2C6CC246DECC10074063B /* SummaryTableViewCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCellViewModelTests.swift; sourceTree = "<group>"; };
 		57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewModelTests.swift; sourceTree = "<group>"; };
 		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
@@ -3071,6 +3073,7 @@
 			isa = PBXGroup;
 			children = (
 				CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */,
+				57EBC91F24EEE61800C1D45B /* WooAnalyticsEvent.swift */,
 				74213449210A323C00C13890 /* WooAnalyticsStat.swift */,
 				747AA0882107CEC60047A89B /* AnalyticsProvider.swift */,
 				747AA08A2107CF8D0047A89B /* TracksProvider.swift */,
@@ -5356,6 +5359,7 @@
 				028BAC4022F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
 				74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
+				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,
 				021FAFCF23556D2B00B99241 /* UIView+SubviewsAxis.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -26,12 +26,8 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     }
 
     func test_isInAppFeedbackCardVisible_is_false_by_default() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-
         // When
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService)
+        let viewModel = makeViewModel()
 
         var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
@@ -45,8 +41,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
     func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService)
+        let viewModel = makeViewModel(featureFlagService: featureFlagService)
 
         var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
@@ -62,9 +57,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: false,
-                                                                  featureFlagService: featureFlagService)
+        let viewModel = makeViewModel(canDisplayInAppFeedbackCard: false)
 
         var emittedValues = [Bool]()
         _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
@@ -80,10 +73,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_isInAppFeedbackCardVisible_is_true_if_the_AppSettingsAction_returns_true() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
+        let viewModel = makeViewModel()
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
@@ -105,10 +95,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_false() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
+        let viewModel = makeViewModel()
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
@@ -130,10 +117,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_an_error() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
+        let viewModel = makeViewModel()
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
@@ -155,10 +139,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_isInAppFeedbackCardVisible_is_recomputed_on_viewDidAppear() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
+        let viewModel = makeViewModel()
 
         storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
@@ -183,10 +164,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_isInAppFedbackCardVisible_is_false_after_tapping_on_card_CTAs() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-        let viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: true,
-                                                                  featureFlagService: featureFlagService,
-                                                                  storesManager: storesManager)
+        let viewModel = makeViewModel()
 
         // Default `loadInAppFeedbackCardVisibility` to true until `setLastFeedbackDate` action sets it to `false`
         var shouldShowFeedbackCard = true
@@ -212,5 +190,15 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual([false, true, false], emittedValues)
+    }
+}
+
+private extension StoreStatsAndTopPerformersPeriodViewModelTests {
+    func makeViewModel(canDisplayInAppFeedbackCard: Bool = true,
+                       featureFlagService: MockFeatureFlagService = .init(isInAppFeedbackOn: true)) -> StoreStatsAndTopPerformersPeriodViewModel {
+        StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: canDisplayInAppFeedbackCard,
+                                                  featureFlagService: featureFlagService,
+                                                  storesManager: storesManager,
+                                                  analytics: analytics)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -8,13 +8,19 @@ import Yosemite
 final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
     private var storesManager: MockupStoresManager!
+    private var analyticsProvider: MockupAnalyticsProvider!
+    private var analytics: WooAnalytics!
 
     override func setUp() {
         super.setUp()
         storesManager = MockupStoresManager(sessionManager: SessionManager.testingInstance)
+        analyticsProvider = MockupAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
     override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
         storesManager = nil
         super.tearDown()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -36,6 +36,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual([false], emittedValues)
+        assertEmpty(analyticsProvider.receivedProperties)
     }
 
     func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() {
@@ -53,6 +54,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual([false, false], emittedValues)
+        assertEmpty(analyticsProvider.receivedProperties)
     }
 
     func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() {
@@ -69,6 +71,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual([false, false], emittedValues)
+        assertEmpty(analyticsProvider.receivedProperties)
     }
 
     func test_isInAppFeedbackCardVisible_is_true_if_the_AppSettingsAction_returns_true() {
@@ -93,6 +96,29 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         XCTAssertEqual([false, true], emittedValues)
     }
 
+    func test_shown_event_action_is_tracked_when_isInAppFeedbackCardVisible_returns_true() throws {
+        // Given
+        let viewModel = makeViewModel()
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case let AppSettingsAction.loadFeedbackVisibility(_, onCompletion) = action {
+                onCompletion(.success(true))
+            }
+        }
+
+        assertEmpty(analyticsProvider.receivedEvents)
+
+        // When
+        viewModel.onViewDidAppear()
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, "app_feedback_prompt")
+
+        let firstPropertiesBatch = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(firstPropertiesBatch["action"] as? String, "shown")
+    }
+
     func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_false() {
         // Given
         let viewModel = makeViewModel()
@@ -113,6 +139,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual([false, false], emittedValues)
+        assertEmpty(analyticsProvider.receivedProperties)
     }
 
     func test_isInAppFeedbackCardVisible_is_false_if_the_AppSettingsAction_returns_an_error() {
@@ -135,6 +162,7 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual([false, false], emittedValues)
+        assertEmpty(analyticsProvider.receivedProperties)
     }
 
     func test_isInAppFeedbackCardVisible_is_recomputed_on_viewDidAppear() throws {


### PR DESCRIPTION
Ref #2548. 

## Changes

This adds two things.  

### Statically-Typed Event Properties Convention

I thought about incorporating @diegoreymendez' analytics tracking improvements (paNNhX-98-p2) into our codebase. Today seems to be a good day to implement it. Thanks to @diegoreymendez for the advice and for allowing me to _borrow_ the code. 🤪 

I believe Diego has explained in the post what sort of problems this solves so I won't explain that here. But let me know if you have any questions. 

A small difference in our implementation is I used `WooAnalyticsStat` instead of `String`:

https://github.com/woocommerce/woocommerce-ios/blob/2b2d41459d0eaeb551daf016f35e7e8144e0b9d6/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift#L40-L43

It is implemented like this in [WordPress-iOS-Shared](https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/fcfef1e440509d92514118d91631708ee67ebdaa/WordPressShared/Core/Analytics/AnalyticsEvent.swift#L41-L49):

```swift
public final class AnalyticsEvent {
    public let name: String
    public let properties: [String: String]
}
```

I wanted to keep the usage of `WooAnalyticsStat` for now because of Aaron's concern in paNNhX-98-p2#comment-283. I documented the rationale in `WooAnalyticsStat`:

https://github.com/woocommerce/woocommerce-ios/blob/2b2d41459d0eaeb551daf016f35e7e8144e0b9d6/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift#L6-L9

### In-app Feedback Card Events

To test this convention, I added tracking for the In-app Feedback Card. 

<img src="https://user-images.githubusercontent.com/198826/88236893-4f12f280-cc3b-11ea-8308-ab4359e809f3.png" width="240">


Event Name | Trigger | Custom Properties
--------|-------|--
`app_feedback_prompt`  |  When the “Enjoying the WooCommerce app?” and the buttons are displayed to the user. | `action="shown"`
`app_feedback_prompt` | When the **I Like It** button is activated. | `action="liked"`
`app_feedback_prompt` | When the **Could Be Better** button is activated. | `action="didnt_like"`

## Testing

1. Delete the app from the device to reset any existing state. 
2. Run the app.
3. Navigate to Orders tab. 
4. Time travel to more than 3 months from now. 
5. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible.
6. Confirm that you can see this log in the console:

    ```
    🔵 Tracked app_feedback_prompt, properties: [AnyHashable("action"): "shown", ...
    ```
7. Tap on the Could Be Better button. 
8. Confirm that you can see this log in the console:

    ```
    🔵 Tracked app_feedback_prompt, properties: [AnyHashable("action"): "didnt_like", ...
    ```
9. Navigate to Orders tab.
10. Time travel to 6 months from the current device's date. 
11. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible again.
12. Tap on the I Like It button. 
13. Confirm that you can see this log in the console:
    ```
    🔵 Tracked app_feedback_prompt, properties: [AnyHashable("action"): "liked", ...
    ```
14. Don't forget to travel back to the present. We need you here! 🤪 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

