### PR TITLE
Remove Unused Reviews Push Notification Code

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/DefaultReviewsDataSource.swift
@@ -244,24 +244,6 @@ extension DefaultReviewsDataSource: ReviewsInteractionDelegate {
         let detailsViewController = ReviewDetailsViewController(productReview: review, product: reviewedProduct, notification: note)
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
     }
-
-    func presentReviewDetails(for noteID: Int64, in viewController: UIViewController) {
-        let notificationMaybe = notificationsResultsController.fetchedObjects.first { $0.noteID == noteID }
-        guard let note = notificationMaybe,
-            let reviewID = note.meta.identifier(forKey: .comment) else {
-            return
-        }
-
-        guard let review = reviewsResultsController.fetchedObjects.first(where: { $0.reviewID == reviewID
-        }) else {
-            return
-        }
-
-        let reviewedProduct = product(id: review.productID)
-
-        let detailsViewController = ReviewDetailsViewController(productReview: review, product: reviewedProduct, notification: note)
-        viewController.navigationController?.pushViewController(detailsViewController, animated: true)
-    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsDataSource.swift
@@ -13,10 +13,6 @@ protocol ReviewsInteractionDelegate: UITableViewDelegate {
     /// to trigger a new page load if necessary
     ///
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath, with syncingCoordinator: SyncingCoordinator)
-
-    /// Called when we want to present a review after receiving a push notification
-    ///
-    func presentReviewDetails(for noteID: Int64, in viewController: UIViewController)
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewController.swift
@@ -128,17 +128,6 @@ final class ReviewsViewController: UIViewController {
             displayRatingPrompt()
         }
     }
-
-    func presentDetails(for noteID: Int64) {
-        syncingCoordinator.synchronizeFirstPage()
-        viewModel.loadReview(for: noteID) { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.viewModel.delegate.presentReviewDetails(for: noteID, in: self)
-        }
-    }
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Notifications/ReviewsViewModel.swift
@@ -79,12 +79,6 @@ final class ReviewsViewModel {
         markAsRead(notes: unreadNotifications, onCompletion: onCompletion)
     }
 
-    func loadReview(for noteID: Int64, onCompletion: @escaping () -> Void) {
-        synchronizeReviews() {
-            onCompletion()
-        }
-    }
-
     func containsMorePages(_ highestVisibleReview: Int) -> Bool {
         return highestVisibleReview > data.reviewCount
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -157,10 +157,6 @@ extension ProductReviewsDataSource: ReviewsInteractionDelegate {
         // no-op: we don't want to catch the selected item in Products
     }
 
-    func presentReviewDetails(for noteID: Int64, in viewController: UIViewController) {
-        // no-op: we don't want to present the review details in Products
-    }
-
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension
     }


### PR DESCRIPTION
Ref #2254. 

This removes some unused code that I didn't remove in #2669.

## Testing

Please do a quick test to make sure that this does not cause a regression in push notifications.

1. Enable push notifications in your sandbox. 
2. Log in and navigate to a tab that is not Reviews. 
3. Place the app in the background.
4. Submit a product review on the web. 
5. Wait for the push notification. If it doesn't come, maybe check the Spam section in Comments. I found that they sometimes get sent there. Loggin in with a user and then submitting a review as that user seems to work better.
6. Tap on the push notification.
7. Wait for a second. 
8. Confirm that the Reviews tab was opened. 
9. Confirm that the Review Details page was presented. 
10. Confirm that the Review Details shows the Product name and the Review comment. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

