### PR TITLE
Add Copied OrderListViewController and OrderListViewModel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -461,49 +461,6 @@ private extension OrderListViewController {
     }
 }
 
-
-// MARK: - UITableViewDataSource Conformance
-//
-@available(iOS 13.0, *)
-extension OrderListViewController: UITableViewDataSource {
-
-    func numberOfSections(in tableView: UITableView) -> Int {
-        viewModel.numberOfSections
-    }
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        viewModel.numberOfRows(in: section)
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
-            fatalError()
-        }
-
-        let detailsViewModel = viewModel.detailsViewModel(at: indexPath)
-        let orderStatus = lookUpOrderStatus(for: detailsViewModel?.order)
-        cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
-        cell.layoutIfNeeded()
-        return cell
-    }
-
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let reuseIdentifier = TwoColumnSectionHeaderView.reuseIdentifier
-        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) as? TwoColumnSectionHeaderView else {
-            return nil
-        }
-
-        header.leftText = {
-            let rawAge = viewModel.sectionInfo(at: section).name
-            return Age(rawValue: rawAge)?.description
-        }()
-        header.rightText = nil
-
-        return header
-    }
-}
-
-
 // MARK: - UITableViewDelegate Conformance
 //
 @available(iOS 13.0, *)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -10,21 +10,22 @@ import XLPagerTabStrip
 
 private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
 
-protocol OrdersViewControllerDelegate: class {
-    /// Called when `OrdersViewController` is about to fetch Orders from the API.
+protocol OrderListViewControllerDelegate: class {
+    /// Called when `OrderListViewController` is about to fetch Orders from the API.
     ///
-    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController)
+    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrderListViewController)
 }
 
-/// OrdersViewController: Displays the list of Orders associated to the active Store / Account.
+/// OrderListViewController: Displays the list of Orders associated to the active Store / Account.
 ///
-/// ## Deprecated
+/// ## Work In Progress
 ///
-/// This will be replaced with `OrderListViewController` when the minimum iOS version is 13.0.
+/// This does not do much at the moment. This will replace `OrdersViewController` later when
+/// iOS 13 is the minimum.
 ///
