### PR TITLE
Issue/2755 display downloadable files for a product test cases

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -58,7 +58,8 @@ private extension AddProductCoordinator {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true)
+                                             isEditProductsRelease3Enabled: true,
+                                             isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewModel.swift
@@ -23,7 +23,7 @@ protocol ProductDownloadListActionHandler {
     func didTapDownloadableFileFromRow(_ indexPath: IndexPath)
 
     // Input field actions
-    func handleDownloadsChange(_ downloads: [ProductDownload])
+    func handleDownloadableFilesChange(_ downloads: [ProductDownload])
     func handleDownloadLimitChange(_ downloadLimit: Int64)
     func handleDownloadExpiryChange(_ downloadExpiry: Int64)
 
@@ -88,7 +88,7 @@ extension ProductDownloadListViewModel: ProductDownloadListActionHandler {
     // MARK: - UI changes
 
     // Input field actions
-    func handleDownloadsChange(_ downloads: [ProductDownload]) {
+    func handleDownloadableFilesChange(_ downloads: [ProductDownload]) {
         self.downloadableFiles = downloads.map { ProductDownloadDragAndDrop(downloadableFile: $0) }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -42,7 +42,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     init(product: EditableProductModel,
          formType: ProductFormType,
          isEditProductsRelease3Enabled: Bool,
-         isEditProductsRelease5Enabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)) {
+         isEditProductsRelease5Enabled: Bool) {
         self.product = product
         self.formType = formType
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -37,13 +37,16 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let product: EditableProductModel
     private let formType: ProductFormType
     private let isEditProductsRelease3Enabled: Bool
+    private let isEditProductsRelease5Enabled: Bool
 
     init(product: EditableProductModel,
          formType: ProductFormType,
-         isEditProductsRelease3Enabled: Bool) {
+         isEditProductsRelease3Enabled: Bool,
+         isEditProductsRelease5Enabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)) {
         self.product = product
         self.formType = formType
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
     }
 
     /// Returns an array of actions that are visible in the product form primary section.
@@ -90,7 +93,7 @@ private extension ProductFormActionsFactory {
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let shouldShowCategoriesRow = isEditProductsRelease3Enabled
         let shouldShowTagsRow = isEditProductsRelease3Enabled
-        let showDownloadableProduct = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5) && product.downloadable
+        let showDownloadableProduct = isEditProductsRelease5Enabled && product.downloadable
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings,
@@ -210,7 +213,7 @@ private extension ProductFormActionsFactory {
             return product.product.tags.isNotEmpty
         // Downloadable files. Only core product types for downloadable files are able to handle downloadable files.
         case .downloadableFiles:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5) && product.downloadable
+            return isEditProductsRelease5Enabled && product.downloadable
         case .briefDescription:
             return product.shortDescription.isNilOrEmpty == false
         // Affiliate products only.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -59,7 +59,8 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
             actionsFactory = ProductFormActionsFactory(product: product,
                                                        formType: formType,
-                                                       isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                                       isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             productSubject.send(product)
         }
     }
@@ -81,21 +82,25 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
     private let productImageActionHandler: ProductImageActionHandler
     private let isEditProductsRelease3Enabled: Bool
+    private let isEditProductsRelease5Enabled: Bool
 
     private var cancellable: ObservationToken?
 
     init(product: EditableProductModel,
          formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandler,
-         isEditProductsRelease3Enabled: Bool) {
+         isEditProductsRelease3Enabled: Bool,
+         isEditProductsRelease5Enabled: Bool) {
         self.formType = formType
         self.productImageActionHandler = productImageActionHandler
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.originalProduct = product
         self.product = product
         self.actionsFactory = ProductFormActionsFactory(product: product,
                                                         formType: formType,
-                                                        isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                                        isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                        isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         self.isUpdateEnabledSubject = PublishSubject<Bool>()
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -27,7 +27,8 @@ struct ProductDetailsFactory {
                                     presentationStyle: presentationStyle,
                                     currencySettings: currencySettings,
                                     isEditProductsEnabled: isEditProductsEnabled,
-                                    isEditProductsRelease3Enabled: isFeatureSwitchOn)
+                                    isEditProductsRelease3Enabled: isFeatureSwitchOn,
+                                    isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
             onCompletion(vc)
         }
         stores.dispatch(action)
@@ -39,7 +40,8 @@ private extension ProductDetailsFactory {
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings,
                                isEditProductsEnabled: Bool,
-                               isEditProductsRelease3Enabled: Bool) -> UIViewController {
+                               isEditProductsRelease3Enabled: Bool,
+                               isEditProductsRelease5Enabled: Bool) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
         let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
@@ -48,7 +50,8 @@ private extension ProductDetailsFactory {
             let viewModel = ProductFormViewModel(product: productModel,
                                                  formType: .edit,
                                                  productImageActionHandler: productImageActionHandler,
-                                                 isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                                 isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                 isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             vc = ProductFormViewController(viewModel: viewModel,
                                            eventLogger: ProductFormEventLogger(),
                                            productImageActionHandler: productImageActionHandler,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F301592200EC0800931B9E /* NSDecimalNumberWooTests.swift */; };
 		74F9E9CD214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */; };
 		74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */; };
+		77423F17251CF77E0016A083 /* ProductDownloadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */; };
 		77E53EB8250E6A4E003D385F /* ProductDownloadListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EB6250E6A4E003D385F /* ProductDownloadListViewController.swift */; };
 		77E53EB9250E6A4E003D385F /* ProductDownloadListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77E53EB7250E6A4E003D385F /* ProductDownloadListViewController.xib */; };
 		77E53EBF2510C153003D385F /* ProductDownloadListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EBE2510C153003D385F /* ProductDownloadListViewModel.swift */; };
