### PR TITLE
Enable DiffableDataSource for Orders Tab and Orders → Search → Filter

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - [*] bugfix: now reviews are refreshed correctly. If you try to delete or to set as spam a review from the web, the result will match in the product reviews list.
 - [*] If the Products switch is on in Settings > Experimental Features:
   - For a variable product, the stock status is not shown in the product details anymore when stock management is disabled since stock status is controlled at variation level.
+- [internal] The Order List and Orders Search → Filter has a new backend architecture (#2820). This was changed as an experiment to fix #1543. This affects iOS 13.0 users only. No new behaviors have been added. Github project: https://git.io/JUBco. 
 
 
 5.0

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -77,7 +77,11 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
     /// Return the ViewControllers for "Processing" and "All Orders".
     ///
     override func viewControllers(for pagerTabStripController: PagerTabStripViewController) -> [UIViewController] {
-        makeDeprecatedViewControllers()
+        if #available(iOS 13, *) {
+            return makeViewControllers()
+        } else {
+            return makeDeprecatedViewControllers()
+        }
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -107,7 +107,7 @@ extension OrderSearchStarterViewController: UITableViewDelegate {
             return message
         }()
         let ordersViewController = OrdersViewController(
-            title: cellViewModel.name ?? NSLocalizedString("Orders", comment: "Default title for Orders List shown when tapping on the Search filter."),
+            title: cellViewModel.name ?? Localization.defaultOrderListTitle,
             viewModel: OrdersViewModel(statusFilter: cellViewModel.orderStatus),
             emptyStateConfig: .simple(message: emptyStateMessage, image: .emptySearchResultsImage)
         )
@@ -123,6 +123,14 @@ extension OrderSearchStarterViewController: UITableViewDelegate {
 extension OrderSearchStarterViewController: KeyboardScrollable {
     var scrollable: UIScrollView {
         tableView
+    }
+}
+
+// MARK: - Other Private Helpers
+
+private extension OrderSearchStarterViewController {
+    enum Localization {
+        static let defaultOrderListTitle = NSLocalizedString("Orders", comment: "Default title for Orders List shown when tapping on the Search filter.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -141,7 +141,7 @@ private extension OrderSearchStarterViewController {
         } else {
             return OrdersViewController(
                 title: title,
-                viewModel: OrdersViewModel(statusFilter: cellViewModel.orderStatus),
+                viewModel: .init(statusFilter: cellViewModel.orderStatus),
                 emptyStateConfig: emptyStateConfig
             )
         }


### PR DESCRIPTION
Closes #2809. 

This enables all the work that was done for implementing DiffableDataSource for Orders to circumvent #1543. This does not fully fix #1543 because that crash happens (sometimes) on our other view controllers too. But if this is successful, then we can then convert everything else to use DiffableDataSource. 

All the PRs that led to this moment are in [this Github project](https://github.com/woocommerce/woocommerce-ios/projects/22). There are still some remaining debts in there that can be tackled later. 

## Reversal

If it turns out that this DiffableDataSource implementation is worse than the original, we can reverse everything by reverting the changes in this PR. 

## Testing

1. Use an iOS 13.0+ device.
1. Navigate to Orders → Processing. Confirm that the orders are filtered by Processing. 
2.. Navigate to Orders → All Orders. Confirm that all orders are shown. 
3. Confirm that the infinite load still works. 
4. Navigate to Orders → Search. 
5. Tap on a filter. Confirm that an order list is shown with orders having the selected filter. 

### Push Notifications 

1. Enable push notifications in your sandbox.
6. Place the app in the background.
7. Submit a new order on the web.
8. Tap on the push notification. Confirm that the order details page is opened.

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

