### PR TITLE
Fix product update error for bookable products

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -460,7 +460,12 @@ public struct Product: Codable, GeneratedCopiable, Equatable {
         try container.encode(virtual, forKey: .virtual)
 
         // Product type
-        try container.encode(productTypeKey, forKey: .productTypeKey)
+        switch productType {
+        case .custom:
+            break
+        default:
+            try container.encode(productTypeKey, forKey: .productTypeKey)
+        }
 
         // Categories
         try container.encode(categories, forKey: .categories)


### PR DESCRIPTION
Fixes #2780 

## Changes

Before this PR, we used to always encode the product type for `Product`. However, as Rachel noticed in WCiOS 5.0 #2780, the `type` parameter in the product update API caused an error for Bookable products using WooCommerce Bookings extension. Ideally, we could exclude the same parameters from the API request so that the product type field isn't sent unless it's changed but the change isn't trivial and I'll p2 this proposal separately. As a hot fix for 5.0 (since WooCommerce Bookings is one of the most used extensions), this PR just encodes the product type only for core product types. The product type is readonly for non-core products.

## Testing

Please follow the steps to repro in https://github.com/woocommerce/woocommerce-ios/issues/2780:

Prerequisite: Add the WooCommerce Bookings extension to your store.

- Add at least one bookable product
- Go to Settings > Experimental Features, and turn on the Products switch
- Go to the Products tab
- Tap on the bookable product
- Try editing some of the editable fields
- Tap "Update" --> the bookable product should be updated remotely

### Sanity check on updating product type

- Go to the Products tab
- Tap on any product of core type (simple/variable/grouped/external)
- Tap on the product type row and select a different product type, confirm the change
- Tap "Update" --> the product type should be updated remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
