### PR TITLE
Feat: added feature flag for Products Release 5

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -9,6 +9,8 @@ struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease4:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .editProductsRelease5:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .issueRefunds:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -17,7 +17,7 @@ enum FeatureFlag: Int {
     /// Edit products - release 4
     ///
     case editProductsRelease4
-    
+
     /// Edit products - release 5
     ///
     case editProductsRelease5

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -17,6 +17,10 @@ enum FeatureFlag: Int {
     /// Edit products - release 4
     ///
     case editProductsRelease4
+    
+    /// Edit products - release 5
+    ///
+    case editProductsRelease5
 
     /// Product Reviews
     ///


### PR DESCRIPTION
Closes #2760 

## Description
This PR aims to start the development of [Product Milestone 5]
https://github.com/woocommerce/woocommerce-ios/projects/21

## Changes
- Adds `.editProductsRelease5` case
- Enable it when `BuildConfiguration.current == .localDeveloper` and `BuildConfiguration.current == .alpha`

### Testing
- Please look at the code
- CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
