### PR TITLE
Edit Product: fixed the leading edge of title cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -144,7 +144,7 @@ private extension ProductFormTableViewDataSource {
             self?.onNameChange?(newName)
             },
                                                             style: .headline,
-                                                            edgeInsets: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))
+                                                            edgeInsets: UIEdgeInsets(top: 8, left: 11, bottom: 8, right: 11))
 
         cell.configure(with: cellViewModel)
     }


### PR DESCRIPTION
Fixes #2741 

After the migration of the title cell from the one that contains a text field to the text view, a wrong leading edge was introduced because the text view has a different internal gap.

## Testing
- Open a Product Detail, and make sure that the title is now aligned with the description.

## Screenshot
<img src="https://user-images.githubusercontent.com/495617/91707398-0aef0800-eb80-11ea-8e25-5496899904d4.png" width=300 />

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
