### PR TITLE
Infinite scroll update - part 1: scroll watcher

### DIFF
--- a/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
@@ -11,6 +11,7 @@ final class ScrollWatcher {
     private let triggerSubject: PublishSubject<Double> = PublishSubject<Double>()
     private let positionThreshold: Double
 
+    private var lastPosition: Double = 0.0
     private var offsetObservation: NSKeyValueObservation?
 
     /// - Parameter positionThreshold: the threshold of scroll position percentage (from 0.0 to 1.0) to trigger an event.
@@ -34,9 +35,10 @@ final class ScrollWatcher {
             // top of the table view and thus we deduct the table view's height.
             let contentHeight = tableView.contentSize.height - tableView.frame.height
             let scrollPosition = Double(1.0 * newContentOffsetY / contentHeight)
-            if scrollPosition >= self.positionThreshold {
+            if scrollPosition >= self.positionThreshold && scrollPosition > self.lastPosition {
                 self.triggerSubject.send(scrollPosition)
             }
+            self.lastPosition = scrollPosition
         }
     }
 }

--- a/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
@@ -5,18 +5,17 @@ import UIKit
 final class ScrollWatcher {
     /// Emits a stream of scroll position percentages from 0.0 (the beginning) to 1.0 (the end) if over a given threshold whenever the user scrolls a
     /// `UIScrollView` or subclass.
-    var scrollTrigger: Observable<Double> {
-        scrollTriggerSubject
+    var trigger: Observable<Double> {
+        triggerSubject
     }
-    private let scrollTriggerSubject: PublishSubject<Double>
-    private let scrollPositionThreshold: Double
+    private let triggerSubject: PublishSubject<Double> = PublishSubject<Double>()
+    private let positionThreshold: Double
 
     private var offsetObservation: NSKeyValueObservation?
 
-    /// - Parameter scrollPositionThreshold: the threshold of scroll position percentage (from 0.0 to 1.0) to trigger an event.
-    init(scrollPositionThreshold: Double = 0.7) {
-        self.scrollPositionThreshold = scrollPositionThreshold
-        self.scrollTriggerSubject = PublishSubject<Double>()
+    /// - Parameter positionThreshold: the threshold of scroll position percentage (from 0.0 to 1.0) to trigger an event.
+    init(positionThreshold: Double = 0.7) {
+        self.positionThreshold = positionThreshold
     }
 
     deinit {
@@ -31,12 +30,12 @@ final class ScrollWatcher {
             guard let newContentOffsetY = change.newValue?.y else {
                 return
             }
-            // When scrolling to the bottom of the list, the maximum content offset is at the top of the table view and thus we deduct the table view's
-            // height.
+            // When scrolling to the bottom of the list, the maximum content offset is at the
+            // top of the table view and thus we deduct the table view's height.
             let contentHeight = tableView.contentSize.height - tableView.frame.height
             let scrollPosition = Double(1.0 * newContentOffsetY / contentHeight)
-            if scrollPosition >= self.scrollPositionThreshold {
-                self.scrollTriggerSubject.send(scrollPosition)
+            if scrollPosition >= self.positionThreshold {
+                self.triggerSubject.send(scrollPosition)
             }
         }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		02913E9523A774C500707A0C /* UnitInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9423A774C500707A0C /* UnitInputFormatter.swift */; };
 		02913E9723A774E600707A0C /* DecimalInputFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02913E9623A774E600707A0C /* DecimalInputFormatter.swift */; };
 		0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295355A245ADF8100BDC42B /* FilterType+Products.swift */; };
+		029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EB24FE38C900D242F8 /* ScrollWatcher.swift */; };
+		029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */; };
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BFD4E24597D4B00FDDEEC /* UIButton+TitleAndImage.swift */; };
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
@@ -414,7 +416,7 @@
 		45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF35238D3C7500127F77 /* ExtendedAddProductImageCollectionViewCell.swift */; };
 		45FBDF3C238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FBDF3B238D4EA800127F77 /* ExtendedAddProductImageCollectionViewCellTests.swift */; };
 		570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */; };
-		57150E0F24F462C200E81611 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E0E24F462C200E81611 /* SwiftPackageProductDependency */; };
+		57150E0F24F462C200E81611 /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E0E24F462C200E81611 /* TestKit */; };
 		5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5718852B2465D9EC00E2486F /* ReviewsCoordinator.swift */; };
 		571B850224CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571B850124CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift */; };
 		571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */; };