@@ -1499,6 +1500,7 @@
 		74F301592200EC0800931B9E /* NSDecimalNumberWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDecimalNumberWooTests.swift; sourceTree = "<group>"; };
 		74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoPeriodDataTableViewCell.xib; sourceTree = "<group>"; };
 		74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoPeriodDataTableViewCell.swift; sourceTree = "<group>"; };
+		77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadListViewModelTests.swift; sourceTree = "<group>"; };
 		77E53EB6250E6A4E003D385F /* ProductDownloadListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadListViewController.swift; sourceTree = "<group>"; };
 		77E53EB7250E6A4E003D385F /* ProductDownloadListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductDownloadListViewController.xib; sourceTree = "<group>"; };
 		77E53EBE2510C153003D385F /* ProductDownloadListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadListViewModel.swift; sourceTree = "<group>"; };
@@ -1988,6 +1990,7 @@
 		020B2F9723BDF2D000BD79AD /* Edit Product */ = {
 			isa = PBXGroup;
 			children = (
+				77423F14251CF59D0016A083 /* Downloadable Files */,
 				02A275C723FEA102005C560F /* ProductFormActionsFactoryTests.swift */,
 				263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */,
 				0258B66A2518754C00EB5CF2 /* ProductFormActionsFactory+AddProductTests.swift */,
@@ -3251,6 +3254,22 @@
 				7493BB8D2149852A003071A9 /* TopPerformersHeaderView.xib */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		77423F14251CF59D0016A083 /* Downloadable Files */ = {
+			isa = PBXGroup;
+			children = (
+				77423F15251CF5AE0016A083 /* FIle List */,
+			);
+			path = "Downloadable Files";
+			sourceTree = "<group>";
+		};
+		77423F15251CF5AE0016A083 /* FIle List */ = {
+			isa = PBXGroup;
+			children = (
+				77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */,
+			);
+			path = "FIle List";
 			sourceTree = "<group>";
 		};
 		77E53EB5250E6972003D385F /* Downloadable Files */ = {
@@ -5757,6 +5776,7 @@
 				D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */,
 				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */,
+				77423F17251CF77E0016A083 /* ProductDownloadListViewModelTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,
 				022A45EE237BADA6001417F0 /* Product+ProductFormTests.swift in Sources */,
 				B57C5C9921B80E7100FF82B2 /* DictionaryWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3259,17 +3259,9 @@
 		77423F14251CF59D0016A083 /* Downloadable Files */ = {
 			isa = PBXGroup;
 			children = (
-				77423F15251CF5AE0016A083 /* FIle List */,
-			);
-			path = "Downloadable Files";
-			sourceTree = "<group>";
-		};
-		77423F15251CF5AE0016A083 /* FIle List */ = {
-			isa = PBXGroup;
-			children = (
 				77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */,
 			);
-			path = "FIle List";
+			path = "Downloadable Files";
 			sourceTree = "<group>";
 		};
 		77E53EB5250E6972003D385F /* Downloadable Files */ = {

--- a/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockProduct.swift
@@ -68,9 +68,9 @@ final class MockProduct {
                    totalSales: 0,
                    virtual: virtual,
                    downloadable: downloadable,
-                   downloads: [],
-                   downloadLimit: -1,
-                   downloadExpiry: -1,
+                   downloads: downloadable ? sampleDownloads() : [],
+                   downloadLimit: downloadable ? 1 : -1,
+                   downloadExpiry: downloadable ? 1 : -1,
                    buttonText: "",
                    externalURL: externalURL,
                    taxStatusKey: taxStatus.rawValue,
@@ -107,6 +107,19 @@ final class MockProduct {
                    menuOrder: menuOrder)
 
     }
+
+    func sampleDownloads() -> [Networking.ProductDownload] {
+         let download1 = ProductDownload(downloadID: "1f9c11f99ceba63d4403c03bd5391b11",
+                                         name: "Song #1",
+                                         fileURL: "https://example.com/woo-single-1.ogg")
+         let download2 = ProductDownload(downloadID: "ec87d8b5-1361-4562-b4b8-18980b5a2cae",
+                                         name: "Artwork",
+                                         fileURL: "https://example.com/cd_4_angle.jpg")
+         let download3 = ProductDownload(downloadID: "240cd543-5457-498e-95e2-6b51fdaf15cc",
+                                         name: "Artwork 2",
+                                         fileURL: "https://example.com/cd_4_flat.jpg")
+         return [download1, download2, download3]
+     }
 
     private func date(with dateString: String) -> Date {
         guard let date = DateFormatter.Defaults.dateTimeFormatter.date(from: dateString) else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -14,7 +14,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings]
@@ -32,7 +33,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings]
@@ -50,7 +52,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: true)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .downloadableFiles]
@@ -70,7 +73,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType]
@@ -92,7 +96,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .productType]
@@ -110,7 +115,8 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: true)
 
         // Assert
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings, .reviews, .downloadableFiles, .productType]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -11,7 +11,10 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                    manageStock: false,
                                                    stockStatusKey: ProductStockStatus.onBackOrder.rawValue)
         let model = EditableProductModel(product: product)
