### PR TITLE
DiffableDataSource: Add Support for Auto-Updating Cells

### DIFF
--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -137,7 +137,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     }
 
     deinit {
-        stopObservingObjectsDidChangeNotification()
+        stopObservingObjectsDidChangeNotifications()
     }
 
     /// Start fetching and emitting snapshots.
@@ -216,7 +216,7 @@ private extension FetchResultSnapshotsProvider {
 
     func startObservingObjectsDidChangeNotifications() {
         // Remove token in case this method was called already.
-        stopObservingObjectsDidChangeNotification()
+        stopObservingObjectsDidChangeNotifications()
 
         objectsDidChangeObservationToken =
             notificationCenter.addObserver(forName: .NSManagedObjectContextObjectsDidChange, object: storage, queue: nil) { [weak self] notification in
@@ -226,7 +226,7 @@ private extension FetchResultSnapshotsProvider {
         }
     }
 
-    func stopObservingObjectsDidChangeNotification() {
+    func stopObservingObjectsDidChangeNotifications() {
         if let token = objectsDidChangeObservationToken {
             notificationCenter.removeObserver(token)
 

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -253,7 +253,7 @@ private extension FetchResultSnapshotsProvider {
     /// object.dateCreated = Date()
     ///
     /// // A new snapshot will be emitted here
-    /// derviedStorage.saveIfNeeded()
+    /// derivedStorage.saveIfNeeded()
     /// ```
     ///
     /// This new snapshot will have the same `itemIdentifiers` (`NSManagedObjectID`) as expected.

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -106,6 +106,9 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     /// In the future, we can allow this to be mutable if necessary.
     private let query: Query
 
+    /// The NotificationCenter to use for observing notifications.
+    private let notificationCenter: NotificationCenter
+
     /// The publisher that emits snapshots when the fetch results arrive and when the data changes.
     public var snapshot: AnyPublisher<FetchResultSnapshot, Never> {
         snapshotSubject.eraseToAnyPublisher()
@@ -131,9 +134,12 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
 
     private var objectsDidChangeObservationToken: Any?
 
-    public init(storageManager: StorageManagerType, query: Query) {
+    public init(storageManager: StorageManagerType,
+                query: Query,
+                notificationCenter: NotificationCenter = .default) {
         self.storage = storageManager.viewStorage
         self.query = query
+        self.notificationCenter = notificationCenter
     }
 
     deinit {
@@ -209,11 +215,6 @@ private extension FetchResultSnapshotsProvider {
 
 @available(iOS 13.0, *)
 private extension FetchResultSnapshotsProvider {
-
-    /// The NotificationCenter to use for observing notifications.
-    var notificationCenter: NotificationCenter {
-        NotificationCenter.default
-    }
 
     /// Start observing `NSManagedObjectContextObjectsDidChange` notifications so that snapshots
     /// for object updates will be emitted.

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -143,6 +143,8 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     /// Start fetching and emitting snapshots.
     public func start() throws {
         try fetchedResultsController.performFetch()
+
+        startObservingObjectsDidChangeNotifications()
     }
 
     /// Retrieve the immutable type pointed to by `objectID`.


### PR DESCRIPTION
Closes #2807. This is part of the fix for #1543. This adds an additional feature that's supported by [`ResultsController`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/Tools/ResultsController.swift) but not by [`FetchResultSnapshotsProvider`](https://github.com/woocommerce/woocommerce-ios/blob/develop/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift). 

## Problem 

This scenario is possible with `ResultsController`: 

1. The user opens the Orders tab. All the listed orders are up to date.
2. The user leaves the app.
3. An order is changed on the web.
4. The user opens the app (still in the Orders tab). This triggers a synchronization in the background.
5. After the sync, the updated order is received and the cell is refreshed.

However, when using `FetchResultSnapshotsProvider`, the cell is not refreshed. 

### But Why?

To recap, we rely on this delegate method in order to emit snapshots: 

https://github.com/woocommerce/woocommerce-ios/blob/2c8d67d899fa7236e26ed41bb6bf081a109fa833/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L170-L174

Consider this object update code:

```swift
let object = derivedStorage.loadObject(...)
object.dateCreated = Date()

derivedStorage.saveIfNeeded()
```

When `saveIfNeeded()` is called, the FRC will _correctly_ call the `controller(:didChangeContentWith snapshot)` delegate with a new snapshot. The problem is that this new snapshot is pretty much the same as the old snapshot. Meaning, the `itemIdentifiers` (`NSManagedObjectIDs`) are the same since only “data updates” happened. And when this new snapshot is applied to `UITableViewDiffableDataSource`, the `UITableViewDiffableDataSource` probably thinks that nothing has changed because the `itemIdentifiers` are **the same**. 

https://github.com/woocommerce/woocommerce-ios/blob/2c8d67d899fa7236e26ed41bb6bf081a109fa833/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L201-L204

I'm not sure if this is a bug in `NSFetchedResultsController` or is just how things are supposed to be. ¯\\\_(ツ)\_/¯

There's a related discussion about this [here](https://developer.apple.com/forums/thread/120320). 

## Solution

To circumvent this, I added a `NSManagedObjectContextObjectsDidChange` observer in `FetchResultSnapshotsProvider`. 

https://github.com/woocommerce/woocommerce-ios/blob/a6aa69faa5a2981fb0294d52699931cf11c6b5b7/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L222-L232

From this `Notification`, we will grab the _updated_ objects. A new snapshot will be created and `reloadItems` will be called on the updated object IDs:

https://github.com/woocommerce/woocommerce-ios/blob/a6aa69faa5a2981fb0294d52699931cf11c6b5b7/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L305-L307

This [`reloadItems`](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot/3375783-reloaditems) method somehow informs `UITableViewDiffableDataSource` to reload the appropriate cells. And this fixes the problem.

### Alternative Considered

As discussed with @jaclync in the past, we considered using the [`didChangeContent:` delegate methods of `NSFetchedResultsControllerDelegate`](https://developer.apple.com/documentation/coredata/nsfetchedresultscontrollerdelegate). However, these methods are no longer called because declaring `controller(:didChangeConetntWith snapshot:)` [silences the other methods](https://developer.apple.com/documentation/coredata/nsfetchedresultscontrollerdelegate/3235742-controller).

> If this method is implemented, no other delegate methods are invoked. 

## Testing

1. Edit the [`viewControllers(for:)` delegate method in `OrdersMasterViewController`](https://github.com/woocommerce/woocommerce-ios/blob/5631e4e1f86a10ead37430d6d8c60f9885aea1be/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift#L79-L81) and replace the contents with:

    ```swift
        if #available(iOS 13.0, *) {
            return makeViewControllers()
        } else {
            return makeDeprecatedViewControllers()
        }
    ```
2. Run the app on a device/simulator with iOS 13.0. 
3. Navigate to Orders. 
4. When the orders are loaded, make note of one of the orders in the visible list. 
5. Place the app in the background. 
6. In wp-admin, change the status of the order that you noted. 
7. Open the app again. This should trigger and auto-sync. 
8. Wait for a bit. Confirm that the order's status is updated.

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

