### PR TITLE
Fix Build Failure and Clarify FeedbackContext Event Argument

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -57,8 +57,9 @@ extension WooAnalyticsEvent {
     public enum FeedbackContext: String {
         /// Shown in Stats but is for asking general feedback.
         case general
-        /// Shown in products banner.
-        case products
+        /// Shown in products banner for Milestone 3 features. New product banners should have
+        /// their own `FeedbackContext` option.
+        case productsM3 = "products_m3"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -103,7 +103,7 @@ extension SurveyViewController {
             case .inAppFeedback:
                 return .general
             case .productsM3Feedback:
-                return .products
+                return .productsM3
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -102,6 +102,8 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return .general
+            case .productsM3Feedback:
+                return .products
             }
         }
     }


### PR DESCRIPTION
Ref #2548. 

This fixes the broken `develop` build. 

I also realized that the `FeedbackContext.products` was too ambiguous. It was meant to be specific for the type of feedback message (e.g. banner) we were presenting. If we have a new feedback request for products, we might name that as `products_m4` or `products_creation`. Leaving this `FeedbackContext.products` as is would just confuse us in the future. 😬 

## Testing

The build passing should be good enough.

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

