### PR TITLE
Add network-layer support for remote feature flags

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -48,6 +48,13 @@
 		02DD6492248A3EC00082523E /* product-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 02DD6491248A3EC00082523E /* product-external.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
+		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
+		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
+		24F98C562502EA4800F49B68 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C552502EA4800F49B68 /* FeatureFlag.swift */; };
+		24F98C582502EA8800F49B68 /* FeatureFlagMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */; };
+		24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C5D2502EDCF00F49B68 /* BundleWooTests.swift */; };
+		24F98C602502EF8200F49B68 /* FeatureFlagRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */; };
+		24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 24F98C612502EFF600F49B68 /* feature-flags-load-all.json */; };
 		265BCA02243056E3004E53EE /* categories-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA01243056E3004E53EE /* categories-all.json */; };
 		26615473242D596B00A31661 /* ProductCategoriesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615472242D596B00A31661 /* ProductCategoriesRemote.swift */; };
 		26615475242D7C9500A31661 /* ProductCategoryListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */; };
@@ -402,6 +409,13 @@
 		02C54CC524D3E937007D658F /* product-variations-load-all-manage-stock-two-states.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variations-load-all-manage-stock-two-states.json"; sourceTree = "<group>"; };
 		02DD6491248A3EC00082523E /* product-external.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-external.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
+		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
+		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
+		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
+		24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagMapper.swift; sourceTree = "<group>"; };
+		24F98C5D2502EDCF00F49B68 /* BundleWooTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleWooTests.swift; sourceTree = "<group>"; };
+		24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
+		24F98C612502EFF600F49B68 /* feature-flags-load-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "feature-flags-load-all.json"; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
 		26615472242D596B00A31661 /* ProductCategoriesRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoriesRemote.swift; sourceTree = "<group>"; };
 		26615474242D7C9500A31661 /* ProductCategoryListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListMapper.swift; sourceTree = "<group>"; };
@@ -851,6 +865,7 @@
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
+				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
 				020D07BF23D8587700FD9580 /* MediaRemoteTests.swift */,
 				B554FA8A2180B1D500C54DFF /* NotificationsRemoteTests.swift */,
@@ -964,6 +979,7 @@
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
+				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
 				B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */,
 				B557DA0120975500005962F4 /* OrdersRemote.swift */,
@@ -1022,6 +1038,7 @@
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
+				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
 				B59325C6217E22FC000B0E8E /* Note.swift */,
 				B59325D0217E4206000B0E8E /* NoteBlock.swift */,
@@ -1076,6 +1093,7 @@
 				74C947812193A6C70024CB60 /* comment-moderate-unapproved.json */,
 				740211DE2193985A002248DA /* comment-moderate-spam.json */,
 				B524194621AC643900D6FC0A /* device-settings.json */,
+				24F98C612502EFF600F49B68 /* feature-flags-load-all.json */,
 				268B68FA24C87384007EBF1D /* leaderboards-products.json */,
 				26B2F74624C55A6E0065CCC8 /* leaderboards-year.json */,
 				268B68FC24C87E37007EBF1D /* leaderboards-year-alt.json */,
@@ -1174,6 +1192,7 @@
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
+				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
 				020D07BD23D8570800FD9580 /* MediaListMapper.swift */,
 				D823D904223746CE00C90817 /* NewShipmentTrackingMapper.swift */,
@@ -1251,6 +1270,7 @@
 				021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */,
 				02BDB83423EA98C800BCC63E /* String+HTML.swift */,
 				57E8FED2246616AC0057CD68 /* Result+Extensions.swift */,
