### PR TITLE
Docs: Add information about Tracking Events

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@
     - [Copiable](#copiable)
         - [Generating Copiable Methods](#generating-copiable-methods)
         - [Modifying The Copiable Code Generation](#modifying-the-copiable-code-generation)
+    - [Tracking Events](#tracking-events)
+        - [Custom Properties](#custom-properties)
 - [Testing](#testing)
 - [Features](#features)
 
@@ -228,6 +230,56 @@ All of them use a single template, [`Models+Copiable.swifttemplate`](../CodeGene
 
 Please refer to the [Sourcery reference](https://cdn.rawgit.com/krzysztofzablocki/Sourcery/master/docs/index.html) for more info about how to write templates.
 
+### Tracking Events
+
+To add a new event, the event name has to be added as a `case` in the [`WooAnalyticsStat` enum](../WooCommerce/Classes/Analytics/WooAnalyticsStat.swift). Tracking the event looks like this:
+
+```swift
+final class ViewController {
+    private let analytics: Analytics
+
+    init(analytics: Analytics = ServiceLocator.analytics) {
+        self.analytics = analytics
+    }
+
+    private func onUpdateButtonPress() {
+        analytics.track(.productDetailUpdateButtonTapped)
+    }
+}
+```
+
+Having the `String` values in the `WooAnalyticsStat` enum helps us with comparing the events being tracked in WooCommerce Android.
+
+#### Custom Properties
+
+If the event has custom properties, add a corresponding `static func` [`WooAnalyticsEvent`](../WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift) constructor of the event. Add the custom properties as parameters of the function. For example:
+
+```swift
+extension WooAnalyticsEvent {
+
+    public enum AppFeedbackPromptAction: String {
+        case shown
+        case liked
+        case didntLike = "didnt_like"
+    }
+
+    static func appFeedbackPrompt(action: AppFeedbackPromptAction) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .appFeedbackPrompt,
+                          properties: ["action": action.rawValue])
+    }
+}
+```
+
+Tracking the event would now look like this:
+
+```swift
+analytics.track(event: .appFeedbackPrompt(action: .liked))
+```
+
+Organizing events and their custom properties this way helps us with:
+
+- Answering what custom properties are available for an event and what the valid values are.
+- Decreasing the risk of costly typos. A typo in an event name or its property would set us back in analyzing the correct data.
 
 ## Testing
 


### PR DESCRIPTION
Ref p91TBi-3bm-p2

Documenting this in here so it doesn't get easily lost in p2s. 🙃 

## Testing

Please review the [Tracking Events section](https://github.com/woocommerce/woocommerce-ios/blob/85b753e592921d09fd98fcf945a06b126604aae3/docs/README.md#tracking-events) in the doc. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

