### PR TITLE
Small improvements to VoiceOver in Edit Product Detail screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
   - A product variation's stock status is now editable in inventory settings.
   - Reviews row is now hidden if reviews are disabled.
   - Now it's possible to open the product's reviews screen also if there are no reviews.
+  - We improved our VoiceOver support in Product Detail screen.
 - [*] In Settings, the "Feature Request" button was replaced with "Send Feedback" (Survey) (https://git.io/JUmUY)
 
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -125,6 +125,10 @@ private extension ProductFormTableViewDataSource {
         cell.onAddImage = { [weak self] in
             self?.onAddImage?()
         }
+        cell.accessibilityLabel = NSLocalizedString(
+            "List of images of the product",
+            comment: "VoiceOver accessibility hint, informing the user about the image section header of a product in product detail screen."
+        )
     }
 
     func configureName(cell: UITableViewCell, name: String?) {
@@ -147,6 +151,10 @@ private extension ProductFormTableViewDataSource {
                                                             edgeInsets: UIEdgeInsets(top: 8, left: 11, bottom: 8, right: 11))
 
         cell.configure(with: cellViewModel)
+        cell.accessibilityLabel = NSLocalizedString(
+            "Title of the product",
+            comment: "VoiceOver accessibility hint, informing the user about the title of a product in product detail screen."
+        )
     }
 
     func configureVariationName(cell: UITableViewCell, name: String) {


### PR DESCRIPTION
Fixes #2116. The part regarding the full product name not displayed was fixed in another PR #2717 already merged.

## Description
I made two small improvements to the Edit Product Detail screen, adding two accessibility labels for improving our VoiceOver support. Before, the Images header was not mentioned, and also there is no mention of the "name" of the product.

## Testing
1. Open an edit product detail screen.
2. Enable VoiceOver or use the Accessibility Inspector.
3. Make sure that the labels for the images header and the title of the product are mentioned now.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
