### PR TITLE
Remove inAppFeedback Feature Flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,8 +7,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .inAppFeedback:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .refunds:
             return true
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -14,12 +14,6 @@ enum FeatureFlag: Int {
     ///
     case editProductsRelease3
 
-    /// To be used for the In-app Feedback tasks until all tasks are completed.
-    ///
-    /// - SeeAlso: https://github.com/woocommerce/woocommerce-ios/projects/18
-    ///
-    case inAppFeedback
-
     /// Product Reviews
     ///
     case reviews

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -19,12 +19,9 @@ extension NSNotification.Name {
 final class MainTabViewModel {
 
     private let storesManager: StoresManager
-    private let featureFlagService: FeatureFlagService
 
-    init(storesManager: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(storesManager: StoresManager = ServiceLocator.stores) {
         self.storesManager = storesManager
-        self.featureFlagService = featureFlagService
     }
 
     /// Callback to be executed when this view model receives new data
@@ -89,10 +86,6 @@ private extension MainTabViewModel {
 
     /// Persists the installation date if it hasn't been done already.
     func saveInstallationDateIfNecessary() {
-        guard featureFlagService.isFeatureFlagEnabled(.inAppFeedback) else {
-            return
-        }
-
         // Unfortunately, our `StoresManager` cannot handle actions (e.g. `AppSettingsAction`) if
         // the user is not logged in. That's because the state will be a `DeauthenticatedState`
         // which just ignores all dispatched actions.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewModel.swift
@@ -19,7 +19,6 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     }
     private let isInAppFeedbackCardVisibleSubject = BehaviorSubject(false)
 
-    private let featureFlagService: FeatureFlagService
     private let storesManager: StoresManager
     private let analytics: Analytics
 
@@ -30,11 +29,9 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     ///     But setting this to `false`, will ensure that it will never be presented.
     ///
     init(canDisplayInAppFeedbackCard: Bool,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          storesManager: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.canDisplayInAppFeedbackCard = canDisplayInAppFeedbackCard
-        self.featureFlagService = featureFlagService
         self.storesManager = storesManager
         self.analytics = analytics
     }
@@ -69,9 +66,8 @@ final class StoreStatsAndTopPerformersPeriodViewModel {
     /// Calculates and updates the value of `isInAppFeedbackCardVisibleSubject`.
     private func refreshIsInAppFeedbackCardVisibleValue() {
         // Abort right away if we don't need to calculate the real value.
-        let isEnabled = canDisplayInAppFeedbackCard && featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
-        guard isEnabled else {
-            return sendIsInAppFeedbackCardVisibleValueAndTrackIfNeeded(isEnabled)
+        guard canDisplayInAppFeedbackCard else {
+            return sendIsInAppFeedbackCardVisibleValueAndTrackIfNeeded(false)
         }
 
         let action = AppSettingsAction.loadFeedbackVisibility(type: .general) { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -12,14 +12,13 @@ struct ProductsTopBannerFactory {
     static func topBanner(isExpanded: Bool,
                           stores: StoresManager = ServiceLocator.stores,
                           analytics: Analytics = ServiceLocator.analytics,
-                          isInAppFeedbackFeatureEnabled: Bool,
                           expandedStateChangeHandler: @escaping () -> Void,
                           onGiveFeedbackButtonPressed: @escaping () -> Void,
                           onDismissButtonPressed: @escaping () -> Void,
                           onCompletion: @escaping (TopBannerView) -> Void) {
         let action = AppSettingsAction.loadProductsFeatureSwitch { isEditProductsRelease3Enabled in
             let title = Strings.title
-            let icon: UIImage = isInAppFeedbackFeatureEnabled ? .megaphoneIcon : .workInProgressBanner
+            let icon: UIImage = .megaphoneIcon
             let infoText = isEditProductsRelease3Enabled ? Strings.infoWhenRelease3IsEnabled: Strings.info
             let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Strings.giveFeedback) {
                 analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .gaveFeedback))
@@ -29,7 +28,7 @@ struct ProductsTopBannerFactory {
                 analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .dismissed))
                 onDismissButtonPressed()
             }
-            let actions: [TopBannerViewModel.ActionButton] = isInAppFeedbackFeatureEnabled ? [giveFeedbackAction, dismissAction] : []
+            let actions = [giveFeedbackAction, dismissAction]
             let viewModel = TopBannerViewModel(title: title,
                                                infoText: infoText,
                                                icon: icon,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -384,9 +384,7 @@ private extension ProductsViewController {
     ///
     func requestAndShowNewTopBannerView() {
         let isExpanded = topBannerView?.isExpanded ?? false
-        let isInAppFeedbackEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppFeedback)
         ProductsTopBannerFactory.topBanner(isExpanded: isExpanded,
-                                           isInAppFeedbackFeatureEnabled: isInAppFeedbackEnabled,
                                            expandedStateChangeHandler: { [weak self] in
             self?.updateTableHeaderView()
         }, onGiveFeedbackButtonPressed: { [weak self] in

--- a/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
@@ -2,20 +2,15 @@
 
 struct MockFeatureFlagService: FeatureFlagService {
     private let isEditProductsRelease3On: Bool
-    private let isInAppFeedbackOn: Bool
 
-    init(isEditProductsRelease3On: Bool = false,
-         isInAppFeedbackOn: Bool = false) {
+    init(isEditProductsRelease3On: Bool = false) {
         self.isEditProductsRelease3On = isEditProductsRelease3On
-        self.isInAppFeedbackOn = isInAppFeedbackOn
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
         case .editProductsRelease3:
             return isEditProductsRelease3On
-        case .inAppFeedback:
-            return isInAppFeedbackOn
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/MainTabViewModelTests.swift
@@ -7,24 +7,12 @@ import Yosemite
 /// Test cases for `MainTabViewModel`.
 final class MainTabViewModelTests: XCTestCase {
 
-    private var featureFlagService: MockFeatureFlagService!
-
-    override func setUp() {
-        super.setUp()
-        featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: true)
-    }
-
-    override func tearDown() {
-        featureFlagService = nil
-        super.tearDown()
-    }
-
     func test_onViewDidAppear_will_save_the_installation_date() throws {
         // Given
         let storesManager = MockupStoresManager(sessionManager: .makeForTesting(authenticated: true))
         storesManager.reset()
 
-        let viewModel = MainTabViewModel(storesManager: storesManager, featureFlagService: featureFlagService)
+        let viewModel = MainTabViewModel(storesManager: storesManager)
 
         assertEmpty(storesManager.receivedActions)
 
@@ -49,7 +37,7 @@ final class MainTabViewModelTests: XCTestCase {
         let storesManager = MockupStoresManager(sessionManager: .makeForTesting(authenticated: false))
         storesManager.reset()
 
-        let viewModel = MainTabViewModel(storesManager: storesManager, featureFlagService: featureFlagService)
+        let viewModel = MainTabViewModel(storesManager: storesManager)
 
         assertEmpty(storesManager.receivedActions)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -222,10 +222,8 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
 }
 
 private extension StoreStatsAndTopPerformersPeriodViewModelTests {
-    func makeViewModel(canDisplayInAppFeedbackCard: Bool = true,
-                       featureFlagService: MockFeatureFlagService = .init(isInAppFeedbackOn: true)) -> StoreStatsAndTopPerformersPeriodViewModel {
+    func makeViewModel(canDisplayInAppFeedbackCard: Bool = true) -> StoreStatsAndTopPerformersPeriodViewModel {
         StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: canDisplayInAppFeedbackCard,
-                                                  featureFlagService: featureFlagService,
                                                   storesManager: storesManager,
                                                   analytics: analytics)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsAndTopPerformersPeriodViewModelTests.swift
@@ -39,24 +39,6 @@ final class StoreStatsAndTopPerformersPeriodViewModelTests: XCTestCase {
         assertEmpty(analyticsProvider.receivedProperties)
     }
 
-    func test_isInAppFeedbackCardVisible_is_false_if_feature_flag_is_off() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isInAppFeedbackOn: false)
-        let viewModel = makeViewModel(featureFlagService: featureFlagService)
-
-        var emittedValues = [Bool]()
-        _ = viewModel.isInAppFeedbackCardVisible.subscribe { value in
-            emittedValues.append(value)
-        }
-
-        // When
-        viewModel.onViewDidAppear()
-
-        // Then
-        XCTAssertEqual([false, false], emittedValues)
-        assertEmpty(analyticsProvider.receivedProperties)
-    }
-
     func test_isInAppFeedbackCardVisible_is_false_if_canDisplayInAppFeedbackCard_is_false() {
         // Given
         let viewModel = makeViewModel(canDisplayInAppFeedbackCard: false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -76,7 +76,6 @@ private extension ProductsTopBannerFactoryTests {
             ProductsTopBannerFactory.topBanner(isExpanded: false,
                                                stores: storesManager,
                                                analytics: analytics,
-                                               isInAppFeedbackFeatureEnabled: true,
                                                expandedStateChangeHandler: {
 
             }, onGiveFeedbackButtonPressed: {


### PR DESCRIPTION
Closes #2554 

This enables the In-app Feedback feature for all users.

## Testing

I think the unit tests should cover this but please still do a quick smoke test:

1. Delete the app from the device.
2. Run and log in.
3. Navigate to Products. 
4. Confirm that the banner and the “Give Fedback” and ”Dismiss” buttons are visible.
5. Time-travel to 3 months from now. 
6. Navigate to My Store. 
7. Confirm that the card with buttons “Could Be Better” and “I Like It” is visible. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

