### PR TITLE
Order List: added "Guest" placeholder in order cell when there is no customer name

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -128,7 +128,7 @@ private extension OrderTableViewCell {
     /// For example, #560 Pamela Nguyen
     ///
     func title(for order: Order) -> String {
-        if let billingAddress = order.billingAddress {
+        if let billingAddress = order.billingAddress, billingAddress.firstName.isNotEmpty || billingAddress.lastName.isNotEmpty {
             return Localization.title(orderNumber: order.number,
                                       firstName: billingAddress.firstName,
                                       lastName: billingAddress.lastName)
@@ -173,11 +173,13 @@ private extension OrderTableViewCell {
         }
 
         static func title(orderNumber: String) -> String {
-            let format = NSLocalizedString("#%@", comment: "In Order List,"
+            let format = NSLocalizedString("#%@ %@", comment: "In Order List,"
                 + " the pattern to show the order number. For example, “#123456”."
                 + " The %@ placeholder is the order number.")
 
-            return String.localizedStringWithFormat(format, orderNumber)
+            let guestName: String = NSLocalizedString("Guest", comment: "In Order List, the name of the billed person when there are no name and last name.")
+
+            return String.localizedStringWithFormat(format, orderNumber, guestName)
         }
     }
 }


### PR DESCRIPTION
Fixes #2739 

## Description
On Order List, there's currently a blank label when there's no customer name. In this PR I added "Guest" instead, like did in Order Detail.

## Testing
1. Select the tab "Order"
2. All the orders without customer name and last name should show "Guest".

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![91700140-afb81800-eb75-11ea-9515-3540d8ae1719](https://user-images.githubusercontent.com/495617/91718145-1d267180-eb93-11ea-902b-1d1e6b962541.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-08-31 at 12 05 27](https://user-images.githubusercontent.com/495617/91718147-1e579e80-eb93-11ea-81ab-635e9b048a88.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
