### PR TITLE
Added feature flag for Products Milestone 4 

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -7,6 +7,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .editProductsRelease4:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .refunds:
             return true
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -14,6 +14,10 @@ enum FeatureFlag: Int {
     ///
     case editProductsRelease3
 
+    /// Edit products - release 4
+    ///
+    case editProductsRelease4
+
     /// Product Reviews
     ///
     case reviews


### PR DESCRIPTION
Closes #2706 

# Description
This tiny PR aims to start the development of [Product Milestone 4]
(https://github.com/woocommerce/woocommerce-ios/projects/15#card-44596018).

# Changes
- Adds `.editProductsRelease4` case
- Enable it when `BuildConfiguration.current == .localDeveloper` and `BuildConfiguration.current == .alpha`

## Testing
- Look at the code
- CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
