### PR TITLE
TopBannerView: Fire layout notification when banner expandes or collapses

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerView.swift
@@ -260,5 +260,8 @@ private extension TopBannerView {
         if isActionEnabled {
             actionStackView.isHidden = !isExpanded
         }
+
+        let accessibleView = isExpanded ? infoLabel : nil
+        UIAccessibility.post(notification: .layoutChanged, argument: accessibleView)
     }
 }


### PR DESCRIPTION
fixes https://github.com/woocommerce/woocommerce-ios/issues/2684

# Why

Prior to this PR, there was no way to let voiceover now that the top banner was collapsed or expanded, which does not comply with our [accessibility guidelines](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/docs/voiceover-guidelines.md#appearing-and-disappearing-elements)

# How 
Fire a `UIAccessibility.post` notification when the top banner changes its expandable/collapsable state.

# Video
[Demo Video](https://github.com/woocommerce/woocommerce-ios/files/5127242/voice-over-demo.mov.zip)

# Testing Steps
- Launch the app and navigate to the products tap
- Enable VoiceOver
- Tap on the top banner  chevron button
- See that voice over correctly focuses on the new banner content
- Tap con the banner content
- See that voice over correctly focuses on the top banner title


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
