### PR TITLE
[IAFeedback] Add Tracking for Product Banner Action Buttons

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -21,8 +21,11 @@ struct ProductsTopBannerFactory {
             let title = Strings.title
             let icon: UIImage = isInAppFeedbackFeatureEnabled ? .megaphoneIcon : .workInProgressBanner
             let infoText = isEditProductsRelease3Enabled ? Strings.infoWhenRelease3IsEnabled: Strings.info
-            let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Strings.giveFeedback, action: onGiveFeedbackButtonPressed)
             let dismissAction = TopBannerViewModel.ActionButton(title: Strings.dismiss, action: onDismissButtonPressed)
+            let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Strings.giveFeedback) {
+                analytics.track(event: .featureFeedbackBanner(context: .products, action: .gaveFeedback))
+                onGiveFeedbackButtonPressed()
+            }
             let actions: [TopBannerViewModel.ActionButton] = isInAppFeedbackFeatureEnabled ? [giveFeedbackAction, dismissAction] : []
             let viewModel = TopBannerViewModel(title: title,
                                                infoText: infoText,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -22,11 +22,11 @@ struct ProductsTopBannerFactory {
             let icon: UIImage = isInAppFeedbackFeatureEnabled ? .megaphoneIcon : .workInProgressBanner
             let infoText = isEditProductsRelease3Enabled ? Strings.infoWhenRelease3IsEnabled: Strings.info
             let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Strings.giveFeedback) {
-                analytics.track(event: .featureFeedbackBanner(context: .products, action: .gaveFeedback))
+                analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .gaveFeedback))
                 onGiveFeedbackButtonPressed()
             }
             let dismissAction = TopBannerViewModel.ActionButton(title: Strings.dismiss) {
-                analytics.track(event: .featureFeedbackBanner(context: .products, action: .dismissed))
+                analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .dismissed))
                 onDismissButtonPressed()
             }
             let actions: [TopBannerViewModel.ActionButton] = isInAppFeedbackFeatureEnabled ? [giveFeedbackAction, dismissAction] : []

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -11,6 +11,7 @@ struct ProductsTopBannerFactory {
     ///   - onCompletion: called when the view controller is created and ready for display.
     static func topBanner(isExpanded: Bool,
                           stores: StoresManager = ServiceLocator.stores,
+                          analytics: Analytics = ServiceLocator.analytics,
                           isInAppFeedbackFeatureEnabled: Bool,
                           expandedStateChangeHandler: @escaping () -> Void,
                           onGiveFeedbackButtonPressed: @escaping () -> Void,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -21,10 +21,13 @@ struct ProductsTopBannerFactory {
             let title = Strings.title
             let icon: UIImage = isInAppFeedbackFeatureEnabled ? .megaphoneIcon : .workInProgressBanner
             let infoText = isEditProductsRelease3Enabled ? Strings.infoWhenRelease3IsEnabled: Strings.info
-            let dismissAction = TopBannerViewModel.ActionButton(title: Strings.dismiss, action: onDismissButtonPressed)
             let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Strings.giveFeedback) {
                 analytics.track(event: .featureFeedbackBanner(context: .products, action: .gaveFeedback))
                 onGiveFeedbackButtonPressed()
+            }
+            let dismissAction = TopBannerViewModel.ActionButton(title: Strings.dismiss) {
+                analytics.track(event: .featureFeedbackBanner(context: .products, action: .dismissed))
+                onDismissButtonPressed()
             }
             let actions: [TopBannerViewModel.ActionButton] = isInAppFeedbackFeatureEnabled ? [giveFeedbackAction, dismissAction] : []
             let viewModel = TopBannerViewModel(title: title,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 		571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */; };
 		571E4674249D1615002ADCB8 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */; };
 		571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */; };
+		573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */; };
 		573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */; };
 		57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57448D27242E775000A56A74 /* EmptyStateViewController.swift */; };
 		57448D2A242E777700A56A74 /* EmptyStateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57448D29242E777700A56A74 /* EmptyStateViewController.xib */; };
@@ -1364,6 +1365,7 @@
 		571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InAppFeedbackCardViewController.xib; sourceTree = "<group>"; };
 		571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZendeskManager.swift; sourceTree = "<group>"; };
+		573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewMirror.swift; sourceTree = "<group>"; };
 		573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
 		57448D27242E775000A56A74 /* EmptyStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewController.swift; sourceTree = "<group>"; };
 		57448D29242E777700A56A74 /* EmptyStateViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmptyStateViewController.xib; sourceTree = "<group>"; };
@@ -2578,6 +2580,7 @@
 			isa = PBXGroup;
 			children = (
 				2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */,