+				24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1259,6 +1279,7 @@
 			isa = PBXGroup;
 			children = (
 				CE6D666E2379E82A007835A1 /* ArrayWooTests.swift */,
+				24F98C5D2502EDCF00F49B68 /* BundleWooTests.swift */,
 				B5C6FCC720A32E4800A4F8E4 /* DateFormatterWooTests.swift */,
 				02BDB83623EA9C4D00BCC63E /* String+HTMLTests.swift */,
 				0212683424C046CB00F8A892 /* MockupNetwork+Path.swift */,
@@ -1468,6 +1489,7 @@
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				740211DF2193985A002248DA /* comment-moderate-spam.json in Resources */,
 				B5147876211B9227007562E5 /* broken-orders-mark-2.json in Resources */,
+				24F98C622502EFF600F49B68 /* feature-flags-load-all.json in Resources */,
 				B58D10C82114D21D00107ED4 /* generic_error.json in Resources */,
 				CE50346721B5DCBE007573C6 /* site-plan.json in Resources */,
 				743E84F322172D0A00FAC9D7 /* shipment_tracking_empty.json in Resources */,
@@ -1664,6 +1686,7 @@
 				B557DA0220975500005962F4 /* JetpackRequest.swift in Sources */,
 				74046E1F217A6B70007DD7BF /* SiteSettingsMapper.swift in Sources */,
 				26B2F74524C5573F0065CCC8 /* LeaderboardListMapper.swift in Sources */,
+				24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
 				CE12FBD9221F3A6F00C59248 /* OrderStatus.swift in Sources */,
 				7426CA1121AF30BD004E9FFC /* SiteAPIMapper.swift in Sources */,
@@ -1698,6 +1721,7 @@
 				7412A8EC21B6E286005D182A /* ReportOrderTotalsMapper.swift in Sources */,
 				5726F72E2460A2820031CAAC /* Copiable.swift in Sources */,
 				74A1D26F21189EA100931DFA /* SiteVisitStatsRemote.swift in Sources */,
+				24F98C562502EA4800F49B68 /* FeatureFlag.swift in Sources */,
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
 				74159625224D4045003C21CF /* SiteSettingGroup.swift in Sources */,
 				26B2F74D24C696E70065CCC8 /* LeaderboardRowContent.swift in Sources */,
@@ -1725,6 +1749,7 @@
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,
 				CE43A8F9229F463000A4FF29 /* ProductDownload.swift in Sources */,
 				B53EF5322180F21C003E146F /* Dictionary+Woo.swift in Sources */,
+				24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */,
 				74A1D26D21189DFF00931DFA /* SiteVisitStatsMapper.swift in Sources */,
 				D8FBFF2222D5266E006E3336 /* OrderStatsV4Interval.swift in Sources */,
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
@@ -1753,6 +1778,7 @@
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,
 				74C8F06820EEB7BD00B6EDC9 /* OrderNotesMapper.swift in Sources */,
+				24F98C582502EA8800F49B68 /* FeatureFlagMapper.swift in Sources */,
 				4501068F2399B19500E24722 /* TaxClassRemote.swift in Sources */,
 				B53EF5342180F646003E146F /* DotcomValidator.swift in Sources */,
 				74046E1D217A6989007DD7BF /* SiteSetting.swift in Sources */,
@@ -1808,6 +1834,7 @@
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,
 				2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */,
 				CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */,
+				24F98C5E2502EDCF00F49B68 /* BundleWooTests.swift in Sources */,
 				74AB0ACA21948CE4008220CD /* CommentResultMapperTests.swift in Sources */,
 				02698CF824C183A5005337C4 /* ProductVariationListMapperTests.swift in Sources */,
 				B524194921AC659500D6FC0A /* DevicesRemoteTests.swift in Sources */,
@@ -1857,6 +1884,7 @@
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,
 				453305EF2459E46100264E50 /* SitePostsRemoteTests.swift in Sources */,
+				24F98C602502EF8200F49B68 /* FeatureFlagRemoteTests.swift in Sources */,
 				740211E121939908002248DA /* CommentRemoteTests.swift in Sources */,
 				B57B1E6A21C925280046E764 /* DotcomValidatorTests.swift in Sources */,
 				B567AF3020A0FB8F00AB6C62 /* DotcomRequestTests.swift in Sources */,

--- a/Networking/Networking/Extensions/Bundle+Woo.swift
+++ b/Networking/Networking/Extensions/Bundle+Woo.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension Bundle {
+    var buildNumber: String {
+        guard let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String else {
+            return "unknown"
+        }
+
+        return buildNumber
+    }
+
+    var marketingVersion: String {
+        guard let marketingVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return "unknown"
+        }
+
+        return marketingVersion
+    }
+}

--- a/Networking/Networking/Mapper/FeatureFlagMapper.swift
+++ b/Networking/Networking/Mapper/FeatureFlagMapper.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Mapper: Feature FLag
+///
+struct FeatureFlagMapper: Mapper {
+
+    /// (Attempts) to convert an instance of Data into an array of Feature Flags.
+    ///
+    func map(response: Data) throws -> FeatureFlagList {
+        return try JSONDecoder().decode(MapperInternalFlagList.self, from: response).featureFlags
+    }
+
+    /// Because the feature flag names can't be known at compile-time we need to read them dynamically – this object decodes them into an array
+    /// that can be passed out of the Mapper.
+    struct MapperInternalFlagList: Decodable {
+
+        let featureFlags: FeatureFlagList
+
+        struct DynamicKey: CodingKey {
+            var stringValue: String
+            init(stringValue: String) {
+                self.stringValue = stringValue
+            }
+
+            /// These are required for protocol conformance but don't actually do anything
+            var intValue: Int?
+            init(intValue: Int) {
+                self.intValue = intValue
+                self.stringValue = "\(intValue)"
+            }
+        }
+
+        /// Create a new `DynamicFeatureFlagList` from JSON
+        init(from decoder: Decoder) throws {
+            let dynamicKeysContainer = try decoder.container(keyedBy: DynamicKey.self)
+
+            self.featureFlags = try dynamicKeysContainer.allKeys.map {
+                let key = $0.stringValue
+                let value = try dynamicKeysContainer.decode(Bool.self, forKey: $0)
+                return FeatureFlag(title: key, value: value)
+            }
+        }
+    }
+}