@@ -1151,6 +1153,8 @@
 		02913E9423A774C500707A0C /* UnitInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitInputFormatter.swift; sourceTree = "<group>"; };
 		02913E9623A774E600707A0C /* DecimalInputFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalInputFormatter.swift; sourceTree = "<group>"; };
 		0295355A245ADF8100BDC42B /* FilterType+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterType+Products.swift"; sourceTree = "<group>"; };
+		029700EB24FE38C900D242F8 /* ScrollWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcher.swift; sourceTree = "<group>"; };
+		029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcherTests.swift; sourceTree = "<group>"; };
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029BFD4E24597D4B00FDDEEC /* UIButton+TitleAndImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+TitleAndImage.swift"; sourceTree = "<group>"; };
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
@@ -1896,7 +1900,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B873E8F8E103966D2182EE67 /* Pods_WooCommerceTests.framework in Frameworks */,
-				57150E0F24F462C200E81611 /* BuildFile in Frameworks */,
+				57150E0F24F462C200E81611 /* TestKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2432,6 +2436,22 @@
 				45F5A3C023DF206B007D40E5 /* ShippingInputFormatter.swift */,
 			);
 			path = UnitInputFormatter;
+			sourceTree = "<group>";
+		};
+		029700EA24FE389C00D242F8 /* InfiniteScroll */ = {
+			isa = PBXGroup;
+			children = (
+				029700EB24FE38C900D242F8 /* ScrollWatcher.swift */,
+			);
+			path = InfiniteScroll;
+			sourceTree = "<group>";
+		};
+		029700ED24FE38DE00D242F8 /* InfiniteScroll */ = {
+			isa = PBXGroup;
+			children = (
+				029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */,
+			);
+			path = InfiniteScroll;
 			sourceTree = "<group>";
 		};
 		029B0F58234197C90010C1F3 /* Order */ = {
@@ -3192,6 +3212,7 @@
 		B53A569521123D27000776C9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				029700ED24FE38DE00D242F8 /* InfiniteScroll */,
 				028AFFB42484ED7F00693C09 /* Logging */,
 				5798191124526FC7000817F8 /* Observables */,
 				D8A8C4F22268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift */,
@@ -3291,14 +3312,15 @@
 		B55D4C2220B716CE00D7A50F /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				575472792451F0A500A94C3C /* Observables */,
 				CECC759A23D61BCC00486676 /* AggregateData */,
-				02C0CD2823B5BAFB00F880B1 /* ImageService */,
 				CEEC9B6121E79EBF0055EEF0 /* AppRatings */,
 				CE9B7E3021C94685000F971C /* Currency */,
 				024A543222BA6DD500F4F38E /* Developer */,
+				02C0CD2823B5BAFB00F880B1 /* ImageService */,
+				029700EA24FE389C00D242F8 /* InfiniteScroll */,
 				B5A03699214C0E7000774E2C /* Logging */,
 				B58B4ABC2108F7F800076FDD /* Notices */,
+				575472792451F0A500A94C3C /* Observables */,
 				B541B2182189F387008FE7C1 /* StringFormatter */,
 				02913E9323A774B000707A0C /* UnitInputFormatter */,
 				CE14452C2188C0EC00A991D8 /* Zendesk */,
@@ -4506,7 +4528,7 @@
 			);
 			name = WooCommerceTests;
 			packageProductDependencies = (
-				57150E0E24F462C200E81611 /* SwiftPackageProductDependency */,
+				57150E0E24F462C200E81611 /* TestKit */,
 			);
 			productName = WooCommerceTests;
 			productReference = B56DB3DD2049BFAA00D4AA8E /* WooCommerceTests.xctest */;
@@ -5005,6 +5027,7 @@
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,
+				029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */,
 				D8C11A4E22DD235F00D4A88D /* OrderDetailsResultsControllers.swift in Sources */,
 				D8C251D9230D256F00F49782 /* NoticePresenter.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,
@@ -5573,6 +5596,7 @@
 				57F2C6CD246DECC10074063B /* SummaryTableViewCellViewModelTests.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,
 				578187B22481D9290063B46B /* XCTestCase+Assertions.swift in Sources */,
