### PR TITLE
Edit Product: move price settings unsaved changes logic to view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -26,7 +26,8 @@ final class ProductPriceSettingsViewController: UIViewController {
         _ dateOnSaleStart: Date?,
         _ dateOnSaleEnd: Date?,
         _ taxStatus: ProductTaxStatus,
-        _ taxClass: TaxClass?) -> Void
+        _ taxClass: TaxClass?,
+        _ hasUnsavedChanges: Bool) -> Void
     private let onCompletion: Completion
 
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
@@ -138,8 +139,9 @@ extension ProductPriceSettingsViewController {
     }
 
     @objc private func completeUpdating() {
-        viewModel.completeUpdating(onCompletion: { [weak self] (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass) in
-            self?.onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass)
+        viewModel.completeUpdating(
+            onCompletion: { [weak self] (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges) in
+                self?.onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges)
             }, onError: { [weak self] error in
                 switch error {
                 case .salePriceWithoutRegularPrice:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -249,7 +249,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
             return
         }
 
-        onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass)
+        onCompletion(regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges())
     }
 
     func hasUnsavedChanges() -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -793,13 +793,14 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func editPriceSettings() {
         let priceSettingsViewController = ProductPriceSettingsViewController(product: product) { [weak self]
-            (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass) in
+            (regularPrice, salePrice, dateOnSaleStart, dateOnSaleEnd, taxStatus, taxClass, hasUnsavedChanges) in
             self?.onEditPriceSettingsCompletion(regularPrice: regularPrice,
                                                 salePrice: salePrice,
                                                 dateOnSaleStart: dateOnSaleStart,
                                                 dateOnSaleEnd: dateOnSaleEnd,
                                                 taxStatus: taxStatus,
-                                                taxClass: taxClass)
+                                                taxClass: taxClass,
+                                                hasUnsavedChanges: hasUnsavedChanges)
         }
         navigationController?.pushViewController(priceSettingsViewController, animated: true)
     }
@@ -809,22 +810,14 @@ private extension ProductFormViewController {
                                        dateOnSaleStart: Date?,
                                        dateOnSaleEnd: Date?,
                                        taxStatus: ProductTaxStatus,
-                                       taxClass: TaxClass?) {
+                                       taxClass: TaxClass?,
+                                       hasUnsavedChanges: Bool) {
         defer {
             navigationController?.popViewController(animated: true)
         }
 
-        let hasChangedData: Bool = {
-                getDecimalPrice(regularPrice) != getDecimalPrice(product.regularPrice) ||
-                getDecimalPrice(salePrice) != getDecimalPrice(product.salePrice) ||
-                dateOnSaleStart != product.dateOnSaleStart ||
-                dateOnSaleEnd != product.dateOnSaleEnd ||
-                taxStatus != product.productTaxStatus ||
-                taxClass?.slug != product.taxClass
-        }()
-
-        ServiceLocator.analytics.track(.productPriceSettingsDoneButtonTapped, withProperties: ["has_changed_data": hasChangedData])
-        guard hasChangedData else {
+        ServiceLocator.analytics.track(.productPriceSettingsDoneButtonTapped, withProperties: ["has_changed_data": hasUnsavedChanges])
+        guard hasUnsavedChanges else {
             return
         }
 
@@ -1117,18 +1110,6 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func onEditStatusCompletion(isEnabled: Bool) {
         viewModel.updateStatus(isEnabled)
-    }
-}
-
-// MARK: Convenience Methods
-//
-private extension ProductFormViewController {
-    func getDecimalPrice(_ price: String?) -> NSDecimalNumber? {
-        guard let price = price else {
-            return nil
-        }
-        let currencyFormatter = CurrencyFormatter()
-        return currencyFormatter.convertToDecimal(from: price)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -498,7 +498,6 @@ private extension ProductFormViewController {
                                                                         case .editSKU:
                                                                             ServiceLocator.analytics.track(.productDetailViewSKUTapped)
                                                                             self?.editSKU()
-                                                                            break
                                                                         }
                                                                     }
         }
@@ -717,6 +716,19 @@ extension ProductFormViewController: KeyboardScrollable {
     }
 }
 
+// MARK: - Navigation actions handling
+//
+private extension ProductFormViewController {
+    func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.exitForm()
+        })
+    }
+}
+
 // MARK: Action - Edit Product Images
 //
 private extension ProductFormViewController {
@@ -749,22 +761,7 @@ private extension ProductFormViewController {
     }
 }
 
-
-// MARK: - Navigation actions handling
-//
-private extension ProductFormViewController {
-    func presentBackNavigationActionSheet() {
-        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
-            guard let self = self else {
-                return
-            }
-            self.exitForm()
-        })
-    }
-}
-
-
-// MARK: Action - Edit Product Parameters
+// MARK: Action - Edit Product Description
 //
 private extension ProductFormViewController {
     func editProductDescription() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductPriceSettingsViewModelTests.swift
@@ -478,7 +478,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _) in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             XCTAssertEqual(error, .salePriceWithoutRegularPrice)
@@ -502,7 +502,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _) in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             // Assert
@@ -525,7 +525,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, finalSalePrice, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, finalSalePrice, _, _, _, _, _) in
             expectation.fulfill()
 
             // Assert


### PR DESCRIPTION
Part of #1985 

## Changes

- Pass unsaved changes boolean from `ProductPriceSettingsViewModel` to `ProductPriceSettingsViewController` to `ProductFormViewController`
- Minor polishes in `ProductFormViewController`

## Testing

Please sanity check on editing price settings for a product:

- Go to the Products tab
- Tap on a simple product
- Tap on the price settings row
- Tap "Done" without editing any fields --> "Update" CTA should not appear in the navigation bar, and should see ` 🔵 Tracked product_price_settings_done_button_tapped` with `has_changed_data: false`
- Tap on the price settings row again
- Edit any one of the price fields and tap "Done" --> "Update" CTA should appear in the navigation bar, and should see ` 🔵 Tracked product_price_settings_done_button_tapped` with `has_changed_data: true`

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
