### PR TITLE
Use DiffableDataSource on OrderListViewModel and OrderListViewController

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+@available(iOS 13.0, *)
+extension UITableViewDiffableDataSource {
+    var numberOfItems: Int {
+        snapshot().numberOfItems
+    }
+}

--- a/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
@@ -13,4 +13,8 @@ extension UITableViewDiffableDataSource {
     var numberOfItems: Int {
         snapshot().numberOfItems
     }
+
+    var isEmpty: Bool {
+        numberOfItems == 0
+    }
 }

--- a/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
@@ -2,6 +2,14 @@ import UIKit
 
 @available(iOS 13.0, *)
 extension UITableViewDiffableDataSource {
+    func indexOfItem(for indexPath: IndexPath) -> Int? {
+        guard let identifier = itemIdentifier(for: indexPath) else {
+            return nil
+        }
+
+        return snapshot().indexOfItem(identifier)
+    }
+
     var numberOfItems: Int {
         snapshot().numberOfItems
     }

--- a/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
@@ -17,4 +17,8 @@ extension UITableViewDiffableDataSource {
     var isEmpty: Bool {
         numberOfItems == 0
     }
+
+    func sectionIdentifier(for sectionIndex: Int) -> SectionIdentifierType? {
+        snapshot().sectionIdentifiers[safe: sectionIndex]
+    }
 }

--- a/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewDiffableDataSource+Helpers.swift
@@ -1,7 +1,11 @@
 import UIKit
 
+/// Additional utilities for `UITableViewDiffableDataSource`.
+///
 @available(iOS 13.0, *)
 extension UITableViewDiffableDataSource {
+    /// Returns the index of the item pointed to by `indexPath` relative to the number of
+    /// items in `snapshot()`.
     func indexOfItem(for indexPath: IndexPath) -> Int? {
         guard let identifier = itemIdentifier(for: indexPath) else {
             return nil
@@ -10,14 +14,20 @@ extension UITableViewDiffableDataSource {
         return snapshot().indexOfItem(identifier)
     }
 
+    /// Returns the total number of items in the current `snapshot()`.
     var numberOfItems: Int {
         snapshot().numberOfItems
     }
 
+    /// Returns `true` if there are no items in the current `snapshot()`.
     var isEmpty: Bool {
         numberOfItems == 0
     }
 
+    /// Returns the section identifier for the given index.
+    ///
+    /// Note that the identifier is _not_ the title of the section. It should probably be converted
+    /// to something else before it is presented to the user.
     func sectionIdentifier(for sectionIndex: Int) -> SectionIdentifierType? {
         snapshot().sectionIdentifiers[safe: sectionIndex]
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -575,8 +575,7 @@ private extension OrderListViewController {
     /// we've got cached results, or not.
     ///
     func transitionToSyncingState() {
-        // WIP Replace with DiffableDataSource logic later
-        // state = viewModel.isEmpty ? .placeholder : .syncing
+        state = dataSource.isEmpty ? .placeholder : .syncing
     }
 
     /// Should be called whenever the results are updated: after Sync'ing (or after applying a filter).

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -105,6 +105,8 @@ final class OrderListViewController: UIViewController {
         }
     }
 
+    private var cancellables = Set<AnyCancellable>()
+
     // MARK: - View Lifecycle
 
     /// Designated initializer.
@@ -120,6 +122,12 @@ final class OrderListViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("Not supported")
+    }
+
+    deinit {
+        cancellables.forEach {
+            $0.cancel()
+        }
     }
 
     override func viewDidLoad() {
@@ -187,6 +195,10 @@ private extension OrderListViewController {
         }
 
         viewModel.activate()
+
+        viewModel.snapshot.sink { snapshot in
+            self.dataSource.apply(snapshot)
+        }.store(in: &cancellables)
 
         // Reload table because the activate call above executes a performFetch()
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -157,7 +157,7 @@ final class OrderListViewController: UIViewController {
     }
 
     private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
-        return { [weak self] tableView, indexPath, managedObjectID in
+        return { [weak self] tableView, indexPath, objectID in
             guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
                 fatalError("Failed to create cell \(OrderTableViewCell.reuseIdentifier)")
             }
@@ -165,11 +165,10 @@ final class OrderListViewController: UIViewController {
                 return cell
             }
 
-            // WIP FIXME later
-            // let detailsViewModel = self.viewModel.detailsViewModel(withID: managedObjectID)
-            // let orderStatus = self.lookUpOrderStatus(for: detailsViewModel?.order)
-            // cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
-            // cell.layoutIfNeeded()
+            let detailsViewModel = self.viewModel.detailsViewModel(withID: objectID)
+            let orderStatus = self.lookUpOrderStatus(for: detailsViewModel?.order)
+            cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
+            cell.layoutIfNeeded()
             return cell
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -35,6 +35,7 @@ final class OrderListViewController: UIViewController {
     ///
     private lazy var tableView = UITableView(frame: .zero, style: .grouped)
 
+    /// The data source that is bound to `tableView`.
     private lazy var dataSource: UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID> = {
         let dataSource = UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>(
             tableView: self.tableView,
@@ -157,6 +158,7 @@ final class OrderListViewController: UIViewController {
         tableView.reloadData()
     }
 
+    /// Returns a function that creates cells for `dataSource`.
     private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
         return { [weak self] tableView, indexPath, objectID in
             guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
@@ -196,6 +198,7 @@ private extension OrderListViewController {
 
         viewModel.activate()
 
+        /// Update the `dataSource` whenever there are is a new snapshot.
         viewModel.snapshot.sink { snapshot in
             self.dataSource.apply(snapshot)
         }.store(in: &cancellables)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -153,6 +153,8 @@ final class OrderListViewController: UIViewController {
 
         // Fix any _incomplete_ animation if the orders were deleted and refetched from
         // a different location (or Orders tab).
+        //
+        // We can remove this once we've replaced XLPagerTabStrip.
         tableView.reloadData()
     }
 
@@ -198,9 +200,6 @@ private extension OrderListViewController {
         viewModel.snapshot.sink { snapshot in
             self.dataSource.apply(snapshot)
         }.store(in: &cancellables)
-
-        // Reload table because the activate call above executes a performFetch()
-        tableView.reloadData()
     }
 
     /// Setup: Order status predicate
@@ -419,7 +418,6 @@ private extension OrderListViewController {
         ghostableTableView.isHidden = true
         ghostableTableView.stopGhostAnimation()
         ghostableTableView.removeGhostContent()
-        tableView.reloadData()
     }
 
     /// Displays the Error Notice.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -532,9 +532,11 @@ extension OrderListViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        // WIP Replace with new PaginationTracker logic later
-        // let orderIndex = viewModel.objectIndex(from: indexPath)
-        // syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: orderIndex)
+        guard let itemIndex = dataSource.indexOfItem(for: indexPath) else {
+            return
+        }
+
+        syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: itemIndex)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import UIKit
 import Gridicons
 import Yosemite
@@ -34,6 +35,15 @@ final class OrderListViewController: UIViewController {
     /// Main TableView.
     ///
     private lazy var tableView = UITableView(frame: .zero, style: .grouped)
+
+    private lazy var dataSource: UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID> = {
+        let dataSource = UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>(
+            tableView: self.tableView,
+            cellProvider: self.makeCellProvider()
+        )
+        dataSource.defaultRowAnimation = .fade
+        return dataSource
+    }()
 
     /// Ghostable TableView.
     ///
@@ -137,6 +147,24 @@ final class OrderListViewController: UIViewController {
         // a different location (or Orders tab).
         tableView.reloadData()
     }
+
+    private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
+        return { [weak self] tableView, indexPath, managedObjectID in
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
+                fatalError("Failed to create cell \(OrderTableViewCell.reuseIdentifier)")
+            }
+            guard let self = self else {
+                return cell
+            }
+
+            // WIP FIXME later
+            // let detailsViewModel = self.viewModel.detailsViewModel(withID: managedObjectID)
+            // let orderStatus = self.lookUpOrderStatus(for: detailsViewModel?.order)
+            // cell.configureCell(viewModel: detailsViewModel, orderStatus: orderStatus)
+            // cell.layoutIfNeeded()
+            return cell
+        }
+    }
 }
 
 
@@ -196,8 +224,7 @@ private extension OrderListViewController {
     ///
     func configureTableView() {
         tableView.delegate = self
-        // WIP Replace with DiffableDataSource later
-        // tableView.dataSource = self
+        tableView.dataSource = dataSource
 
         view.backgroundColor = .listBackground
         tableView.backgroundColor = .listBackground

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -512,12 +512,10 @@ extension OrderListViewController: UITableViewDelegate {
             return
         }
 
-        // WIP Replace with DiffableDataSource implementation later
-        //
-        // guard let orderDetailsViewModel = viewModel.detailsViewModel(at: indexPath) else {
-        //     return
-        // }
-        let orderDetailsViewModel: OrderDetailsViewModel? = nil
+        guard let objectID = dataSource.itemIdentifier(for: indexPath),
+            let orderDetailsViewModel = viewModel.detailsViewModel(withID: objectID) else {
+                return
+        }
 
         guard let orderDetailsVC = OrderDetailsViewController.instantiatedViewControllerFromStoryboard() else {
             assertionFailure("Expected OrderDetailsViewController to be instantiated")
@@ -526,10 +524,7 @@ extension OrderListViewController: UITableViewDelegate {
 
         orderDetailsVC.viewModel = orderDetailsViewModel
 
-        // WIP Remove guard later
-        guard let order = orderDetailsViewModel?.order else {
-            return
-        }
+        let order = orderDetailsViewModel.order
         ServiceLocator.analytics.track(.orderOpen, withProperties: ["id": order.orderID,
                                                                     "status": order.statusKey])
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -380,13 +380,11 @@ extension OrderListViewController {
     /// Whenever we're sync'ing an Orders Page that's beyond what we're currently displaying, this method will return *true*.
     ///
     private func mustStartFooterSpinner() -> Bool {
-        // WIP Replace with DiffableDataSource later
-        // guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
-        //     return false
-        // }
-        //
-        // return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > viewModel.numberOfObjects
-        return false
+        guard let highestPageBeingSynced = syncingCoordinator.highestPageBeingSynced else {
+            return false
+        }
+
+        return highestPageBeingSynced * SyncingCoordinator.Defaults.pageSize > dataSource.numberOfItems
     }
 
     /// Stops animating the Footer Spinner.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -582,8 +582,7 @@ private extension OrderListViewController {
     /// Transitions to `.results` or `.empty`.
     ///
     func transitionToResultsUpdatedState() {
-        // WIP Replace with DiffableDataSource logic later
-        // state = viewModel.isEmpty ? .empty : .results
+        state = dataSource.isEmpty ? .empty : .results
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -11,11 +11,10 @@ import XLPagerTabStrip
 
 private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
 
-@available(iOS 13.0, *)
 protocol OrderListViewControllerDelegate: class {
-    /// Called when `OrderListViewController` is about to fetch Orders from the API.
+    /// Called when `OrderListViewController` (or `OrdersViewController`) is about to fetch Orders from the API.
     ///
-    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrderListViewController)
+    func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController)
 }
 
 /// OrderListViewController: Displays the list of Orders associated to the active Store / Account.
@@ -312,7 +311,7 @@ extension OrderListViewController {
 extension OrderListViewController {
     @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
-        delegate?.ordersViewControllerWillSynchronizeOrders(self)
+        delegate?.orderListViewControllerWillSynchronizeOrders(self)
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }
@@ -430,7 +429,7 @@ private extension OrderListViewController {
                 return
             }
 
-            self.delegate?.ordersViewControllerWillSynchronizeOrders(self)
+            self.delegate?.orderListViewControllerWillSynchronizeOrders(self)
             self.sync(pageNumber: pageNumber, pageSize: pageSize, reason: reason)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -198,7 +198,7 @@ private extension OrderListViewController {
 
         viewModel.activate()
 
-        /// Update the `dataSource` whenever there are is a new snapshot.
+        /// Update the `dataSource` whenever there is a new snapshot.
         viewModel.snapshot.sink { snapshot in
             self.dataSource.apply(snapshot)
         }.store(in: &cancellables)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -538,6 +538,24 @@ extension OrderListViewController: UITableViewDelegate {
 
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: itemIndex)
     }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let reuseIdentifier = TwoColumnSectionHeaderView.reuseIdentifier
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: reuseIdentifier) as? TwoColumnSectionHeaderView else {
+            return nil
+        }
+
+        header.leftText = {
+            guard let sectionIdentifier = dataSource.sectionIdentifier(for: section) else {
+                return nil
+            }
+
+            return viewModel.sectionTitleFor(sectionIdentifier: sectionIdentifier)
+        }()
+        header.rightText = nil
+
+        return header
+    }
 }
 
 // MARK: - Finite State Machine Management

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -152,6 +152,7 @@ final class OrderListViewModel {
 }
 
 // MARK: - Remote Notifications Observation
+
 @available(iOS 13.0, *)
 private extension OrderListViewModel {
     /// Watch for "new order" Remote Notifications that are received while the app is in the
@@ -171,5 +172,18 @@ private extension OrderListViewModel {
 
     func stopObservingForegroundRemoteNotifications() {
         cancellable?.cancel()
+    }
+}
+
+// MARK: - TableView Support
+
+@available(iOS 13.0, *)
+extension OrderListViewModel {
+    func detailsViewModel(withID objectID: FetchResultSnapshotObjectID) -> OrderDetailsViewModel? {
+        guard let order = snapshotsProvider.object(withID: objectID) else {
+            return nil
+        }
+
+        return OrderDetailsViewModel(order: order)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Yosemite
 import class AutomatticTracks.CrashLogging
 import protocol Storage.StorageManagerType
@@ -49,6 +50,35 @@ final class OrderListViewModel {
     ///
     private var isAppActive: Bool = true
 
+    private lazy var snapshotsProvider: FetchResultSnapshotsProvider<StorageOrder> = {
+        let predicate: NSPredicate = {
+            let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
+            let excludeNonMatchingStatus = statusFilter.map { NSPredicate(format: "statusKey = %@", $0.slug) }
+
+            var predicates = [ excludeSearchCache, excludeNonMatchingStatus ].compactMap { $0 }
+            if !includesFutureOrders, let nextMidnight = Date().nextMidnight() {
+                // Exclude orders on and after midnight of today's date
+                let dateSubPredicate = NSPredicate(format: "dateCreated < %@", nextMidnight as NSDate)
+                predicates.append(dateSubPredicate)
+            }
+
+            return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        }()
+
+        let query = FetchResultSnapshotsProvider<StorageOrder>.Query(
+            sortDescriptor: NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false),
+            predicate: predicate,
+            sectionNameKeyPath: "\(#selector(StorageOrder.normalizedAgeAsString))"
+        )
+
+        return .init(storageManager: self.storageManager, query: query)
+    }()
+
+    /// Emits snapshots of orders that should be displayed in the table view.
+    var snapshot: AnyPublisher<FetchResultSnapshot, Never> {
+        snapshotsProvider.snapshot
+    }
+
     init(storageManager: StorageManagerType = ServiceLocator.storageManager,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
@@ -71,12 +101,23 @@ final class OrderListViewModel {
     /// And only when the corresponding view was loaded.
     ///
     func activate() {
+        startReceivingSnapshots()
+
         notificationCenter.addObserver(self, selector: #selector(handleAppDeactivation),
                                        name: UIApplication.willResignActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(handleAppActivation),
                                        name: UIApplication.didBecomeActiveNotification, object: nil)
 
         observeForegroundRemoteNotifications()
+    }
+
+    /// Starts the snapshotsProvider, logging any errors.
+    private func startReceivingSnapshots() {
+        do {
+            try snapshotsProvider.start()
+        } catch {
+            CrashLogging.logError(error)
+        }
     }
 
     @objc private func handleAppDeactivation() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -186,4 +186,8 @@ extension OrderListViewModel {
 
         return OrderDetailsViewModel(order: order)
     }
+
+    func sectionTitleFor(sectionIdentifier: String) -> String? {
+        Age(rawValue: sectionIdentifier)?.description
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -179,6 +179,7 @@ private extension OrderListViewModel {
 
 @available(iOS 13.0, *)
 extension OrderListViewModel {
+    /// Creates an `OrderDetailsViewModel` for the `Order` pointed to by `objectID`.
     func detailsViewModel(withID objectID: FetchResultSnapshotObjectID) -> OrderDetailsViewModel? {
         guard let order = snapshotsProvider.object(withID: objectID) else {
             return nil
@@ -187,6 +188,7 @@ extension OrderListViewModel {
         return OrderDetailsViewModel(order: order)
     }
 
+    /// Returns the corresponding section title for the given identifier.
     func sectionTitleFor(sectionIdentifier: String) -> String? {
         Age(rawValue: sectionIdentifier)?.description
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -87,26 +87,23 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
         // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
         // text in here. We want the string to be translated.
         let processingOrdersVC = OrdersViewController(
-            title: NSLocalizedString("Processing", comment: "Title for the first page in the Orders tab."),
+            title: Localization.processingTitle,
             viewModel: OrdersViewModel(statusFilter: processingOrderStatus),
             emptyStateConfig: .simple(
-                message: NSAttributedString(string: NSLocalizedString("All orders have been fulfilled",
-                                                                      comment: "The message shown in the Orders → Processing tab if the list is empty.")),
+                message: NSAttributedString(string: Localization.processingEmptyStateMessage),
                 image: .waitingForCustomersImage
             )
         )
         processingOrdersVC.delegate = self
 
         let allOrdersVC = OrdersViewController(
-            title: NSLocalizedString("All Orders", comment: "Title for the second page in the Orders tab."),
+            title: Localization.allOrdersTitle,
             viewModel: OrdersViewModel(statusFilter: nil, includesFutureOrders: false),
             emptyStateConfig: .withLink(
-                message: NSAttributedString(string: NSLocalizedString("Waiting for your first order",
-                                                                      comment: "The message shown in the Orders → All Orders tab if the list is empty.")),
+                message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                 image: .emptyOrdersImage,
-                details: NSLocalizedString("We'll notify you when you receive a new order. In the meantime, explore how you can increase your store sales.",
-                                           comment: "The detailed message shown in the Orders → All Orders tab if the list is empty."),
-                linkTitle: NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty."),
+                details: Localization.allOrdersEmptyStateDetail,
+                linkTitle: Localization.learnMore,
                 linkURL: WooConstants.URLs.blog.asURL()
             )
         )
@@ -198,3 +195,23 @@ extension OrdersMasterViewController {
         return button
     }
 }
+
+// MARK: - Localization
+
+private extension OrdersMasterViewController {
+    enum Localization {
+        static let processingTitle = NSLocalizedString("Processing", comment: "Title for the first page in the Orders tab.")
+        static let processingEmptyStateMessage =
+            NSLocalizedString("All orders have been fulfilled",
+                              comment: "The message shown in the Orders → Processing tab if the list is empty.")
+        static let allOrdersTitle = NSLocalizedString("All Orders", comment: "Title for the second page in the Orders tab.")
+        static let allOrdersEmptyStateMessage =
+            NSLocalizedString("Waiting for your first order",
+                              comment: "The message shown in the Orders → All Orders tab if the list is empty.")
+        static let allOrdersEmptyStateDetail =
+            NSLocalizedString("We'll notify you when you receive a new order. In the meantime, explore how you can increase your store sales.",
+                              comment: "The detailed message shown in the Orders → All Orders tab if the list is empty.")
+        static let learnMore = NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty.")
+    }
+}
+

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -164,6 +164,48 @@ extension OrdersMasterViewController {
         return button
     }
 
+    /// Creates the view controllers to be shown in tabs. This will soon replace
+    /// `makeDeprecatedViewControllers()` when iOS 13 is the minimum version.
+    ///
+    /// This is intentionally currently unused.
+    @available(iOS 13.0, *)
+    func makeViewControllers() -> [UIViewController] {
+        // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.
+        let processingOrderStatus = OrderStatus(
+            name: OrderStatusEnum.processing.rawValue,
+            siteID: Int64.max,
+            slug: OrderStatusEnum.processing.rawValue,
+            total: 0
+        )
+
+        // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
+        // text in here. We want the string to be translated.
+        let processingOrdersVC = OrderListViewController(
+            title: Localization.processingTitle,
+            viewModel: OrderListViewModel(statusFilter: processingOrderStatus),
+            emptyStateConfig: .simple(
+                message: NSAttributedString(string: Localization.processingEmptyStateMessage),
+                image: .waitingForCustomersImage
+            )
+        )
+        processingOrdersVC.delegate = self
+
+        let allOrdersVC = OrderListViewController(
+            title: Localization.allOrdersTitle,
+            viewModel: OrderListViewModel(statusFilter: nil, includesFutureOrders: false),
+            emptyStateConfig: .withLink(
+                message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
+                image: .emptyOrdersImage,
+                details: Localization.allOrdersEmptyStateDetail,
+                linkTitle: Localization.learnMore,
+                linkURL: WooConstants.URLs.blog.asURL()
+            )
+        )
+        allOrdersVC.delegate = self
+
+        return [processingOrdersVC, allOrdersVC]
+    }
+
     /// These view controllers will soon be deleted when iOS 13 is the minimum.
     func makeDeprecatedViewControllers() -> [UIViewController] {
         // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -118,8 +118,8 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
 
 // MARK: - OrdersViewControllerDelegate
 
-extension OrdersMasterViewController: OrdersViewControllerDelegate {
-    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController) {
+extension OrdersMasterViewController: OrderListViewControllerDelegate {
+    func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController) {
         viewModel.syncOrderStatuses()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -262,4 +262,3 @@ private extension OrdersMasterViewController {
         static let learnMore = NSLocalizedString("Learn more", comment: "Title of button shown in the Orders → All Orders tab if the list is empty.")
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -77,40 +77,9 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
     /// Return the ViewControllers for "Processing" and "All Orders".
     ///
     override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
-        // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.
-        let processingOrderStatus = OrderStatus(
-            name: OrderStatusEnum.processing.rawValue,
-            siteID: Int64.max,
-            slug: OrderStatusEnum.processing.rawValue,
-            total: 0
-        )
-        // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
-        // text in here. We want the string to be translated.
-        let processingOrdersVC = OrdersViewController(
-            title: Localization.processingTitle,
-            viewModel: OrdersViewModel(statusFilter: processingOrderStatus),
-            emptyStateConfig: .simple(
-                message: NSAttributedString(string: Localization.processingEmptyStateMessage),
-                image: .waitingForCustomersImage
-            )
-        )
-        processingOrdersVC.delegate = self
-
-        let allOrdersVC = OrdersViewController(
-            title: Localization.allOrdersTitle,
-            viewModel: OrdersViewModel(statusFilter: nil, includesFutureOrders: false),
-            emptyStateConfig: .withLink(
-                message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
-                image: .emptyOrdersImage,
-                details: Localization.allOrdersEmptyStateDetail,
-                linkTitle: Localization.learnMore,
-                linkURL: WooConstants.URLs.blog.asURL()
-            )
-        )
-        allOrdersVC.delegate = self
-
-        return [processingOrdersVC, allOrdersVC]
+        makeDeprecatedViewControllers()
     }
+
 }
 
 // MARK: - OrdersViewControllerDelegate
@@ -193,6 +162,43 @@ extension OrdersMasterViewController {
         button.accessibilityIdentifier = "order-search-button"
 
         return button
+    }
+
+    /// These view controllers will soon be deleted when iOS 13 is the minimum.
+    func makeDeprecatedViewControllers() -> [UIViewController] {
+        // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.
+        let processingOrderStatus = OrderStatus(
+            name: OrderStatusEnum.processing.rawValue,
+            siteID: Int64.max,
+            slug: OrderStatusEnum.processing.rawValue,
+            total: 0
+        )
+        // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
+        // text in here. We want the string to be translated.
+        let processingOrdersVC = OrdersViewController(
+            title: Localization.processingTitle,
+            viewModel: OrdersViewModel(statusFilter: processingOrderStatus),
+            emptyStateConfig: .simple(
+                message: NSAttributedString(string: Localization.processingEmptyStateMessage),
+                image: .waitingForCustomersImage
+            )
+        )
+        processingOrdersVC.delegate = self
+
+        let allOrdersVC = OrdersViewController(
+            title: Localization.allOrdersTitle,
+            viewModel: OrdersViewModel(statusFilter: nil, includesFutureOrders: false),
+            emptyStateConfig: .withLink(
+                message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
+                image: .emptyOrdersImage,
+                details: Localization.allOrdersEmptyStateDetail,
+                linkTitle: Localization.learnMore,
+                linkURL: WooConstants.URLs.blog.asURL()
+            )
+        )
+        allOrdersVC.delegate = self
+
+        return [processingOrdersVC, allOrdersVC]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -10,12 +10,6 @@ import XLPagerTabStrip
 
 private typealias SyncReason = OrderListSyncActionUseCase.SyncReason
 
-protocol OrdersViewControllerDelegate: class {
-    /// Called when `OrdersViewController` is about to fetch Orders from the API.
-    ///
-    func ordersViewControllerWillSynchronizeOrders(_ viewController: OrdersViewController)
-}
-
 /// OrdersViewController: Displays the list of Orders associated to the active Store / Account.
 ///
 /// ## Deprecated
@@ -24,7 +18,7 @@ protocol OrdersViewControllerDelegate: class {
 ///
 final class OrdersViewController: UIViewController {
 
-    weak var delegate: OrdersViewControllerDelegate?
+    weak var delegate: OrderListViewControllerDelegate?
 
     private let viewModel: OrdersViewModel
 
@@ -268,7 +262,7 @@ extension OrdersViewController {
 extension OrdersViewController {
     @objc func pullToRefresh(sender: UIRefreshControl) {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
-        delegate?.ordersViewControllerWillSynchronizeOrders(self)
+        delegate?.orderListViewControllerWillSynchronizeOrders(self)
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }
@@ -384,7 +378,7 @@ private extension OrdersViewController {
                 return
             }
 
-            self.delegate?.ordersViewControllerWillSynchronizeOrders(self)
+            self.delegate?.orderListViewControllerWillSynchronizeOrders(self)
             self.sync(pageNumber: pageNumber, pageSize: pageSize, reason: reason)
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5718852B2465D9EC00E2486F /* ReviewsCoordinator.swift */; };
 		571B850224CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571B850124CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift */; };
 		571B850424CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */; };
+		571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571CDD59250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift */; };
 		571FDDAE24C768DC00D486A5 /* MockZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */; };
 		573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A960224F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift */; };
 		573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */; };
@@ -1373,6 +1374,7 @@
 		5718852B2465D9EC00E2486F /* ReviewsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsCoordinator.swift; sourceTree = "<group>"; };
 		571B850124CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppFeedbackCardViewController.swift; sourceTree = "<group>"; };
 		571B850324CF7ECD00CF58A7 /* InAppFeedbackCardViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InAppFeedbackCardViewController.xib; sourceTree = "<group>"; };
+		571CDD59250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewDiffableDataSource+Helpers.swift"; sourceTree = "<group>"; };
 		571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockZendeskManager.swift; sourceTree = "<group>"; };
 		573A960224F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsTopBannerFactoryTests.swift; sourceTree = "<group>"; };
 		573A960424F4374B0091F3A5 /* TopBannerViewMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewMirror.swift; sourceTree = "<group>"; };
@@ -3982,6 +3984,7 @@
 				57612988245888E2007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlus.swift */,
 				02BA12842461674B008D8325 /* Optional+String.swift */,
 				02B8650E24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift */,
+				571CDD59250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5409,6 +5412,7 @@
 				CE4DA5CA21DEA78E00074607 /* NSDecimalNumber+Helpers.swift in Sources */,
 				CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */,
 				02162726237963AF000208D2 /* ProductFormViewController.swift in Sources */,
+				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,
 				020DD49123239DD6005822B1 /* PaginatedListViewControllerStateCoordinator.swift in Sources */,
 				0202B6952387AD1B00F3EBE0 /* UITabBar+Order.swift in Sources */,

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -138,7 +138,8 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     /// }
     /// ```
     public func object(withID objectID: FetchResultSnapshotObjectID) -> MutableType.ReadOnlyType? {
-        assert(!objectID.isTemporaryID, "Expected objectID \(objectID) to be a permanent NSManagedObjectID.")
+        // WIP This assertion will be restored soon.
+        // assert(!objectID.isTemporaryID, "Expected objectID \(objectID) to be a permanent NSManagedObjectID.")
 
         if let storageOrder = storage.loadObject(ofType: MutableType.self, with: objectID) {
             return storageOrder.toReadOnly()

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -68,7 +68,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
         /// those values can be converted to a user-friendly value.
         public let sectionNameKeyPath: String?
 
-        init(sortDescriptor: NSSortDescriptor, predicate: NSPredicate? = nil, sectionNameKeyPath: String? = nil) {
+        public init(sortDescriptor: NSSortDescriptor, predicate: NSPredicate? = nil, sectionNameKeyPath: String? = nil) {
             self.sortDescriptor = sortDescriptor
             self.predicate = predicate
             self.sectionNameKeyPath = sectionNameKeyPath


### PR DESCRIPTION
Part of the DiffableDataSource fix for #1543. This is a continuation of #2797.

⚠️ Depends on #2797. Please review that first. 🙂    

## What

Continuing the plan mentioned in #2797, this implements DiffableDataSource and `FetchResultSnapshotsProvider` on the new (#2797) `OrderListViewController` and `OrderListViewModel` classes. 

![image](https://user-images.githubusercontent.com/198826/92823166-3648d280-f38a-11ea-8b17-b9e81f6fd4d3.png)

### OrderListViewModel Key Changes

`OrderListViewModel` now declares a `snapshotsProvider` which uses the same conditions as the old [`OrdersViewModel.resultsController`](https://github.com/woocommerce/woocommerce-ios/blob/c720e7415d83df7412237d304d6d8fc3c16c8a35/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L52-L76). 

https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift#L53-L75

It's not accessible by the view controller. The view controller will only care about subscribing to new snapshots which are emitted by:

https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift#L77-L80

### OrderListViewController Key Changes

`OrderListViewController` now declares a `DiffableDataSource` which is bound to `tableView.dataSource`. 

https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L38-L46

In order to _feed_ new data to this `DiffableDataSource`, we only need to subscribe to `OrderListViewModel.snapshot`:

https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L201-L204

This subscription is how the `UITableView` will update its sections and rows.

## Key Concepts

### The DiffableDataSource Is The Source of Truth

A key difference between `DiffableDataSource` and the `FetchedResultsController` we used is that the `DiffableDataSource` is the source of truth. Once it has a snapshot, `DiffableDataSource` **does not need** the `FetchedResultsController` to determine how it will present its data. 

Question | Old FRC Implementation | New DiffableDataSource |
--------|-------|---
How many sections?        |    FRC ([sections.count](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L209-L213))   | DataSource (automatically handled)
How many rows in a section? | FRC ([sectionInfo.numberOfObjects](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L215-L219)) | DataSource (automatically handled)
What object is at this `indexPath`? | FRC ([objectIndex](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L203-L207)) | [DataSource.itemIdenfier](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L515-L518) but with support from [FetchResultSnapshotsProvider.object(withID:)](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift#L184)

As you can see, in the old FRC implementation, there are two sources of truth: `UITableView` and `FRC`. The `UITableView` keeps its own list of objects and the FRC also keeps its own list of objects. In the new implementation, there is only one: `DiffableDataSource`. In fact, if the `FetchResultSnapshotsProvider` stops working and stops emitting snapshots, the `DiffableDataSource` can still work. It will be presenting stale data but it will still work. 😄 

### Avoid Using Index Paths

We should avoid using index paths. As much as possible, we should use the `ObjectID`. If you look at the implementation in this PR, we interact with the `DiffableDataSource` first before trying to access more data. For example, in the [`didSelectRowAt` delegate method](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L508), we are only given an `indexPath`. In order to retrieve the actual object (`OrderDetailsViewModel`), we retrieve the `ObjectID` from the `DiffableDataSource` first. And then we _fetch_ the object using the `ObjectID`. 

https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L515-L518

Fetching the `ObjectID` [uses the `StorageType`](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L140-L149) directly and doesn't care whether the FRC (SnapshotsProvider) is in an incorrect state or not. Thereby avoiding the #1543 crash. 

What happens if we tried to use index paths for retrieving the object instead? That would mean that we're now back to the _old way_ of [accessing the object from the `FRC` using index paths](https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift#L190). And that means we're back to having **two sources of truth**. So if it happens that the FRC and the UITableView are not in sync, we get #1543 again 💥.

The same is true with sections, we should use section identifiers instead of the section index as much as possible. 

https://github.com/woocommerce/woocommerce-ios/blob/a13bf7699bcc76576100ebbfc67586603705852d/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L549-L553

In summary, **never trust** the data in `FetchedResultsController`. Only trust its snapshots and the `DiffableDataSource`. 😄 

## Intentional Bug

In the previous PRs (like #2777), I mentioned that I exposed `obtainPermanentIDs` to fix a bug that is caused by using the snapshots of `NSFetchedResultsController`. I intentionally did not use that in this PR yet in order for you, dear reviewer, to be aware of the bug. 😄 I will fix it in a separate PR. 

For now, expect to see empty cells like this:

<img src="https://user-images.githubusercontent.com/198826/92823650-c5ee8100-f38a-11ea-80cf-f59c3102aeb5.png" width="240">

## Testing

1. Edit the [`viewControllers(for:)` delegate method in `OrdersMasterViewController`](https://github.com/woocommerce/woocommerce-ios/blob/5631e4e1f86a10ead37430d6d8c60f9885aea1be/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift#L79-L81) and replace the contents with:

    ```swift
        if #available(iOS 13.0, *) {
            return makeViewControllers()
        } else {
            return makeDeprecatedViewControllers()
        }
    ```
2. Run the app on a device/simulator with iOS 13.0. 
3. Navigate to Orders. 
4. Confirm that orders are loaded and displayed.
5. Pull to refresh and scroll down to load subsequent pages. Confirm that new pages are loaded. Expect to see empty cells at this point. Also, **notice** that when loading subsequent pages, the animation is a little funky and you seem to be thrown to a different location in the table view. That's another bug that will be fixed with `obtainPermanentIDs`. 😁 
6. Tap on an order. Confirm that the correct order details page is shown. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