-        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit, isEditProductsRelease3Enabled: true)
+        let actionsFactory = ProductFormActionsFactory(product: model,
+                                                       formType: .edit,
+                                                       isEditProductsRelease3Enabled: true,
+                                                       isEditProductsRelease5Enabled: false)
 
         // Action
         let tableViewModel = DefaultProductFormTableViewModel(product: model, actionsFactory: actionsFactory, currency: "")
@@ -38,7 +41,10 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
                                                    manageStock: false,
                                                    stockStatusKey: ProductStockStatus.onBackOrder.rawValue)
         let model = EditableProductModel(product: product)
-        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit, isEditProductsRelease3Enabled: true)
+        let actionsFactory = ProductFormActionsFactory(product: model,
+                                                       formType: .edit,
+                                                       isEditProductsRelease3Enabled: true,
+                                                       isEditProductsRelease5Enabled: false)
 
         // Action
         let tableViewModel = DefaultProductFormTableViewModel(product: model, actionsFactory: actionsFactory, currency: "")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewModelTests.swift
@@ -1,0 +1,33 @@
+//
+//  ProductDownloadListViewModelTests.swift
+//  WooCommerceTests
+//
+//  Created by Partho Biswas on 9/24/20.
+//  Copyright © 2020 Automattic. All rights reserved.
+//
+
+import XCTest
+
+class ProductDownloadListViewModelTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewModelTests.swift
@@ -1,33 +1,163 @@
-//
-//  ProductDownloadListViewModelTests.swift
-//  WooCommerceTests
-//
-//  Created by Partho Biswas on 9/24/20.
-//  Copyright © 2020 Automattic. All rights reserved.
-//
-
 import XCTest
