### PR TITLE
Order Details: refetch results for all results controllers after storage is reset

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -100,7 +100,11 @@ private extension OrderDetailsResultsControllers {
             onReload()
         }
 
-        trackingResultsController.onDidResetContent = {
+        trackingResultsController.onDidResetContent = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.refetchAllResultsControllers()
             onReload()
         }
 
@@ -112,7 +116,11 @@ private extension OrderDetailsResultsControllers {
             onReload()
         }
 
-        productResultsController.onDidResetContent = {
+        productResultsController.onDidResetContent = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.refetchAllResultsControllers()
             onReload()
         }
 
@@ -124,10 +132,21 @@ private extension OrderDetailsResultsControllers {
             onReload()
         }
 
-        refundResultsController.onDidResetContent = {
+        refundResultsController.onDidResetContent = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.refetchAllResultsControllers()
             onReload()
         }
 
         try? refundResultsController.performFetch()
+    }
+
+    func refetchAllResultsControllers() {
+        try? productResultsController.performFetch()
+        try? refundResultsController.performFetch()
+        try? trackingResultsController.performFetch()
+        try? statusResultsController.performFetch()
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -143,6 +143,8 @@ private extension OrderDetailsResultsControllers {
         try? refundResultsController.performFetch()
     }
 
+    /// Refetching all the results controllers is necessary after a storage reset in `onDidResetContent` callback and before reloading UI that
+    /// involves more than one results controller.
     func refetchAllResultsControllers() {
         try? productResultsController.performFetch()
         try? refundResultsController.performFetch()


### PR DESCRIPTION
Attempted fix for #2251

While looking into another crash of the same reason (`Object's persistent store is not reachable from this NSManagedObjectContext's coordinator`), I came to understand a bit more when this type of crash might occur after the Core Data reset (resetting the main context & persistent store):
- Loading results from a context that has been reset without another fetch
- Saving objects to a child context created before the reset

For #2251, it's the first case where the `ResultsController` (FRC underneath) is reloading UI that access the objects from another FRC whose objects haven't been refreshed. After the storage reset, each FRC has to call `performFetch` again so that it fetches the objects from the updated context. The objects from a FRC without `performFetch` after the reset have un unknown persistent store since [the previous store was destroyed](https://github.com/woocommerce/woocommerce-ios/blob/2fb6346361477633c210b39c265d72ed2b5a5b75/Storage/Storage/CoreData/CoreDataManager.swift#L153-L166).

The crash only happens for UI that relies on more than one FRC and whose UI involves another FRC, because `ResultsController` [already calls `performFetch` before the `onDidResetContent` callback](https://github.com/woocommerce/woocommerce-ios/blob/2fb6346361477633c210b39c265d72ed2b5a5b75/Yosemite/Yosemite/Tools/ResultsController.swift#L256-L267) after storage reset. As the [stack trace](https://sentry.io/organizations/a8c/issues/1703307167/?project=1458804&query=is%3Aunresolved&sort=user&statsPeriod=14d) indicates, it's the **refund FRC** reloading UI that reads `[Product]` from **product FRC** that hasn't been refreshed. From my testing, the refund FRC's `onDidResetContent` is always called first before other FRCs.

[FRC: Fetched results controller ([`NSFetchedResultsController`](https://developer.apple.com/documentation/coredata/nsfetchedresultscontroller))]

## Changes

- Since Order Details UI has 4 FRCs, and each result controller's `onDidResetContent` is called upon NSNotification observation, I thought it'd be safer to call `performFetch` for all FRCs before any reload UI action in each result controller's `onDidResetContent`.

## Testing

- Launch the app in logged in state
- Go to the Orders tab
- Tap on an order with the products section shown
- Go to the My Store tab > Settings, and log out --> the app should be logged out without crashing (it crashes consistently before the PR)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
