### PR TITLE
Edit Product: support for multiline product title

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -139,13 +139,13 @@ private extension NewNoteViewController {
                           comment: "Spoken accessibility label for an icon image that indicates it's a private note and is not seen by the customer.")
         let cellViewModel = TextViewTableViewCell.ViewModel(icon: .asideImage,
                                                             iconAccessibilityLabel: iconAccessibilityLabel,
-                                        iconTint: isCustomerNote ? .primary : .textSubtle,
-                                        onTextChange: { [weak self] (text) in
-                                            self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
-                                            self?.noteText = text
+                                                            iconTint: isCustomerNote ? .primary : .textSubtle,
+                                                            onTextChange: { [weak self] (text) in
+                                                                self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
+                                                                self?.noteText = text
         })
 
-        cell.configure(viewModel: cellViewModel)
+        cell.configure(with: cellViewModel)
     }
 
     private func setupEmailCustomerCell(_ cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -132,18 +132,20 @@ private extension NewNoteViewController {
             fatalError()
         }
 
-        cell.iconImage = .asideImage
-        cell.iconTint = isCustomerNote ? .primary : .textSubtle
-        cell.iconImage?.accessibilityLabel = isCustomerNote ?
-            NSLocalizedString("Note to customer",
-                              comment: "Spoken accessibility label for an icon image that indicates it's a note to the customer.") :
-            NSLocalizedString("Private note",
-                              comment: "Spoken accessibility label for an icon image that indicates it's a private note and is not seen by the customer.")
+        let iconAccessibilityLabel = isCustomerNote ?
+        NSLocalizedString("Note to customer",
+                          comment: "Spoken accessibility label for an icon image that indicates it's a note to the customer.") :
+        NSLocalizedString("Private note",
+                          comment: "Spoken accessibility label for an icon image that indicates it's a private note and is not seen by the customer.")
+        let cellViewModel = TextViewTableViewCell.ViewModel(icon: .asideImage,
+                                                            iconAccessibilityLabel: iconAccessibilityLabel,
+                                        iconTint: isCustomerNote ? .primary : .textSubtle,
+                                        onTextChange: { [weak self] (text) in
+                                            self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
+                                            self?.noteText = text
+        })
 
-        cell.noteTextView.onTextChange = { [weak self] (text) in
-            self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
-            self?.noteText = text
-        }
+        cell.configure(viewModel: cellViewModel)
     }
 
     private func setupEmailCustomerCell(_ cell: UITableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -156,7 +156,7 @@ private extension ProductPurchaseNoteViewController {
                                                             onTextChange: { [weak self] (text) in
             self?.productSettings.purchaseNote = text
         })
-        cell.configure(viewModel: cellViewModel)
+        cell.configure(with: cellViewModel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -86,7 +86,7 @@ private extension ProductPurchaseNoteViewController {
     func configureTextViewFirstResponder() {
         if let indexPath = sections.indexPathForRow(.purchaseNote) {
             let cell = tableView.cellForRow(at: indexPath) as? TextViewTableViewCell
-            cell?.noteTextView.becomeFirstResponder()
+            cell?.becomeFirstResponder()
         }
     }
 }
@@ -148,12 +148,15 @@ private extension ProductPurchaseNoteViewController {
     }
 
     func configurePurchaseNote(cell: TextViewTableViewCell) {
-        cell.iconImage = nil
-        cell.noteTextView.placeholder = NSLocalizedString("Add a purchase note...", comment: "Placeholder text in Product Purchase Note screen")
-        cell.noteTextView.text = productSettings.purchaseNote?.strippedHTML
-        cell.noteTextView.onTextChange = { [weak self] (text) in
+        let placeholder = NSLocalizedString("Add a purchase note...",
+                                            comment: "Placeholder text in Product Purchase Note screen")
+
+        let cellViewModel = TextViewTableViewCell.ViewModel(text: productSettings.purchaseNote?.strippedHTML,
+                                                            placeholder: placeholder,
+                                                            onTextChange: { [weak self] (text) in
             self?.productSettings.purchaseNote = text
-        }
+        })
+        cell.configure(viewModel: cellViewModel)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -27,7 +27,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         case .images:
             return [ProductImagesHeaderTableViewCell.self]
         case .name:
-            return [TextFieldTableViewCell.self]
+            return [TextViewTableViewCell.self]
         case .variationName:
             return [cellType]
         case .description:
@@ -44,7 +44,7 @@ extension ProductFormSection.PrimaryFieldRow: ReusableTableRow {
         case .images:
             return ProductImagesHeaderTableViewCell.self
         case .name:
-            return TextFieldTableViewCell.self
+            return TextViewTableViewCell.self
         case .variationName:
             return BasicTableViewCell.self
         case .description(let description):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -128,19 +128,24 @@ private extension ProductFormTableViewDataSource {
     }
 
     func configureName(cell: UITableViewCell, name: String?) {
-        guard let cell = cell as? TextFieldTableViewCell else {
+        guard let cell = cell as? TextViewTableViewCell else {
             fatalError()
         }
 
         cell.accessoryType = .none
 
         let placeholder = NSLocalizedString("Title", comment: "Placeholder in the Product Title row on Product form screen.")
-        let viewModel = TextFieldTableViewCell.ViewModel(text: name, placeholder: placeholder, onTextChange: { [weak self] newName in
+
+        let cellViewModel = TextViewTableViewCell.ViewModel(text: name,
+                                                            placeholder: placeholder,
+                                                            textViewMinimumHeight: 10.0,
+                                                            isScrollEnabled: false,
+                                                            onTextChange: { [weak self] (newName) in
             self?.onNameChange?(newName)
-            }, onTextDidBeginEditing: {
-                ServiceLocator.analytics.track(.productDetailViewProductNameTapped)
-        }, inputFormatter: nil, keyboardType: .default)
-        cell.configure(viewModel: viewModel)
+            },
+                                                            style: .headline)
+
+        cell.configure(viewModel: cellViewModel)
     }
 
     func configureVariationName(cell: UITableViewCell, name: String) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -146,7 +146,7 @@ private extension ProductFormTableViewDataSource {
                                                             style: .headline,
                                                             edgeInsets: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))
 
-        cell.configure(viewModel: cellViewModel)
+        cell.configure(with: cellViewModel)
     }
 
     func configureVariationName(cell: UITableViewCell, name: String) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -143,7 +143,8 @@ private extension ProductFormTableViewDataSource {
                                                             onTextChange: { [weak self] (newName) in
             self?.onNameChange?(newName)
             },
-                                                            style: .headline)
+                                                            style: .headline,
+                                                            edgeInsets: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))
 
         cell.configure(viewModel: cellViewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -746,6 +746,10 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func onEditProductNameCompletion(newName: String) {
         viewModel.updateName(newName)
+
+        /// This refresh is used to adapt the size of the cell to the text
+        tableView.beginUpdates()
+        tableView.endUpdates()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -57,7 +57,8 @@ final class EnhancedTextView: UITextView {
 //
 private extension EnhancedTextView {
     func configurePlaceholderLabel() {
-        placeholderLabel = UILabel(frame: bounds)
+        let frameRect = CGRect(x: Constants.margin, y: Constants.margin, width: bounds.width, height: bounds.height)
+        placeholderLabel = UILabel(frame: frameRect)
         if let unwrappedLabel = placeholderLabel {
             addSubview(unwrappedLabel)
         }
@@ -91,6 +92,7 @@ extension EnhancedTextView: UITextViewDelegate {
 private extension EnhancedTextView {
 
     enum Constants {
-        static let animationDuration    = 0.2
+        static let animationDuration = 0.2
+        static let margin = 0.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -5,6 +5,7 @@ import UIKit
 final class EnhancedTextView: UITextView {
 
     var onTextChange: ((String) -> Void)?
+    var onTextDidBeginEditing: (() -> Void)?
 
     var placeholder: String? {
         didSet {
@@ -72,6 +73,7 @@ extension EnhancedTextView: UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         hidePlaceholder()
+        onTextDidBeginEditing?()
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -93,6 +93,6 @@ private extension EnhancedTextView {
 
     enum Constants {
         static let animationDuration = 0.2
-        static let margin = 0.0
+        static let margin: CGFloat = 8.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -1,7 +1,9 @@
 import UIKit
 import Gridicons
 
-class TextViewTableViewCell: UITableViewCell {
+/// A table view cell that containt an icon and a text view.
+///
+final class TextViewTableViewCell: UITableViewCell {
     struct ViewModel {
         var icon: UIImage? = nil
         var iconAccessibilityLabel: String? = nil

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -31,8 +31,6 @@ final class TextViewTableViewCell: UITableViewCell {
     @IBOutlet private weak var leadingContraint: NSLayoutConstraint!
     @IBOutlet private weak var topContraint: NSLayoutConstraint!
 
-    private var viewModel: ViewModel?
-
     private var iconImage: UIImage? {
         get {
             return noteIconButton.image(for: .normal)
@@ -63,8 +61,7 @@ final class TextViewTableViewCell: UITableViewCell {
         noteIconButton.accessibilityTraits = .image
     }
 
-    func configure(viewModel: ViewModel) {
-        self.viewModel = viewModel
+    func configure(with viewModel: ViewModel) {
 
         iconImage = viewModel.icon
         iconImage?.accessibilityLabel = viewModel.iconAccessibilityLabel

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -2,13 +2,30 @@ import UIKit
 import Gridicons
 
 class TextViewTableViewCell: UITableViewCell {
+    struct ViewModel {
+        var icon: UIImage? = nil
+        var iconAccessibilityLabel: String? = nil
+        var iconTint: UIColor? = nil
+        var text: String? = nil
+        var placeholder: String? = nil
+        var textViewMinimumHeight: CGFloat? = nil
+        var isScrollEnabled: Bool = true
+        var onTextChange: ((_ text: String) -> Void)? = nil
+        var onTextDidBeginEditing: (() -> Void)? = nil
+        var keyboardType: UIKeyboardType = .default
+        var style: Style = .body
+    }
 
     @IBOutlet private weak var noteIconView: UIView!
-    @IBOutlet var noteIconButton: UIButton!
+    @IBOutlet private var noteIconButton: UIButton!
 
-    @IBOutlet var noteTextView: EnhancedTextView!
+    @IBOutlet private var noteTextView: EnhancedTextView!
 
-    var iconImage: UIImage? {
+    @IBOutlet private weak var textViewHeightConstraint: NSLayoutConstraint!
+
+    private var viewModel: ViewModel?
+
+    private var iconImage: UIImage? {
         get {
             return noteIconButton.image(for: .normal)
         }
@@ -20,7 +37,7 @@ class TextViewTableViewCell: UITableViewCell {
         }
     }
 
-    var iconTint: UIColor? {
+    private var iconTint: UIColor? {
         get {
             return noteIconButton.backgroundColor
         }
@@ -37,8 +54,54 @@ class TextViewTableViewCell: UITableViewCell {
 
         noteIconButton.accessibilityTraits = .image
     }
+
+    func configure(viewModel: ViewModel) {
+        self.viewModel = viewModel
+
+        iconImage = viewModel.icon
+        iconImage?.accessibilityLabel = viewModel.iconAccessibilityLabel
+        iconTint = viewModel.iconTint
+        noteTextView.text = viewModel.text
+        noteTextView.placeholder = viewModel.placeholder
+        if let minimumHeight = viewModel.textViewMinimumHeight {
+            textViewHeightConstraint.constant = minimumHeight
+        }
+        noteTextView.isScrollEnabled = viewModel.isScrollEnabled
+        noteTextView.onTextChange = viewModel.onTextChange
+        noteTextView.onTextDidBeginEditing = viewModel.onTextDidBeginEditing
+        noteTextView.keyboardType = viewModel.keyboardType
+        self.applyStyle(style: viewModel.style)
+    }
+
+    @discardableResult
+    override func becomeFirstResponder() -> Bool {
+        noteTextView.becomeFirstResponder()
+    }
 }
 
+// Styles
+extension TextViewTableViewCell {
+
+    enum Style {
+        case body
+        case headline
+    }
+
+    func applyStyle(style: Style) {
+        switch style {
+        case .body:
+            noteTextView.adjustsFontForContentSizeCategory = true
+            noteTextView.font = .body
+            noteTextView.textColor = .text
+        case .headline:
+            noteTextView.adjustsFontForContentSizeCategory = true
+            noteTextView.font = .headline
+            noteTextView.textColor = .text
+        }
+    }
+}
+
+// Private methods
 private extension TextViewTableViewCell {
     func configureBackground() {
         applyDefaultBackgroundStyle()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.swift
@@ -14,6 +14,7 @@ class TextViewTableViewCell: UITableViewCell {
         var onTextDidBeginEditing: (() -> Void)? = nil
         var keyboardType: UIKeyboardType = .default
         var style: Style = .body
+        var edgeInsets: UIEdgeInsets?
     }
 
     @IBOutlet private weak var noteIconView: UIView!
@@ -21,7 +22,12 @@ class TextViewTableViewCell: UITableViewCell {
 
     @IBOutlet private var noteTextView: EnhancedTextView!
 
+    /// Constraints
     @IBOutlet private weak var textViewHeightConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var bottomContraint: NSLayoutConstraint!
+    @IBOutlet private weak var trailingContraint: NSLayoutConstraint!
+    @IBOutlet private weak var leadingContraint: NSLayoutConstraint!
+    @IBOutlet private weak var topContraint: NSLayoutConstraint!
 
     private var viewModel: ViewModel?
 
@@ -71,6 +77,12 @@ class TextViewTableViewCell: UITableViewCell {
         noteTextView.onTextDidBeginEditing = viewModel.onTextDidBeginEditing
         noteTextView.keyboardType = viewModel.keyboardType
         self.applyStyle(style: viewModel.style)
+        if let edgeInsets = viewModel.edgeInsets {
+            bottomContraint.constant = edgeInsets.bottom
+            trailingContraint.constant = edgeInsets.right
+            leadingContraint.constant = edgeInsets.left
+            topContraint.constant = edgeInsets.top
+        }
     }
 
     @discardableResult

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -62,6 +62,7 @@
                 <outlet property="noteIconButton" destination="WYv-eb-Aor" id="xbs-pE-r7t"/>
                 <outlet property="noteIconView" destination="pmR-Dp-2I7" id="U2C-nH-hCb"/>
                 <outlet property="noteTextView" destination="Ath-1M-eR6" id="P9H-JP-Ibj"/>
+                <outlet property="textViewHeightConstraint" destination="eNh-b6-Kat" id="Nez-qS-EWK"/>
             </connections>
             <point key="canvasLocation" x="34" y="141"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TextViewTableViewCell.xib
@@ -59,10 +59,14 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomContraint" destination="1ga-S8-Ec3" id="1k7-cf-koq"/>
+                <outlet property="leadingContraint" destination="Vx3-3a-3Fo" id="cIH-ke-8pA"/>
                 <outlet property="noteIconButton" destination="WYv-eb-Aor" id="xbs-pE-r7t"/>
                 <outlet property="noteIconView" destination="pmR-Dp-2I7" id="U2C-nH-hCb"/>
                 <outlet property="noteTextView" destination="Ath-1M-eR6" id="P9H-JP-Ibj"/>
                 <outlet property="textViewHeightConstraint" destination="eNh-b6-Kat" id="Nez-qS-EWK"/>
+                <outlet property="topContraint" destination="yDM-uQ-kCz" id="JO2-b9-7eg"/>
+                <outlet property="trailingContraint" destination="Gwo-v6-d3E" id="jyz-Ue-7DJ"/>
             </connections>
             <point key="canvasLocation" x="34" y="141"/>
         </tableViewCell>


### PR DESCRIPTION
Fixes #2603 

## Description
From now we show the entire title on a Product Detail screen since the cell now contains a text view and no more a text field. I edited the cell used to be a `TextViewTableViewCell`, and I refactored it introducing the `ViewModel` struct for the configuration of the cell. In that way, all the properties are private now. I also adapted all the code where `TextViewTableViewCell` was used before. I also fixed the placeholder showed inside `EnhancedTextView` because it was not correctly aligned.

## Testing
1. Navigate to the product list.
2. Open a product detail with a long title. -> The title should be shown entirely.
3. Try to edit it. -> The cell will be automatically expanded based on the content of the product title.
4. Open a product without a title. -> The placeholder should appear on the cell, and it will disappear when you try to edit it.

#### Extra testing 1 (sanity check):
1. Open an order detail.
2. Try to add a new order note. -> The cell note appearance should appear like before.

#### Extra testing 2 (sanity check):
1. Open a product detail.
2. Open product settings.
3. Tap “Purchase note”. -> The cell appearance should appear like before.

## Gif
<img src="https://user-images.githubusercontent.com/495617/91290604-17e0b580-e794-11ea-9515-21274832ac96.gif" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