+				029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */,
 				0225C42A24768CE900C5B4F0 /* FilterProductListViewModelProductListFilterTests.swift in Sources */,
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
@@ -6357,7 +6381,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		57150E0E24F462C200E81611 /* SwiftPackageProductDependency */ = {
+		57150E0E24F462C200E81611 /* TestKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestKit;
 		};

--- a/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
@@ -59,7 +59,7 @@ final class ScrollWatcherTests: XCTestCase {
         tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 1000), size: frame.size), animated: false)
         // Scrolls to 99%
         tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 990), size: frame.size), animated: false)
-        // Scrolls to 99%
+        // Scrolls to 80%
         tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 800), size: frame.size), animated: false)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import WooCommerce
+
+final class ScrollWatcherTests: XCTestCase {
+    private var cancellable: ObservationToken?
+
+    func test_scroll_trigger_is_emitted_only_after_scrolling_to_above_threshold() {
+        // Arrange
+        let frame = CGRect(origin: .zero, size: CGSize(width: 320, height: 100))
+        let tableView = UITableView(frame: frame, style: .grouped)
+        let contentSize = CGSize(width: 320, height: 1100)
+        tableView.contentSize = contentSize
+        let threshold = 0.8
+        let scrollWatcher = ScrollWatcher(scrollPositionThreshold: threshold)
+        scrollWatcher.startObservingScrollPosition(tableView: tableView)
+        var triggeredScrollPositions = [Double]()
+        cancellable = scrollWatcher.scrollTrigger.subscribe { scrollPosition in
+            triggeredScrollPositions.append(scrollPosition)
+        }
+
+        // Action
+        // Scrolls to 50%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 500), size: frame.size), animated: false)
+        // Scrolls to 70%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 700), size: frame.size), animated: false)
+        // Scrolls to 80%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 800), size: frame.size), animated: false)
+        // Scrolls to 100%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 1000), size: frame.size), animated: false)
+
+        // Assert
+        XCTAssertEqual(triggeredScrollPositions, [0.8, 1.0])
+    }
+}

--- a/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
@@ -37,4 +37,32 @@ final class ScrollWatcherTests: XCTestCase {
         // Assert
         XCTAssertEqual(triggeredScrollPositions, [0.8, 1.0])
     }
+
+    func test_scroll_trigger_is_not_emitted_after_scrolling_upward() {
+        // Arrange
+        let frame = CGRect(origin: .zero, size: CGSize(width: 320, height: 100))
+        let tableView = UITableView(frame: frame, style: .grouped)
+        let contentSize = CGSize(width: 320, height: 1100)
+        tableView.contentSize = contentSize
+        let threshold = 0.8
+        let scrollWatcher = ScrollWatcher(positionThreshold: threshold)
+        scrollWatcher.startObservingScrollPosition(tableView: tableView)
+        var triggeredScrollPositions = [Double]()
+        cancellable = scrollWatcher.trigger.subscribe { scrollPosition in
+            triggeredScrollPositions.append(scrollPosition)
+        }
+
+        // Action
+        // Scrolls to 80%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 800), size: frame.size), animated: false)
+        // Scrolls to 100%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 1000), size: frame.size), animated: false)
+        // Scrolls to 99%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 990), size: frame.size), animated: false)
+        // Scrolls to 99%
+        tableView.scrollRectToVisible(CGRect(origin: CGPoint(x: 0, y: 800), size: frame.size), animated: false)
+
+        // Assert
+        XCTAssertEqual(triggeredScrollPositions, [0.8, 1.0])
+    }
 }

--- a/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/InfiniteScroll/ScrollWatcherTests.swift
@@ -4,6 +4,12 @@ import XCTest
 final class ScrollWatcherTests: XCTestCase {
     private var cancellable: ObservationToken?
 
+    override func tearDown() {
+        cancellable?.cancel()
+
+        super.tearDown()
+    }
+
     func test_scroll_trigger_is_emitted_only_after_scrolling_to_above_threshold() {
         // Arrange
         let frame = CGRect(origin: .zero, size: CGSize(width: 320, height: 100))
@@ -11,10 +17,10 @@ final class ScrollWatcherTests: XCTestCase {
         let contentSize = CGSize(width: 320, height: 1100)
         tableView.contentSize = contentSize
         let threshold = 0.8
-        let scrollWatcher = ScrollWatcher(scrollPositionThreshold: threshold)
+        let scrollWatcher = ScrollWatcher(positionThreshold: threshold)
         scrollWatcher.startObservingScrollPosition(tableView: tableView)
         var triggeredScrollPositions = [Double]()
-        cancellable = scrollWatcher.scrollTrigger.subscribe { scrollPosition in
+        cancellable = scrollWatcher.trigger.subscribe { scrollPosition in
             triggeredScrollPositions.append(scrollPosition)
         }
 


### PR DESCRIPTION
Part of #2738 
More details about the context: p91TBi-30X-p2

- [x] ⚠️ Make sure PR base is `develop` after https://github.com/woocommerce/woocommerce-ios/pull/2746 is merged ⚠️ 

The [full diffs](https://github.com/woocommerce/woocommerce-ios/compare/issue/2738-replace-SyncingCoordinator-in-paginated-list-selector?expand=1) are too big (~1000 diffs), so I'm breaking up the changes into a few parts for easier review.

## Changes

- Created `ScrollWatcher` that observes scroll view's content offset and emits scroll positions above the given threshold
  - In a future PR, the scroll watcher's `scrollTrigger: Observable<Double>` will be used to ensure the next page of results has been synced

## Testing

Just CI, since the new class isn't used yet 🙂 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