+@testable import WooCommerce
+@testable import Yosemite
 
-class ProductDownloadListViewModelTests: XCTestCase {
+final class ProductDownloadListViewModelTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    // MARK: - Initialization
+
+    func testReadonlyValuesAreAsExpectedAfterInitializingAProductWithNonEmptyDownloadableFiles() throws {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+
+        // Assert
+        XCTAssertEqual(viewModel.count(), 3)
+        XCTAssertEqual(viewModel.downloadLimit, 1)
+        XCTAssertEqual(viewModel.downloadExpiry, 1)
+        let file = try XCTUnwrap(viewModel.item(at: 0))
+        XCTAssertEqual(file.downloadableFile.downloadID, "1f9c11f99ceba63d4403c03bd5391b11")
+        XCTAssertEqual(file.downloadableFile.name, "Song #1")
+        XCTAssertEqual(file.downloadableFile.fileURL, "https://example.com/woo-single-1.ogg")
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testReadonlyValuesAreAsExpectedAfterInitializingAProductWithEmptyDownloadableFiles() {
+        // Arrange
+        let product = MockProduct().product(downloadable: false)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+
+        // Assert
+        XCTAssertEqual(viewModel.count(), 0)
+        XCTAssertEqual(viewModel.downloadLimit, -1)
+        XCTAssertEqual(viewModel.downloadExpiry, -1)
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    // MARK: - `handleDownloadableFilesChange`
+
+    func testHandlingADuplicateDownloadableFilesUpdatesWithError() {
+
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func testHandlingAValidDownloadableFilesUpdatesWithSuccess() {
+
+    }
+
+    func testHandlingTheOriginalDownloadableFilesIsAlwaysValidAndUnique() {
+
+    }
+
+    func testHandlingAValidDownloadableFilesAddsWithSuccess() {
+
+    }
+
+    func testHandlingAValidExistingDownloadableFileRemovesWithSuccess() {
+
+    }
+
+    // MARK: - `handleDownloadLimitChange`
+
+    func testHandlingAValidDownloadLimitUpdatesWithSuccess() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+        viewModel.handleDownloadLimitChange(5)
+
+        // Assert
+        XCTAssertEqual(viewModel.downloadLimit, 5)
+    }
+
+    // MARK: - `handleDownloadExpiryChange`
+
+    func testHandlingAValidDownloadExpiryUpdatesWithSuccess() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+        viewModel.handleDownloadExpiryChange(5)
+
+        // Assert
+        XCTAssertEqual(viewModel.downloadExpiry, 5)
+    }
+
+    // MARK: - `hasUnsavedChanges`
+
+    func testViewModelHasUnsavedChangesAfterUpdatingDownloadFileLimit() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+        viewModel.handleDownloadLimitChange(5)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+
+    }
+
+    func testViewModelHasUnsavedChangesAfterUpdatingDownloadFileExpiry() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+        viewModel.handleDownloadExpiryChange(5)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func testViewModelHasUnsavedChangesAfterUpdatingDownloadFilesOrder() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+        guard let firstFile = viewModel.remove(at: 0) else {
+            XCTFail()
+            return
         }
+        viewModel.insert(firstFile, at: 1)
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func testViewModelHasUnsavedChangesAfterRemovingDownloadFileIndividually() {
+
+    }
+
+    func testViewModelHasUnsavedChangesAfterAddingDownloadFileIndividually() {
+
+    }
+
+    func testViewModelHasUnsavedChangesAfterUpdatingSingleDownloadFileIndividually() {
+
+    }
+
+    func testViewModelHasNoUnsavedChangesAfterUpdatingWithTheOriginalValues() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadListViewModel(product: model)
+        viewModel.handleDownloadableFilesChange(MockProduct().sampleDownloads())
+
+        // Assert
+        XCTAssertFalse(viewModel.hasUnsavedChanges())
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
@@ -6,7 +6,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
 
     // MARK: - Initialization
 
-    func testReadonlyValuesAreAsExpectedAfterInitializingAProductWithNonEmptyDownloadableFiles() throws {
+    func test_readonly_values_are_as_expected_after_initializing_a_product_with_non_empty_downloadable_files() throws {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -24,7 +24,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertEqual(file.downloadableFile.fileURL, "https://example.com/woo-single-1.ogg")
     }
 
-    func testReadonlyValuesAreAsExpectedAfterInitializingAProductWithEmptyDownloadableFiles() {
+    func test_readonly_values_are_as_expected_after_initializing_a_product_with_empty_downloadable_files() {
         // Arrange
         let product = MockProduct().product(downloadable: false)
         let model = EditableProductModel(product: product)
@@ -38,31 +38,11 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.downloadExpiry, -1)
     }
 
-    // MARK: - `handleDownloadableFilesChange`
-
-    func testHandlingADuplicateDownloadableFilesUpdatesWithError() {
-
-    }
-
-    func testHandlingAValidDownloadableFilesUpdatesWithSuccess() {
-
-    }
-
-    func testHandlingTheOriginalDownloadableFilesIsAlwaysValidAndUnique() {
-
-    }
-
-    func testHandlingAValidDownloadableFilesAddsWithSuccess() {
-
-    }
-
-    func testHandlingAValidExistingDownloadableFileRemovesWithSuccess() {
-
-    }
+    // TODO: - test cases for `handleDownloadableFilesChange`
 
     // MARK: - `handleDownloadLimitChange`
 
-    func testHandlingAValidDownloadLimitUpdatesWithSuccess() {
+    func test_handling_a_valid_downloadLimit_updates_with_success() {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -77,7 +57,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
 
     // MARK: - `handleDownloadExpiryChange`
 
-    func testHandlingAValidDownloadExpiryUpdatesWithSuccess() {
+    func test_handling_a_valid_downloadExpiry_updates_with_success() {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -92,7 +72,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
 
     // MARK: - `hasUnsavedChanges`
 
-    func testViewModelHasUnsavedChangesAfterUpdatingDownloadFileLimit() {
+    func test_viewModel_has_unsaved_changes_after_updating_downloadLimit() {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -106,7 +86,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
 
     }
 
-    func testViewModelHasUnsavedChangesAfterUpdatingDownloadFileExpiry() {
+    func test_viewModel_has_unsaved_changes_after_updating_downloadExpiry() {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -119,7 +99,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testViewModelHasUnsavedChangesAfterUpdatingDownloadFilesOrder() {
+    func test_viewModel_has_unsaved_changes_after_updating_downloadableFiles_order() {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)
@@ -127,7 +107,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         // Act
         let viewModel = ProductDownloadListViewModel(product: model)
         guard let firstFile = viewModel.remove(at: 0) else {
-            XCTFail()
+            XCTFail("Downloadable file does not exist")
             return
         }
         viewModel.insert(firstFile, at: 1)
@@ -136,19 +116,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
-    func testViewModelHasUnsavedChangesAfterRemovingDownloadFileIndividually() {
-
-    }
-
-    func testViewModelHasUnsavedChangesAfterAddingDownloadFileIndividually() {
-
-    }
-
-    func testViewModelHasUnsavedChangesAfterUpdatingSingleDownloadFileIndividually() {
-
-    }
-
-    func testViewModelHasNoUnsavedChangesAfterUpdatingWithTheOriginalValues() {
+    func test_viewModel_has_unsaved_changes_after_updating_with_the_original_values() {
         // Arrange
         let product = MockProduct().product(downloadable: true)
         let model = EditableProductModel(product: product)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+AddProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+AddProductTests.swift
@@ -12,7 +12,8 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .add,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -39,7 +40,8 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .add,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -62,7 +64,8 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .add,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+EditProductsM3Tests.swift
@@ -15,7 +15,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -43,7 +44,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -71,7 +73,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -98,7 +101,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: true)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -126,7 +130,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -153,7 +158,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -177,7 +183,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -198,7 +205,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -219,7 +227,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -240,7 +249,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -261,7 +271,8 @@ final class ProductFormActionsFactory_EditProductsM3Tests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
@@ -163,7 +163,7 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
 
     // MARK: - Downloadable Files
 
-    func testDownloadableFilesRowIsVisibleForDownloadableProductWithNonEmptyDownloadableFiles() {
+    func test_downloadableFiles_row_is_visible_for_downloadable_product_with_non_empty_downloadableFiles() {
         // Arrange
         let product = Fixtures.downloadableProduct
         let model = EditableProductModel(product: product)
@@ -171,13 +171,14 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: true)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.downloadableFiles))
     }
 
-    func testDownloadableFilesRowIsInvisibleForNonDownloadableProductWithoutDownloadableFiles() {
+    func test_downloadableFiles_row_is_invisible_for_non_downloadable_product_without_downloadableFiles() {
         // Arrange
         let product = Fixtures.nonDownloadableProduct
         let model = EditableProductModel(product: product)
@@ -185,7 +186,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: true)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.downloadableFiles))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
@@ -162,7 +162,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
     }
 
     // MARK: - Downloadable Files
-    // Don't commit these unless you are done with https://github.com/woocommerce/woocommerce-ios/issues/2759
 
     func testDownloadableFilesRowIsVisibleForDownloadableProductWithNonEmptyDownloadableFiles() {
         // Arrange

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
@@ -160,6 +160,37 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         XCTAssertFalse(factory.settingsSectionActions().contains(.briefDescription))
         XCTAssertTrue(factory.bottomSheetActions().contains(.editBriefDescription))
     }
+
+    // MARK: - Downloadable Files
+    // Don't commit these unless you are done with https://github.com/woocommerce/woocommerce-ios/issues/2759
+
+    func testDownloadableFilesRowIsVisibleForDownloadableProductWithNonEmptyDownloadableFiles() {
+        // Arrange
+        let product = Fixtures.downloadableProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                formType: .edit,
+                                                isEditProductsRelease3Enabled: true)
+
+        // Assert
+        XCTAssertTrue(factory.settingsSectionActions().contains(.downloadableFiles))
+    }
+
+    func testDownloadableFilesRowIsInvisibleForNonDownloadableProductWithoutDownloadableFiles() {
+        // Arrange
+        let product = Fixtures.nonDownloadableProduct
+        let model = EditableProductModel(product: product)
+
+        // Action
+        let factory = ProductFormActionsFactory(product: model,
+                                                formType: .edit,
+                                                isEditProductsRelease3Enabled: true)
+
+        // Assert
+        XCTAssertFalse(factory.settingsSectionActions().contains(.downloadableFiles))
+    }
 }
 
 private extension ProductFormActionsFactory_VisibilityTests {
@@ -184,5 +215,10 @@ private extension ProductFormActionsFactory_VisibilityTests {
         // Brief description
         static let productWithNonEmptyBriefDescription = MockProduct().product(briefDescription: "desc", productType: .simple)
         static let productWithEmptyBriefDescription = MockProduct().product(briefDescription: "", productType: .simple)
+
+        // Downloadable Files
+        static let downloadableProduct = MockProduct().product(downloadable: true)
+        static let nonDownloadableProduct = MockProduct().product(downloadable: false)
+
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
@@ -13,7 +13,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings))
@@ -27,7 +28,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.priceSettings))
@@ -43,7 +45,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.inventorySettings))
@@ -58,7 +61,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.inventorySettings))
@@ -75,7 +79,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.shippingSettings))
@@ -90,7 +95,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.shippingSettings))
@@ -107,7 +113,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.categories))
@@ -122,7 +129,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.categories))
@@ -139,7 +147,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertTrue(factory.settingsSectionActions().contains(.briefDescription))
@@ -154,7 +163,8 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true)
+                                                isEditProductsRelease3Enabled: true,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         XCTAssertFalse(factory.settingsSectionActions().contains(.briefDescription))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactoryTests.swift
@@ -15,7 +15,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -40,7 +41,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -63,7 +65,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: true)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]
@@ -87,7 +90,8 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: false)
+                                                isEditProductsRelease3Enabled: false,
+                                                isEditProductsRelease5Enabled: false)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images, .name, .description]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -16,7 +16,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
 
         // Action
