### PR TITLE
[IAFeedback] Track Survey Screen Events

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -12,15 +12,19 @@ final class SurveyCoordinatingController: WooNavigationController {
 
     private let analytics: Analytics
 
+    /// What kind of survey to present.
+    private let survey: SurveyViewController.Source
+
     init(survey: SurveyViewController.Source,
          zendeskManager: ZendeskManagerProtocol = ZendeskManager.shared,
          viewControllersFactory: SurveyViewControllersFactoryProtocol = SurveyViewControllersFactory(),
          analytics: Analytics = ServiceLocator.analytics) {
+        self.survey = survey
         self.zendeskManager = zendeskManager
         self.viewControllersFactory = viewControllersFactory
         self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
-        startSurveyNavigation(survey: survey)
+        startSurveyNavigation()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -33,7 +37,7 @@ private extension SurveyCoordinatingController {
 
     /// Starts navigation with `SurveyViewController` as root view controller.
     ///
-    func startSurveyNavigation(survey: SurveyViewController.Source) {
+    func startSurveyNavigation() {
         let surveyViewController = viewControllersFactory.makeSurveyViewController(survey: survey) { [weak self] in
             self?.navigateToSurveySubmitted()
         }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -38,6 +38,8 @@ private extension SurveyCoordinatingController {
     /// Starts navigation with `SurveyViewController` as root view controller.
     ///
     func startSurveyNavigation() {
+        analytics.track(event: .surveyScreen(context: survey.feedbackContextForEvents, action: .opened))
+
         let surveyViewController = viewControllersFactory.makeSurveyViewController(survey: survey) { [weak self] in
             guard let self = self else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -39,7 +39,14 @@ private extension SurveyCoordinatingController {
     ///
     func startSurveyNavigation() {
         let surveyViewController = viewControllersFactory.makeSurveyViewController(survey: survey) { [weak self] in
-            self?.navigateToSurveySubmitted()
+            guard let self = self else {
+                return
+            }
+
+            self.analytics.track(event: .surveyScreen(context: self.survey.feedbackContextForEvents,
+                                                      action: .completed))
+
+            self.navigateToSurveySubmitted()
         }
         setViewControllers([surveyViewController], animated: false)
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -10,11 +10,15 @@ final class SurveyCoordinatingController: WooNavigationController {
     /// Factory that creates view controllers needed for this flow
     private let viewControllersFactory: SurveyViewControllersFactoryProtocol
 
+    private let analytics: Analytics
+
     init(survey: SurveyViewController.Source,
          zendeskManager: ZendeskManagerProtocol = ZendeskManager.shared,
-         viewControllersFactory: SurveyViewControllersFactoryProtocol = SurveyViewControllersFactory()) {
+         viewControllersFactory: SurveyViewControllersFactoryProtocol = SurveyViewControllersFactory(),
+         analytics: Analytics = ServiceLocator.analytics) {
         self.zendeskManager = zendeskManager
         self.viewControllersFactory = viewControllersFactory
+        self.analytics = analytics
         super.init(nibName: nil, bundle: nil)
         startSurveyNavigation(survey: survey)
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -12,6 +12,9 @@ final class SurveyCoordinatingController: WooNavigationController {
 
     private let analytics: Analytics
 
+    /// Is true when `self` is being dismissed because the user has finished the survey.
+    private var receivedSurveyFinishedEvent: Bool = false
+
     /// What kind of survey to present.
     private let survey: SurveyViewController.Source
 
@@ -30,6 +33,14 @@ final class SurveyCoordinatingController: WooNavigationController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        if isBeingDismissed && !receivedSurveyFinishedEvent {
+            analytics.track(event: .surveyScreen(context: survey.feedbackContextForEvents, action: .canceled))
+        }
+    }
 }
 
 // MARK: Navigation
@@ -45,6 +56,7 @@ private extension SurveyCoordinatingController {
                 return
             }
 
+            self.receivedSurveyFinishedEvent = true
             self.analytics.track(event: .surveyScreen(context: self.survey.feedbackContextForEvents,
                                                       action: .completed))
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -91,6 +91,14 @@ extension SurveyViewController {
                 return NSLocalizedString("How can we improve?", comment: "Title on the navigation bar for the in-app feedback survey")
             }
         }
+
+        /// The corresponding `FeedbackContext` for event tracking purposes.
+        var feedbackContextForEvents: WooAnalyticsEvent.FeedbackContext {
+            switch self {
+            case .inAppFeedback:
+                return .general
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewControllersFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewControllersFactory.swift
@@ -3,9 +3,13 @@ import Foundation
 /// Declares functions to create appropiate view controllers for the in-app Survey flow
 ///
 protocol SurveyViewControllersFactoryProtocol {
-    /// Creates a `ViewController` that conforms to `SurveyViewControllerOutputs` based on a given suvery source and a completion block
+    /// Creates a `ViewController` that conforms to `SurveyViewControllerOutputs` based on a given
+    /// survey source and a completion block
     ///
-    func makeSurveyViewController(survey: SurveyViewController.Source, onCompletion: @escaping () -> Void) -> SurveyViewControllerOutputs
+    /// - Parameter onCompletion: Called when the user successfully submitted the survey.
+    ///
+    func makeSurveyViewController(survey: SurveyViewController.Source,
+                                  onCompletion: @escaping () -> Void) -> SurveyViewControllerOutputs
 
     /// Creates a `ViewController` that conforms to`SurveySubmittedViewControllerOutputs` by providing the necesary actions
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
@@ -94,16 +94,16 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
                                          viewControllersFactory: factory,
                                          analytics: analytics)
 
-        assertEmpty(analyticsProvider.receivedEvents)
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
 
         // When
         factory.surveyViewController.onCompletion()
 
         // Then
-        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
-        XCTAssertEqual(analyticsProvider.receivedEvents.first, "survey_screen")
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 2)
+        XCTAssertEqual(analyticsProvider.receivedEvents.last, "survey_screen")
 
-        let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties.last)
         XCTAssertEqual(properties["context"] as? String, "general")
         XCTAssertEqual(properties["action"] as? String, "completed")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyCoordinatorControllerTests.swift
@@ -107,6 +107,24 @@ final class SurveyCoordinatingControllerTests: XCTestCase {
         XCTAssertEqual(properties["context"] as? String, "general")
         XCTAssertEqual(properties["action"] as? String, "completed")
     }
+
+    func test_it_tracks_a_surveyScreen_opened_event_when_started() throws {
+        // Given
+        let factory = MockSurveyViewControllersFactory()
+
+        // When
+        _ = SurveyCoordinatingController(survey: .inAppFeedback,
+                                         viewControllersFactory: factory,
+                                         analytics: analytics)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, "survey_screen")
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(properties["context"] as? String, "general")
+        XCTAssertEqual(properties["action"] as? String, "opened")
+    }
 }
 
 private final class MockSurveyViewControllersFactory: SurveyViewControllersFactoryProtocol {


### PR DESCRIPTION
Part of #2548.

This adds tracking for these events:

Event Name | Trigger | Custom Properties
--------|-------|---
`survey_screen` | When the survey screen is shown. | `context="general"` <br> `action="opened"`
`survey_screen` | When the user closes the survey screen without finishing the survey.  | `context="general"` <br> `action="canceled"`
`survey_screen` | When this survey completion screen is shown.  | `context="general"` <br> `action="completed"`

## Notes

I could not make a unit test for the `canceled` event because I could not find a way to make `isBeingDismissed` return `true` in a unit test. 

https://github.com/woocommerce/woocommerce-ios/blob/7b0ffcd8fa64a7f92c00b95d65a875aa04360ef3/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift#L40-L42

Please let me know if you have any ideas! 

## Testing

1. Delete the app from the device to reset any existing state. 
2. Run the app.
3. Navigate to Orders tab. 
4. Time travel to more than 3 months from now. 
5. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible.
6. Tap on Could Be Better.
6. Confirm that you can see this log in the console:

    ```
    Tracked survey_screen, properties: [AnyHashable("action"): "opened", AnyHashable("context"): "general", ...]
    ```
8. Dismiss the survey window.
9. Confirm that you can see this log in the console:

    ````
    Tracked survey_screen, properties: [AnyHashable("context"): "general", AnyHashable("action"): "canceled", ...]
    ````
9. Navigate to Orders tab.
10. Time travel to 6 months from the current device's date. 
11. Go back to the app and navigate to My Store. The In-app Feedback Card should be visible again.
12. Tap on the Could Be Better button again.
13. Fill in and submit the survey.
13. Confirm that you can see this log in the console:
    ```
    Tracked survey_screen, properties: [AnyHashable("action"): "completed", AnyHashable("context"): "general", ...]
    ```

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

