### PR TITLE
fix: `test_addProduct_relays_netwoking_error()` now calls the correct API request

### DIFF
--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -115,7 +115,7 @@ final class ProductsRemoteTests: XCTestCase {
         let product = sampleProduct()
         var result: Result<Product, Error>?
         waitForExpectation { expectation in
-            remote.updateProduct(product: product) { aResult in
+            remote.addProduct(product: product) { aResult in
                 result = aResult
                 expectation.fulfill()
             }


### PR DESCRIPTION
Fixes #2854

## Description
Minor change. There was an error in our Unit Tests: `test_addProduct_relays_netwoking_error()` was calling the wrong API request.

## Testing
This PR doesn't affect existing behavior, just CI!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
