### PR TITLE
Infinite scroll update - part 2: send `hasNextPage` on sync completion

### DIFF
--- a/Networking/Networking/Remote/ProductShippingClassRemote.swift
+++ b/Networking/Networking/Remote/ProductShippingClassRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// ProductShippingClass: Remote Endpoints
 ///
@@ -19,7 +18,7 @@ public class ProductShippingClassRemote: Remote {
                         context: String? = nil,
                         pageNumber: Int = Default.pageNumber,
                         pageSize: Int = Default.pageSize,
-                        completion: @escaping ([ProductShippingClass]?, Error?) -> Void) {
+                        completion: @escaping (Result<[ProductShippingClass], Error>) -> Void) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),

--- a/Networking/NetworkingTests/Remote/ProductShippingClassRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductShippingClassRemoteTests.swift
@@ -29,14 +29,16 @@ final class ProductShippingClassRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "products/shipping_classes", filename: "product-shipping-classes-load-all")
 
-        remote.loadAll(for: sampleSiteID) { productShippingClasses, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(productShippingClasses)
-            XCTAssertEqual(productShippingClasses?.count, 3)
+        remote.loadAll(for: sampleSiteID) { result in
+            guard case let .success(productShippingClasses) = result else {
+                XCTFail("Unexpected result: \(result)")
+                return
+            }
+            XCTAssertEqual(productShippingClasses.count, 3)
 
             // Validates on Shipping Class of ID 94.
             let expectedShippingClassID: Int64 = 94
-            guard let expectedShippingClass = productShippingClasses?.first(where: { $0.shippingClassID == expectedShippingClassID }) else {
+            guard let expectedShippingClass = productShippingClasses.first(where: { $0.shippingClassID == expectedShippingClassID }) else {
                 XCTFail("Product shipping class with ID \(expectedShippingClassID) should exist")
                 return
             }
@@ -57,9 +59,8 @@ final class ProductShippingClassRemoteTests: XCTestCase {
         let remote = ProductShippingClassRemote(network: network)
         let expectation = self.expectation(description: "Load All Product Shipping Classes returns error")
 
-        remote.loadAll(for: sampleSiteID) { (productShippingClasses, error) in
-            XCTAssertNil(productShippingClasses)
-            XCTAssertNotNil(error)
+        remote.loadAll(for: sampleSiteID) { result in
+            XCTAssertTrue(result.isFailure)
             expectation.fulfill()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Grouped Products/ProductListMultiSelectorDataSource.swift
@@ -67,13 +67,14 @@ final class ProductListMultiSelectorDataSource: PaginatedListSelectorDataSource 
                                  productType: nil,
                                  sortOrder: .nameAscending,
                                  excludedProductIDs: excludedProductIDs,
-                                 shouldDeleteStoredProductsOnFirstPage: false) { error in
-                                    if let error = error {
+                                 shouldDeleteStoredProductsOnFirstPage: false) { result in
+                                    switch result {
+                                    case .failure(let error):
                                         DDLogError("⛔️ Error synchronizing products on product list selector: \(error)")
                                         onCompletion?(false)
-                                        return
+                                    case .success:
+                                        onCompletion?(true)
                                     }
-                                    onCompletion?(true)
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/PaginatedProductShippingClassListSelectorDataSource.swift
@@ -44,11 +44,14 @@ struct PaginatedProductShippingClassListSelectorDataSource: PaginatedListSelecto
 
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
         let action = ProductShippingClassAction
-            .synchronizeProductShippingClassModels(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { error in
-                if let error = error {
+            .synchronizeProductShippingClassModels(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { result in
+                switch result {
+                case .failure(let error):
                     DDLogError("⛔️ Error synchronizing product shipping classes: \(error)")
+                    onCompletion?(false)
+                case .success:
+                    onCompletion?(true)
                 }
-                onCompletion?(error == nil)
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -680,21 +680,22 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                  stockStatus: filters.stockStatus,
                                  productStatus: filters.productStatus,
                                  productType: filters.productType,
-                                 sortOrder: sortOrder) { [weak self] error in
+                                 sortOrder: sortOrder) { [weak self] result in
                                     guard let self = self else {
                                         return
                                     }
 
-                                    if let error = error {
+                                    switch result {
+                                    case .failure(let error):
                                         ServiceLocator.analytics.track(.productListLoadError, withError: error)
                                         DDLogError("⛔️ Error synchronizing products: \(error)")
                                         self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize)
-                                    } else {
+                                    case .success:
                                         ServiceLocator.analytics.track(.productListLoaded)
                                     }
 
                                     self.transitionToResultsUpdatedState()
-                                    onCompletion?(error == nil)
+                                    onCompletion?(result.isSuccess)
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -186,7 +186,7 @@ final class MockReviewsStoresManager: DefaultStoresManager {
         switch action {
         case .retrieveProducts(_, _, _, _, onCompletion: let onCompletion):
             retrieveProductsIsHit = true
-            onCompletion(.success([]))
+            onCompletion(.success((products: [], hasNextPage: false)))
         default:
             return
         }

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -12,6 +12,8 @@ public enum ProductAction: Action {
 
     /// Synchronizes the Products matching the specified criteria.
     ///
+    /// - Parameter onCompletion: called when sync completes, returns an error or a boolean that indicates whether there might be more products to sync.
+    ///
     case synchronizeProducts(siteID: Int64,
         pageNumber: Int,
         pageSize: Int,
@@ -21,7 +23,7 @@ public enum ProductAction: Action {
         sortOrder: ProductsSortOrder,
         excludedProductIDs: [Int64] = [],
         shouldDeleteStoredProductsOnFirstPage: Bool = true,
-        onCompletion: (Error?) -> Void)
+        onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Retrieves the specified Product.
     ///
@@ -29,11 +31,14 @@ public enum ProductAction: Action {
 
     /// Retrieves a specified list of Products.
     ///
+    /// - Parameter onCompletion: called when retrieval for a page completes, returns an error or a tuple of a list of products and a boolean that
+    ///                           indicates whether there might be more products to fetch.
+    ///
     case retrieveProducts(siteID: Int64,
         productIDs: [Int64],
         pageNumber: Int = ProductsRemote.Default.pageNumber,
         pageSize: Int = ProductsRemote.Default.pageSize,
-        onCompletion: (Result<[Product], Error>) -> Void)
+        onCompletion: (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void)
 
     /// Deletes all of the cached products.
     ///

--- a/Yosemite/Yosemite/Actions/ProductShippingClassAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductShippingClassAction.swift
@@ -7,7 +7,9 @@ public enum ProductShippingClassAction: Action {
 
     /// Synchronizes the ProductShippingClass's matching the specified criteria.
     ///
-    case synchronizeProductShippingClassModels(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
+    /// - Parameter onCompletion: called when sync completes, returns an error or a boolean that indicates whether there might be more shipping classes to sync.
+    ///
+    case synchronizeProductShippingClassModels(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Retrieves the specified ProductShippingClass.
     ///

--- a/Yosemite/Yosemite/Stores/ProductShippingClassStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductShippingClassStore.swift
@@ -40,22 +40,23 @@ private extension ProductShippingClassStore {
 
     /// Synchronizes the `ProductShippingClass`s associated with a given Site ID (if any!).
     ///
-    func synchronizeProductShippingClassModels(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
+    func synchronizeProductShippingClassModels(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         let remote = ProductShippingClassRemote(network: network)
 
-        remote.loadAll(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (models, error) in
-            guard let models = models else {
-                onCompletion(error)
-                return
-            }
+        remote.loadAll(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let models):
+                if pageNumber == Default.firstPageNumber {
+                    self?.deleteStoredProductShippingClassModels(siteID: siteID)
+                }
 
-            if pageNumber == Default.firstPageNumber {
-                self?.deleteStoredProductShippingClassModels(siteID: siteID)
-            }
-
-            self?.upsertStoredProductShippingClassModelsInBackground(readOnlyProductShippingClassModels: models,
-                                                                     siteID: siteID) {
-                                                                        onCompletion(nil)
+                self?.upsertStoredProductShippingClassModelsInBackground(readOnlyProductShippingClassModels: models,
+                                                                         siteID: siteID) {
+                                                                            let hasNextPage = models.count == pageSize
+                                                                            onCompletion(.success(hasNextPage))
+                }
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/ProductShippingClassStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductShippingClassStore.swift
@@ -48,12 +48,16 @@ private extension ProductShippingClassStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let models):
-                if pageNumber == Default.firstPageNumber {
-                    self?.deleteStoredProductShippingClassModels(siteID: siteID)
+                guard let self = self else {
+                    return
                 }
 
-                self?.upsertStoredProductShippingClassModelsInBackground(readOnlyProductShippingClassModels: models,
-                                                                         siteID: siteID) {
+                if pageNumber == Default.firstPageNumber {
+                    self.deleteStoredProductShippingClassModels(siteID: siteID)
+                }
+
+                self.upsertStoredProductShippingClassModelsInBackground(readOnlyProductShippingClassModels: models,
+                                                                        siteID: siteID) {
                                                                             let hasNextPage = models.count == pageSize
                                                                             onCompletion(.success(hasNextPage))
                 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -145,11 +145,15 @@ private extension ProductStore {
                                 case .failure(let error):
                                     onCompletion(.failure(error))
                                 case .success(let products):
-                                    if pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage {
-                                        self?.deleteStoredProducts(siteID: siteID)
+                                    guard let self = self else {
+                                        return
                                     }
 
-                                    self?.upsertStoredProductsInBackground(readOnlyProducts: products) {
+                                    if pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage {
+                                        self.deleteStoredProducts(siteID: siteID)
+                                    }
+
+                                    self.upsertStoredProductsInBackground(readOnlyProducts: products) {
                                         let hasNextPage = products.count == pageSize
                                         onCompletion(.success(hasNextPage))
                                     }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -129,7 +129,7 @@ private extension ProductStore {
                              sortOrder: ProductsSortOrder,
                              excludedProductIDs: [Int64],
                              shouldDeleteStoredProductsOnFirstPage: Bool,
-                             onCompletion: @escaping (Error?) -> Void) {
+                             onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         let remote = ProductsRemote(network: network)
 
         remote.loadAllProducts(for: siteID,
@@ -143,14 +143,15 @@ private extension ProductStore {
                                excludedProductIDs: excludedProductIDs) { [weak self] result in
                                 switch result {
                                 case .failure(let error):
-                                    onCompletion(error)
+                                    onCompletion(.failure(error))
                                 case .success(let products):
                                     if pageNumber == Default.firstPageNumber && shouldDeleteStoredProductsOnFirstPage {
                                         self?.deleteStoredProducts(siteID: siteID)
                                     }
 
                                     self?.upsertStoredProductsInBackground(readOnlyProducts: products) {
-                                        onCompletion(nil)
+                                        let hasNextPage = products.count == pageSize
+                                        onCompletion(.success(hasNextPage))
                                     }
                                 }
         }
@@ -191,9 +192,9 @@ private extension ProductStore {
                           productIDs: [Int64],
                           pageNumber: Int,
                           pageSize: Int,
-                          onCompletion: @escaping (Result<[Product], Error>) -> Void) {
+                          onCompletion: @escaping (Result<(products: [Product], hasNextPage: Bool), Error>) -> Void) {
         guard productIDs.isEmpty == false else {
-            onCompletion(.success([]))
+            onCompletion(.success((products: [], hasNextPage: false)))
             return
         }
 
@@ -201,10 +202,11 @@ private extension ProductStore {
             switch result {
             case .success(let products):
                 self?.upsertStoredProductsInBackground(readOnlyProducts: products, onCompletion: {
-                    onCompletion(result)
+                    let hasNextPage = products.count == pageSize
+                    onCompletion(.success((products: products, hasNextPage: hasNextPage)))
                 })
-            case .failure:
-                onCompletion(result)
+            case .failure(let error):
+                onCompletion(.failure(error))
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
@@ -60,9 +60,9 @@ final class ProductShippingClassStoreTests: XCTestCase {
         let action = ProductShippingClassAction
             .synchronizeProductShippingClassModels(siteID: sampleSiteID,
                                                    pageNumber: defaultPageNumber,
-                                                   pageSize: defaultPageSize) { error in
+                                                   pageSize: defaultPageSize) { result in
                                                     XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 3)
-                                                    XCTAssertNil(error)
+                                                    XCTAssertTrue(result.isSuccess)
 
                                                     let sampleRemoteID: Int64 = 94
                                                     let storedProductShippingClass = self.viewStorage
@@ -93,8 +93,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
         let action = ProductShippingClassAction
             .synchronizeProductShippingClassModels(siteID: sampleSiteID,
                                                    pageNumber: defaultPageNumber,
-                                                   pageSize: defaultPageSize) { error in
-                                                    XCTAssertNil(error)
+                                                   pageSize: defaultPageSize) { result in
+                                                    XCTAssertTrue(result.isSuccess)
 
                                                     let storedProductShippingClasses = self.viewStorage.loadProductShippingClasses(siteID: self.sampleSiteID)
                                                     XCTAssertEqual(storedProductShippingClasses?.count, 3)
@@ -109,8 +109,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
                                                     let action = ProductShippingClassAction
                                                         .synchronizeProductShippingClassModels(siteID: self.sampleSiteID,
                                                                                                pageNumber: self.defaultPageNumber,
-                                                                                               pageSize: self.defaultPageSize) { error in
-                                                                                                XCTAssertNil(error)
+                                                                                               pageSize: self.defaultPageSize) { result in
+                                                                                                XCTAssertTrue(result.isSuccess)
 
                                                                                                 let storedProductShippingClasses = self.viewStorage
                                                                                                     .loadProductShippingClasses(siteID: self.sampleSiteID)
@@ -134,6 +134,58 @@ final class ProductShippingClassStoreTests: XCTestCase {
         wait(for: [expectation], timeout: Constants.expectationTimeout)
     }
 
+    func test_synchronizing_product_shipping_classes_of_the_same_page_size_has_next_page() {
+        // Arrange
+        let store = ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products/shipping_classes", filename: "product-shipping-classes-load-all")
+
+        // Action
+        // The `pageSize` must match the response size in `product-shipping-classes-load-all.json`.
+        let pageSize = 3
+        var result: Result<Bool, Error>?
+        waitForExpectation { expectation in
+            let action = ProductShippingClassAction
+                .synchronizeProductShippingClassModels(siteID: sampleSiteID, pageNumber: defaultPageNumber, pageSize: pageSize) { aResult in
+                    result = aResult
+                    expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Assert
+        guard case let .success(hasNextPage) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertTrue(hasNextPage)
+    }
+
+    func test_synchronizing_product_shipping_classes_of_smaller_size_than_page_size_has_no_next_page() {
+        // Arrange
+        let store = ProductShippingClassStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products/shipping_classes", filename: "product-shipping-classes-load-all")
+
+        // Action
+        // The `pageSize` must be larger than the response size in `product-shipping-classes-load-all.json`.
+        let pageSize = 25
+        var result: Result<Bool, Error>?
+        waitForExpectation { expectation in
+            let action = ProductShippingClassAction
+                .synchronizeProductShippingClassModels(siteID: sampleSiteID, pageNumber: defaultPageNumber, pageSize: pageSize) { aResult in
+                    result = aResult
+                    expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Assert
+        guard case let .success(hasNextPage) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertFalse(hasNextPage)
+    }
+
     /// Verifies that `ProductShippingClassAction.synchronizeProductShippingClasss` returns an error whenever there is an error response from the backend.
     ///
     func testRetrieveProductShippingClasssReturnsErrorUponReponseError() {
@@ -144,8 +196,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         let action = ProductShippingClassAction.synchronizeProductShippingClassModels(siteID: sampleSiteID,
                                                                                       pageNumber: defaultPageNumber,
-                                                                                      pageSize: defaultPageSize) { error in
-                                                                                        XCTAssertNotNil(error)
+                                                                                      pageSize: defaultPageSize) { result in
+                                                                                        XCTAssertTrue(result.isFailure)
 
                                                                                         expectation.fulfill()
         }
@@ -162,8 +214,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         let action = ProductShippingClassAction.synchronizeProductShippingClassModels(siteID: sampleSiteID,
                                                                                       pageNumber: defaultPageNumber,
-                                                                                      pageSize: defaultPageSize) { error in
-                                                                                        XCTAssertNotNil(error)
+                                                                                      pageSize: defaultPageSize) { result in
+                                                                                        XCTAssertTrue(result.isFailure)
 
                                                                                         expectation.fulfill()
         }
@@ -192,8 +244,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         let action = ProductShippingClassAction.synchronizeProductShippingClassModels(siteID: siteID1,
                                                                                       pageNumber: Store.Default.firstPageNumber,
-                                                                                      pageSize: defaultPageSize) { error in
-            XCTAssertNil(error)
+                                                                                      pageSize: defaultPageSize) { result in
+            XCTAssertTrue(result.isSuccess)
 
             // The previously upserted ProductVariation for siteID1 should be deleted.
             let storedModelForSite1 = self.viewStorage.loadProductShippingClass(siteID: siteID1, remoteID: shippingClassID)
@@ -229,8 +281,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         let action = ProductShippingClassAction.synchronizeProductShippingClassModels(siteID: siteID,
                                                                                       pageNumber: 6,
-                                                                                      pageSize: defaultPageSize) { error in
-            XCTAssertNil(error)
+                                                                                      pageSize: defaultPageSize) { result in
+            XCTAssertTrue(result.isSuccess)
 
             // The previously upserted model should stay in storage.
             let storedModel = self.viewStorage.loadProductShippingClass(siteID: siteID, remoteID: shippingClassID)
@@ -265,8 +317,8 @@ final class ProductShippingClassStoreTests: XCTestCase {
 
         let action = ProductShippingClassAction.synchronizeProductShippingClassModels(siteID: siteID,
                                                                                       pageNumber: 6,
-                                                                                      pageSize: defaultPageSize) { error in
-                                                                            XCTAssertNotNil(error)
+                                                                                      pageSize: defaultPageSize) { result in
+                                                                            XCTAssertTrue(result.isFailure)
 
             // The previously upserted model should stay in storage.
             let storedModel = self.viewStorage.loadProductShippingClass(siteID: siteID, remoteID: shippingClassID)

--- a/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
@@ -153,11 +153,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         }
 
         // Assert
-        guard case let .success(hasNextPage) = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
-        XCTAssertTrue(hasNextPage)
+        XCTAssertTrue(try XCTUnwrap(result).get())
     }
 
     func test_synchronizing_product_shipping_classes_of_smaller_size_than_page_size_has_no_next_page() {
@@ -179,11 +175,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         }
 
         // Assert
-        guard case let .success(hasNextPage) = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
-        XCTAssertFalse(hasNextPage)
+        XCTAssertFalse(try XCTUnwrap(result).get())
     }
 
     /// Verifies that `ProductShippingClassAction.synchronizeProductShippingClasss` returns an error whenever there is an error response from the backend.

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -291,11 +291,7 @@ final class ProductStoreTests: XCTestCase {
         }
 
         // Assert
-        guard case let .success(hasNextPage) = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
-        XCTAssertTrue(hasNextPage)
+        XCTAssertTrue(try XCTUnwrap(result).get())
     }
 
     func test_synchronizing_products_of_smaller_size_than_page_size_has_no_next_page() {
@@ -320,11 +316,7 @@ final class ProductStoreTests: XCTestCase {
         }
 
         // Assert
-        guard case let .success(hasNextPage) = result else {
-            XCTFail("Unexpected result: \(String(describing: result))")
-            return
-        }
-        XCTAssertFalse(hasNextPage)
+        XCTAssertFalse(try XCTUnwrap(result).get())
     }
 
     /// Verifies that ProductAction.synchronizeProducts returns an error whenever there is an error response from the backend.

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -78,11 +78,10 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 10)
-            XCTAssertNil(error)
-
-            expectation.fulfill()
+                                                       sortOrder: .nameAscending) { result in
+                                                        XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Product.self), 10)
+                                                        XCTAssertTrue(result.isSuccess)
+                                                        expectation.fulfill()
         }
 
         productStore.onAction(action)
@@ -106,8 +105,8 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertNil(error)
+                                                       sortOrder: .nameAscending) { result in
+            XCTAssertTrue(result.isSuccess)
 
             let storedProduct = self.viewStorage.loadProduct(siteID: self.sampleSiteID, productID: self.sampleProductID)
             let readOnlyStoredProduct = storedProduct?.toReadOnly()
@@ -173,8 +172,8 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertNil(error)
+                                                       sortOrder: .nameAscending) { result in
+            XCTAssertTrue(result.isSuccess)
 
             // The previously upserted Product for siteID1 should be deleted.
             let storedProductForSite1 = self.viewStorage.loadProduct(siteID: siteID1, productID: productID)
@@ -215,8 +214,8 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertNil(error)
+                                                       sortOrder: .nameAscending) { result in
+            XCTAssertTrue(result.isSuccess)
 
             // The previously upserted Product's should stay in storage.
             let storedProductForSite1 = self.viewStorage.loadProduct(siteID: siteID, productID: productID)
@@ -254,8 +253,8 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertNotNil(error)
+                                                       sortOrder: .nameAscending) { result in
+            XCTAssertTrue(result.isFailure)
 
             // The previously upserted Product's should stay in storage.
             let storedProductForSite1 = self.viewStorage.loadProduct(siteID: siteID, productID: productID)
@@ -268,6 +267,64 @@ final class ProductStoreTests: XCTestCase {
 
         productStore.onAction(action)
         wait(for: [expectation], timeout: Constants.expectationTimeout)
+    }
+
+    func test_synchronizing_products_of_the_same_page_size_has_next_page() {
+        // Arrange
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+
+        // Action
+        var result: Result<Bool, Error>?
+        waitForExpectation { expectation in
+            let action = ProductAction.synchronizeProducts(siteID: sampleSiteID,
+                                                           pageNumber: 1,
+                                                           pageSize: 10, // This matches the response size in `products-load-all.json`
+                                                           stockStatus: nil,
+                                                           productStatus: nil,
+                                                           productType: nil,
+                                                           sortOrder: .nameAscending) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Assert
+        guard case let .success(hasNextPage) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertTrue(hasNextPage)
+    }
+
+    func test_synchronizing_products_of_smaller_size_than_page_size_has_no_next_page() {
+        // Arrange
+        let store = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all")
+
+        // Action
+        var result: Result<Bool, Error>?
+        waitForExpectation { expectation in
+            let action = ProductAction.synchronizeProducts(siteID: sampleSiteID,
+                                                           pageNumber: 1,
+                                                           pageSize: 20, // This must be larger than the response size in `products-load-all.json`
+                                                           stockStatus: nil,
+                                                           productStatus: nil,
+                                                           productType: nil,
+                                                           sortOrder: .nameAscending) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            store.onAction(action)
+        }
+
+        // Assert
+        guard case let .success(hasNextPage) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertFalse(hasNextPage)
     }
 
     /// Verifies that ProductAction.synchronizeProducts returns an error whenever there is an error response from the backend.
@@ -283,8 +340,8 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertNotNil(error)
+                                                       sortOrder: .nameAscending) { result in
+            XCTAssertTrue(result.isFailure)
             expectation.fulfill()
         }
 
@@ -304,8 +361,8 @@ final class ProductStoreTests: XCTestCase {
                                                        stockStatus: nil,
                                                        productStatus: nil,
                                                        productType: nil,
-                                                       sortOrder: .nameAscending) { error in
-            XCTAssertNotNil(error)
+                                                       sortOrder: .nameAscending) { result in
+            XCTAssertTrue(result.isFailure)
             expectation.fulfill()
         }
 
@@ -1062,8 +1119,9 @@ final class ProductStoreTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.localizedDescription)
-            case .success(let products):
+            case .success((let products, let hasNextPage)):
                 retrievedProducts = products
+                XCTAssertFalse(hasNextPage)
             }
             expectation.fulfill()
         }
@@ -1073,6 +1131,58 @@ final class ProductStoreTests: XCTestCase {
         // Assert
         XCTAssertEqual(retrievedProducts, [expectedProduct])
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Product.self), 1)
+    }
+
+    func test_retrieving_products_of_the_same_page_size_has_next_page() {
+        // Arrange
+        let remote = MockProductsRemote()
+        let expectedProducts: [Yosemite.Product] = .init(repeating: MockProduct().product(), count: 25)
+        remote.whenLoadingProducts(siteID: sampleSiteID, productIDs: [sampleProductID], thenReturn: .success(expectedProducts))
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // Action
+        var result: Result<(products: [Yosemite.Product], hasNextPage: Bool), Error>?
+        waitForExpectation { expectation in
+            let action = ProductAction.retrieveProducts(siteID: sampleSiteID, productIDs: [sampleProductID], pageNumber: 1, pageSize: 25) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            productStore.onAction(action)
+        }
+
+        // Assert
+        guard case let .success((products: products, hasNextPage: hasNextPage)) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertEqual(products, expectedProducts)
+        XCTAssertTrue(hasNextPage)
+    }
+
+    func test_retrieving_products_of_smaller_size_than_page_size_has_no_next_page() {
+        // Arrange
+        let remote = MockProductsRemote()
+        let expectedProducts: [Yosemite.Product] = .init(repeating: MockProduct().product(), count: 24)
+        remote.whenLoadingProducts(siteID: sampleSiteID, productIDs: [sampleProductID], thenReturn: .success(expectedProducts))
+        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // Action
+        var result: Result<(products: [Yosemite.Product], hasNextPage: Bool), Error>?
+        waitForExpectation { expectation in
+            let action = ProductAction.retrieveProducts(siteID: sampleSiteID, productIDs: [sampleProductID], pageNumber: 1, pageSize: 25) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            productStore.onAction(action)
+        }
+
+        // Assert
+        guard case let .success((products: products, hasNextPage: hasNextPage)) = result else {
+            XCTFail("Unexpected result: \(String(describing: result))")
+            return
+        }
+        XCTAssertEqual(products, expectedProducts)
+        XCTAssertFalse(hasNextPage)
     }
 
     /// Verifies that ProductAction.retrieveProducts with a page number and size makes a network request that includes these params.
@@ -1119,8 +1229,9 @@ final class ProductStoreTests: XCTestCase {
             switch result {
             case .failure(let error):
                 XCTFail(error.localizedDescription)
-            case .success(let products):
+            case .success((let products, let hasNextPage)):
                 retrievedProducts = products
+                XCTAssertFalse(hasNextPage)
             }
             expectation.fulfill()
         }


### PR DESCRIPTION
Part of #2738
More details about the context: p91TBi-30X#comment-1291-p2

- [x] ⚠️ Make sure PR base is `develop` after https://github.com/woocommerce/woocommerce-ios/pull/2746 is merged ⚠️ 

The [full diffs](https://github.com/woocommerce/woocommerce-ios/compare/issue/2738-replace-SyncingCoordinator-in-paginated-list-selector?expand=1) are too big (~1000 diffs), so I'm breaking up the changes into a few parts for easier review.

## Changes

The goal of this PR is to enable the infinite support based on the updated architecture in p91TBi-30X#comment-1291-p2. Currently, the infinite scroll only works if the API response size matches the table view size for each page. To move away from this assumption, we need another way to know whether there are more pages to fetch from the API. This PR provides `hasNextPage: Bool` in Yosemite layer based on whether the API response is full - if the API response size is smaller than the requested page size, we can assume that is no next page. Note that `hasNextPage` isn't used in the app layer yet, and you can see how it's used in the [branch](https://github.com/woocommerce/woocommerce-ios/compare/issue/2738-replace-SyncingCoordinator-in-paginated-list-selector?expand=1).

- Networking layer:
  - Updated `ProductShippingClassRemote` to return `Result<[ProductShippingClass], Error>` instead of `([ProductShippingClass]?, Error?)` in the completion block, and its unit tests
- Yosemite layer:
  - Updated completion callback to include `hasNextPage` info in `ProductShippingClassAction.synchronizeProductShippingClassModels` with unit tests
  - Updated completion callback to include `hasNextPage` info in `ProductAction.synchronizeProducts` and `ProductAction.retrieveProducts` with unit tests
- App layer:
  - Updated affected action usage in `ProductListMultiSelectorDataSource`, `PaginatedProductShippingClassListSelectorDataSource`, and `ProductsViewController` while keeping the existing behavior

## Testing

Please sanity check on the affected screens, no user-facing changes are expected:

### Product shipping classes

- Go to the Products tab
- Tap on a simple physical product
- Tap on the shipping row or from the bottom sheet, and then the shipping class row --> the paginated list should load as before, with the correct selection

### Grouped products

- Make sure the products feature switch is on under Settings > Experimental Features
- Go to the Products tab
- Tap on a grouped product
- Tap on the grouped products row --> the paginated list should load as before
- Tap "Add Products" CTA --> the paginated list of products should load as before

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
