### PR TITLE
Order Filter Counts: Show The Full Numbers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 - [*] If the Products switch is on in Settings > Experimental Features:
   - For a variable product, the stock status is not shown in the product details anymore when stock management is disabled since stock status is controlled at variation level.
 - [internal] The Order List and Orders Search → Filter has a new backend architecture (#2820). This was changed as an experiment to fix #1543. This affects iOS 13.0 users only. No new behaviors have been added. Github project: https://git.io/JUBco. 
+- [*] Orders → Search list will now show the full counts instead of “99+”. #2825
 
 
 5.0

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -13,6 +13,8 @@ import protocol Storage.StorageManagerType
 final class OrderSearchStarterViewModel {
     private let siteID: Int64
     private let storageManager: StorageManagerType
+    /// The locale to use for formattinng the total number.
+    private let locale: Locale
 
     /// The `ViewModel` containing only the data used by the displayed cell.
     ///
@@ -41,9 +43,11 @@ final class OrderSearchStarterViewModel {
     }()
 
     init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min,
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         locale: Locale = .current) {
         self.siteID = siteID
         self.storageManager = storageManager
+        self.locale = locale
     }
 
     /// Start all the operations that this `ViewModel` is responsible for.

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -13,7 +13,7 @@ import protocol Storage.StorageManagerType
 final class OrderSearchStarterViewModel {
     private let siteID: Int64
     private let storageManager: StorageManagerType
-    /// The locale to use for formattinng the total number.
+    /// The locale to use for formatting the total number.
     private let locale: Locale
 
     /// The `ViewModel` containing only the data used by the displayed cell.
@@ -87,8 +87,7 @@ extension OrderSearchStarterViewModel {
     ///
     func cellViewModel(at indexPath: IndexPath) -> CellViewModel {
         let orderStatus = resultsController.object(at: indexPath)
-
-        let total = NumberFormatter.localizedOrNinetyNinePlus(orderStatus.total)
+        let total = NSNumber(value: orderStatus.total).description(withLocale: locale)
 
         return CellViewModel(name: orderStatus.name,
                              slug: orderStatus.slug,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
@@ -31,7 +31,7 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func testItLoadsAllTheOrderStatusForTheGivenSite() {
+    func test_it_loads_all_the_OrderStatus_for_the_given_site() {
         // Given
         let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
 
@@ -52,7 +52,7 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.cellViewModels.contains(where: { $0.slug == unexpectedItem.slug }))
     }
 
-    func testItSortsTheOrderStatusesBySlug() {
+    func test_it_sorts_the_OrderStatuses_by_slug() {
         // Given
         let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
 
@@ -70,7 +70,7 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.cellViewModels.slugs, expectedSlugs)
     }
 
-    func testItReturnsTheNameSlugAndTotalInTheCellViewModel() {
+    func test_it_returns_the_name_slug_and_total_in_the_CellViewModel() {
         // Given
         let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
 
@@ -90,7 +90,7 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
                        NumberFormatter.localizedString(from: NSNumber(value: 18), number: .none))
     }
 
-    func testGivenAnOrderStatusTotalOfMoreThanNinetyNineItUsesNinetyNinePlus() {
+    func test_given_an_OrderStatus_total_of_more_than_ninety_nine_it_uses_ninety_nine_plus() {
         // Given
         let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchStarterViewModelTests.swift
@@ -90,11 +90,13 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
                        NumberFormatter.localizedString(from: NSNumber(value: 18), number: .none))
     }
 
-    func test_given_an_OrderStatus_total_of_more_than_ninety_nine_it_uses_ninety_nine_plus() {
+    func test_total_given_an_OrderStatus_total_of_more_than_ninety_nine_it_uses_the_complete_localized_number() {
         // Given
-        let viewModel = OrderSearchStarterViewModel(siteID: siteID, storageManager: storageManager)
+        let viewModel = OrderSearchStarterViewModel(siteID: siteID,
+                                                    storageManager: storageManager,
+                                                    locale: Locale(identifier: "en_US"))
 
-        insert(OrderStatus(name: "Processing", siteID: siteID, slug: "slug", total: 200))
+        insert(OrderStatus(name: "Processing", siteID: siteID, slug: "slug", total: 2187))
 
         viewModel.activateAndForwardUpdates(to: UITableView())
 
@@ -102,7 +104,24 @@ final class OrderSearchStarterViewModelTests: XCTestCase {
         let cellViewModel = viewModel.cellViewModel(at: IndexPath(row: 0, section: 0))
 
         // Then
-        XCTAssertEqual(cellViewModel.total, NSLocalizedString("99+", comment: ""))
+        XCTAssertEqual(cellViewModel.total, "2,187")
+    }
+
+    func test_total_given_a_zero_OrderStatus_total_it_uses_a_zero_string() {
+        // Given
+        let viewModel = OrderSearchStarterViewModel(siteID: siteID,
+                                                    storageManager: storageManager,
+                                                    locale: Locale(identifier: "en_US"))
+
+        insert(OrderStatus(name: "Processing", siteID: siteID, slug: "slug", total: 0))
+
+        viewModel.activateAndForwardUpdates(to: UITableView())
+
+        // When
+        let cellViewModel = viewModel.cellViewModel(at: IndexPath(row: 0, section: 0))
+
+        // Then
+        XCTAssertEqual(cellViewModel.total, "0")
     }
 }
 


### PR DESCRIPTION
As requested in p4a5px-2D8-p2, this changes the Order filter counts to show the full number instead of truncating it to “99+”. 

This was also done in Android: https://github.com/woocommerce/woocommerce-android/pull/2853.

## Design

Before | After 
--------|-------
![Simulator Screen Shot - iPhone 11 (Develop) - 2020-09-16 at 09 08 59](https://user-images.githubusercontent.com/198826/93356363-50f0d080-f7fc-11ea-92ea-a5816947cab4.png)        |       ![Simulator Screen Shot - iPhone 11 - 2020-09-16 at 09 08 16](https://user-images.githubusercontent.com/198826/93356373-53532a80-f7fc-11ea-9974-0a2ce10e3f73.png)

## Testing

1. Use a site that has more than 99 orders with the same status (e.g. “Processing”).
2. Navigate to Orders tab → Search.
3. Confirm that you don't see “99+” for that status and instead can see all the actual count. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

