### PR TITLE
[Issue Refunds] Feature Flag

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,8 +9,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease4:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .refunds:
-            return true
+        case .issueRefunds:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -24,5 +24,5 @@ enum FeatureFlag: Int {
 
     /// Refunds
     ///
-    case refunds
+    case issueRefunds
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -567,23 +567,9 @@ extension OrderDetailsDataSource {
                 return nil
             }
 
-            // Order Items section with Refunds hidden
-            guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.refunds) else {
-                var rows: [Row] = Array(repeating: .orderItem, count: items.count)
-
-                if isProcessingPayment {
-                    rows.append(.fulfillButton)
-                } else {
-                    rows.append(.details)
-                }
-
-                return Section(title: Localization.pluralizedProducts(count: items.count), rightTitle: nil, rows: rows, headerStyle: .primary)
-            }
-
             var rows = [Row]()
 
-            let refundsEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.refunds)
-            if refundedProductsCount > 0 && refundsEnabled {
+            if refundedProductsCount > 0 {
                 rows = Array(repeating: .aggregateOrderItem, count: aggregateOrderItems.count)
             } else {
                 rows = Array(repeating: .orderItem, count: items.count)
@@ -603,11 +589,6 @@ extension OrderDetailsDataSource {
         }()
 
         let refundedProducts: Section? = {
-            // Refunds off
-            guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.refunds) else {
-                return nil
-            }
-
             // Refunds on
             guard refundedProductsCount > 0 else {
                 return nil
@@ -642,13 +623,10 @@ extension OrderDetailsDataSource {
 
         let payment: Section = {
             var rows: [Row] = [.payment, .customerPaid]
-
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(. refunds) {
-                if order.refunds.count > 0 {
-                    let refunds = Array<Row>(repeating: .refund, count: order.refunds.count)
-                    rows.append(contentsOf: refunds)
-                    rows.append(.netAmount)
-                }
+            if order.refunds.count > 0 {
+                let refunds = Array<Row>(repeating: .refund, count: order.refunds.count)
+                rows.append(contentsOf: refunds)
+                rows.append(.netAmount)
             }
 
             return Section(title: Title.payment, rows: rows)


### PR DESCRIPTION
closes #2763 

# Why and How
The project already had a `refunds` feature flag which I have renamed to `issueRefunds`. I also have removed the code that was conditionally under `.refunds` as that flag was always returning `true`.

# Testing steps
- Launch the app and navigate to an order with a refund
- Make sure the refund section is visible
<img width="407" alt="ref" src="https://user-images.githubusercontent.com/562080/92276751-3abb4a00-eeb7-11ea-9e4b-60385c09ae1e.png">

- Launch the app and navigate to an order without a refund
- Make sure the refund section is hidden
<img width="401" alt="no-ref" src="https://user-images.githubusercontent.com/562080/92276788-4d358380-eeb7-11ea-9b82-bc0bd15b5de1.png">



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
