### PR TITLE
Order Detail: "Guest" placeholder is showed on order details card when there is no customer name

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - [*] Order details > product details: tapping outside of the bottom sheet from "Add more details" menu does not dismiss the whole product details anymore.
 - [*] If the Products switch is on in Settings > Experimental Features, product editing for basic fields are enabled for non-core products (whose product type is not simple/external/variable/grouped) - images, name, description, readonly price, readonly inventory, tags, categories, short description, and product settings.
+- [*] Order Detail: added "Guest" placeholder on Order Details card when there's no customer name.
 
 4.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/SummaryTableViewCell.swift
@@ -39,11 +39,12 @@ struct SummaryTableViewCellViewModel {
     /// The full name from the billing address
     ///
     var billedPersonName: String {
-        if let billingAddress = billingAddress {
+        if let billingAddress = billingAddress,
+            billingAddress.firstName.isNotEmpty || billingAddress.lastName.isNotEmpty {
             return Localization.billedPerson(firstName: billingAddress.firstName,
                                              lastName: billingAddress.lastName)
         } else {
-            return ""
+            return Localization.guestName
         }
     }
 
@@ -199,5 +200,8 @@ private extension SummaryTableViewCellViewModel {
 
             return String.localizedStringWithFormat(format, firstName, lastName)
         }
+
+        static let guestName: String = NSLocalizedString("Guest",
+                                                         comment: "In Order Details, the name of the billed person when there are no name and last name.")
     }
 }


### PR DESCRIPTION
Fixes #2591 
Fixes #2404 

## Description
On Order Details, there's currently a blank label when there's no customer name. In this PR I added the "Guest" placeholder when there is no customer name or last name.

## Testing
1. Create a new order on the web.
2. From the web, open the order detail, and remove the name and last name of the customer.
3. Launch the app.
4. Open the order detail.
5. You will see the "Guest" placeholder. 

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/91579653-3be6f700-e94c-11ea-9f32-1d6e4f5b6a7c.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