-final class OrdersViewController: UIViewController {
+final class OrderListViewController: UIViewController {
 
-    weak var delegate: OrdersViewControllerDelegate?
+    weak var delegate: OrderListViewControllerDelegate?
 
     private let viewModel: OrdersViewModel
 
@@ -139,7 +140,7 @@ final class OrdersViewController: UIViewController {
 
 // MARK: - User Interface Initialization
 //
-private extension OrdersViewController {
+private extension OrderListViewController {
     /// Initialize ViewModel operations
     ///
     func configureViewModel() {
@@ -246,7 +247,7 @@ private extension OrdersViewController {
 
 // MARK: - Notifications
 //
-extension OrdersViewController {
+extension OrderListViewController {
 
     /// Wires all of the Notification Hooks
     ///
@@ -265,7 +266,7 @@ extension OrdersViewController {
 
 // MARK: - Actions
 //
-extension OrdersViewController {
+extension OrderListViewController {
     @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.ordersViewControllerWillSynchronizeOrders(self)
@@ -277,7 +278,7 @@ extension OrdersViewController {
 
 // MARK: - Sync'ing Helpers
 //
-extension OrdersViewController: SyncingCoordinatorDelegate {
+extension OrderListViewController: SyncingCoordinatorDelegate {
 
     /// Synchronizes the Orders for the Default Store (if any).
     ///
@@ -317,7 +318,7 @@ extension OrdersViewController: SyncingCoordinatorDelegate {
 
 // MARK: - Spinner Helpers
 //
-extension OrdersViewController {
+extension OrderListViewController {
 
     /// Starts the Footer Spinner animation, whenever `mustStartFooterSpinner` returns *true*.
     ///
@@ -349,7 +350,7 @@ extension OrdersViewController {
 
 // MARK: - Placeholders & Ghostable Table
 //
-private extension OrdersViewController {
+private extension OrderListViewController {
 
     /// Renders the Placeholder Orders
     ///
@@ -436,7 +437,7 @@ private extension OrdersViewController {
 
 // MARK: - Convenience Methods
 //
-private extension OrdersViewController {
+private extension OrderListViewController {
 
     func lookUpOrderStatus(for order: Order?) -> OrderStatus? {
         guard let order = order else {
@@ -454,7 +455,7 @@ private extension OrdersViewController {
 
 // MARK: - UITableViewDataSource Conformance
 //
-extension OrdersViewController: UITableViewDataSource {
+extension OrderListViewController: UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
         viewModel.numberOfSections
@@ -495,7 +496,7 @@ extension OrdersViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate Conformance
 //
-extension OrdersViewController: UITableViewDelegate {
+extension OrderListViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
@@ -530,7 +531,7 @@ extension OrdersViewController: UITableViewDelegate {
 
 // MARK: - Finite State Machine Management
 //
-private extension OrdersViewController {
+private extension OrderListViewController {
 
     func didEnter(state: State) {
         switch state {
@@ -575,10 +576,10 @@ private extension OrdersViewController {
 
 // MARK: - IndicatorInfoProvider Conformance
 
-// This conformance is not used directly by `OrdersViewController`. We only need this because
+// This conformance is not used directly by `OrderListViewController`. We only need this because
 // `Self` is used as a child of `OrdersMasterViewController` which is a
 // `ButtonBarPagerTabStripViewController`.
-extension OrdersViewController: IndicatorInfoProvider {
+extension OrderListViewController: IndicatorInfoProvider {
     /// Return `self.title` under `IndicatorInfo`.
     ///
     func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
@@ -589,7 +590,7 @@ extension OrdersViewController: IndicatorInfoProvider {
 
 // MARK: - Nested Types
 //
-private extension OrdersViewController {
+private extension OrderListViewController {
 
     enum Settings {
         static let estimatedHeaderHeight = CGFloat(43)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -1,0 +1,606 @@
+import UIKit
+import Gridicons
+import Yosemite
+import WordPressUI
+import SafariServices
+import StoreKit
+
+// Used for protocol conformance of IndicatorInfoProvider only.
+import XLPagerTabStrip
+
+private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
+
+protocol OrdersViewControllerDelegate: class {
+    /// Called when `OrdersViewController` is about to fetch Orders from the API.
+    ///
+    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController)
+}
+
+/// OrdersViewController: Displays the list of Orders associated to the active Store / Account.
+///
+/// ## Deprecated
+///
+/// This will be replaced with `OrderListViewController` when the minimum iOS version is 13.0.
+///
+final class OrdersViewController: UIViewController {
+
+    weak var delegate: OrdersViewControllerDelegate?
+
+    private let viewModel: OrdersViewModel
+
+    /// Main TableView.
+    ///
+    private lazy var tableView = UITableView(frame: .zero, style: .grouped)
+
+    /// Ghostable TableView.
+    ///
+    private(set) var ghostableTableView = UITableView()
+
+    /// Pull To Refresh Support.
+    ///
+    private lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(pullToRefresh(sender:)), for: .valueChanged)
+        return refreshControl
+    }()
+
+    /// Footer "Loading More" Spinner.
+    ///
+    private lazy var footerSpinnerView = {
+        return FooterSpinnerView(tableViewStyle: tableView.style)
+    }()
+
+    /// The configuration to use for the view if the list is empty.
+    ///
+    private let emptyStateConfig: EmptyStateViewController.Config
+
+    /// The view shown if the list is empty.
+    ///
+    private lazy var emptyStateViewController = EmptyStateViewController(style: .list)
+
+    /// Used for looking up the `OrderStatus` to show in the `OrderTableViewCell`.
+    ///
+    /// The `OrderStatus` data is fetched from the API by `OrdersMasterViewModel`.
+    ///
+    private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
+        let storageManager = ServiceLocator.storageManager
+        let descriptor = NSSortDescriptor(key: "slug", ascending: true)
+
+        return ResultsController<StorageOrderStatus>(storageManager: storageManager, sortedBy: [descriptor])
+    }()
+
+    /// SyncCoordinator: Keeps tracks of which pages have been refreshed, and encapsulates the "What should we sync now" logic.
+    ///
+    private let syncingCoordinator = SyncingCoordinator()
+
+    /// The current list of order statuses for the default site
+    ///
+    private var currentSiteStatuses: [OrderStatus] {
+        return statusResultsController.fetchedObjects
+    }
+
+    /// UI Active State
+    ///
+    private var state: State = .results {
+        didSet {
+            guard oldValue != state else {
+                return
+            }
+
+            didLeave(state: oldValue)
+            didEnter(state: state)
+        }
+    }
+
+    // MARK: - View Lifecycle
+
+    /// Designated initializer.
+    ///
+    init(title: String, viewModel: OrdersViewModel, emptyStateConfig: EmptyStateViewController.Config) {
+        self.viewModel = viewModel
+        self.emptyStateConfig = emptyStateConfig
+
+        super.init(nibName: nil, bundle: nil)
+
+        self.title = title
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("Not supported")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        registerTableViewHeadersAndCells()
+        configureTableView()
+        configureGhostableTableView()
+
+        refreshStatusPredicate()
+        configureStatusResultsController()
+
+        configureViewModel()
+        configureSyncingCoordinator()
+
+        startListeningToNotifications()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        syncingCoordinator.resynchronize()
+
+        // Fix any _incomplete_ animation if the orders were deleted and refetched from
+        // a different location (or Orders tab).
+        tableView.reloadData()
+    }
+}
+
+
+// MARK: - User Interface Initialization
+//
+private extension OrdersViewController {
+    /// Initialize ViewModel operations
+    ///
+    func configureViewModel() {
+        viewModel.onShouldResynchronizeIfViewIsVisible = { [weak self] in
+            guard let self = self,
+                  // Avoid synchronizing if the view is not visible. The refresh will be handled in
+                  // `viewWillAppear` instead.
+                  self.viewIfLoaded?.window != nil else {
+                return
+            }
+
+            self.syncingCoordinator.resynchronize()
+        }
+
+        viewModel.activateAndForwardUpdates(to: tableView)
+
+        // Reload table because the activate call above executes a performFetch()
+        tableView.reloadData()
+    }
+
+    /// Setup: Order status predicate
+    ///
+    func refreshStatusPredicate() {
+        // Bugfix for https://github.com/woocommerce/woocommerce-ios/issues/751.
+        // Because we are listening for default account changes,
+        // this will also fire upon logging out, when the account
+        // is set to nil. So let's protect against multi-threaded
+        // access attempts if the account is indeed nil.
+        guard ServiceLocator.stores.isAuthenticated,
+            ServiceLocator.stores.needsDefaultStore == false else {
+                return
+        }
+
+        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+    }
+
+    /// Setup: Status Results Controller
+    ///
+    func configureStatusResultsController() {
+        try? statusResultsController.performFetch()
+    }
+
+    /// Setup: Sync'ing Coordinator
+    ///
+    func configureSyncingCoordinator() {
+        syncingCoordinator.delegate = self
+    }
+
+    /// Setup: TableView
+    ///
+    func configureTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+
+        view.backgroundColor = .listBackground
+        tableView.backgroundColor = .listBackground
+        tableView.refreshControl = refreshControl
+        tableView.tableFooterView = footerSpinnerView
+        tableView.estimatedSectionHeaderHeight = Settings.estimatedHeaderHeight
+        tableView.sectionHeaderHeight = UITableView.automaticDimension
+        tableView.sectionFooterHeight = .leastNonzeroMagnitude
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = UITableView.automaticDimension
+
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(tableView)
+    }
+
+    /// Setup: Ghostable TableView
+    ///
+    func configureGhostableTableView() {
+        view.addSubview(ghostableTableView)
+        ghostableTableView.isHidden = true
+
+        ghostableTableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ghostableTableView.widthAnchor.constraint(equalTo: tableView.widthAnchor),
+            ghostableTableView.heightAnchor.constraint(equalTo: tableView.heightAnchor),
+            ghostableTableView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            ghostableTableView.topAnchor.constraint(equalTo: tableView.topAnchor)
+        ])
+
+        view.backgroundColor = .listBackground
+        ghostableTableView.backgroundColor = .listBackground
+        ghostableTableView.isScrollEnabled = false
+    }
+
+    /// Registers all of the available table view cells and headers
+    ///
+    func registerTableViewHeadersAndCells() {
+        let cells = [ OrderTableViewCell.self ]
+
+        for cell in cells {
+            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+            ghostableTableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        }
+
+        let headerType = TwoColumnSectionHeaderView.self
+        tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)
+    }
+}
+
+
+// MARK: - Notifications
+//
+extension OrdersViewController {
+
+    /// Wires all of the Notification Hooks
+    ///
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
+    }
+
+    /// Runs whenever the default Account is updated.
+    ///
+    @objc func defaultAccountWasUpdated() {
+        refreshStatusPredicate()
+        syncingCoordinator.resetInternalState()
+    }
+}
+
+// MARK: - Actions
+//
+extension OrdersViewController {
+    @objc func pullToRefresh(sender: UIRefreshControl) {
+        ServiceLocator.analytics.track(.ordersListPulledToRefresh)
+        delegate?.ordersViewControllerWillSynchronizeOrders(self)
+        syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
+            sender.endRefreshing()
+        }
+    }
+}
+
+// MARK: - Sync'ing Helpers
+//
+extension OrdersViewController: SyncingCoordinatorDelegate {
+
+    /// Synchronizes the Orders for the Default Store (if any).
+    ///
+    func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)? = nil) {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            onCompletion?(false)
+            return
+        }
+
+        transitionToSyncingState()
+
+        let action = viewModel.synchronizationAction(
+            siteID: siteID,
+            pageNumber: pageNumber,
+            pageSize: pageSize,
+            reason: SyncReason(rawValue: reason ?? "")) { [weak self] error in
+                guard let self = self else {
+                    return
+                }
+
+                if let error = error {
+                    DDLogError("⛔️ Error synchronizing orders: \(error)")
+                    self.displaySyncingErrorNotice(pageNumber: pageNumber, pageSize: pageSize, reason: reason)
+                } else {
+                    let status = self.viewModel.statusFilter?.slug ?? String()
+                    ServiceLocator.analytics.track(.ordersListLoaded, withProperties: ["status": status])
+                }
+
+                self.transitionToResultsUpdatedState()
+                onCompletion?(error == nil)
+        }
+
+        ServiceLocator.stores.dispatch(action)
+    }
+}
+
+
+// MARK: - Spinner Helpers
+//
+extension OrdersViewController {
+
+    /// Starts the Footer Spinner animation, whenever `mustStartFooterSpinner` returns *true*.
+    ///
+    private func ensureFooterSpinnerIsStarted() {
+        guard mustStartFooterSpinner() else {
+            return
+        }
+
+        footerSpinnerView.startAnimating()
+    }
+
+    /// Whenever we're sync'ing an Orders Page that's beyond what we're currently displaying, this method will return *true*.
+    ///
+    private func mustStartFooterSpinner() -> Bool {
+        guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
+            return false
+        }
+
+        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > viewModel.numberOfObjects
+    }
+
+    /// Stops animating the Footer Spinner.
+    ///
+    private func ensureFooterSpinnerIsStopped() {
+        footerSpinnerView.stopAnimating()
+    }
+}
+
+
+// MARK: - Placeholders & Ghostable Table
+//
+private extension OrdersViewController {
+
+    /// Renders the Placeholder Orders
+    ///
+    func displayPlaceholderOrders() {
+        let options = GhostOptions(reuseIdentifier: OrderTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
+
+        // If the ghostable table view gets stuck for any reason,
+        // let's reset the state before using it again
+        ghostableTableView.removeGhostContent()
+        ghostableTableView.displayGhostContent(options: options,
+                                               style: .wooDefaultGhostStyle)
+        ghostableTableView.startGhostAnimation()
+        ghostableTableView.isHidden = false
+    }
+
+    /// Removes the Placeholder Orders (and restores the ResultsController <> UITableView link).
+    ///
+    func removePlaceholderOrders() {
+        ghostableTableView.isHidden = true
+        ghostableTableView.stopGhostAnimation()
+        ghostableTableView.removeGhostContent()
+        tableView.reloadData()
+    }
+
+    /// Displays the Error Notice.
+    ///
+    func displaySyncingErrorNotice(pageNumber: Int, pageSize: Int, reason: String?) {
+        let message = NSLocalizedString("Unable to refresh list", comment: "Refresh Action Failed")
+        let actionTitle = NSLocalizedString("Retry", comment: "Retry Action")
+        let notice = Notice(title: message, feedbackType: .error, actionTitle: actionTitle) { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.delegate?.ordersViewControllerWillSynchronizeOrders(self)
+            self.sync(pageNumber: pageNumber, pageSize: pageSize, reason: reason)
+        }
+
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+    }
+
+    /// Shows the EmptyStateViewController
+    ///
+    func displayEmptyViewController() {
+        let childController = emptyStateViewController
+
+        // Abort if we are already displaying this childController
+        guard childController.parent == nil else {
+            return
+        }
+        guard let childView = childController.view else {
+            return
+        }
+
+        childController.configure(emptyStateConfig)
+
+        childView.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(childController)
+        view.addSubview(childView)
+        NSLayoutConstraint.activate([
+            childView.leadingAnchor.constraint(equalTo: tableView.leadingAnchor),
+            childView.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
+            childView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            childView.bottomAnchor.constraint(equalTo: tableView.bottomAnchor)
+        ])
+        childController.didMove(toParent: self)
+    }
+
+    func removeEmptyViewController() {
+        let childController = emptyStateViewController
+
+        guard childController.parent == self,
+            let childView = childController.view else {
+            return
+        }
+
+        childController.willMove(toParent: nil)
+        childView.removeFromSuperview()
+        childController.removeFromParent()
+    }
+}
+
+
+// MARK: - Convenience Methods
+//
+private extension OrdersViewController {
+
+    func lookUpOrderStatus(for order: Order?) -> OrderStatus? {
+        guard let order = order else {
+            return nil
+        }
+
+        for orderStatus in currentSiteStatuses where orderStatus.slug == order.statusKey {
+            return orderStatus
+        }
+
+        return nil
+    }
+}
+
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension OrdersViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        viewModel.numberOfSections
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.numberOfRows(in: section)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
+            fatalError()
+        }
+
+        let detailsViewModel = viewModel.detailsViewModel(at: indexPath)
+        let orderStatus = lookUpOrderStatus(for: detailsViewModel?.order)
+        cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
+        cell.layoutIfNeeded()
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let reuseIdentifier = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) as? TwoColumnSectionHeaderView else {
+            return nil
+        }
+
+        header.leftText = {
+            let rawAge = viewModel.sectionInfo(at: section).name
+            return Age(rawValue: rawAge)?.description
+        }()
+        header.rightText = nil
+
+        return header
+    }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension OrdersViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        guard state != .placeholder else {
+            return
+        }
+
+        guard let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath) else {
+            return
+        }
+
+        guard let orderDetailsVC = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
+            assertionFailure("Expected OrderDetailsViewController to be instantiated")
+            return
+        }
+
+        orderDetailsVC.viewModel = orderDetailsViewModel
+
+        let order = orderDetailsViewModel.order
+        ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
+                                                                    "status": order.statusKey])
+
+        navigationController?.pushViewController(orderDetailsVC, animated: true)
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        let orderIndex = viewModel.objectIndex(from: indexPath)
+        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
+    }
+}
+
+// MARK: - Finite State Machine Management
+//
+private extension OrdersViewController {
+
+    func didEnter(state: State) {
+        switch state {
+        case .empty:
+            displayEmptyViewController()
+        case .placeholder:
+            displayPlaceholderOrders()
+        case .syncing:
+            ensureFooterSpinnerIsStarted()
+        case .results:
+            break
+        }
+    }
+
+    func didLeave(state: State) {
+        switch state {
+        case .empty:
+            removeEmptyViewController()
+        case .placeholder:
+            removePlaceholderOrders()
+        case .syncing:
+            ensureFooterSpinnerIsStopped()
+        case .results:
+            break
+        }
+    }
+
+    /// Should be called before Sync'ing. Transitions to either `results` or `placeholder` state, depending on whether if
+    /// we've got cached results, or not.
+    ///
+    func transitionToSyncingState() {
+        state = viewModel.isEmpty ? .placeholder : .syncing
+    }
+
+    /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
+    /// Transitions to `.results` or `.empty`.
+    ///
+    func transitionToResultsUpdatedState() {
+        state = viewModel.isEmpty ? .empty : .results
+    }
+}
+
+// MARK: - IndicatorInfoProvider Conformance
+
+// This conformance is not used directly by `OrdersViewController`. We only need this because
+// `Self` is used as a child of `OrdersMasterViewController` which is a
+// `ButtonBarPagerTabStripViewController`.
+extension OrdersViewController: IndicatorInfoProvider {
+    /// Return `self.title` under `IndicatorInfo`.
+    ///
+    func indicatorInfo(for pagerTabStripController: PagerTabStripViewController) -> IndicatorInfo {
+        IndicatorInfo(title: title)
+    }
+}
+
+
+// MARK: - Nested Types
+//
+private extension OrdersViewController {
+
+    enum Settings {
+        static let estimatedHeaderHeight = CGFloat(43)
+        static let estimatedRowHeight = CGFloat(86)
+        static let placeholderRowsPerSection = [3]
+    }
+
+    enum State {
+        case placeholder
+        case syncing
+        case results
+        case empty
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -196,7 +196,8 @@ private extension OrderListViewController {
     ///
     func configureTableView() {
         tableView.delegate = self
-        tableView.dataSource = self
+        // WIP Replace with DiffableDataSource later
+        // tableView.dataSource = self
 
         view.backgroundColor = .listBackground
         tableView.backgroundColor = .listBackground
@@ -340,11 +341,13 @@ extension OrderListViewController {
     /// Whenever we're sync'ing an Orders Page that's beyond what we're currently displaying, this method will return *true*.
     ///
     private func mustStartFooterSpinner() -> Bool {
-        guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
-            return false
-        }
-
-        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > viewModel.numberOfObjects
+        // WIP Replace with DiffableDataSource later
+        // guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
+        //     return false
+        // }
+        //
+        // return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > viewModel.numberOfObjects
+        return false
     }
 
     /// Stops animating the Footer Spinner.
@@ -473,9 +476,12 @@ extension OrderListViewController: UITableViewDelegate {
             return
         }
 
-        guard let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath) else {
-            return
-        }
+        // WIP Replace with DiffableDataSource implementation later
+        //
+        // guard let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath) else {
+        //     return
+        // }
+        let orderDetailsViewModel: OrderDetailsViewModel? = nil
 
         guard let orderDetailsVC = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
             assertionFailure("Expected OrderDetailsViewController to be instantiated")
@@ -484,7 +490,10 @@ extension OrderListViewController: UITableViewDelegate {
 
         orderDetailsVC.viewModel = orderDetailsViewModel
 
-        let order = orderDetailsViewModel.order
+        // WIP Remove guard later
+        guard let order = orderDetailsViewModel?.order else {
+            return
+        }
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
                                                                     "status": order.statusKey])
 
@@ -492,8 +501,9 @@ extension OrderListViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let orderIndex = viewModel.objectIndex(from: indexPath)
-        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
+        // WIP Replace with new PaginationTracker logic later
+        // let orderIndex = viewModel.objectIndex(from: indexPath)
+        // syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
     }
 }
 
@@ -532,14 +542,16 @@ private extension OrderListViewController {
     /// we've got cached results, or not.
     ///
     func transitionToSyncingState() {
-        state = viewModel.isEmpty ? .placeholder : .syncing
+        // WIP Replace with DiffableDataSource logic later
+        // state = viewModel.isEmpty ? .placeholder : .syncing
     }
 
     /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).
     /// Transitions to `.results` or `.empty`.
     ///
     func transitionToResultsUpdatedState() {
-        state = viewModel.isEmpty ? .empty : .results
+        // WIP Replace with DiffableDataSource logic later
+        // state = viewModel.isEmpty ? .empty : .results
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -10,6 +10,7 @@ import XLPagerTabStrip
 
 private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
 
+@available(iOS 13.0, *)
 protocol OrderListViewControllerDelegate: class {
     /// Called when `OrderListViewController` is about to fetch Orders from the API.
     ///
@@ -23,6 +24,7 @@ protocol OrderListViewControllerDelegate: class {
 /// This does not do much at the moment. This will replace `OrdersViewController` later when
 /// iOS 13 is the minimum.
 ///
+@available(iOS 13.0, *)
 final class OrderListViewController: UIViewController {
 
     weak var delegate: OrderListViewControllerDelegate?
@@ -140,6 +142,7 @@ final class OrderListViewController: UIViewController {
 
 // MARK: - User Interface Initialization
 //
+@available(iOS 13.0, *)
 private extension OrderListViewController {
     /// Initialize ViewModel operations
     ///
@@ -247,6 +250,7 @@ private extension OrderListViewController {
 
 // MARK: - Notifications
 //
+@available(iOS 13.0, *)
 extension OrderListViewController {
 
     /// Wires all of the Notification Hooks
@@ -266,6 +270,7 @@ extension OrderListViewController {
 
 // MARK: - Actions
 //
+@available(iOS 13.0, *)
 extension OrderListViewController {
     @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
@@ -278,6 +283,7 @@ extension OrderListViewController {
 
 // MARK: - Sync'ing Helpers
 //
+@available(iOS 13.0, *)
 extension OrderListViewController: SyncingCoordinatorDelegate {
 
     /// Synchronizes the Orders for the Default Store (if any).
@@ -318,6 +324,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
 
 // MARK: - Spinner Helpers
 //
+@available(iOS 13.0, *)
 extension OrderListViewController {
 
     /// Starts the Footer Spinner animation, whenever `mustStartFooterSpinner` returns *true*.
@@ -350,6 +357,7 @@ extension OrderListViewController {
 
 // MARK: - Placeholders & Ghostable Table
 //
+@available(iOS 13.0, *)
 private extension OrderListViewController {
 
     /// Renders the Placeholder Orders
@@ -437,6 +445,7 @@ private extension OrderListViewController {
 
 // MARK: - Convenience Methods
 //
+@available(iOS 13.0, *)
 private extension OrderListViewController {
 
     func lookUpOrderStatus(for order: Order?) -> OrderStatus? {
@@ -455,6 +464,7 @@ private extension OrderListViewController {
 
 // MARK: - UITableViewDataSource Conformance
 //
+@available(iOS 13.0, *)
 extension OrderListViewController: UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -496,6 +506,7 @@ extension OrderListViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate Conformance
 //
+@available(iOS 13.0, *)
 extension OrderListViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -531,6 +542,7 @@ extension OrderListViewController: UITableViewDelegate {
 
 // MARK: - Finite State Machine Management
 //
+@available(iOS 13.0, *)
 private extension OrderListViewController {
 
     func didEnter(state: State) {
@@ -579,6 +591,7 @@ private extension OrderListViewController {
 // This conformance is not used directly by `OrderListViewController`. We only need this because
 // `Self` is used as a child of `OrdersMasterViewController` which is a
 // `ButtonBarPagerTabStripViewController`.
+@available(iOS 13.0, *)
 extension OrderListViewController: IndicatorInfoProvider {
     /// Return `self.title` under `IndicatorInfo`.
     ///
@@ -590,6 +603,7 @@ extension OrderListViewController: IndicatorInfoProvider {
 
 // MARK: - Nested Types
 //
+@available(iOS 13.0, *)
 private extension OrderListViewController {
 
     enum Settings {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -158,7 +158,7 @@ private extension OrderListViewController {
             self.syncingCoordinator.resynchronize()
         }
 
-        viewModel.activateAndForwardUpdates(to: tableView)
+        viewModel.activate()
 
         // Reload table because the activate call above executes a performFetch()
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -27,7 +27,7 @@ final class OrderListViewController: UIViewController {
 
     weak var delegate: OrderListViewControllerDelegate?
 
-    private let viewModel: OrdersViewModel
+    private let viewModel: OrderListViewModel
 
     /// Main TableView.
     ///
@@ -97,7 +97,7 @@ final class OrderListViewController: UIViewController {
 
     /// Designated initializer.
     ///
-    init(title: String, viewModel: OrdersViewModel, emptyStateConfig: EmptyStateViewController.Config) {
+    init(title: String, viewModel: OrderListViewModel, emptyStateConfig: EmptyStateViewController.Config) {
         self.viewModel = viewModel
         self.emptyStateConfig = emptyStateConfig
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -1,0 +1,134 @@
+import Yosemite
+import class AutomatticTracks.CrashLogging
+import protocol Storage.StorageManagerType
+
+/// ViewModel for `OrderListViewController`. This will make `OrdersViewModel` obsolete when
+/// iOS 13.0 is set as the minimum version.
+///
+/// This is an incremental WIP. Eventually, we should move all the data loading in here.
+///
+/// Important: The `OrdersViewController` **owned** by `OrdersMasterViewController` currently
+/// does not get deallocated when switching sites. This `ViewModel` should consider that and not
+/// keep site-specific information as much as possible. For example, we shouldn't keep `siteID`
+/// in here but grab it from the `SessionManager` when we need it. Hopefully, we will be able to
+/// fix this in the future.
+///
+/// ## Work In Progress
+///
+/// This does not do anything at the moment. We will integrate `FetchResultsSnapshotsProvider`
+/// in here next.
+///
+@available(iOS 13.0, *)
+final class OrderListViewModel {
+    private let storageManager: StorageManagerType
+    private let pushNotificationsManager: PushNotesManager
+    private let notificationCenter: NotificationCenter
+
+    /// Used for cancelling the observer for Remote Notifications when `self` is deallocated.
+    ///
+    private var cancellable: ObservationToken?
+
+    /// The block called if self requests a resynchronization of the first page. The
+    /// resynchronization should only be done if the view is visible.
+    ///
+    var onShouldResynchronizeIfViewIsVisible: (() -> ())?
+
+    /// OrderStatus that must be matched by retrieved orders.
+    ///
+    let statusFilter: OrderStatus?
+
+    /// If true, orders created after today's day will be included in the result.
+    ///
+    /// This will generally only be false for the All Orders tab. All other screens should show orders in the future.
+    ///
+    /// Defaults to `true`.
+    ///
+    private let includesFutureOrders: Bool
+
+    /// Used for tracking whether the app was _previously_ in the background.
+    ///
+    private var isAppActive: Bool = true
+
+    init(storageManager: StorageManagerType = ServiceLocator.storageManager,
+         pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         notificationCenter: NotificationCenter = .default,
+         statusFilter: OrderStatus?,
+         includesFutureOrders: Bool = true) {
+        self.storageManager = storageManager
+        self.pushNotificationsManager = pushNotificationsManager
+        self.notificationCenter = notificationCenter
+        self.statusFilter = statusFilter
+        self.includesFutureOrders = includesFutureOrders
+    }
+
+    deinit {
+        stopObservingForegroundRemoteNotifications()
+    }
+
+    /// Start fetching DB results and forward new changes to the given `tableView`.
+    ///
+    /// This is the main activation method for this ViewModel. This should only be called once.
+    /// And only when the corresponding view was loaded.
+    ///
+    func activate() {
+        notificationCenter.addObserver(self, selector: #selector(handleAppDeactivation),
+                                       name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(handleAppActivation),
+                                       name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        observeForegroundRemoteNotifications()
+    }
+
+    @objc private func handleAppDeactivation() {
+        isAppActive = false
+    }
+
+    /// Request a resynchornization if the app was previously in the background.
+    ///
+    @objc private func handleAppActivation() {
+        guard !isAppActive else {
+            return
+        }
+
+        isAppActive = true
+        onShouldResynchronizeIfViewIsVisible?()
+    }
+
+    /// Returns what `OrderAction` should be used when synchronizing.
+    func synchronizationAction(siteID: Int64,
+                               pageNumber: Int,
+                               pageSize: Int,
+                               reason: OrderListSyncActionUseCase.SyncReason?,
+                               completionHandler: @escaping (Error?) -> Void) -> OrderAction {
+        let useCase = OrderListSyncActionUseCase(siteID: siteID,
+                                                 statusFilter: statusFilter,
+                                                 includesFutureOrders: includesFutureOrders)
+        return useCase.actionFor(pageNumber: pageNumber,
+                                 pageSize: pageSize,
+                                 reason: reason,
+                                 completionHandler: completionHandler)
+    }
+}
+
+// MARK: - Remote Notifications Observation
+@available(iOS 13.0, *)
+private extension OrderListViewModel {
+    /// Watch for "new order" Remote Notifications that are received while the app is in the
+    /// foreground.
+    ///
+    /// A refresh will be requested when receiving them.
+    ///
+    func observeForegroundRemoteNotifications() {
+        cancellable = pushNotificationsManager.foregroundNotifications.subscribe { [weak self] notification in
+            guard notification.kind == .storeOrder else {
+                return
+            }
+
+            self?.onShouldResynchronizeIfViewIsVisible?()
+        }
+    }
+
+    func stopObservingForegroundRemoteNotifications() {
+        cancellable?.cancel()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		57C503E023E8D4D600EC0790 /* OrdersMasterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */; };
 		57C5FF7A25091A350074EC26 /* OrderListSyncActionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */; };
 		57C5FF7C25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */; };
+		57C5FF7F250925C90074EC26 /* OrderListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5FF7D250925000074EC26 /* OrderListViewModel.swift */; };
 		57C9A8FC24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C9A8FB24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift */; };
 		57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */; };
 		57CFCD28248845B4003F51EC /* PrimarySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */; };
@@ -1403,6 +1404,7 @@
 		57C503DF23E8D4D600EC0790 /* OrdersMasterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersMasterViewModel.swift; sourceTree = "<group>"; };
 		57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncActionUseCase.swift; sourceTree = "<group>"; };
 		57C5FF7B25091DE50074EC26 /* OrderListSyncActionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncActionUseCaseTests.swift; sourceTree = "<group>"; };
+		57C5FF7D250925000074EC26 /* OrderListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListViewModel.swift; sourceTree = "<group>"; };
 		57C9A8FB24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsCoordinatorTests.swift; sourceTree = "<group>"; };
 		57C9A8FD24C23335001E1C2F /* MockNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNoticePresenter.swift; sourceTree = "<group>"; };
 		57CFCD27248845B4003F51EC /* PrimarySectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimarySectionHeaderView.swift; sourceTree = "<group>"; };
@@ -3905,6 +3907,7 @@
 				B509112E2049E27A007D25DC /* OrdersViewController.swift */,
 				576F92212423C3C0003E5FEF /* OrdersViewModel.swift */,
 				57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */,
+				57C5FF7D250925000074EC26 /* OrderListViewModel.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -5268,6 +5271,7 @@
 				5754727F24520B2A00A94C3C /* Observer.swift in Sources */,
 				027B8BBA23FE0D0C0040944E /* ObservationToken.swift in Sources */,
 				B517EA18218B232700730EC4 /* StringFormatter+Notes.swift in Sources */,
+				57C5FF7F250925C90074EC26 /* OrderListViewModel.swift in Sources */,
 				CE583A072107849F00D73C1C /* SwitchTableViewCell.swift in Sources */,
 				D8149F562251EE300006A245 /* UITextField+Helpers.swift in Sources */,
 				0212276124498A270042161F /* ProductFormBottomSheetListSelectorCommand.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -445,6 +445,7 @@
 		5795F22E23E26A9E00F6707C /* OrderSearchStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */; };
 		5795F23023E26B5300F6707C /* OrderSearchStarterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */; };
 		5798191324526FE8000817F8 /* PublishSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5798191224526FE8000817F8 /* PublishSubjectTests.swift */; };
+		57A49128250A7EB2000FEF21 /* OrderListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A49127250A7EB2000FEF21 /* OrderListViewController.swift */; };
 		57ABE36824EB048A00A64F49 /* MockSwitchStoreUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */; };
 		57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B374B5245B331100D58BE0 /* EmptyStateViewControllerTests.swift */; };
 		57C2F6E624C27B3100131012 /* SwitchStoreNoticePresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */; };
@@ -1396,6 +1397,7 @@
 		5795F22D23E26A9E00F6707C /* OrderSearchStarterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewController.swift; sourceTree = "<group>"; };
 		5795F22F23E26B5300F6707C /* OrderSearchStarterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchStarterViewModel.swift; sourceTree = "<group>"; };
 		5798191224526FE8000817F8 /* PublishSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSubjectTests.swift; sourceTree = "<group>"; };
+		57A49127250A7EB2000FEF21 /* OrderListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListViewController.swift; sourceTree = "<group>"; };
 		57ABE36724EB048A00A64F49 /* MockSwitchStoreUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSwitchStoreUseCase.swift; sourceTree = "<group>"; };
 		57B374B5245B331100D58BE0 /* EmptyStateViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateViewControllerTests.swift; sourceTree = "<group>"; };
 		57C2F6E524C27B3100131012 /* SwitchStoreNoticePresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreNoticePresenterTests.swift; sourceTree = "<group>"; };
@@ -3908,6 +3910,7 @@
 				576F92212423C3C0003E5FEF /* OrdersViewModel.swift */,
 				57C5FF7925091A350074EC26 /* OrderListSyncActionUseCase.swift */,
 				57C5FF7D250925000074EC26 /* OrderListViewModel.swift */,
+				57A49127250A7EB2000FEF21 /* OrderListViewController.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -5150,6 +5153,7 @@
 				D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */,
 				CE4DA5C621DD755E00074607 /* CurrencyFormatter.swift in Sources */,
 				0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */,
+				57A49128250A7EB2000FEF21 /* OrderListViewController.swift in Sources */,
 				265BCA092430E6E0004E53EE /* ProductCategoryListViewModel.swift in Sources */,
 				451A04E62386CE8700E368C9 /* ProductImagesHeaderTableViewCell.swift in Sources */,
 				B59C09D92188CBB100AB41D6 /* Array+Notes.swift in Sources */,


### PR DESCRIPTION
Part of the DiffableDataSource fix for #1543. This is a continuation of #2791.  

🇨🇦 Sorry for the 732 lines. The contents are mainly copy-pasta from the original `OrdersViewController` and `OrdersViewModel` code. 

## The Plan

The plan is still the same as what I mentioned in #2791. There will be **new** `OrderListViewController` and `OrderListViewModel` classes. These classes will be similar to the existing [`OrdersViewController`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift) and [`OrdersViewModel`](https://github.com/woocommerce/woocommerce-ios/blob/develop/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift) classes except that the new versions will be using `DiffableDataSource` instead of `FetchedResultsController`. These new classes will only be used if the device is using iOS 13.0. Eventually, we will remove the old classes when the minimum is set to iOS 13.0.

Here's a diagram of the plan:

![image](https://user-images.githubusercontent.com/198826/92627628-dfa79f80-f288-11ea-93aa-8474f33748c8.png)

Please let me know if you have any concerns. 

## What This PR Does

This PR copies the original `OrdersViewController` and `OrdersViewModel` to the new classes. 

Source | Target 
--------|-------
`OrdersViewController`        |       `OrderListViewController`
`OrdersViewModel` | `OrderListViewModel`

The only changes from the originals are:

- I exluded the references to the [`OrdersViewModel.resultsController`](https://github.com/woocommerce/woocommerce-ios/blob/c720e7415d83df7412237d304d6d8fc3c16c8a35/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L52-L76)
- I excluded the [`UITableViewDataSource` conformance](https://github.com/woocommerce/woocommerce-ios/blob/c720e7415d83df7412237d304d6d8fc3c16c8a35/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift#L455-L493). This will be replaced by `UITableViewDiffableDataSource`. 
- I [marked the classes](https://github.com/woocommerce/woocommerce-ios/blob/91b45a8477fbfab272a4788f1f57204beac4044c/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L27) as `iOS 13.0` only.
- I added WIP placeholders [like this](https://github.com/woocommerce/woocommerce-ios/blob/91b45a8477fbfab272a4788f1f57204beac4044c/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L344-L350) to make the code compile for now. These placeholders are where the `DiffableDataSource` implementation will be added. 

So, in summary, these classes do not do anything and do not use `DiffableDataSource` or the new [`FetchResultSnapshotsProvider`](https://github.com/woocommerce/woocommerce-ios/blob/issue/1543-add-empty-orders-vc/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift) yet. I wanted to submit that as a **separate PR** to hopefully make it easier to review the actual implementation of `DiffableDataSource`. 

## Testing

These currently cannot be tested. Please make sure the build passes for now. 🙇 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

