### PR TITLE
Core Data: Fix CoreDataManager if the store is in a bad state and can't be loaded

### DIFF
--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -90,7 +90,7 @@ final class CoreDataIterativeMigrator {
         var debugMessages = [String]()
 
         guard modelsToMigrate.count > 1 else {
-            return (false, [])
+            return (false, ["Skipping migration. Unexpectedly found less than 2 models to perform a migration."])
         }
 
         // Migrate between each model. Count - 2 because of zero-based index and we want

--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -89,6 +89,10 @@ final class CoreDataIterativeMigrator {
 
         var debugMessages = [String]()
 
+        guard modelsToMigrate.count > 1 else {
+            return (false, [])
+        }
+
         // Migrate between each model. Count - 2 because of zero-based index and we want
         // to stop at the last pair (you can't migrate the last model to nothingness).
         let upperBound = modelsToMigrate.count - 2

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -63,11 +63,13 @@ public final class CoreDataManager: StorageManagerType {
             var persistentStoreRemovalError: Error?
             do {
                 let fileManager = FileManager.default
-                let storePath = self.storeURL.path
-                let files = try fileManager.contentsOfDirectory(atPath: storePath)
+                let pathToStore = self.storeURL.deletingLastPathComponent().path
+                let files = try fileManager.contentsOfDirectory(atPath: pathToStore)
                 try files.forEach { (file) in
-                    let fullPath = URL(fileURLWithPath: storePath).appendingPathComponent(file).path
-                    try fileManager.removeItem(atPath: fullPath)
+                    if file.hasPrefix(self.storeURL.lastPathComponent) {
+                        let fullPath = URL(fileURLWithPath: pathToStore).appendingPathComponent(file).path
+                        try fileManager.removeItem(atPath: fullPath)
+                    }
                 }
             } catch {
                 persistentStoreRemovalError = error

--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -58,22 +58,17 @@ public final class CoreDataManager: StorageManagerType {
 
             DDLogError("⛔️ [CoreDataManager] loadPersistentStore failed. Attempting to recover... \(persistentStoreLoadingError)")
 
-            /// Backup the old Store
-            ///
-            var persistentStoreBackupError: Error?
-            do {
-                let sourceURL = self.storeURL
-                let backupURL = sourceURL.appendingPathExtension("~")
-                try FileManager.default.copyItem(at: sourceURL, to: backupURL)
-            } catch {
-                persistentStoreBackupError = error
-            }
-
-            /// Remove the old Store
+            /// Remove the old Store which is either corrupted or has an invalid model we can't migrate from
             ///
             var persistentStoreRemovalError: Error?
             do {
-                try FileManager.default.removeItem(at: self.storeURL)
+                let fileManager = FileManager.default
+                let storePath = self.storeURL.path
+                let files = try fileManager.contentsOfDirectory(atPath: storePath)
+                try files.forEach { (file) in
+                    let fullPath = URL(fileURLWithPath: storePath).appendingPathComponent(file).path
+                    try fileManager.removeItem(atPath: fullPath)
+                }
             } catch {
                 persistentStoreRemovalError = error
             }
@@ -88,7 +83,6 @@ public final class CoreDataManager: StorageManagerType {
                 let message = "☠️ [CoreDataManager] Recovery Failed!"
 
                 let logProperties: [String: Any?] = ["persistentStoreLoadingError": persistentStoreLoadingError,
-                                                     "persistentStoreBackupError": persistentStoreBackupError,
                                                      "persistentStoreRemovalError": persistentStoreRemovalError,
                                                      "retryError": error,
                                                      "appState": UIApplication.shared.applicationState.rawValue,
@@ -100,7 +94,6 @@ public final class CoreDataManager: StorageManagerType {
             }
 
             let logProperties: [String: Any?] = ["persistentStoreLoadingError": persistentStoreLoadingError,
-                                                 "persistentStoreBackupError": persistentStoreBackupError,
                                                  "persistentStoreRemovalError": persistentStoreRemovalError,
                                                  "appState": UIApplication.shared.applicationState.rawValue,
                                                  "migrationMessages": migrationDebugMessages]


### PR DESCRIPTION
Issue: #2473 (this doesn't fully close the issue yet)

We're trying to fix several issues with the Core Data Stacl and were directed by Apple to not use `FileManager` to do any copying/backup operations of the SQLite databases. There is a catch that wasn't really considered by Apple at the time - we're trying to do these operations outside of a functioning container. The `PersistentStoreCoordinator` methods recommended for use require a functioning (and fully migrated) store in place. Copying a store copies each individual object over and persists it in the new store.

I dug into this a bit and realized that one of the crashes we're trying to fix was relating to the backup operation within `CoreDataManager` failing. I think the scenario is as such:

1. App loads and a migration change did happen or wasn't detected.
2. Persistent store isn't able to load (for whatever reason - there could be many here).
3. A backup copy of the sqlite file is made with an appended tilde to the filename (weird, but okay).
4. Then it tries to delete the sqlite file.
5. Next it tries loading the persistent store one more time with effectively a wiped db.
6. Step 4 didn't delete the -wal and -shm files so when the new db is created it fails to load properly because of the whacky journaling files from the previous database being there.
7. App fails to load.

## What I fixed

* **No longer back up the database upon a failure -** We don't do anything with it so why bother making a copy? If we end up making tools for a user to submit copies of the db in a support session, we can be wiser about this.
* **Delete all of the files associated with the SQLite db** - This mirrors the logic in the incremental migration class which I know works from previous experience.
* **Make CoreDataIterativeMigrator act better in bad situations** - I added a guard to the migrator class to not throw a runtime except if there aren't two models to migrate (which really shouldn't happen in production). Helps testing a little and robustifies the already cranky class.

## How to test

This is really hard to test. No matter what I tried to do I couldn't get the file manager to fail out fully. I think the fixes that Jaclyn put in do prevent the crash from happening. I did verify that my fix does in fact delete the files as expected to make the re-creation of the db fairly seamless.

You can force a full deletion/recover of the db by:
1. Loading this PR.
2. Editing the current model version and adding a field to any of the entities.
3. Launch the app.
4. The model shouldn't match from the db and it should get deleted and the db reloaded from scratch.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
