### PR TITLE
Enables selection guide in ProductTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -54,7 +54,7 @@ class ProductTableViewCell: UITableViewCell {
         priceLabel.applyBodyStyle()
         detailLabel.applyFootnoteStyle()
         applyProductImageStyle()
-        contentView.backgroundColor = .listForeground
+        backgroundColor = .listForeground
         bottomBorderView.backgroundColor = .systemColor(.separator)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift
@@ -56,6 +56,7 @@ class ProductTableViewCell: UITableViewCell {
         applyProductImageStyle()
         backgroundColor = .listForeground
         bottomBorderView.backgroundColor = .systemColor(.separator)
+        selectionStyle = .default
     }
 
     private func applyProductImageStyle() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="104" id="KGk-i7-Jjw" customClass="ProductTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="104" id="KGk-i7-Jjw" customClass="ProductTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="288" height="104"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">


### PR DESCRIPTION

# Why 

I noticed a strange lag when tapping on a top performer's cell. To debug that issue @astralbodies figured it would be nice to see the selection state of the cell to identify any touch problem.

# How

After enabling the selection style on the cell xib, Xcode changed the IB version, and the lag disappeared. 🤷 

# Testing Steps
- Launch the app
- Tap on a top performers product row
- Make sure that there is no lag and that the cell shows a selection guide

# Gif 
Lag + no Selection | No lag + Selection
---- | ----
![original-lag](https://user-images.githubusercontent.com/562080/93392009-b0b79d80-f835-11ea-860c-1cee748747db.gif) |  ![new-no-lag](https://user-images.githubusercontent.com/562080/93391985-a7c6cc00-f835-11ea-9f9a-589233f00f27.gif)
 

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
