### PR TITLE
Yosemite: Log Fatal Errors to Sentry

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/WooCommerce Alpha.xcscheme
@@ -70,6 +70,12 @@
             ReferencedContainer = "container:WooCommerce.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-force-crash-logging 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		45ED4F16239E939A004F1BE3 /* TaxClassStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */; };
 		570B05CF246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */; };
 		57150E1124F462D900E81611 /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 57150E1024F462D900E81611 /* TestKit */; };
+		571D7E3F251BB9FA00606E96 /* LogErrorAndExit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571D7E3E251BB9FA00606E96 /* LogErrorAndExit.swift */; };
 		5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5726456E250BD4E4005BBD7C /* OrdersUpsertUseCase.swift */; };
 		57264572250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57264571250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift */; };
 		572F2B8D247312E4005A5F74 /* StorageManagerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */; };
@@ -340,6 +341,7 @@
 		45E18631237046CB009241F3 /* ShippingLine+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLine+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		45ED4F15239E939A004F1BE3 /* TaxClassStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxClassStoreTests.swift; sourceTree = "<group>"; };
 		570B05CE246B6AAD00C186AE /* RetrieveProductReviewFromNoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveProductReviewFromNoteUseCase.swift; sourceTree = "<group>"; };
+		571D7E3E251BB9FA00606E96 /* LogErrorAndExit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogErrorAndExit.swift; sourceTree = "<group>"; };
 		5726456E250BD4E4005BBD7C /* OrdersUpsertUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersUpsertUseCase.swift; sourceTree = "<group>"; };
 		57264571250BE2E7005BBD7C /* OrdersUpsertUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersUpsertUseCaseTests.swift; sourceTree = "<group>"; };
 		572F2B8C247312E4005A5F74 /* StorageManagerConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageManagerConcurrencyTests.swift; sourceTree = "<group>"; };
@@ -1053,6 +1055,7 @@
 				933A27342222352500C2143A /* Logging.swift */,
 				743057B2218B69D100441A76 /* Queue.swift */,
 				02E4F5E323CD5628003B0010 /* NSOrderedSet+Array.swift */,
+				571D7E3E251BB9FA00606E96 /* LogErrorAndExit.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1414,6 +1417,7 @@
 				749375042249691D007D85D1 /* Product+ReadOnlyConvertible.swift in Sources */,
 				CE43A90222A072D800A4FF29 /* ProductDownload+ReadOnlyConvertible.swift in Sources */,
 				B5C9DE182087FF0E006B910A /* Assert.swift in Sources */,
+				571D7E3F251BB9FA00606E96 /* LogErrorAndExit.swift in Sources */,
 				CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */,
 				0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */,
 				2614E12A24C7451D007CEE60 /* LeaderboardStatsConverter.swift in Sources */,