+				573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */,
 			);
 			path = TopBanner;
 			sourceTree = "<group>";
@@ -5647,6 +5650,7 @@
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */,
+				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 		571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */; };
 		571E4674249D1615002ADCB8 /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */; };
 		571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */; };
+		573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A960224F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift */; };
 		573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */; };
 		573D0ACF2458665C004DE614 /* OrderSearchStarterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */; };
 		57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57448D27242E775000A56A74 /* EmptyStateViewController.swift */; };
@@ -1365,6 +1366,7 @@
 		571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InAppFeedbackCardViewController.xib; sourceTree = "<group>"; };
 		571E4673249D1615002ADCB8 /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZendeskManager.swift; sourceTree = "<group>"; };
+		573A960224F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewMirror.swift; sourceTree = "<group>"; };
 		573D0ACE2458665C004DE614 /* OrderSearchStarterViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModelTests.swift; sourceTree = "<group>"; };
 		57448D27242E775000A56A74 /* EmptyStateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewController.swift; sourceTree = "<group>"; };
@@ -2261,6 +2263,7 @@
 				02BAB02224D0250300F8B06E /* ProductVariation+ProductFormTests.swift */,
 				0259EF76246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift */,
 				0271139924DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift */,
+				573A960224F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -5521,6 +5524,7 @@
 				B53A569D21123EEB000776C9 /* MockupStorage.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
+				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,
 				F997174723DC070D00592D8E /* XLPagerStrip+AccessibilityIdentifierTests.swift in Sources */,
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -42,6 +42,25 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(properties["context"] as? String, "products_m3")
         XCTAssertEqual(properties["action"] as? String, "gave_feedback")
     }
+
+    func test_it_tracks_featureFeedbackBanner_dismissed_event_when_dismiss_button_is_pressed() throws {
+        // Given
+        let bannerMirror = try makeBannerViewMirror()
+        let dismissButton = try XCTUnwrap(bannerMirror.actionButtons.last)
+
+        assertEmpty(analyticsProvider.receivedEvents)
+
+        // When
+        dismissButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(properties["context"] as? String, "products_m3")
+        XCTAssertEqual(properties["action"] as? String, "dismissed")
+    }
 }
 
 private extension ProductsTopBannerFactoryTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import WooCommerce
