### PR TITLE
Update StatsVersionCoordinator to return V4 as the default stats version

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsVersionCoordinator.swift
@@ -34,7 +34,7 @@ final class StatsVersionCoordinator {
                 return
             }
 
-            let lastStatsVersion: StatsVersion = initialStatsVersion ?? StatsVersion.v3
+            let lastStatsVersion: StatsVersion = initialStatsVersion ?? StatsVersion.v4
             self.version = lastStatsVersion
 
             // Execute network request to check if the API supports the V4 stats

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -61,7 +61,7 @@ final class DashboardUIFactoryTests: XCTestCase {
     }
 
     /// Stats v4 --> v4
-    func testWhenV4IsAvailableWhileStatsV4IsLastShown() {
+    func test_when_V4_is_available_while_stats_V4_is_last_shown() {
         mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
                                                             sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = true
@@ -80,7 +80,7 @@ final class DashboardUIFactoryTests: XCTestCase {
     }
 
     /// Stats v4 --> v3 --> v4
-    func testWhenV4IsUnavailableAndThenAvailableWhileStatsV4IsLastShown() {
+    func test_when_V4_is_unavailable_and_then_available_while_stats_v4_is_last_shown() {
         mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
                                                             sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardUIFactoryTests.swift
@@ -15,47 +15,49 @@ final class DashboardUIFactoryTests: XCTestCase {
         super.tearDown()
     }
 
-    func testWhenV4IsAvailableWhileNoStatsVersionIsSaved() {
+    func test_it_loads_only_statsV4_when_V4_is_available_while_no_stats_version_is_saved() {
+        // Given
         mockStoresManager = MockupStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = true
         ServiceLocator.setStores(mockStoresManager)
-
         dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
 
-        var dashboardUITypes: [UIViewController.Type] = []
-        let expectedDashboardUITypes: [UIViewController.Type] = [DeprecatedDashboardStatsViewController.self,
-                                                                 // `StoreStatsAndTopPerformersViewController` is the VC for the v4 stats
-                                                                 StoreStatsAndTopPerformersViewController.self]
-        let expectation = self.expectation(description: "Wait for the stats v4")
-        expectation.expectedFulfillmentCount = 1
-
-        dashboardUIFactory.reloadDashboardUI { dashboardUI in
-            dashboardUITypes.append(type(of: dashboardUI))
-            if dashboardUITypes.count >= expectedDashboardUITypes.count {
-                for i in 0..<dashboardUITypes.count {
-                    XCTAssertTrue(dashboardUITypes[i] == expectedDashboardUITypes[i])
-                }
-                expectation.fulfill()
+        // When
+        var dashboard: DashboardUI?
+        waitForExpectation { exp in
+            dashboardUIFactory.reloadDashboardUI { dashboardUI in
+                dashboard = dashboardUI
+                exp.fulfill()
             }
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+
+        // Then
+        XCTAssertTrue(dashboard is StoreStatsAndTopPerformersViewController)
     }
 
-    func testWhenV4IsUnavailableWhileNoStatsVersionIsSaved() {
+    func test_it_loads_deprecated_dashboard_when_V4_is_unavailable_while_no_stats_version_is_saved() {
+        // Given
         mockStoresManager = MockupStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.isStatsV4Available = false
         ServiceLocator.setStores(mockStoresManager)
-
         dashboardUIFactory = DashboardUIFactory(siteID: mockSiteID)
 
-        let expectation = self.expectation(description: "Wait for the stats v4")
-        expectation.expectedFulfillmentCount = 1
+        // When
+        var dashboardUITypes: [UIViewController.Type] = []
+        let expectedDashboardUITypes: [UIViewController.Type] = [StoreStatsAndTopPerformersViewController.self,
+                                                                 DeprecatedDashboardStatsViewController.self]
 
-        dashboardUIFactory.reloadDashboardUI { dashboardUI in
-            XCTAssertTrue(dashboardUI is DeprecatedDashboardStatsViewController)
-            expectation.fulfill()
+        waitForExpectation(description: #function, count: expectedDashboardUITypes.count) { exp in
+            dashboardUIFactory.reloadDashboardUI { dashboardUI in
+                dashboardUITypes.append(type(of: dashboardUI))
+                exp.fulfill()
+            }
         }
-        waitForExpectations(timeout: 0.1, handler: nil)
+
+        // Then
+        XCTAssertEqual(dashboardUITypes.count, expectedDashboardUITypes.count)
+        XCTAssertTrue(dashboardUITypes[0] == expectedDashboardUITypes[0])
+        XCTAssertTrue(dashboardUITypes[1] == expectedDashboardUITypes[1])
     }
 
     /// Stats v4 --> v4

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsVersionCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsVersionCoordinatorTests.swift
@@ -46,7 +46,7 @@ final class StatsVersionCoordinatorTests: XCTestCase {
     }
 
     /// Stats v3 --> v4
-    func testWhenV4IsAvailableWhileStatsV3IsLastShown() {
+    func test_when_V4_is_available_while_stats_V3_is_last_shown() {
         // Given
         mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v3,
                                                             sessionManager: SessionManager.testingInstance)
@@ -63,7 +63,7 @@ final class StatsVersionCoordinatorTests: XCTestCase {
     }
 
     /// Stats v3 --> v3
-    func testWhenV4IsUnavailableWhileStatsV3IsLastShown() {
+    func test_when_V4_is_unavailable_while_stats_V3_is_last_shown() {
         // Given
         mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v3,
                                                             sessionManager: SessionManager.testingInstance)
@@ -81,7 +81,7 @@ final class StatsVersionCoordinatorTests: XCTestCase {
     }
 
     /// Stats v4 --> v3
-    func testWhenV4IsUnavailableWhileStatsV4IsLastShown() {
+    func test_when_V4_is_unavailable_while_stats_V4_is_last_shown() {
         // Given
         mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
                                                             sessionManager: SessionManager.testingInstance)
@@ -98,7 +98,7 @@ final class StatsVersionCoordinatorTests: XCTestCase {
     }
 
     /// V4 --> v4
-    func testWhenV4IsAvailableWhileStatsV4IsLastShown() {
+    func test_when_V4_is_available_while_stats_V4_is_last_shown() {
         // Given
         mockStoresManager = MockupStatsVersionStoresManager(initialStatsVersionLastShown: .v4,
                                                             sessionManager: SessionManager.testingInstance)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsVersionCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsVersionCoordinatorTests.swift
@@ -11,15 +11,15 @@ final class StatsVersionCoordinatorTests: XCTestCase {
         super.tearDown()
     }
 
-    func testWhenV4IsAvailableWhileNoStatsVersionWasShownBefore() {
+    func test_it_returns_v4_version_when_V4_is_available_while_no_stats_version_was_shown_before() {
         // Given
         mockStoresManager = MockupStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.statsVersionLastShown = nil
         mockStoresManager.isStatsV4Available = true
         ServiceLocator.setStores(mockStoresManager)
 
-        // V3 is returned because it is the default value if `statsVersionLastShown` is `nil`
-        let expectedVersions: [StatsVersion] = [.v3, .v4]
+        // V4 is returned because it is the default value if `statsVersionLastShown` is `nil`
+        let expectedVersions: [StatsVersion] = [.v4]
 
         // When
         let actualVersions = checkStatsVersionAndWait(expectedVersionChangesCount: expectedVersions.count)
@@ -28,15 +28,15 @@ final class StatsVersionCoordinatorTests: XCTestCase {
         XCTAssertEqual(actualVersions, expectedVersions)
     }
 
-    func testWhenV4IsUnavailableWhileNoStatsVersionWasShownBefore() {
+    func test_it_transition_from_v4_to_v3_when_V4_is_unavailable_while_no_stats_version_was_shown_before() {
         // Given
         mockStoresManager = MockupStatsVersionStoresManager(sessionManager: SessionManager.testingInstance)
         mockStoresManager.statsVersionLastShown = nil
         mockStoresManager.isStatsV4Available = false
         ServiceLocator.setStores(mockStoresManager)
 
-        // We will only receive one change because the stats-check should return the same value.
-        let expectedVersions: [StatsVersion] = [.v3]
+        // Initial value is `.v4` when `statsVersionLastShown` is `nil`
+        let expectedVersions: [StatsVersion] = [.v4, .v3]
 
         // When
         let actualVersions = checkStatsVersionAndWait(expectedVersionChangesCount: expectedVersions.count)


### PR DESCRIPTION
# Why

@astralbodies noticed that the experience for a new user is not the best since the "Deprecated Stats" screen is shown for a bit while the app fetches the stats version availability.

# How

To mitigate this, I'm making `.V4` to be the default version. This implies that a new user will see the stats loading screen immediately and will change to the deprecated stats screen only after validating that `.V4` is not available.

# Gifs

Before - V4 YES | After - V4 YES | After - V4 NO
---- | ---- | ----
![before-v4-yes](https://user-images.githubusercontent.com/562080/93485301-8cf16780-f8c8-11ea-8e82-9eb9258750cf.gif) | ![after-v4-yes](https://user-images.githubusercontent.com/562080/93485344-98449300-f8c8-11ea-91dd-8482f88a6958.gif) | ![after-no-v4](https://user-images.githubusercontent.com/562080/93485402-a72b4580-f8c8-11ea-96ec-b74b3326aef0.gif)

# Testing steps
- Make sure v4 is enabled by changing the line `45` in `StatsVersionCoordinator.swift` to
```swift
let nextVersion: StatsVersion = .v4
```
- Logout from the app.
- Login to your store.
- Make sure there is no glitch(screen swapping) when logging in.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