--- a/Yosemite/Yosemite/Base/Dispatcher.swift
+++ b/Yosemite/Yosemite/Base/Dispatcher.swift
@@ -38,7 +38,7 @@ public class Dispatcher {
         assertMainThread()
 
         guard processors[actionType.identifier] == nil else {
-            fatalError("An action type can only be handled by a single processor!")
+            logErrorAndExit("An action type can only be handled by a single processor!")
         }
 
         processors[actionType.identifier] = WeakProcessor(processor: processor)

--- a/Yosemite/Yosemite/Base/Store.swift
+++ b/Yosemite/Yosemite/Base/Store.swift
@@ -49,13 +49,13 @@ open class Store: ActionsProcessor {
     /// Subclasses should override this and register for supported Dispatcher Actions.
     ///
     open func registerSupportedActions(in dispatcher: Dispatcher) {
-        fatalError("Override me!")
+        logErrorAndExit("Override me!")
     }
 
     /// This method is called for every Action. Subclasses should override this and deal with the Actions relevant to them.
     ///
     open func onAction(_ action: Action) {
-        fatalError("Override me!")
+        logErrorAndExit("Override me!")
     }
 }
 

--- a/Yosemite/Yosemite/Internal/LogErrorAndExit.swift
+++ b/Yosemite/Yosemite/Internal/LogErrorAndExit.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Logs the error in CocoaLumberjack and stops app execution.
+///
+/// Prefer to use this instead of `fatalError()` since messages in fatal errors are not visible
+/// in Sentry.
+///
+internal func logErrorAndExit(_ message: String, file: StaticString = #file, line: UInt = #line) {
+    DDLogError(message)
+    fatalError(message, file: file, line: line)
+}

--- a/Yosemite/Yosemite/Internal/LogErrorAndExit.swift
+++ b/Yosemite/Yosemite/Internal/LogErrorAndExit.swift
@@ -2,10 +2,11 @@ import Foundation
 
 /// Logs the error in CocoaLumberjack and stops app execution.
 ///
-/// Prefer to use this instead of `fatalError()` since messages in fatal errors are not visible
-/// in Sentry.
+/// Prefer to use this instead of `fatalError()` since messages in fatal errors are not shown
+/// in Sentry. Using this method, Sentry will still only show “Fatal error” in the Issue message
+/// but the `message` can now be accessed through the Encrypted Logging Console.
 ///
-internal func logErrorAndExit(_ message: String, file: StaticString = #file, line: UInt = #line) {
+internal func logErrorAndExit(_ message: String, file: StaticString = #file, line: UInt = #line) -> Never {
     DDLogError(message)
     fatalError(message, file: file, line: line)
 }

--- a/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
+++ b/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval+Date.swift
@@ -4,7 +4,7 @@ extension OrderStatsV4Interval {
     /// Returns the interval start date by parsing the `dateStart` string.
     public func dateStart(timeZone: TimeZone) -> Date {
         guard let date = createDateFormatter(timeZone: timeZone).date(from: dateStart) else {
-            fatalError("Failed to parse date: \(dateStart)")
+            logErrorAndExit("Failed to parse date: \(dateStart)")
         }
         return date
     }
@@ -12,7 +12,7 @@ extension OrderStatsV4Interval {
     /// Returns the interval end date by parsing the `dateEnd` string.
     public func dateEnd(timeZone: TimeZone) -> Date {
         guard let date = createDateFormatter(timeZone: timeZone).date(from: dateEnd) else {
-            fatalError("Failed to parse date: \(dateEnd)")
+            logErrorAndExit("Failed to parse date: \(dateEnd)")
         }
         return date
     }

--- a/Yosemite/Yosemite/Stores/NotificationCountStore.swift
+++ b/Yosemite/Yosemite/Stores/NotificationCountStore.swift
@@ -23,7 +23,7 @@ public final class NotificationCountStore: Store {
     ///
     private lazy var fileURL: URL = {
         guard let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            fatalError("Cannot find app document directory URL")
+            logErrorAndExit("Cannot find app document directory URL")
         }
         return documents.appendingPathComponent(Constants.notificationCountFileName)
     }()


### PR DESCRIPTION
This is supposed to help with diagnosing #2858. We should also do the same for Storage (#2364) and Networking (#2372).   

## Changes

I added a new function, `logErrorAndExit()` which uses `DDLogError` and `fatalError` internally. The `DDLogError` will be sent to the Encrypted Logs. The `fatalError()` will be sent to Sentry with just “Fatal error” like before. But now, the underlying message will be accessible in the Encrypted Logs. Read more about Encrypted Logging at paaHJt-1ms-p2. 

https://github.com/woocommerce/woocommerce-ios/blob/5732be3f36caa0358edc33d265bc31110dd7a773/Yosemite/Yosemite/Internal/LogErrorAndExit.swift#L9-L12

## Testing

1. Use the WooCommerce Alpha scheme. 
2. Turn the `force-crash-logging` launch argument on

    <img src="https://user-images.githubusercontent.com/198826/94052090-b4977280-fd95-11ea-9bb3-c0766315a343.png" width="340">

3. Add a breakpoint on [this line](https://github.com/Automattic/Automattic-Tracks-iOS/blob/5f96537a62a8b7d3eb6635cb4dd8489dd39fc62a/Automattic-Tracks-iOS/Event%20Logging/EventLogging%2BSentry.swift#L33) of the Tracks `EventLogging+Sentry.swift` file. 
4. Change [this line](https://github.com/woocommerce/woocommerce-ios/blob/5732be3f36caa0358edc33d265bc31110dd7a773/Yosemite/Yosemite/Model/Extensions/OrderStatsV4Interval%2BDate.swift#L6) of the `OrderStatsV4Internal+Date` file to this so that it will crash later:

    ```swift
        guard let date = createDateFormatter(timeZone: timeZone).date(from: "abc") else {
    ```
5. Run and install the app on the simulator. 
6. Log in. The app will crash.
7. Stop debugging. 
8. Open the app on the simulator again. Not from Xcode. Open it a few times. This is to make sure that the crash will be queued. 
9. Revert the change in Step 4. 
10. Run the app from Xcode again. 
11. The app should stop in the breakpoint in Step 3. 
12. Capture and save the value of `logFile.uuid`. 
13. Let the app finish running so it will update the crash to Sentry. 
14. Head to the Encrypted Logs Console. 
15. Enter the `UUID` you captured in step 12 and click on View.
16. Confirm that you see the error message like this:

    <img src="https://user-images.githubusercontent.com/198826/94052742-98e09c00-fd96-11ea-8277-0d79757158a6.png" width="440">


## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

