### PR TITLE
TopBannerView: Fix button layout on large accessibility traits

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -44,6 +44,9 @@ final class TopBannerView: UIView {
         return stackView
     }()
 
+    // Needed to change the axis on larger accesibility traits
+    private let buttonsStackView = UIStackView()
+
     private let actionButtons: [UIButton]
 
     private let isActionEnabled: Bool
@@ -80,6 +83,7 @@ private extension TopBannerView {
 
         renderContent(of: viewModel)
         configureBannerType(type: viewModel.type)
+        configureStackViewsAxis()
     }
 
     func renderContent(of viewModel: TopBannerViewModel) {
@@ -175,7 +179,6 @@ private extension TopBannerView {
 
     func configureActionStackView(with viewModel: TopBannerViewModel) {
         // StackView to hold the action buttons
-        let buttonsStackView = UIStackView()
         buttonsStackView.distribution = .fillEqually
         buttonsStackView.spacing = 0.5
 
@@ -236,6 +239,12 @@ private extension TopBannerView {
             return .warningBackground
         }
     }
+
+    /// Changes the axis of the stack views that need speacial treatment on larger size categories
+    ///
+    func configureStackViewsAxis() {
+        buttonsStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
+    }
 }
 
 private extension TopBannerView {
@@ -247,6 +256,15 @@ private extension TopBannerView {
         self.isExpanded = !isExpanded
         updateExpandCollapseState(isExpanded: isExpanded)
         onTopButtonTapped?()
+    }
+}
+
+// MARK: Accessibility Handling
+//
+extension TopBannerView {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        configureStackViewsAxis()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -44,7 +44,7 @@ final class TopBannerView: UIView {
         return stackView
     }()
 
-    // Needed to change the axis on larger accesibility traits
+    // StackView to hold the action buttons. Needed to change the axis on larger accessibility traits
     private let buttonsStackView = UIStackView()
 
     private let actionButtons: [UIButton]
@@ -83,7 +83,7 @@ private extension TopBannerView {
 
         renderContent(of: viewModel)
         configureBannerType(type: viewModel.type)
-        configureStackViewsAxis()
+        updateStackViewsAxis()
     }
 
     func renderContent(of viewModel: TopBannerViewModel) {
@@ -178,7 +178,6 @@ private extension TopBannerView {
     }
 
     func configureActionStackView(with viewModel: TopBannerViewModel) {
-        // StackView to hold the action buttons
         buttonsStackView.distribution = .fillEqually
         buttonsStackView.spacing = 0.5
 
@@ -240,9 +239,9 @@ private extension TopBannerView {
         }
     }
 
-    /// Changes the axis of the stack views that need speacial treatment on larger size categories
+    /// Changes the axis of the stack views that need special treatment on larger size categories
     ///
-    func configureStackViewsAxis() {
+    func updateStackViewsAxis() {
         buttonsStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
     }
 }
@@ -264,7 +263,7 @@ private extension TopBannerView {
 extension TopBannerView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        configureStackViewsAxis()
+        updateStackViewsAxis()
     }
 }
 


### PR DESCRIPTION
fixes #2698 

# Why

Prior to this PR the `TopBannerView` class didn't support well multiple action buttons on bigger accessibility traits.

<img width="200" alt="banner-max-2" src="https://user-images.githubusercontent.com/562080/91063865-1e382b80-e5f4-11ea-9141-aff1098ef036.png">


# How

I tried to make the buttons to spawn over multiple lines but it didn't look good due to how letters are wrapped.
<img width="200" alt="accessible" src="https://user-images.githubusercontent.com/562080/91224213-62f0bf00-e6e7-11ea-8b21-10e5f9ce8445.png">


In the end, I decided to modify the button layout from horizontal to vertical when an accessibility trait is used.

![accessible-buttons](https://user-images.githubusercontent.com/562080/91224350-9b909880-e6e7-11ea-800a-40b74b20b30f.gif)


# Testing Steps
- Delete the app to erase saved settings
- Set the bigger text size on your iPhone 
- Open the app and navigate to the products tab
- Expand the top banner
- See that the buttons are laid out correctly.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
