### PR TITLE
Edit Product: reviews row is now hidden if reviews are disabled

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 - [*] Order details > product details: tapping outside of the bottom sheet from "Add more details" menu does not dismiss the whole product details anymore.
 - [*] If the Products switch is on in Settings > Experimental Features, product editing for basic fields are enabled for non-core products (whose product type is not simple/external/variable/grouped) - images, name, description, readonly price, readonly inventory, tags, categories, short description, and product settings.
-- [x] Edit Product: reviews row is now hidden if reviews are disabled.
+- [*] Edit Product: reviews row is now hidden if reviews are disabled.
 
 
 4.9

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 -----
 - [*] Order details > product details: tapping outside of the bottom sheet from "Add more details" menu does not dismiss the whole product details anymore.
 - [*] If the Products switch is on in Settings > Experimental Features, product editing for basic fields are enabled for non-core products (whose product type is not simple/external/variable/grouped) - images, name, description, readonly price, readonly inventory, tags, categories, short description, and product settings.
+- [x] Edit Product: reviews row is now hidden if reviews are disabled.
+
 
 4.9
 -----
@@ -10,7 +12,8 @@
 - [*] Edit Products: the update action now shows up on the product details after updating just the sale price.
 - [*] Fix a crash that sometimes happen when tapping on a Product Review push notification.
 - [*] Variable product > variation list: a warning banner is shown if any variations do not have a price, and warning text is shown on these variation rows.
- 
+
+
 4.8
 -----
 - [*] Enabled right/left swipe on product images.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -71,6 +71,10 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.taxClass
     }
 
+    var reviewsAllowed: Bool {
+        product.reviewsAllowed
+    }
+
     var averageRating: String {
         product.averageRating
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -95,6 +95,10 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         productVariation.taxClass
     }
 
+    var reviewsAllowed: Bool {
+        false
+    }
+
     var averageRating: String {
         "0.00"
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -183,8 +183,8 @@ private extension ProductFormActionsFactory {
             // The price settings action is always visible in the settings section.
             return true
         case .reviews:
-            // The reviews action is always visible in the settings section.
-            return true
+            // The reviews action is visible only if reviews are enabled in product settings.
+            return product.reviewsAllowed
         case .productType:
             // The product type action is always visible in the settings section.
             return true

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -79,7 +79,7 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForSimpleProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
         let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
@@ -99,7 +99,7 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForAffiliateProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
         let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -118,7 +118,7 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForGroupedProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
         let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -136,7 +136,7 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
         let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -154,7 +154,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForNonCoreProduct() -> [ProductFormEditAction] {
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
         let shouldShowProductTypeRow = isEditProductsRelease3Enabled
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
@@ -183,8 +183,8 @@ private extension ProductFormActionsFactory {
             // The price settings action is always visible in the settings section.
             return true
         case .reviews:
-            // The reviews action is visible only if reviews are enabled in product settings.
-            return product.reviewsAllowed
+            // The reviews action is always visible in the settings section.
+            return true
         case .productType:
             // The product type action is always visible in the settings section.
             return true

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -31,6 +31,7 @@ protocol ProductFormDataModel {
     var taxClass: String? { get }
 
     // Reviews
+    var reviewsAllowed: Bool { get }
     var averageRating: String { get }
     var ratingCount: Int { get }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -28,7 +28,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     }
 
     private var tableViewModel: ProductFormTableViewModel
-    private var tableViewDataSource: ProductFormTableViewDataSource
+    private var tableViewDataSource: ProductFormTableViewDataSource {
+        didSet {
+            registerTableViewCells()
+        }
+    }
 
     private let productImageActionHandler: ProductImageActionHandler
     private let productUIImageLoader: ProductUIImageLoader

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -61,6 +61,32 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
+    func test_viewModel_for_physical_simple_product_with_reviews_disabled() {
+        // Arrange
+        let product = Fixtures.physicalSimpleProductWithReviewsDisabled
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                isEditProductsRelease3Enabled: true)
+
+        // Assert
+        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
+        XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
+
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings,
+                                                                       .shippingSettings,
+                                                                       .inventorySettings,
+                                                                       .categories,
+                                                                       .tags,
+                                                                       .briefDescription,
+                                                                       .productType]
+        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+
+        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
+        XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
+    }
+
     func testViewModelForDownloadableSimpleProduct() {
         // Arrange
         let product = Fixtures.downloadableSimpleProduct
@@ -260,6 +286,15 @@ private extension ProductFormActionsFactory_EditProductsM3Tests {
                                                                               manageStock: true, sku: "uks", stockQuantity: nil,
                                                                               dimensions: ProductDimensions(length: "", width: "", height: ""), weight: "2",
                                                                               virtual: false,
+                                                                              categories: [category],
+                                                                              tags: [tag],
+                                                                              images: [image])
+        // downloadable: false, virtual: true, reviews: false, with inventory/shipping/categories/tags/brief description
+        static let physicalSimpleProductWithReviewsDisabled = MockProduct().product(downloadable: false, briefDescription: "desc", productType: .simple,
+                                                                              manageStock: true, sku: "uks", stockQuantity: nil,
+                                                                              dimensions: ProductDimensions(length: "", width: "", height: ""), weight: "2",
+                                                                              virtual: false,
+                                                                              reviewsAllowed: false,
                                                                               categories: [category],
                                                                               tags: [tag],
                                                                               images: [image])


### PR DESCRIPTION
Fixes #2718 

## Description
Rachel noticed that if she disables reviews in Product Settings, she still see a Reviews section in the product details. The expected behavior after a discussion here p5T066-1tW-p2#comment-5629  is to hide the Reviews section in product details when reviews are disabled on the product.

## Changes
- Added `reviewsAllowed` in `ProductFormDataModel`, and added conformance to `EditableProductModel` and `EditableProductVariationModel`.
- `ProductFormActionsFactory`: now reviews row is showed based on `reviewsAllowed` parameter.
- Now table view cells are registered every time the product `tableViewDataSource` is updated.

## Testing
1. Go to Settings > Experimental features and enable Product Editing.
2. Go to the Products tab.
3. Select a product.
4. Go to the ellipsis menu > Product Settings.
5. Toggle the "Enable reviews" setting OFF.
6. Go back to product details and notice the Reviews section is now hidden.
7. Go to the ellipsis menu > Product Settings.
8. Toggle the "Enable reviews" setting ON.
9. Go back to product details and notice the Reviews section is now showed.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