+
+import Yosemite
+
+final class ProductsTopBannerFactoryTests: XCTestCase {
+
+    private var analyticsProvider: MockupAnalyticsProvider!
+    private var analytics: WooAnalytics!
+    private var storesManager: MockupStoresManager!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockupAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        storesManager = MockupStoresManager(sessionManager: .makeForTesting())
+    }
+
+    override func tearDown() {
+        storesManager = nil
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
+    func test_it_tracks_featureFeedbackBanner_gaveFeedback_event_when_giveFeedback_button_is_pressed() throws {
+        // Given
+        let bannerMirror = try makeBannerViewMirror()
+        let giveFeedbackButton = try XCTUnwrap(bannerMirror.actionButtons.first)
+
+        assertEmpty(analyticsProvider.receivedEvents)
+
+        // When
+        giveFeedbackButton.sendActions(for: .touchUpInside)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
+
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
+        XCTAssertEqual(properties["context"] as? String, "products_m3")
+        XCTAssertEqual(properties["action"] as? String, "gave_feedback")
+    }
+}
+
+private extension ProductsTopBannerFactoryTests {
+    func makeBannerViewMirror() throws -> TopBannerViewMirror {
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case let .loadProductsFeatureSwitch(onCompletion) = action {
+                onCompletion(true)
+            }
+        }
+
+        var banner: TopBannerView?
+        waitForExpectation { exp in
+            ProductsTopBannerFactory.topBanner(isExpanded: false,
+                                               stores: storesManager,
+                                               analytics: analytics,
+                                               isInAppFeedbackFeatureEnabled: true,
+                                               expandedStateChangeHandler: {
+
+            }, onGiveFeedbackButtonPressed: {
+
+            }, onDismissButtonPressed: {
+
+            }) { aBanner in
+                banner = aBanner
+                exp.fulfill()
+            }
+        }
+
+        return try TopBannerViewMirror(from: try XCTUnwrap(banner))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewMirror.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewMirror.swift
@@ -1,0 +1,17 @@
+import UIKit
+import XCTest
+
+@testable import WooCommerce
+
+/// Represents the private properties of `TopBannerView`.
+struct TopBannerViewMirror {
+    let actionStackView: UIStackView
+    let actionButtons: [UIButton]
+
+    init(from view: TopBannerView) throws {
+        let mirror = Mirror(reflecting: view)
+
+        self.actionStackView = try XCTUnwrap(mirror.descendant("actionStackView") as? UIStackView)
+        self.actionButtons = try XCTUnwrap(mirror.descendant("actionButtons") as? [UIButton])
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
@@ -9,7 +9,7 @@ final class TopBannerViewTests: XCTestCase {
         let topBannerView = TopBannerView(viewModel: viewModel)
 
         // When
-        let mirrorView = try mirror(of: topBannerView)
+        let mirrorView = try TopBannerViewMirror(from: topBannerView)
 
         // Then
         XCTAssertTrue(mirrorView.actionButtons.isEmpty)
@@ -24,7 +24,7 @@ final class TopBannerViewTests: XCTestCase {
         let topBannerView = TopBannerView(viewModel: viewModel)
 
         // When
-        let mirrorView = try mirror(of: topBannerView)
+        let mirrorView = try TopBannerViewMirror(from: topBannerView)
 
         // Then
         XCTAssertEqual(mirrorView.actionButtons.count, 2)
@@ -41,7 +41,7 @@ final class TopBannerViewTests: XCTestCase {
         let topBannerView = TopBannerView(viewModel: viewModel)
 
         // When
-        let mirrorView = try mirror(of: topBannerView)
+        let mirrorView = try TopBannerViewMirror(from: topBannerView)
         mirrorView.actionButtons[0].sendActions(for: .touchUpInside)
 
         // Then
@@ -52,23 +52,5 @@ final class TopBannerViewTests: XCTestCase {
 private extension TopBannerViewTests {
     func createViewModel(with actionButtons: [TopBannerViewModel.ActionButton]) -> TopBannerViewModel {
         TopBannerViewModel(title: "", infoText: "", icon: nil, isExpanded: true, topButton: .chevron(handler: nil), actionButtons: actionButtons)
-    }
-}
-
-
-// MARK: - Mirroring
-
-private extension TopBannerViewTests {
-    struct TopBannerViewMirror {
-        let actionStackView: UIStackView
-        let actionButtons: [UIButton]
-    }
-
-    func mirror(of view: TopBannerView) throws -> TopBannerViewMirror {
-        let mirror = Mirror(reflecting: view)
-        return TopBannerViewMirror(
-            actionStackView: try XCTUnwrap(mirror.descendant("actionStackView") as? UIStackView),
-            actionButtons: try XCTUnwrap(mirror.descendant("actionButtons") as? [UIButton])
-        )
     }
 }


### PR DESCRIPTION
Closes #2548. 

⚠️  Depends on #2695 to be merged first. 

This adds tracking for the product banner buttons added in #2686.  

Event Name | Trigger | Custom Properties
--------|-------|--
`feature_feedback_banner` | When the **Give Feedback** button is activated. | `context="products_m3"` <br> `action="gave_feedback"`
`feature_feedback_banner` | When the **Dismissed** button is activated. | `context="products_m3"` <br> `action="dismissed"`

## Changes

I thought about adding the tracking in [`TopBannerView`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2548-add-feature-banner-tracking/WooCommerce/Classes/ViewRelated/Top%20Banner/TopBannerView.swift) itself but that class seemed to be too generic. The "Give Feedback" and "Dismiss" buttons are configured in `ProductsTopBannerFactory` so that's where I added the tracking: 

https://github.com/woocommerce/woocommerce-ios/blob/34214e6bb1088887574924fb159193a528ad136b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift#L24-L31

## Testing

### Give Feedback

1. Delete the app to reset any saved settings
2. Open the app and login into a store
3. Navigate to products
4. Tap on the collapsed products banner
5. Tap on "Give Feedback"
6. Confirm that you see this logged in the console:

    ```
    🔵 Tracked feature_feedback_banner, properties: [AnyHashable("context"): "products_m3", AnyHashable("action"): "gave_feedback", ...]
    ```

### Dismiss

1. Delete the app to reset any saved settings
2. Open the app and login into a store
3. Navigate to products
4. Tap on the collapsed products banner
5. Tap on "Dismiss"
6. Confirm that you see this logged in the console:

    ```
    🔵 Tracked feature_feedback_banner, properties: [AnyHashable("context"): "products_m3", AnyHashable("action"): "dismissed", ...]
    ```


## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

