### PR TITLE
Products: fix the variations warning banner when one variation has no price but is disabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -183,7 +183,12 @@ private extension ProductVariationsViewController {
     }
 
     func updateTopBannerView() {
-        let hasVariationsMissingPrice = resultsController.fetchedObjects.contains { $0.price.isEmpty }
+        let hasVariationsMissingPrice = resultsController.fetchedObjects.contains {
+            EditableProductVariationModel(productVariation: $0,
+                                          allAttributes: allAttributes,
+                                          parentProductSKU: parentProductSKU)
+                .isEnabledAndMissingPrice
+        }
         topBannerView.isHidden = hasVariationsMissingPrice == false
         tableView.updateHeaderHeight()
     }


### PR DESCRIPTION
Fixes #2708

## Changes

- For variations price warning banner visibility, updated to check `isEnabledAndMissingPrice` instead of just whether the price is empty. It is not a concern if a variation doesn't have a price when it's disabled.

## Testing

Prerequisite: the store has a variable product whose variations all have a price except for one, and this variation is disabled ("Enabled" switch is off)

- Go to the Products tab
- Tap on the variable product in the prerequisite
- Tap on the variations row --> there should not be a warning banner (on `develop`, a warning banner shows up in this case. if you turn on the "Enabled" switch for the disabled variation that doesn't have a price, the warning banner should show up)

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-08-27 at 13 52 37](https://user-images.githubusercontent.com/1945542/91393220-bf311b80-e86c-11ea-9079-ca6ecdfa2b55.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-27 at 13 47 46](https://user-images.githubusercontent.com/1945542/91393142-b9d3d100-e86c-11ea-82d6-aee4902f0379.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
