### PR TITLE
[issue Refund] Add issue refund button

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -644,7 +644,7 @@ extension OrderDetailsDataSource {
                 rows.append(.netAmount)
             }
 
-            if isIssueRefundsEnabled {
+            if isIssueRefundsEnabled && !isRefundedStatus {
                 rows.append(.issueRefundButton)
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -146,7 +146,7 @@ final class OrderDetailsDataSource: NSObject {
 
     init(order: Order,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         isIssueRefundsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.issueRefunds)) {
+         isIssueRefundsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.issueRefunds)) {
         self.storageManager = storageManager
         self.order = order
         self.couponLines = order.coupons

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -11,6 +11,9 @@ final class OrderDetailsDataSource: NSObject {
     /// This is only used to pass as a dependency to `OrderDetailsResultsControllers`.
     private let storageManager: StorageManagerType
 
+    /// Used while the `issueRefunds` feature is under development
+    private let isIssueRefundsEnabled: Bool
+
     private(set) var order: Order
     private let couponLines: [OrderCouponLine]?
 
@@ -141,10 +144,13 @@ final class OrderDetailsDataSource: NSObject {
 
     private let imageService: ImageService = ServiceLocator.imageService
 
-    init(order: Order, storageManager: StorageManagerType = ServiceLocator.storageManager) {
+    init(order: Order,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         isIssueRefundsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(FeatureFlag.issueRefunds)) {
         self.storageManager = storageManager
         self.order = order
         self.couponLines = order.coupons
+        self.isIssueRefundsEnabled = isIssueRefundsEnabled
 
         super.init()
     }
@@ -638,7 +644,9 @@ extension OrderDetailsDataSource {
                 rows.append(.netAmount)
             }
 
-            rows.append(.issueRefundButton)
+            if isIssueRefundsEnabled {
+                rows.append(.issueRefundButton)
+            }
 
             return Section(title: Title.payment, rows: rows)
         }()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -251,6 +251,8 @@ private extension OrderDetailsDataSource {
             configureSummary(cell: cell)
         case let cell as WooBasicTableViewCell where row == .refundedProducts:
             configureRefundedProducts(cell)
+        case let cell as IssueRefundTableViewCell:
+            configureIssueRefundButton(cell: cell)
         default:
             fatalError("Unidentified customer info row type")
         }
@@ -443,6 +445,13 @@ private extension OrderDetailsDataSource {
         }
     }
 
+    // TODO: Change: actions
+    private func configureIssueRefundButton(cell: IssueRefundTableViewCell) {
+        cell.onIssueRefundTouchUp = {
+            print("Issue refund pressed")
+        }
+    }
+
     private func configureTracking(cell: OrderTrackingTableViewCell, at indexPath: IndexPath) {
         guard let tracking = orderTracking(at: indexPath) else {
             return
@@ -628,6 +637,8 @@ extension OrderDetailsDataSource {
                 rows.append(contentsOf: refunds)
                 rows.append(.netAmount)
             }
+
+            rows.append(.issueRefundButton)
 
             return Section(title: Title.payment, rows: rows)
         }()
@@ -923,6 +934,7 @@ extension OrderDetailsDataSource {
         case fulfillButton
         case details
         case refundedProducts
+        case issueRefundButton
         case customerNote
         case shippingAddress
         case shippingMethod
@@ -952,6 +964,8 @@ extension OrderDetailsDataSource {
                 return WooBasicTableViewCell.reuseIdentifier
             case .refundedProducts:
                 return WooBasicTableViewCell.reuseIdentifier
+            case .issueRefundButton:
+                return IssueRefundTableViewCell.reuseIdentifier
             case .customerNote:
                 return CustomerNoteTableViewCell.reuseIdentifier
             case .shippingAddress:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -158,7 +158,8 @@ extension OrderDetailsViewModel {
             ProductDetailsTableViewCell.self,
             OrderTrackingTableViewCell.self,
             SummaryTableViewCell.self,
-            FulfillButtonTableViewCell.self
+            FulfillButtonTableViewCell.self,
+            IssueRefundTableViewCell.self
         ]
 
         for cell in cells {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Displays a  button to issue new refunds.
 ///
 final class IssueRefundTableViewCell: UITableViewCell {
-    @IBOutlet public var issueRefundButton: UIButton!
+    @IBOutlet private var issueRefundButton: UIButton!
 
     var onIssueRefundTouchUp: (() -> Void)?
 
@@ -17,7 +17,7 @@ final class IssueRefundTableViewCell: UITableViewCell {
 
 // MARK: Actions
 extension IssueRefundTableViewCell {
-    @IBAction func issueReffundWasPressed() {
+    @IBAction func issueRefundWasPressed() {
         onIssueRefundTouchUp?()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+/// Displays a  button to issue new refunds.
+///
+final class IssueRefundTableViewCell: UITableViewCell {
+    @IBOutlet public var issueRefundButton: UIButton!
+
+    var onIssueRefundTouchUp: (() -> Void)?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureBackground()
+        configureIssueRefundButton()
+    }
+}
+
+// MARK: Actions
+extension IssueRefundTableViewCell {
+    @IBAction func issueReffundWasPressed() {
+        onIssueRefundTouchUp?()
+    }
+}
+
+// MARK: View Configuration
+private extension IssueRefundTableViewCell {
+    func configureBackground() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func configureIssueRefundButton() {
+        issueRefundButton.applySecondaryButtonStyle()
+        issueRefundButton.setTitle(Localization.buttonTitle, for: .normal)
+    }
+}
+
+// MARK: Localization
+private extension IssueRefundTableViewCell {
+    enum Localization {
+        static let buttonTitle = NSLocalizedString("Issue Refund", comment: "Text on the button that starts a new refund process")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="75" id="fuv-Nn-28X" userLabel="Issue Refund Table View Cell" customClass="IssueRefundTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fuv-Nn-28X" id="CG6-L4-IlA">
+                <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dGs-KW-oeN">
+                        <rect key="frame" x="20" y="19" width="291" height="37"/>
+                        <state key="normal" title="Button"/>
+                        <connections>
+                            <action selector="issueReffundWasPressed" destination="fuv-Nn-28X" eventType="touchUpInside" id="gJF-ZY-Rl9"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="dGs-KW-oeN" firstAttribute="trailing" secondItem="CG6-L4-IlA" secondAttribute="trailingMargin" id="D71-hO-tsp"/>
+                    <constraint firstItem="dGs-KW-oeN" firstAttribute="top" secondItem="CG6-L4-IlA" secondAttribute="topMargin" constant="8" id="J1U-2h-Tr9"/>
+                    <constraint firstItem="dGs-KW-oeN" firstAttribute="leading" secondItem="CG6-L4-IlA" secondAttribute="leadingMargin" id="d8d-tf-cqg"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="dGs-KW-oeN" secondAttribute="bottom" constant="8" id="etE-u2-ANx"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="Qis-3m-y2m"/>
+            <connections>
+                <outlet property="issueRefundButton" destination="dGs-KW-oeN" id="C3N-Yi-k6W"/>
+            </connections>
+            <point key="canvasLocation" x="39.200000000000003" y="75.112443778110944"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/IssueRefundTableViewCell.xib
@@ -21,7 +21,7 @@
                         <rect key="frame" x="20" y="19" width="291" height="37"/>
                         <state key="normal" title="Button"/>
                         <connections>
-                            <action selector="issueReffundWasPressed" destination="fuv-Nn-28X" eventType="touchUpInside" id="gJF-ZY-Rl9"/>
+                            <action selector="issueRefundWasPressed" destination="fuv-Nn-28X" eventType="touchUpInside" id="p0d-jQ-7to"/>
                         </connections>
                     </button>
                 </subviews>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -321,6 +321,8 @@
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
+		26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ABCE522518EAF300721CB0 /* IssueRefundTableViewCell.swift */; };
+		26ABCE552518EB0600721CB0 /* IssueRefundTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26ABCE542518EB0600721CB0 /* IssueRefundTableViewCell.xib */; };
 		26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */; };
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
@@ -1280,6 +1282,8 @@
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
 		2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SurveySubmittedViewController.xib; sourceTree = "<group>"; };
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
+		26ABCE522518EAF300721CB0 /* IssueRefundTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundTableViewCell.swift; sourceTree = "<group>"; };
+		26ABCE542518EB0600721CB0 /* IssueRefundTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundTableViewCell.xib; sourceTree = "<group>"; };
 		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
@@ -4051,6 +4055,8 @@
 				CE2A9FCD23C4F2C8002BEC1C /* RefundedProductsViewController.xib */,
 				CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */,
 				CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */,
+				26ABCE522518EAF300721CB0 /* IssueRefundTableViewCell.swift */,
+				26ABCE542518EB0600721CB0 /* IssueRefundTableViewCell.xib */,
 			);
 			path = Refunds;
 			sourceTree = "<group>";
@@ -4831,6 +4837,7 @@
 				02C8876E24501FAC00E4470F /* FilterListViewController.xib in Resources */,
 				CE21B3D820FE669A00A259D5 /* BasicTableViewCell.xib in Resources */,
 				74334F37214AB130006D6AC5 /* ProductTableViewCell.xib in Resources */,
+				26ABCE552518EB0600721CB0 /* IssueRefundTableViewCell.xib in Resources */,
 				4592A54C24BF58DD00BC3DE0 /* ProductTagsViewController.xib in Resources */,
 				CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */,
 				74F9E9CD214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib in Resources */,
@@ -5229,6 +5236,7 @@
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
 				02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */,
+				26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */,
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -4,13 +4,13 @@ final class MockOrders {
     let siteID: Int64 = 1234
     let orderID: Int64 = 5678
 
-    func makeOrder(items: [OrderItem] = []) -> Order {
+    func makeOrder(status: OrderStatusEnum = .processing, items: [OrderItem] = []) -> Order {
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
                      customerID: 11,
                      number: "963",
-                     statusKey: "processing",
+                     statusKey: status.rawValue,
                      currency: "USD",
                      customerNote: "",
                      dateCreated: date(with: "2018-04-03T23:05:12"),


### PR DESCRIPTION
fixes #1487 

# Why

This would be the entry point for the refunds flow.

# How
- Added a new `IssueRefundTableViewCell` to represent the "issue refund button "
- Hide the button if the `.issueRefunds` feature flag is disabled or if the order is refunded.

# Screenshots

<img width="388" alt="Screen Shot 2020-09-21 at 3 08 51 PM" src="https://user-images.githubusercontent.com/562080/93815944-6dd23d00-fc1c-11ea-84cf-4c70c3c73930.png">


# Testing Steps
- Create an order on the web-store
- Navigate to the order in the app and see that the "issue refund" button is visible.
- Do a full refund on web admin
- Refresh the order in the app and see that the "issue refund" button is not visible.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
