### PR TITLE
[Issue Refund] Refund Item Cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -16,7 +16,7 @@ final class RefundItemTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var itemTitle: UILabel!
 
-    /// Item caption: Product quanity and price
+    /// Item caption: Product quantity and price
     ///
     @IBOutlet private var itemCaption: UILabel!
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -26,7 +26,11 @@ final class RefundItemTableViewCell: UITableViewCell {
 
     /// Needed to change it's axis with larger accessibility traits
     ///
-    @IBOutlet private var contentStackView: UIStackView!
+    @IBOutlet private var itemsStackView: UIStackView!
+
+    /// Needed to make sure the `itemImageView` grows at the same ratio as the dynamic fonts
+    ///
+    @IBOutlet private var itemImageViewHeightConstraint: NSLayoutConstraint!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -35,7 +39,8 @@ final class RefundItemTableViewCell: UITableViewCell {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        adjustContentStackViewAxis()
+        adjustItemsStackViewAxis()
+        adjustItemImageViewHeight()
     }
 }
 
@@ -46,12 +51,13 @@ private extension RefundItemTableViewCell {
         applyItemImageStyles()
         applyLabelsStyles()
         //applyRefundQuantityButtonStyle()
-        adjustContentStackViewAxis()
+        adjustItemsStackViewAxis()
     }
 
     func applyItemImageStyles() {
         itemImageView.layer.borderWidth = 0.5
         itemImageView.layer.borderColor = UIColor.border.cgColor
+        adjustItemImageViewHeight()
     }
 
     func applyCellBackgroundStyle() {
@@ -68,8 +74,16 @@ private extension RefundItemTableViewCell {
         itemQuantityButton.titleLabel?.applyBodyStyle()
     }
 
-    func adjustContentStackViewAxis() {
-        contentStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
+    /// Changes the items stack view axis depending on the view `preferredContentSizeCategory`.
+    ///
+    func adjustItemsStackViewAxis() {
+        itemsStackView.axis = traitCollection.preferredContentSizeCategory > .accessibilityMedium ? .vertical : .horizontal
+    }
+
+    /// Changes the items image view height acording to the current trait collection
+    ///
+    func adjustItemImageViewHeight() {
+        itemImageViewHeightConstraint.constant = UIFontMetrics.default.scaledValue(for: 39, compatibleWith: traitCollection)
     }
 }
 
@@ -84,9 +98,8 @@ extension RefundItemTableViewCell {
         itemQuantityButton.setTitle(viewModel.quantityToRefund, for: .normal)
         applyRefundQuantityButtonStyle()
 
-        if let imageURL = viewModel.productImage {
+        if let _ = viewModel.productImage {
             // TODO: fill product image
-            print(imageURL)
             placeholderImageView.image = nil
         } else {
             itemImageView.image = nil
@@ -102,9 +115,8 @@ private extension RefundItemTableViewCell {
     }
 }
 
-#if canImport(SwiftUI) && DEBUG
-
 // MARK: - Previews
+#if canImport(SwiftUI) && DEBUG
 
 import SwiftUI
 
@@ -149,9 +161,14 @@ struct RefundItemTableViewCell_Previews: PreviewProvider {
                 .previewDisplayName("Dark")
 
             makeStack()
-                .previewLayout(.fixed(width: 359, height: 300))
-                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .previewLayout(.fixed(width: 359, height: 96))
+                .environment(\.sizeCategory, .accessibilityMedium)
                 .previewDisplayName("Large Font")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 420))
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .previewDisplayName("Extra Large Font")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -25,6 +25,19 @@ final class RefundItemTableViewCell: UITableViewCell {
     }
 }
 
+// MARK: ViewModel Rendering
+extension RefundItemTableViewCell {
+
+    /// Configure cell with the provided view model
+    ///
+    func configure(with viewModel: RefundItemViewModel) {
+        itemImageView.image = .productPlaceholderImage
+        itemTitle.text = viewModel.productTitle
+        itemCaption.text = viewModel.productQuantityAndPrice
+        itemQuantityButton.setTitle(viewModel.quantityToRefund, for: .normal)
+    }
+}
+
 // MARK: Actions
 private extension RefundItemTableViewCell {
     @IBAction func quantityButtonPressed(_ sender: Any) {
@@ -41,8 +54,16 @@ import SwiftUI
 private struct RefundItemTableViewCellRepresentable: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let nib = UINib(nibName: "RefundItemTableViewCell", bundle: nil)
-        let views = nib.instantiate(withOwner: self, options: nil)
-        return views.first as! UIView
+        guard let cell = nib.instantiate(withOwner: self, options: nil).first as? RefundItemTableViewCell else {
+            fatalError("Could not create RefundItemTableViewCell")
+        }
+
+        let viewModel = RefundItemViewModel(productImage: nil,
+                                            productTitle: "Hoddie - Big",
+                                            productQuantityAndPrice: "2 x $29.99 each",
+                                            quantityToRefund: "1")
+        cell.configure(with: viewModel)
+        return cell
     }
 
     func updateUIView(_ view: UIView, context: Context) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -4,7 +4,30 @@ import UIKit
 ///
 final class RefundItemTableViewCell: UITableViewCell {
 
+    /// Item image view: Product image
+    ///
+    @IBOutlet private var itemImageView: UIImageView!
+
+    /// Item title: Product name
+    ///
+    @IBOutlet private var itemTitle: UILabel!
+
+    /// Item caption: Product quanity and price
+    ///
+    @IBOutlet private var itemCaption: UILabel!
+
+    /// Quantity button: Quantity to be refunded
+    ///
+    @IBOutlet private var itemQuantityButton: UIButton!
+
     override func awakeFromNib() {
         super.awakeFromNib()
+    }
+}
+
+// MARK: Actions
+private extension RefundItemTableViewCell {
+    @IBAction func quantityButtonPressed(_ sender: Any) {
+        print("Item quantity button pressed")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+/// Displays an item to be refunded
+///
+final class RefundItemTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -24,8 +24,52 @@ final class RefundItemTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var itemQuantityButton: UIButton!
 
+    /// Needed to change it's axis with larger accessibility traits
+    ///
+    @IBOutlet private var contentStackView: UIStackView!
+
     override func awakeFromNib() {
         super.awakeFromNib()
+        applyCellStyles()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        adjustContentStackViewAxis()
+    }
+}
+
+// MARK: View Styles Configuration
+private extension RefundItemTableViewCell {
+    func applyCellStyles() {
+        applyCellBackgroundStyle()
+        applyItemImageStyles()
+        applyLabelsStyles()
+        //applyRefundQuantityButtonStyle()
+        adjustContentStackViewAxis()
+    }
+
+    func applyItemImageStyles() {
+        itemImageView.layer.borderWidth = 0.5
+        itemImageView.layer.borderColor = UIColor.border.cgColor
+    }
+
+    func applyCellBackgroundStyle() {
+        applyDefaultBackgroundStyle()
+    }
+
+    func applyLabelsStyles() {
+        itemTitle.applyBodyStyle()
+        itemCaption.applyFootnoteStyle()
+    }
+
+    func applyRefundQuantityButtonStyle() {
+        itemQuantityButton.applySecondaryButtonStyle()
+        itemQuantityButton.titleLabel?.applyBodyStyle()
+    }
+
+    func adjustContentStackViewAxis() {
+        contentStackView.axis = traitCollection.preferredContentSizeCategory > .extraExtraExtraLarge ? .vertical : .horizontal
     }
 }
 
@@ -105,7 +149,7 @@ struct RefundItemTableViewCell_Previews: PreviewProvider {
                 .previewDisplayName("Dark")
 
             makeStack()
-                .previewLayout(.fixed(width: 359, height: 100))
+                .previewLayout(.fixed(width: 359, height: 300))
                 .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
                 .previewDisplayName("Large Font")
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -35,12 +35,12 @@ final class RefundItemTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         applyCellStyles()
+        applyAccessibilityChanges()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        adjustItemsStackViewAxis()
-        adjustItemImageViewHeight()
+        applyAccessibilityChanges()
     }
 }
 
@@ -50,14 +50,12 @@ private extension RefundItemTableViewCell {
         applyCellBackgroundStyle()
         applyItemImageStyles()
         applyLabelsStyles()
-        //applyRefundQuantityButtonStyle()
-        adjustItemsStackViewAxis()
+        applyRefundQuantityButtonStyle()
     }
 
     func applyItemImageStyles() {
         itemImageView.layer.borderWidth = 0.5
         itemImageView.layer.borderColor = UIColor.border.cgColor
-        adjustItemImageViewHeight()
     }
 
     func applyCellBackgroundStyle() {
@@ -72,6 +70,15 @@ private extension RefundItemTableViewCell {
     func applyRefundQuantityButtonStyle() {
         itemQuantityButton.applySecondaryButtonStyle()
         itemQuantityButton.titleLabel?.applyBodyStyle()
+        itemQuantityButton.contentEdgeInsets = .init(top: 8, left: 22, bottom: 8, right: 22)
+    }
+}
+
+// MARK: Accessibility
+private extension RefundItemTableViewCell {
+    func applyAccessibilityChanges() {
+        adjustItemsStackViewAxis()
+        adjustItemImageViewHeight()
     }
 
     /// Changes the items stack view axis depending on the view `preferredContentSizeCategory`.
@@ -96,7 +103,6 @@ extension RefundItemTableViewCell {
         itemTitle.text = viewModel.productTitle
         itemCaption.text = viewModel.productQuantityAndPrice
         itemQuantityButton.setTitle(viewModel.quantityToRefund, for: .normal)
-        applyRefundQuantityButtonStyle()
 
         if let _ = viewModel.productImage {
             // TODO: fill product image

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -54,7 +54,7 @@ private extension RefundItemTableViewCell {
     }
 
     func applyItemImageStyles() {
-        itemImageView.layer.borderWidth = 0.5
+        itemImageView.layer.borderWidth = Constants.itemImageViewBorderWidth
         itemImageView.layer.borderColor = UIColor.border.cgColor
     }
 
@@ -70,7 +70,7 @@ private extension RefundItemTableViewCell {
     func applyRefundQuantityButtonStyle() {
         itemQuantityButton.applySecondaryButtonStyle()
         itemQuantityButton.titleLabel?.applyBodyStyle()
-        itemQuantityButton.contentEdgeInsets = .init(top: 8, left: 22, bottom: 8, right: 22)
+        itemQuantityButton.contentEdgeInsets = Constants.quantityButtonInsets
     }
 }
 
@@ -90,7 +90,7 @@ private extension RefundItemTableViewCell {
     /// Changes the items image view height acording to the current trait collection
     ///
     func adjustItemImageViewHeight() {
-        itemImageViewHeightConstraint.constant = UIFontMetrics.default.scaledValue(for: 39, compatibleWith: traitCollection)
+        itemImageViewHeightConstraint.constant = UIFontMetrics.default.scaledValue(for: Constants.itemImageViewHeight, compatibleWith: traitCollection)
     }
 }
 
@@ -118,6 +118,15 @@ extension RefundItemTableViewCell {
 private extension RefundItemTableViewCell {
     @IBAction func quantityButtonPressed(_ sender: Any) {
         print("Item quantity button pressed")
+    }
+}
+
+// MARK: Constats
+private extension RefundItemTableViewCell {
+    enum Constants {
+        static let itemImageViewHeight: CGFloat = 39.0
+        static let itemImageViewBorderWidth: CGFloat = 0.5
+        static let quantityButtonInsets = UIEdgeInsets(top: 8, left: 22, bottom: 8, right: 22)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -8,6 +8,10 @@ final class RefundItemTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var itemImageView: UIImageView!
 
+    /// Placeholder image view: Needed to show a placeholder that has some insets from the `itemImageView`
+    ///
+    @IBOutlet private var placeholderImageView: UIImageView!
+
     /// Item title: Product name
     ///
     @IBOutlet private var itemTitle: UILabel!
@@ -31,10 +35,19 @@ extension RefundItemTableViewCell {
     /// Configure cell with the provided view model
     ///
     func configure(with viewModel: RefundItemViewModel) {
-        itemImageView.image = .productPlaceholderImage
         itemTitle.text = viewModel.productTitle
         itemCaption.text = viewModel.productQuantityAndPrice
         itemQuantityButton.setTitle(viewModel.quantityToRefund, for: .normal)
+        applyRefundQuantityButtonStyle()
+
+        if let imageURL = viewModel.productImage {
+            // TODO: fill product image
+            print(imageURL)
+            placeholderImageView.image = nil
+        } else {
+            itemImageView.image = nil
+            placeholderImageView.image = .productPlaceholderImage
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -31,3 +31,51 @@ private extension RefundItemTableViewCell {
         print("Item quantity button pressed")
     }
 }
+
+#if canImport(SwiftUI) && DEBUG
+
+// MARK: - Previews
+
+import SwiftUI
+
+private struct RefundItemTableViewCellRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let nib = UINib(nibName: "RefundItemTableViewCell", bundle: nil)
+        let views = nib.instantiate(withOwner: self, options: nil)
+        return views.first as! UIView
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        // no op
+    }
+}
+
+@available(iOS 13.0, *)
+struct RefundItemTableViewCell_Previews: PreviewProvider {
+
+    private static func makeStack() -> some View {
+        VStack {
+            RefundItemTableViewCellRepresentable()
+        }
+    }
+
+    static var previews: some View {
+        Group {
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 76))
+                .previewDisplayName("Light")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 76))
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 100))
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .previewDisplayName("Large Font")
+        }
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -27,27 +27,24 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eze-ho-4Ji">
-                                <rect key="frame" x="51" y="0.0" width="184" height="39"/>
+                                <rect key="frame" x="51" y="0.0" width="190" height="39"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YD3-Od-CW6">
-                                        <rect key="frame" x="0.0" y="0.0" width="184" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YD3-Od-CW6">
+                                        <rect key="frame" x="0.0" y="0.0" width="190" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYR-FG-H5Y">
-                                        <rect key="frame" x="0.0" y="20.5" width="184" height="18.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYR-FG-H5Y">
+                                        <rect key="frame" x="0.0" y="20.5" width="190" height="18.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgz-K2-4QI">
-                                <rect key="frame" x="247" y="0.0" width="52" height="39"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="mgz-K2-4QI" secondAttribute="height" multiplier="2:1.5" id="tWv-f3-YPC"/>
-                                </constraints>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgz-K2-4QI">
+                                <rect key="frame" x="253" y="0.0" width="46" height="39"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
                                     <action selector="quantityButtonPressed:" destination="NHn-Ig-21K" eventType="touchUpInside" id="RV6-SD-eDo"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -65,7 +65,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="jGT-mb-SEw"/>
             <connections>
-                <outlet property="itemCaption" destination="YD3-Od-CW6" id="fhu-yo-62O"/>
+                <outlet property="itemCaption" destination="TYR-FG-H5Y" id="s5F-4Z-Xf3"/>
                 <outlet property="itemImageView" destination="7Pw-e6-EmO" id="g1W-Tr-WU9"/>
                 <outlet property="itemQuantityButton" destination="mgz-K2-4QI" id="rG4-Y9-VVb"/>
                 <outlet property="itemTitle" destination="YD3-Od-CW6" id="nD7-vb-g74"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -16,9 +16,61 @@
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NHn-Ig-21K" id="e54-cO-Yp4">
                 <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zVi-xD-XJo">
+                        <rect key="frame" x="16" y="18" width="299" height="39"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Pw-e6-EmO">
+                                <rect key="frame" x="0.0" y="0.0" width="39" height="39"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="7Pw-e6-EmO" secondAttribute="height" multiplier="1:1" id="YdS-FV-fZR"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eze-ho-4Ji">
+                                <rect key="frame" x="51" y="0.0" width="184" height="39"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YD3-Od-CW6">
+                                        <rect key="frame" x="0.0" y="0.0" width="184" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYR-FG-H5Y">
+                                        <rect key="frame" x="0.0" y="20.5" width="184" height="18.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgz-K2-4QI">
+                                <rect key="frame" x="247" y="0.0" width="52" height="39"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="mgz-K2-4QI" secondAttribute="height" multiplier="2:1.5" id="tWv-f3-YPC"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <action selector="quantityButtonPressed:" destination="NHn-Ig-21K" eventType="touchUpInside" id="RV6-SD-eDo"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="zVi-xD-XJo" secondAttribute="trailing" constant="16" id="2NF-L3-SdL"/>
+                    <constraint firstItem="zVi-xD-XJo" firstAttribute="top" secondItem="e54-cO-Yp4" secondAttribute="top" constant="18" id="AMl-pT-Tkc"/>
+                    <constraint firstAttribute="bottom" secondItem="zVi-xD-XJo" secondAttribute="bottom" constant="18" id="Xrh-MH-bcS"/>
+                    <constraint firstItem="zVi-xD-XJo" firstAttribute="leading" secondItem="e54-cO-Yp4" secondAttribute="leading" constant="16" id="Z0T-1q-43b"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="jGT-mb-SEw"/>
-            <point key="canvasLocation" x="39.200000000000003" y="75.112443778110944"/>
+            <connections>
+                <outlet property="itemCaption" destination="YD3-Od-CW6" id="fhu-yo-62O"/>
+                <outlet property="itemImageView" destination="7Pw-e6-EmO" id="g1W-Tr-WU9"/>
+                <outlet property="itemQuantityButton" destination="mgz-K2-4QI" id="rG4-Y9-VVb"/>
+                <outlet property="itemTitle" destination="YD3-Od-CW6" id="nD7-vb-g74"/>
+            </connections>
+            <point key="canvasLocation" x="38.405797101449281" y="74.665178571428569"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -69,6 +69,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="jGT-mb-SEw"/>
             <connections>
+                <outlet property="contentStackView" destination="zVi-xD-XJo" id="exS-bG-agg"/>
                 <outlet property="itemCaption" destination="TYR-FG-H5Y" id="s5F-4Z-Xf3"/>
                 <outlet property="itemImageView" destination="7Pw-e6-EmO" id="g1W-Tr-WU9"/>
                 <outlet property="itemQuantityButton" destination="mgz-K2-4QI" id="rG4-Y9-VVb"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -20,7 +20,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zVi-xD-XJo">
                         <rect key="frame" x="16" y="18" width="299" height="39"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Pw-e6-EmO">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Pw-e6-EmO">
                                 <rect key="frame" x="0.0" y="0.0" width="39" height="39"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="7Pw-e6-EmO" secondAttribute="height" multiplier="1:1" id="YdS-FV-fZR"/>
@@ -52,12 +52,19 @@
                             </button>
                         </subviews>
                     </stackView>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zbT-5U-aGx">
+                        <rect key="frame" x="24" y="25" width="24" height="24"/>
+                    </imageView>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="zVi-xD-XJo" secondAttribute="trailing" constant="16" id="2NF-L3-SdL"/>
+                    <constraint firstItem="zbT-5U-aGx" firstAttribute="bottom" secondItem="7Pw-e6-EmO" secondAttribute="bottom" constant="-8" id="7ni-Fh-rJ1"/>
                     <constraint firstItem="zVi-xD-XJo" firstAttribute="top" secondItem="e54-cO-Yp4" secondAttribute="top" constant="18" id="AMl-pT-Tkc"/>
+                    <constraint firstItem="zbT-5U-aGx" firstAttribute="top" secondItem="7Pw-e6-EmO" secondAttribute="top" constant="7" id="Gm4-Nr-7Pq"/>
                     <constraint firstAttribute="bottom" secondItem="zVi-xD-XJo" secondAttribute="bottom" constant="18" id="Xrh-MH-bcS"/>
                     <constraint firstItem="zVi-xD-XJo" firstAttribute="leading" secondItem="e54-cO-Yp4" secondAttribute="leading" constant="16" id="Z0T-1q-43b"/>
+                    <constraint firstItem="zbT-5U-aGx" firstAttribute="trailing" secondItem="7Pw-e6-EmO" secondAttribute="trailing" constant="-7" id="bfq-N9-C4W"/>
+                    <constraint firstItem="zbT-5U-aGx" firstAttribute="leading" secondItem="7Pw-e6-EmO" secondAttribute="leading" constant="8" id="ro7-xY-x9y"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="jGT-mb-SEw"/>
@@ -66,6 +73,7 @@
                 <outlet property="itemImageView" destination="7Pw-e6-EmO" id="g1W-Tr-WU9"/>
                 <outlet property="itemQuantityButton" destination="mgz-K2-4QI" id="rG4-Y9-VVb"/>
                 <outlet property="itemTitle" destination="YD3-Od-CW6" id="nD7-vb-g74"/>
+                <outlet property="placeholderImageView" destination="zbT-5U-aGx" id="dkk-rg-knh"/>
             </connections>
             <point key="canvasLocation" x="38.405797101449281" y="74.665178571428569"/>
         </tableViewCell>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="75" id="NHn-Ig-21K" userLabel="RefundItemTableViewCell" customClass="RefundItemTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NHn-Ig-21K" id="e54-cO-Yp4">
+                <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="jGT-mb-SEw"/>
+            <point key="canvasLocation" x="39.200000000000003" y="75.112443778110944"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.xib
@@ -10,50 +10,56 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="75" id="NHn-Ig-21K" userLabel="RefundItemTableViewCell" customClass="RefundItemTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="76" id="NHn-Ig-21K" userLabel="RefundItemTableViewCell" customClass="RefundItemTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="331" height="76"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NHn-Ig-21K" id="e54-cO-Yp4">
-                <rect key="frame" x="0.0" y="0.0" width="331" height="75"/>
+                <rect key="frame" x="0.0" y="0.0" width="331" height="76"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zVi-xD-XJo">
-                        <rect key="frame" x="16" y="18" width="299" height="39"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zVi-xD-XJo">
+                        <rect key="frame" x="16" y="18" width="299" height="40"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Pw-e6-EmO">
-                                <rect key="frame" x="0.0" y="0.0" width="39" height="39"/>
+                                <rect key="frame" x="0.0" y="0.5" width="39" height="39"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="7Pw-e6-EmO" secondAttribute="height" multiplier="1:1" id="YdS-FV-fZR"/>
+                                    <constraint firstAttribute="height" constant="39" id="rGW-xt-XK1"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eze-ho-4Ji">
-                                <rect key="frame" x="51" y="0.0" width="190" height="39"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="tMf-3g-8E1">
+                                <rect key="frame" x="51" y="0.0" width="248" height="40"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YD3-Od-CW6">
-                                        <rect key="frame" x="0.0" y="0.0" width="190" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYR-FG-H5Y">
-                                        <rect key="frame" x="0.0" y="20.5" width="190" height="18.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eze-ho-4Ji">
+                                        <rect key="frame" x="0.0" y="0.0" width="190" height="40"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YD3-Od-CW6">
+                                                <rect key="frame" x="0.0" y="0.0" width="190" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYR-FG-H5Y">
+                                                <rect key="frame" x="0.0" y="20.5" width="190" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgz-K2-4QI">
+                                        <rect key="frame" x="202" y="5" width="46" height="30"/>
+                                        <state key="normal" title="Button"/>
+                                        <connections>
+                                            <action selector="quantityButtonPressed:" destination="NHn-Ig-21K" eventType="touchUpInside" id="RV6-SD-eDo"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgz-K2-4QI">
-                                <rect key="frame" x="253" y="0.0" width="46" height="39"/>
-                                <state key="normal" title="Button"/>
-                                <connections>
-                                    <action selector="quantityButtonPressed:" destination="NHn-Ig-21K" eventType="touchUpInside" id="RV6-SD-eDo"/>
-                                </connections>
-                            </button>
                         </subviews>
                     </stackView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zbT-5U-aGx">
-                        <rect key="frame" x="24" y="25" width="24" height="24"/>
+                        <rect key="frame" x="24" y="25.5" width="24" height="24"/>
                     </imageView>
                 </subviews>
                 <constraints>
@@ -69,14 +75,15 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="jGT-mb-SEw"/>
             <connections>
-                <outlet property="contentStackView" destination="zVi-xD-XJo" id="exS-bG-agg"/>
                 <outlet property="itemCaption" destination="TYR-FG-H5Y" id="s5F-4Z-Xf3"/>
                 <outlet property="itemImageView" destination="7Pw-e6-EmO" id="g1W-Tr-WU9"/>
+                <outlet property="itemImageViewHeightConstraint" destination="rGW-xt-XK1" id="grE-fq-ZMQ"/>
                 <outlet property="itemQuantityButton" destination="mgz-K2-4QI" id="rG4-Y9-VVb"/>
                 <outlet property="itemTitle" destination="YD3-Od-CW6" id="nD7-vb-g74"/>
+                <outlet property="itemsStackView" destination="tMf-3g-8E1" id="BkK-4S-VDr"/>
                 <outlet property="placeholderImageView" destination="zbT-5U-aGx" id="dkk-rg-knh"/>
             </connections>
-            <point key="canvasLocation" x="38.405797101449281" y="74.665178571428569"/>
+            <point key="canvasLocation" x="38.405797101449281" y="75"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Represents an order item to be refunded. Meant to be rendered by `RefundItemTableViewCell`
+///
+struct RefundItemViewModel {
+    let productImage: URL?
+    let productTitle: String
+    let productQuantityAndPrice: String
+    let quantityToRefund: String
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -331,6 +331,8 @@
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
+		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
+		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
@@ -1296,6 +1298,8 @@
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
+		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
+		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyLoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
@@ -2734,6 +2738,23 @@
 			path = Survey;
 			sourceTree = "<group>";
 		};
+		26E1BEC7251BE50C0096D0A1 /* Issue Refunds */ = {
+			isa = PBXGroup;
+			children = (
+				26E1BEC8251BE5270096D0A1 /* Cells */,
+			);
+			path = "Issue Refunds";
+			sourceTree = "<group>";
+		};
+		26E1BEC8251BE5270096D0A1 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */,
+				26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
 		26FE09E224DCFE4000B9BDF5 /* inAppFeedback */ = {
 			isa = PBXGroup;
 			children = (
@@ -4083,6 +4104,7 @@
 				CE35F1132343E715007B2A6B /* Customer Section */,
 				CE35F1142343E832007B2A6B /* Payment Section */,
 				CE35F10D2343E613007B2A6B /* Shipment Tracking Section */,
+				26E1BEC7251BE50C0096D0A1 /* Issue Refunds */,
 				CE35F10A2343E4E6007B2A6B /* Order Notes Section */,
 			);
 			path = "Order Details";
@@ -4741,6 +4763,7 @@
 				0262DA5923A23AC80029AF30 /* ProductShippingSettingsViewController.xib in Resources */,
 				B5F571B021BF149D0010D1B8 /* o.caf in Resources */,
 				0212275E2449728A0042161F /* BottomSheetListSelectorSectionHeaderView.xib in Resources */,
+				26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */,
 				022BF7FE23B9D708000A1DFB /* InProgressViewController.xib in Resources */,
 				45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */,
 				B5D1AFC820BC7B9600DB0E8C /* StorePickerViewController.xib in Resources */,
@@ -5421,6 +5444,7 @@
 				5718852C2465D9EC00E2486F /* ReviewsCoordinator.swift in Sources */,
 				028BAC4022F2EFA5008BB4AF /* StoreStatsAndTopPerformersPeriodViewController.swift in Sources */,
 				74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */,
+				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
+		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
 		26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */; };
 		26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */; };
 		26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */; };
@@ -1300,6 +1301,7 @@
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
+		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
 		26FE09DC24D9F3F600B9BDF5 /* SurveyLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyLoadingView.swift; sourceTree = "<group>"; };
 		26FE09DE24DB871100B9BDF5 /* SurveyViewControllersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllersFactory.swift; sourceTree = "<group>"; };
 		26FE09E024DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatorControllerTests.swift; sourceTree = "<group>"; };
@@ -2749,6 +2751,7 @@
 		26E1BEC8251BE5270096D0A1 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */,
 				26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */,
 				26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */,
 			);
@@ -5073,6 +5076,7 @@
 				B5F571A421BEC90D0010D1B8 /* NoteDetailsHeaderPlainTableViewCell.swift in Sources */,
 				4592A54B24BF58DD00BC3DE0 /* ProductTagsViewController.swift in Sources */,
 				D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */,
+				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,


### PR DESCRIPTION
closes #2839

# Why

The end goal is to build the refund UI, but this PR focuses on building a single refund item cell(enclosed in the blue rectangle). 
<img width="382" alt="end-goal" src="https://user-images.githubusercontent.com/562080/94196217-aa4ea480-fe79-11ea-8d74-b2d7830f259f.png">


# How

- Created `RefundItemTableViewCell` backed up by it's `xib`
- Created simple `RefundItemViewModel` to aid rendering content on `RefundItemTableViewCell`. This just declares properties for now. More logic will be added as the development progresses.
- I'm changing a bit the alignment of components as the UI grows in order to make content more readable.

One particularly weird thing that I did was to have a separate image view for the product placeholder which is inseted from the main product image view. This is to avoid the contentMode change we do in most of our cells. I think this looks a bit cleaner!

https://github.com/woocommerce/woocommerce-ios/blob/d42b886b808ce821261bf98cafda9928ac398e43/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/Cells/ProductTableViewCell.swift#L83-L96

# Screenshots

<img width="482" alt="screenshots" src="https://user-images.githubusercontent.com/562080/94196329-cfdbae00-fe79-11ea-9223-f699533babcf.png">


# Testing Steps
- Nothing much to test as the cell is not integrated yet 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
