### PR TITLE
Switches to an in-memory SQLite store which works better for testing

### DIFF
--- a/Yosemite/YosemiteTests/Mockups/MockupStorage.swift
+++ b/Yosemite/YosemiteTests/Mockups/MockupStorage.swift
@@ -115,7 +115,8 @@ extension MockupStorageManager {
     ///
     var storeDescription: NSPersistentStoreDescription {
         let description = NSPersistentStoreDescription()
-        description.type = NSInMemoryStoreType
+        description.type = NSSQLiteStoreType
+        description.url = URL(fileURLWithPath: "/dev/null")
         return description
     }
 }


### PR DESCRIPTION
The traditional in-memory store doesn't have all of the same functionality that SQLite does. In particular, it can't enforce certain constraints from the model like uniqueness and a few others. In 2018, [Apple mentioned](https://developer.apple.com/videos/play/wwdc2018/224/?time=1838) that the SQLite in-memory store option was available by specifying the file location of `/dev/null`.

I've updated the unit testing Core Data stack to use this type of store. All of the unit tests continue to pass!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.