### PR TITLE
CoreDataManager: Log metadataForPersistentStore error

### DIFF
--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -177,8 +177,11 @@ public final class CoreDataManager: StorageManagerType {
             return debugMessages
         }
 
-        guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType, at: storeURL, options: nil) else {
-            debugMessages.append("Cannot get metadata for persistent store at URL \(storeURL)")
+        let metadata: [String: Any]
+        do {
+            metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType, at: storeURL, options: nil)
+        } catch {
+            debugMessages.append("Cannot get metadata for persistent store at URL \(storeURL): \(error)")
             return debugMessages
         }
 


### PR DESCRIPTION
Ref #2667. 

## Findings

In some of the “Recovery Failed” errors like [this](https://sentry.io/share/issue/d1497b3ad58e4cba8249599fd9efc0eb/), I noticed that the app failed to load the metadata here:

https://github.com/woocommerce/woocommerce-ios/blob/6a31c4106d4ff25cebe62c27cd186e06a6ecd353/Storage/Storage/CoreData/CoreDataManager.swift#L180-L183

And then after that, the backup failed that says `“The file “WooCommerce.sqlite” doesn’t exist.”`. 

What's curious is that we have a file existence check **before** any of the above happened.

https://github.com/woocommerce/woocommerce-ios/blob/6a31c4106d4ff25cebe62c27cd186e06a6ecd353/Storage/Storage/CoreData/CoreDataManager.swift#L173-L178

And the file existence check _passed_. Did the file disappear in between? Who knows. 🤷 

## Solution

This PR adds logging for the error thrown by `NSPersistentStoreCoordinator.metadataForPersistentStore` so we have more information about these types of errors. 

## Testing 

1. Use `develop` and run and install the app so there will be an initial `WooCommerce.sqlite` file.
2. Use this branch. 
3. Add breakpoints on these lines:

    https://github.com/woocommerce/woocommerce-ios/blob/fb5fbc906b6b42107c95b4b6087a4de78645a09d/Storage/Storage/CoreData/CoreDataManager.swift#L182

    https://github.com/woocommerce/woocommerce-ios/blob/fb5fbc906b6b42107c95b4b6087a4de78645a09d/Storage/Storage/CoreData/CoreDataManager.swift#L185
4. Run the app on a simulator.
5. When the first breakpoint is hit, delete the file pointed to by `storeURL` (the `WooCommerce.sqlite` file). 
6. Continue running.
7. When the second breakpoint is hit, confirm that the `debugMessages` variable contains the error message `“Cannot get metadata for persistent store at URL...”` along with the error. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