--- a/Networking/Networking/Model/FeatureFlag.swift
+++ b/Networking/Networking/Model/FeatureFlag.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct FeatureFlag {
+    public let title: String
+    public let value: Bool
+
+    public init(title: String, value: Bool) {
+        self.title = title
+        self.value = value
+    }
+}
+
+public typealias FeatureFlagList = [FeatureFlag]

--- a/Networking/Networking/Remote/FeatureFlagsRemote.swift
+++ b/Networking/Networking/Remote/FeatureFlagsRemote.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Feature Flags: Remote Endpoints
+///
+public class FeatureFlagsRemote: Remote {
+
+    public typealias FetchResponse = (Result<FeatureFlagList, Error>) -> Void
+
+    public func loadAllFeatureFlags(forDeviceId deviceId: String, completion: @escaping FetchResponse) {
+
+        let parameters: [String: String] = [
+            ParameterKeys.deviceId: deviceId,
+            ParameterKeys.platform: "apple",
+            ParameterKeys.buildNumber: Bundle.main.buildNumber,
+            ParameterKeys.marketingVersion: Bundle.main.marketingVersion,
+            ParameterKeys.bundleIdentifier: Bundle.main.bundleIdentifier ?? "unknown",
+        ]
+
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: Paths.lookup, parameters: parameters)
+        let mapper = FeatureFlagMapper()
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: - Constants!
+//
+private extension FeatureFlagsRemote {
+
+    enum Paths {
+        static let lookup = "mobile/feature-flags"
+    }
+
+    enum ParameterKeys {
+        static let deviceId = "device_id"
+        static let platform = "platform"
+        static let buildNumber = "build_number"
+        static let marketingVersion = "marketing_version"
+        static let bundleIdentifier = "bundle_identifier"
+    }
+}

--- a/Networking/NetworkingTests/Extensions/BundleWooTests.swift
+++ b/Networking/NetworkingTests/Extensions/BundleWooTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Networking
+
+class BundleWooTests: XCTestCase {
+
+    func testBuildNumberCanBeRead() {
+        XCTAssertNotEqual("unknown", Bundle.main.buildNumber)
+    }
+
+    /// There's no CFBundleShortVersionString in Info.plist in a test environment, so we can't test it
+//    func testMarketingVersionCanBeRead() {
+//        XCTAssertNotEqual("unknown", Bundle.main.marketingVersion)
+//    }
+}

--- a/Networking/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
@@ -17,7 +17,7 @@ class FeatureFlagRemoteTests: XCTestCase {
 
     /// Verifies that loadAllFeatureFlags properly parses the `feature-flags-load-all` sample response.
     ///
-    func testLoadAllOrdersProperlyReturnsParsedOrders() throws {
+    func testLoadAllFeatureFlagsProperlyReturnsParsedFeatureFlags() throws {
         // Given
         let remote = FeatureFlagsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "feature-flags-load-all")
@@ -36,7 +36,7 @@ class FeatureFlagRemoteTests: XCTestCase {
         XCTAssert(featureFlags.count == 2)
     }
 
-    func testLoadAllOrdersProperlyHandlesErrors() throws {
+    func testLoadAllFeatureFlagsProperlyHandlesErrors() throws {
         // Given
         let remote = FeatureFlagsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "generic_error")

--- a/Networking/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Networking
+
+class FeatureFlagRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockupNetwork()
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - Load All Feature Flag Tests
+
+    /// Verifies that loadAllFeatureFlags properly parses the `feature-flags-load-all` sample response.
+    ///
+    func testLoadAllOrdersProperlyReturnsParsedOrders() throws {
+        // Given
+        let remote = FeatureFlagsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "feature-flags-load-all")
+
+        // When
+        var result: Result<FeatureFlagList, Error>?
+        waitForExpectation { expectation in
+            remote.loadAllFeatureFlags(forDeviceId: UUID().uuidString) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        let featureFlags = try XCTUnwrap(result?.get())
+        XCTAssert(featureFlags.count == 2)
+    }
+
+    func testLoadAllOrdersProperlyHandlesErrors() throws {
+        // Given
+        let remote = FeatureFlagsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "generic_error")
+
+        // When
+        var result: Result<FeatureFlagList, Error>?
+        waitForExpectation { expectation in
+            remote.loadAllFeatureFlags(forDeviceId: UUID().uuidString) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isFailure)
+    }
+}

--- a/Networking/NetworkingTests/Responses/feature-flags-load-all.json
+++ b/Networking/NetworkingTests/Responses/feature-flags-load-all.json
@@ -1,0 +1,4 @@
+{
+    "woocommerce_test_feature_flag_true_response": true,
+    "woocommerce_test_feature_flag_false_response": false
+}


### PR DESCRIPTION
This PR adds network-layer support for remote feature flags.

The included unit test should cover this functionality well.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
