### PR TITLE
Add product - part 1: add CTA to the products tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -227,6 +227,10 @@ private extension ProductsViewController {
     @objc func scanProducts() {
         // TODO-2407: scan barcodes for products
     }
+
+    @objc func addProduct() {
+        // TODO-2740: add product flow
+    }
 }
 
 // MARK: - View Configuration
@@ -257,8 +261,22 @@ private extension ProductsViewController {
             return button
         }()
 
+        var rightBarButtonItems = [UIBarButtonItem]()
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease4) {
+            let buttonItem: UIBarButtonItem = {
+                let button = UIBarButtonItem(image: .plusImage,
+                                             style: .plain,
+                                             target: self,
+                                             action: #selector(addProduct))
+                button.accessibilityTraits = .button
+                button.accessibilityLabel = NSLocalizedString("Add a product", comment: "The action to add a product")
+                return button
+            }()
+            rightBarButtonItems.append(buttonItem)
+        }
+
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.barcodeScanner) {
-            navigationItem.rightBarButtonItem = {
+            let buttonItem: UIBarButtonItem = {
                 let button = UIBarButtonItem(image: .scanImage,
                                              style: .plain,
                                              target: self,
@@ -272,7 +290,10 @@ private extension ProductsViewController {
 
                 return button
             }()
+            rightBarButtonItems.append(buttonItem)
         }
+
+        navigationItem.rightBarButtonItems = rightBarButtonItems
     }
 
     /// Apply Woo styles.


### PR DESCRIPTION
Part 1 of #2740

## Changes

- In `ProductsViewController`, added CTA for creating a product to the products tab. the position is before the barcode scanner. no tap action for now!

## Testing

### M4 feature flag is enabled

- Go to the Products tab --> there should be a "+" CTA in the navigation bar on the right side, and tapping on it is no-op

### M4 feature flag is disabled

- You can disable the feature flag in `DefaultFeatureFlagService` by returning `false` for `editProductsRelease4`
- Go to the Products tab --> there should be no "+" CTA in the navigation bar on the right side

## Example screenshots

M4 flag on | M4 flag off
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-09-01 at 17 23 29](https://user-images.githubusercontent.com/1945542/91832799-71efe800-ec78-11ea-8bcb-c4b08c72dd05.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-01 at 17 27 41](https://user-images.githubusercontent.com/1945542/91832812-76b49c00-ec78-11ea-9d44-ed772a8e2856.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
