### PR TITLE
Disable product type for custom product types

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -67,7 +67,9 @@ private extension DefaultProductFormTableViewModel {
             case .reviews:
                 return .reviews(viewModel: reviewsRow(product: product), ratingCount: product.ratingCount, averageRating: product.averageRating)
             case .productType:
-                return .productType(viewModel: productTypeRow(product: product))
+                return .productType(viewModel: productTypeRow(product: product), isEditable: true)
+            case .readonlyProductType:
+                return .productType(viewModel: productTypeRow(product: product, isEditable: false), isEditable: false)
             case .shippingSettings:
                 return .shipping(viewModel: shippingSettingsRow(product: product))
             case .inventorySettings:
@@ -210,7 +212,7 @@ private extension DefaultProductFormTableViewModel {
                                                         isActionable: isEditable)
     }
 
-    func productTypeRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
+    func productTypeRow(product: ProductFormDataModel, isEditable: Bool = true) -> ProductFormSection.SettingsRow.ViewModel {
         let icon = UIImage.productImage
         let title = Constants.productTypeTitle
 
@@ -232,7 +234,8 @@ private extension DefaultProductFormTableViewModel {
 
         return ProductFormSection.SettingsRow.ViewModel(icon: icon,
                                                         title: title,
-                                                        details: details)
+                                                        details: details,
+                                                        isActionable: isEditable)
     }
 
     func shippingSettingsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -27,6 +27,7 @@ enum ProductFormEditAction {
     // Non-core products only (e.g. subscription products, booking products)
     case readonlyPriceSettings
     case readonlyInventorySettings
+    case readonlyProductType
 }
 
 /// Creates actions for different sections/UI on the product form.
@@ -168,7 +169,7 @@ private extension ProductFormActionsFactory {
             shouldShowCategoriesRow ? .categories: nil,
             shouldShowTagsRow ? .tags: nil,
             .briefDescription,
-            shouldShowProductTypeRow ? .productType : nil
+            shouldShowProductTypeRow ? .readonlyProductType : nil
         ]
         return actions.compactMap { $0 }
     }
@@ -217,7 +218,7 @@ private extension ProductFormActionsFactory {
             // The variations row is always visible in the settings section for a variable product.
             return true
         // Non-core products only.
-        case .readonlyPriceSettings, .readonlyInventorySettings:
+        case .readonlyPriceSettings, .readonlyInventorySettings, .readonlyProductType:
             // The readonly rows are always visible in the settings section for a non-core product.
             return true
         default:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -190,7 +190,7 @@ private extension ProductFormTableViewDataSource {
         switch row {
         case .price(let viewModel, _),
              .inventory(let viewModel, _),
-             .productType(let viewModel),
+             .productType(let viewModel, _),
              .shipping(let viewModel),
              .categories(let viewModel),
              .tags(let viewModel),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -24,7 +24,7 @@ enum ProductFormSection: Equatable {
     enum SettingsRow: Equatable {
         case price(viewModel: ViewModel, isEditable: Bool)
         case reviews(viewModel: ViewModel, ratingCount: Int, averageRating: String)
-        case productType(viewModel: ViewModel)
+        case productType(viewModel: ViewModel, isEditable: Bool)
         case shipping(viewModel: ViewModel)
         case inventory(viewModel: ViewModel, isEditable: Bool)
         case categories(viewModel: ViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -268,7 +268,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
-            case .productType:
+            case .productType(_, let isEditable):
+                guard isEditable else {
+                    return
+                }
                 ServiceLocator.analytics.track(.productDetailViewProductTypeTapped)
                 let cell = tableView.cellForRow(at: indexPath)
                 editProductType(cell: cell)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -209,7 +209,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews, .readonlyInventorySettings, .productType]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews, .readonlyInventorySettings, .readonlyProductType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editBriefDescription]
@@ -229,7 +229,7 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
         XCTAssertEqual(factory.primarySectionActions(), expectedPrimarySectionActions)
 
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.readonlyPriceSettings, .reviews, .readonlyInventorySettings, .productType]
+        let expectedSettingsSectionActions: [ProductFormEditAction] = [.readonlyPriceSettings, .reviews, .readonlyInventorySettings, .readonlyProductType]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editBriefDescription]


### PR DESCRIPTION
Fixes #2736 

## Changes

- Added `ProductFormEditAction.readonlyProductType` for non core product types
- Added `isEditable: Bool` parameter to `ProductFormSection.SettingsRow.productType` and set it to `false` for `ProductFormEditAction.readonlyProductType`
- Disabled action handling if the product type is not editable in `ProductFormViewController`

## Testing

### Non-core product types

Prerequisite: the store has at least one product that isn't a core product type (e.g. subscription)
- Make sure Products switch is on under Settings > Experimental Features
- Go to the Products tab
- Tap on a non-core product --> the product type should not be editable

### Core product types - sanity check
- Go to the Products tab
- Tap on a simple/variable/external/grouped product --> the product type should be editable, feel free to test changing it to a different product type

## Example screenshots

custom type | core type
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-08-31 at 14 25 44](https://user-images.githubusercontent.com/1945542/91691546-64643080-eb9a-11ea-812a-e5a0fae212b2.png) | ![Simulator Screen Shot - iPhone 11 - 2020-08-31 at 14 25 34](https://user-images.githubusercontent.com/1945542/91691537-60d0a980-eb9a-11ea-9c06-fd127ee79fbf.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
