### PR TITLE
Add Product > Product Settings: set password to empty without fetching password remotely

### DIFF
--- a/Networking/Networking/Remote/SitePostsRemote.swift
+++ b/Networking/Networking/Remote/SitePostsRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 
 /// WP.com Site Posts API: Remote Endpoints
@@ -33,7 +32,7 @@ public class SitePostsRemote: Remote {
     ///     - post: Post that we will use to update the post.
     ///     - completion: Closure to be executed upon completion.
     ///
-    public func updateSitePost(for siteID: Int64, postID: Int64, post: Post, completion: @escaping (Post?, Error?) -> Void) {
+    public func updateSitePost(for siteID: Int64, postID: Int64, post: Post, completion: @escaping (Result<Post, Error>) -> Void) {
         do {
             var parameters = try post.toDictionary()
             let parametersFields = ["fields": "site_ID,password"]
@@ -44,7 +43,7 @@ public class SitePostsRemote: Remote {
 
             enqueue(request, mapper: mapper, completion: completion)
         } catch {
-            completion(nil, error)
+            completion(.failure(error))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -23,10 +23,14 @@ final class ProductSettingsViewController: UIViewController {
     ///
     init(product: Product,
          password: String?,
+         formType: ProductFormType,
          isEditProductsRelease3Enabled: Bool,
          completion: @escaping Completion,
          onPasswordRetrieved: @escaping PasswordRetrievedCompletion) {
-        viewModel = ProductSettingsViewModel(product: product, password: password, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+        viewModel = ProductSettingsViewModel(product: product,
+                                             password: password,
+                                             formType: formType,
+                                             isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
         onCompletion = completion
         onPasswordCompletion = onPasswordRetrieved
         super.init(nibName: nil, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -582,15 +582,14 @@ private extension ProductFormViewController {
         if let password = viewModel.password, viewModel.hasPasswordChanged() {
             group.enter()
             let passwordUpdateAction = SitePostAction.updateSitePostPassword(siteID: product.siteID, postID: product.productID,
-                                                                             password: password) { [weak self] (password, error) in
-                guard let _ = password else {
-                    DDLogError("⛔️ Error updating product password: \(error.debugDescription)")
-                    group.leave()
-                    return
-                }
-
-                self?.viewModel.resetPassword(password)
-                group.leave()
+                                                                             password: password) { [weak self] result in
+                                                                                switch result {
+                                                                                case .failure(let error):
+                                                                                    DDLogError("⛔️ Error updating product password: \(error)")
+                                                                                case .success(let password):
+                                                                                    self?.viewModel.resetPassword(password)
+                                                                                }
+                                                                                group.leave()
             }
             ServiceLocator.stores.dispatch(passwordUpdateAction)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -644,6 +644,7 @@ private extension ProductFormViewController {
 
         let viewController = ProductSettingsViewController(product: product.product,
                                                            password: password,
+                                                           formType: viewModel.formType,
                                                            isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
                                                            completion: { [weak self] (productSettings) in
             guard let self = self else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -24,6 +24,9 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         product
     }
 
+    /// The form type could change from .add to .edit after creation.
+    private(set) var formType: ProductFormType
+
     /// Creates actions available on the bottom sheet.
     private(set) var actionsFactory: ProductFormActionsFactoryProtocol
 
@@ -81,8 +84,10 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     private var cancellable: ObservationToken?
 
     init(product: EditableProductModel,
+         formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandler,
          isEditProductsRelease3Enabled: Bool) {
+        self.formType = formType
         self.productImageActionHandler = productImageActionHandler
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         self.originalProduct = product

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModelProtocol.swift
@@ -1,5 +1,11 @@
 import Yosemite
 
+/// The type of product form: adding a new one or editing an existing one.
+enum ProductFormType {
+    case add
+    case edit
+}
+
 /// A view model for `ProductFormViewController` to add/edit a generic product model (e.g. `Product` or `ProductVariation`).
 ///
 protocol ProductFormViewModelProtocol {
@@ -7,6 +13,9 @@ protocol ProductFormViewModelProtocol {
 
     /// Emits product on change, except when the product name is the only change (`productName` is emitted for this case).
     var observableProduct: Observable<ProductModel> { get }
+
+    /// The type of form: adding a new product or editing an existing product.
+    var formType: ProductFormType { get }
 
     /// Emits product name on change. If the name is not editable (e.g. when the product model is `ProductVariation`), `nil` is returned.
     var productName: Observable<String>? { get }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -22,6 +22,9 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
     /// Creates actions available on the bottom sheet.
     private(set) var actionsFactory: ProductFormActionsFactoryProtocol
 
+    /// Product variation form only supports editing
+    let formType: ProductFormType = .edit
+
     /// Not applicable to product variation form
     private(set) var password: String? = nil
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -46,6 +46,7 @@ private extension ProductDetailsFactory {
                                                                   product: productModel)
         if isEditProductsEnabled {
             let viewModel = ProductFormViewModel(product: productModel,
+                                                 formType: .edit,
                                                  productImageActionHandler: productImageActionHandler,
                                                  isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
             vc = ProductFormViewController(viewModel: viewModel,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -14,6 +14,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
@@ -54,6 +55,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -72,6 +74,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -91,6 +94,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         let expectation = self.expectation(description: "Wait for image upload")
@@ -116,6 +120,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -140,6 +145,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -158,6 +164,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: true)
 
@@ -181,6 +188,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: true)
 
@@ -203,6 +211,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -221,6 +230,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -239,6 +249,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -257,6 +268,7 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -28,6 +28,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
@@ -76,6 +77,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         var isProductUpdated: Bool?
@@ -117,6 +119,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         var isProductUpdated: Bool?
@@ -154,6 +157,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         // The password is set from a separate DotCom API.
@@ -198,6 +202,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: defaultSiteID, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
         var isProductUpdated: Bool?

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -12,6 +12,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -29,6 +30,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -46,6 +48,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -79,6 +82,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -111,6 +115,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -143,6 +148,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -166,6 +172,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: true)
 
@@ -187,6 +194,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: true)
 
@@ -207,6 +215,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -224,6 +233,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -264,6 +274,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -281,6 +292,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 
@@ -300,6 +312,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: 0, product: model)
         let viewModel = ProductFormViewModel(product: model,
+                                             formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: false)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -66,6 +66,6 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
 private extension ProductSettingsViewModel {
     convenience init(product: Product, password: String?) {
-        self.init(product: product, password: password, isEditProductsRelease3Enabled: true)
+        self.init(product: product, password: password, formType: .edit, isEditProductsRelease3Enabled: true)
     }
 }

--- a/Yosemite/Yosemite/Actions/SitePostAction.swift
+++ b/Yosemite/Yosemite/Actions/SitePostAction.swift
@@ -10,5 +10,5 @@ public enum SitePostAction: Action {
 
     /// Update site post password
     ///
-    case updateSitePostPassword(siteID: Int64, postID: Int64, password: String, onCompletion: (_ password: String?, _ error: Error?) -> Void)
+    case updateSitePostPassword(siteID: Int64, postID: Int64, password: String, onCompletion: (Result<String?, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/SitePostStore.swift
+++ b/Yosemite/Yosemite/Stores/SitePostStore.swift
@@ -45,15 +45,16 @@ private extension SitePostStore {
 
     /// Update the password for a specific site post from WP.com
     ///
-    func updateSitePostPassword(siteID: Int64, postID: Int64, password: String, onCompletion: @escaping (_ password: String?, _ error: Error?) -> Void) {
+    func updateSitePostPassword(siteID: Int64, postID: Int64, password: String, onCompletion: @escaping (Result<String?, Error>) -> Void) {
         let remote = SitePostsRemote(network: network)
         let newSitePost = Post(siteID: siteID, password: password)
-        remote.updateSitePost(for: siteID, postID: postID, post: newSitePost) { (sitePost, error) in
-            guard error == nil else {
-                onCompletion(nil, error)
-                return
+        remote.updateSitePost(for: siteID, postID: postID, post: newSitePost) { result in
+            switch result {
+            case .failure(let error):
+                onCompletion(.failure(error))
+            case .success(let post):
+                onCompletion(.success(post.password))
             }
-            onCompletion(sitePost?.password, nil)
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/SitePostStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/SitePostStoreTests.swift
@@ -56,23 +56,24 @@ final class SitePostStoreTests: XCTestCase {
     /// Verifies that SitePostAction.updateSitePostPassword returns the expected result.
     ///
     func testUpdateSitePostPasswordReturnsExpectedResult() {
-        let expectation = self.expectation(description: "Update site post password")
+        // Arrange
         let sitePostStore = SitePostStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-
         let postID: Int64 = 7
-
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/posts/\(postID)", filename: "site-post-update")
 
+        // Action
         let newPassword = "new-password"
-        let action = SitePostAction.updateSitePostPassword(siteID: sampleSiteID, postID: postID, password: newPassword) { (password, error) in
-            XCTAssertNil(error)
-            XCTAssertNotNil(password)
-            XCTAssertEqual(password, newPassword)
-            expectation.fulfill()
+        var result: Result<String?, Error>?
+        waitForExpectation { expectation in
+            let action = SitePostAction.updateSitePostPassword(siteID: sampleSiteID, postID: postID, password: newPassword) { aResult in
+                result = aResult
+                expectation.fulfill()
+            }
+            sitePostStore.onAction(action)
         }
 
-        sitePostStore.onAction(action)
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
+        // Assert
+        XCTAssertEqual(try XCTUnwrap(result?.get()), newPassword)
     }
 
 }


### PR DESCRIPTION
This PR includes a subset of backend changes for adding/editing a product #2740 

## Background

When editing a product, the product already has a remote ID and we fetch the product (post)'s password from WP.com API in the product settings screen before the user can tap into the visibility row. On the other hand, when adding a product, there is no password so we don't have to perform this fetch anymore.

This PR also updated password update's completion block to `Result`.

## Changes

- Updated `SitePostAction.updateSitePostPassword` to return `Result<String?, Error>` instead of `(_ password: String?, _ error: Error?)`
  - Networking layer: updated `SitePostsRemote.updateSitePost` similarly
  - In `ProductFormViewController`, updated to use the `Result` type
  - Updated unit tests with Arrange/Action/Assert
- Created `ProductFormType` enum that contains two cases: `.add` for adding a product and `.edit` for editing a product (existing feature)
  - Added `ProductFormType` enum to `ProductFormViewModelProtocol`
    - `ProductFormViewModel` implementation takes in a `ProductFormType` enum and is privately mutable
    - `ProductVariationFormViewModel` implementation always returns `.edit` because we don't plan to support adding a product variation with similar UI/UX
  - Updated unit tests to pass `ProductFormType.edit`
- Only fetching the password via WP.com API when editing a product
  - In `ProductSettingsViewModel`, the password is fetched when editing a product; otherwise, the password is set to empty
  - DI'ed `ProductFormType` from `ProductFormViewController` to `ProductSettingsViewController` to `ProductSettingsViewModel`

## Testing

There's no UI integration for adding a product yet, please sanity check on viewing a product's settings:

### Product without a password

- Make sure the products feature switch is on under Settings > Experimental Features
- Go to the Products tab
- Tap on any product that is not password protected
- Tap on the ellipsis (...) menu and then "Product Settings"
- Tap on the "Visibility" row when it's tappable --> the expected visibility row should be selected (public/private)

### Product with a password

- Go to the Products tab
- Tap on any product that is password protected
- Tap on the ellipsis (...) menu and then "Product Settings"
- Tap on the "Visibility" row when it's tappable --> the "Password Protected" row should be selected with the correct password

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