@@ -55,7 +56,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         viewModel.updateName("this new product name")
@@ -72,7 +74,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let settings = ProductSettings(from: product, password: "secret secret")
@@ -90,7 +93,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         let expectation = self.expectation(description: "Wait for image upload")
         productImageActionHandler.addUpdateObserver(self) { statuses in
             if statuses.productImageStatuses.isNotEmpty {
@@ -114,7 +118,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let productImage = ProductImage(imageID: 6,
@@ -137,7 +142,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         viewModel.updateDescription("Another way to describe the product?")
@@ -154,7 +160,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true)
+                                             isEditProductsRelease3Enabled: true,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let categoryID = Int64(1234)
@@ -176,7 +183,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true)
+                                             isEditProductsRelease3Enabled: true,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let tagID = Int64(1234)
@@ -197,7 +205,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         viewModel.updateBriefDescription("A short one")
@@ -214,7 +223,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         viewModel.updatePriceSettings(regularPrice: "999999", salePrice: "888888", dateOnSaleStart: nil, dateOnSaleEnd: nil, taxStatus: .none, taxClass: nil)
@@ -231,7 +241,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         viewModel.updateInventorySettings(sku: "", manageStock: false, soldIndividually: true, stockQuantity: 888888, backordersSetting: nil, stockStatus: nil)
@@ -248,7 +259,8 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         viewModel.updateShippingSettings(weight: "88888",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -30,7 +30,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
         cancellableProduct = viewModel.observableProduct.subscribe { _ in
             // Assert
@@ -79,7 +80,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
             isProductUpdated = true
@@ -121,7 +123,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
             isProductUpdated = true
@@ -159,7 +162,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         // The password is set from a separate DotCom API.
         viewModel.resetPassword("134")
 
@@ -204,7 +208,8 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
             isProductUpdated = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -124,6 +124,7 @@ private extension ProductFormViewModel_SaveTests {
         return ProductFormViewModel(product: model,
                                     formType: formType,
                                     productImageActionHandler: productImageActionHandler,
-                                    isEditProductsRelease3Enabled: true)
+                                    isEditProductsRelease3Enabled: true,
+                                    isEditProductsRelease5Enabled: false)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -14,7 +14,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newName = "<p> cool product </p>"
@@ -32,7 +33,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newDescription = "<p> cool product </p>"
@@ -50,7 +52,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newWeight = "9999.88"
@@ -84,7 +87,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newRegularPrice = "32.45"
@@ -117,7 +121,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newSKU = "94115"
@@ -150,7 +155,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newImage = ProductImage(imageID: 17,
@@ -174,7 +180,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true)
+                                             isEditProductsRelease3Enabled: true,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let categoryID = Int64(1234)
@@ -196,7 +203,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true)
+                                             isEditProductsRelease3Enabled: true,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let tagID = Int64(1234)
@@ -217,7 +225,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newBriefDescription = "<p> deal of the day! </p>"
@@ -235,7 +244,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let newStatus = "pending"
@@ -276,7 +286,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let sku = "woooo"
@@ -294,7 +305,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let externalURL = "woo.com"
@@ -314,7 +326,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false)
+                                             isEditProductsRelease3Enabled: false,
+                                             isEditProductsRelease5Enabled: false)
 
         // Action
         let groupedProductIDs: [Int64] = [630, 22]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -112,6 +112,7 @@ private extension ProductFormViewModelTests {
         return ProductFormViewModel(product: model,
                                     formType: formType,
                                     productImageActionHandler: productImageActionHandler,
-                                    isEditProductsRelease3Enabled: true)
+                                    isEditProductsRelease3Enabled: true,
+                                    isEditProductsRelease5Enabled: false)
     }
 }


### PR DESCRIPTION
Fixes: #2755 
Depends On: https://github.com/woocommerce/woocommerce-ios/pull/2814

## Description
This PR only contains unit testing code for https://github.com/woocommerce/woocommerce-ios/pull/2814 

## Changes
- Update `MockProduct.swift` for downloadable files	
- Add test cases for `ProductDownloadListViewModel`
- Add test case for downloadable files row visibility on the edit product page, on `ProductFormActionsFactory+VisibilityTests.swift` file

### Testing
Only testable via running the Unit Tests suits. It doesn't contain any visible UI and functionality changes.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
