### PR TITLE
Edit Product: show empty state screen in product's reviews when product has no reviews

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - [*] Order details > product details: tapping outside of the bottom sheet from "Add more details" menu does not dismiss the whole product details anymore.
 - [*] If the Products switch is on in Settings > Experimental Features, product editing for basic fields are enabled for non-core products (whose product type is not simple/external/variable/grouped) - images, name, description, readonly price, readonly inventory, tags, categories, short description, and product settings.
+- [*] Edit Product: now it's possible to open the product's reviews screen also if there are no reviews.
 
 4.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -229,6 +229,7 @@ private extension ProductFormTableViewDataSource {
                        details: viewModel.details ?? "",
                        ratingCount: ratingCount,
                        averageRating: averageRating)
+        cell.accessoryType = .disclosureIndicator
     }
 
     func configureSettingsRowWithASwitch(cell: UITableViewCell, viewModel: ProductFormSection.SettingsRow.SwitchableViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -229,9 +229,6 @@ private extension ProductFormTableViewDataSource {
                        details: viewModel.details ?? "",
                        ratingCount: ratingCount,
                        averageRating: averageRating)
-        if ratingCount > 0 {
-            cell.accessoryType = .disclosureIndicator
-        }
     }
 
     func configureSettingsRowWithASwitch(cell: UITableViewCell, viewModel: ProductFormSection.SettingsRow.SwitchableViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -263,9 +263,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 eventLogger.logPriceSettingsTapped()
                 editPriceSettings()
             case .reviews:
-                guard product.ratingCount > 0 else {
-                    return
-                }
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
             case .productType:
@@ -837,7 +834,7 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func showReviews() {
-        guard let product = product as? EditableProductModel, product.product.ratingCount > 0 else {
+        guard let product = product as? EditableProductModel else {
             return
         }
 


### PR DESCRIPTION
Fixes #2729 
Slack Discussion: C6H8C3G23/p1598612996142500

## Description
On Android, if a product has reviews enabled but no reviews yet, we link to the reviews empty state screen. I implemented the same behavior on iOS. No big changes involved.

## Testing
1. Open a product with no reviews.
2. Tap the reviews row.
3. The empty state screen of the product's reviews should be shown.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/91561273-99bf1300-e93b-11ea-84c8-a8175e2bc909.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
