### PR TITLE
Fixes issue where products filter bar dissapears

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -39,7 +39,7 @@ final class ProductsViewController: UIViewController {
         let subviews = [topBannerContainerView, toolbar]
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.axis = .vertical
-        stackView.spacing = 8
+        stackView.spacing = Constants.headerViewSpacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -171,7 +171,7 @@ final class ProductsViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        updateTableHeaderView()
+        updateTableHeaderViewHeight()
     }
 }
 
@@ -388,7 +388,7 @@ private extension ProductsViewController {
         ProductsTopBannerFactory.topBanner(isExpanded: isExpanded,
                                            isInAppFeedbackFeatureEnabled: isInAppFeedbackEnabled,
                                            expandedStateChangeHandler: { [weak self] in
-            self?.updateTableHeaderView()
+            self?.updateTableHeaderViewHeight()
         }, onGiveFeedbackButtonPressed: { [weak self] in
             self?.presentProductsFeedback()
         }, onDismissButtonPressed: { [weak self] in
@@ -396,20 +396,20 @@ private extension ProductsViewController {
         }, onCompletion: { [weak self] topBannerView in
             self?.topBannerContainerView.updateSubview(topBannerView)
             self?.topBannerView = topBannerView
-            self?.updateTableHeaderView()
+            self?.updateTableHeaderViewHeight()
         })
     }
 
     func hideTopBannerView() {
         topBannerView?.removeFromSuperview()
         topBannerView = nil
-        updateTableHeaderView()
+        updateTableHeaderViewHeight()
     }
 
     /// Updates table header view with the correct spacing / edges depending if `topBannerContainerView` is empty or not.
     ///
-    func updateTableHeaderView() {
-        topStackView.spacing = topBannerContainerView.subviews.isNotEmpty ? 8 : 0
+    func updateTableHeaderViewHeight() {
+        topStackView.spacing = topBannerContainerView.subviews.isNotEmpty ? Constants.headerViewSpacing : 0
         tableView.updateHeaderHeight()
     }
 
@@ -799,6 +799,7 @@ extension ProductsViewController {
 private extension ProductsViewController {
 
     enum Constants {
+        static let headerViewSpacing = CGFloat(8)
         static let estimatedRowHeight = CGFloat(86)
         static let placeholderRowsPerSection = [3]
         static let headerDefaultHeight = CGFloat(130)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -171,7 +171,7 @@ final class ProductsViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        tableView.updateHeaderHeight()
+        updateTableHeaderView()
     }
 }
 
@@ -388,7 +388,7 @@ private extension ProductsViewController {
         ProductsTopBannerFactory.topBanner(isExpanded: isExpanded,
                                            isInAppFeedbackFeatureEnabled: isInAppFeedbackEnabled,
                                            expandedStateChangeHandler: { [weak self] in
-            self?.tableView.updateHeaderHeight()
+            self?.updateTableHeaderView()
         }, onGiveFeedbackButtonPressed: { [weak self] in
             self?.presentProductsFeedback()
         }, onDismissButtonPressed: { [weak self] in
@@ -396,14 +396,20 @@ private extension ProductsViewController {
         }, onCompletion: { [weak self] topBannerView in
             self?.topBannerContainerView.updateSubview(topBannerView)
             self?.topBannerView = topBannerView
-            self?.tableView.updateHeaderHeight()
+            self?.updateTableHeaderView()
         })
     }
 
     func hideTopBannerView() {
         topBannerView?.removeFromSuperview()
         topBannerView = nil
-        tableView.tableHeaderView = nil
+        updateTableHeaderView()
+    }
+
+    /// Updates table header view with the correct spacing / edges depending if `topBannerContainerView` is empty or not.
+    ///
+    func updateTableHeaderView() {
+        topStackView.spacing = topBannerContainerView.subviews.isNotEmpty ? 8 : 0
         tableView.updateHeaderHeight()
     }
 


### PR DESCRIPTION
fixes #2720 

# Why 

While trying to [dismiss the product banner](https://github.com/woocommerce/woocommerce-ios/pull/2686#issuecomment-678276742) I introduced a bug that hides the products filter bar as well 😇 

# How

- Do not `nil` the table header view when trying to dismiss the top banner
- Adjust the spacing of the outer container stack view(that serves as the header view for the table view) to be `0` when it does not have any top banner presented, to remove an unwanted separator space.

# Gif
Before | After
---- | ----
<img src="https://user-images.githubusercontent.com/198826/91350837-7f066600-e7a4-11ea-9f37-5c28d7b9ecc9.gif" width="300"> | <img src="https://user-images.githubusercontent.com/562080/91467782-a584d980-e856-11ea-9d26-0d0bbcd05c3e.gif" width="330">

# Testing Steps
- Delete the app from the device.
- Run and navigate to Products.
- Tap on Give Feedback. 
- Dismiss the survey URL.
- Make sure that the products filter bar is still visible


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
