### PR TITLE
Reset SnapshotsProvider When The StorageManager Is Reset

### DIFF
--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -167,8 +167,9 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
         try fetchedResultsController.performFetch()
     }
 
-    /// Returns `true` if the `start()` method was previously called.
-    private var isStarted: Bool {
+    /// Returns `true` if the `performFetch()` method was previously called, which activates
+    /// the `fetchedResultsController`.
+    private var fetchedResultsControllerIsActive: Bool {
         fetchedResultsController.fetchedObjects != nil
     }
 
@@ -388,7 +389,7 @@ private extension FetchResultSnapshotsProvider {
     ///    “tested” that it works because it was already called in `start()`.
     ///
     func restart() {
-        guard isStarted else {
+        guard fetchedResultsControllerIsActive else {
             return
         }
 

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -150,10 +150,21 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
 
     /// Start fetching and emitting snapshots.
     public func start() throws {
-        try fetchedResultsController.performFetch()
+        try performFetch()
 
         startObservingStorageManagerDidResetNotifications()
         startObservingObjectsDidChangeNotifications()
+    }
+
+    /// Start `fetchedResultsController` fetching and dispatching of snapshots.
+    ///
+    /// This needs to be called when:
+    ///
+    /// 1. This class is started in `start()`.
+    /// 2. The `StorageManager` is reset.
+    /// 3. When `self.query` changes.
+    private func performFetch() throws {
+        try fetchedResultsController.performFetch()
     }
 
     /// Returns `true` if the `start()` method was previously called.
@@ -367,7 +378,7 @@ private extension FetchResultSnapshotsProvider {
         }
     }
 
-    /// If previously started, restart fetching and re-observe notifications.
+    /// If previously started, restart `fetchedResultsController` fetching notifications.
     ///
     /// Exceptions are swallowed because:
     ///
@@ -381,11 +392,8 @@ private extension FetchResultSnapshotsProvider {
             return
         }
 
-        // We only really need to call `performFetch()` to restart everything and fix the crash.
-        // I just think it's a simpler flow to have one single method to “start” and ”restart”
-        // this class.
         do {
-            try self.start()
+            try performFetch()
         } catch {
             DDLogError("⛔️ FetchResultSnapshotsProvider: Failed to restart with error \(error)")
         }

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -191,23 +191,22 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
 @available(iOS 13.0, *)
 private extension FetchResultSnapshotsProvider {
     /// Start `fetchedResultsController` fetching and dispatching of snapshots.
+    func activateFetchedResultsController() throws {
+        try fetchedResultsController.performFetch()
+    }
+
+    /// Returns `true` if the `activateFetchedResultsController()` method was previously called.
+    var fetchedResultsControllerIsActive: Bool {
+        fetchedResultsController.fetchedObjects != nil
+    }
+
+    /// If previously activated, restart `fetchedResultsController` fetching and dispatching of snapshots.
     ///
     /// This needs to be called when:
     ///
     /// 1. This class is started in `start()`.
     /// 2. The `StorageManager` is reset.
     /// 3. When `self.query` changes.
-    func activateFetchedResultsController() throws {
-        try fetchedResultsController.performFetch()
-    }
-
-    /// Returns `true` if the `performFetch()` method was previously called, which activates
-    /// the `fetchedResultsController`.
-    var fetchedResultsControllerIsActive: Bool {
-        fetchedResultsController.fetchedObjects != nil
-    }
-
-    /// If previously activated, restart `fetchedResultsController` fetching and dispatching of snapshots.
     ///
     /// Exceptions are swallowed because:
     ///

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -209,9 +209,8 @@ private extension FetchResultSnapshotsProvider {
     ///
     /// This needs to be called when:
     ///
-    /// 1. This class is started in `start()`.
-    /// 2. The `StorageManager` is reset.
-    /// 3. When `self.query` changes.
+    /// 1. The `StorageManager` is reset.
+    /// 2. When `self.query` changes.
     ///
     /// Exceptions are swallowed because:
     ///

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -101,6 +101,10 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     /// probably move this to a background `StorageType` since `UITableViewDiffableDataSource`
     /// allows consuming snapshots in the background.
     private let storage: StorageType
+    /// The `StorageManagerType` that `self.storage` belongs to.
+    ///
+    /// This is used for observing notifications.
+    private let storageManager: StorageManagerType
     /// The conditions to use when fetching the results.
     ///
     /// In the future, we can allow this to be mutable if necessary.
@@ -138,6 +142,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     public init(storageManager: StorageManagerType,
                 query: Query,
                 notificationCenter: NotificationCenter = .default) {
+        self.storageManager = storageManager
         self.storage = storageManager.viewStorage
         self.query = query
         self.notificationCenter = notificationCenter
@@ -399,7 +404,7 @@ private extension FetchResultSnapshotsProvider {
         stopObservingStorageManagerDidResetNotifications()
 
         storageManagerDidResetObservationToken =
-            notificationCenter.addObserver(forName: .StorageManagerDidResetStorage, object: nil, queue: nil) { _ in
+            notificationCenter.addObserver(forName: .StorageManagerDidResetStorage, object: storageManager, queue: nil) { _ in
                 self.restartFetchedResultsController()
         }
     }

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -144,6 +144,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     }
 
     deinit {
+        stopObservingStorageManagerDidResetNotifications()
         stopObservingObjectsDidChangeNotifications()
     }
 

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -150,7 +150,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
 
     /// Start fetching and emitting snapshots.
     public func start() throws {
-        try performFetch()
+        try activateFetchedResultsController()
 
         startObservingStorageManagerDidResetNotifications()
         startObservingObjectsDidChangeNotifications()
@@ -163,7 +163,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     /// 1. This class is started in `start()`.
     /// 2. The `StorageManager` is reset.
     /// 3. When `self.query` changes.
-    private func performFetch() throws {
+    private func activateFetchedResultsController() throws {
         try fetchedResultsController.performFetch()
     }
 
@@ -394,7 +394,7 @@ private extension FetchResultSnapshotsProvider {
         }
 
         do {
-            try performFetch()
+            try activateFetchedResultsController()
         } catch {
             DDLogError("⛔️ FetchResultSnapshotsProvider: Failed to restart with error \(error)")
         }

--- a/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -133,6 +133,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     private lazy var hiddenFetchedResultsControllerDelegate = HiddenFetchedResultsControllerDelegate(self)
 
     private var objectsDidChangeObservationToken: Any?
+    private var storageManagerDidResetObservationToken: Any?
 
     public init(storageManager: StorageManagerType,
                 query: Query,
@@ -150,6 +151,7 @@ public final class FetchResultSnapshotsProvider<MutableType: FetchResultSnapshot
     public func start() throws {
         try fetchedResultsController.performFetch()
 
+        startObservingStorageManagerDidResetNotifications()
         startObservingObjectsDidChangeNotifications()
     }
 
@@ -323,5 +325,32 @@ private struct ObjectsDidChangeNotification {
 
     var updatedObjects: Set<NSManagedObject> {
         (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) ?? Set()
+    }
+}
+
+// MARK: - StorageManager Reset Handling
+
+@available(iOS 13.0, *)
+private extension FetchResultSnapshotsProvider {
+
+    func startObservingStorageManagerDidResetNotifications() {
+        // Remove just in case this method was called already.
+        stopObservingStorageManagerDidResetNotifications()
+
+        storageManagerDidResetObservationToken =
+            notificationCenter.addObserver(forName: .StorageManagerDidResetStorage, object: nil, queue: nil) { _ in
+
+        }
+    }
+
+    /// Stop observing `StorageManagerDidResetStorage` notifications
+    ///
+    /// - SeeAlso: startObservingStorageManagerDidResetNotifications
+    func stopObservingStorageManagerDidResetNotifications() {
+        if let token = storageManagerDidResetObservationToken {
+            notificationCenter.removeObserver(token)
+
+            storageManagerDidResetObservationToken = nil
+        }
     }
 }


### PR DESCRIPTION
Fixes #2831. Thanks to @jaclync for finding this crash before production! 😌 

## Findings

The crash that happens after performing the steps in #2831 is something like this:

```
[error] error: Serious application error.  Exception was caught during Core Data change processing.  This is usually a bug within an observer of NSManagedObjectContextObjectsDidChangeNotification.  Object's persistent store is not reachable from this NSManagedObjectContext's coordinator with userInfo (null)
```

The stack trace indicates that the root cause is the same as what we experienced in https://github.com/woocommerce/woocommerce-ios/pull/2821 and https://github.com/woocommerce/woocommerce-ios/issues/2830. It's because we destroy the persistent store when the user logs out:

https://github.com/woocommerce/woocommerce-ios/blob/feb952d722b96decdac07fd42e9e75a678155432/Storage/Storage/CoreData/CoreDataManager.swift#L153-L158

As for why the `FetchResultSnapshotsProvider` reacts to this, I had thought that this was because we have an observer for `NSManagedObjectContextObjectsDidChange`:

https://github.com/woocommerce/woocommerce-ios/blob/feb952d722b96decdac07fd42e9e75a678155432/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L276-L281

But when I removed that code, the crash still happens. I'm positive that the crash is coming from [`NSFetchedResultsController`  itself](https://github.com/woocommerce/woocommerce-ios/blob/feb952d722b96decdac07fd42e9e75a678155432/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L122-L134), which also uses that `Notification`. 

## Solution

Luckily, this problem was already solved in our [`ResultsController`](https://github.com/woocommerce/woocommerce-ios/blob/issue/2831-diffabledatasource-react-on-reset/Yosemite/Yosemite/Tools/ResultsController.swift). `ResultsController` simply executes `performFetch()` again if the `StorageManager` is reset. 

https://github.com/woocommerce/woocommerce-ios/blob/feb952d722b96decdac07fd42e9e75a678155432/Storage/Storage/CoreData/CoreDataManager.swift#L153-L158

And that's also what I came up with for `FetchResultSnapshotsProvider`:

https://github.com/woocommerce/woocommerce-ios/blob/feb952d722b96decdac07fd42e9e75a678155432/Yosemite/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift#L405-L408

## Testing

1. Launch the app in a logged-in state
2. Navigate to the Orders tab and wait for some data to load.
3. Log out from the app
4. Log in to a store.
5. Navigate to the Orders tab. Confirm that the app did not crash and orders are loaded and displayed on the table.

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

