### PR TITLE
Show stock status in variation list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 5.2
 -----
+- [*] Enhancement: for variable products, the stock status is now shown in its variation list.
 - [*] Sign In With Apple: if the Apple ID has been disconnected from the WordPress app (e.g. in Settings > Apple ID > Password & Security > Apps using Apple ID), the app is logged out on app launch or app switch.
  
 5.1

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
@@ -15,6 +15,28 @@ extension ProductsTabProductViewModel {
 
 private extension EditableProductVariationModel {
     func createDetailsAttributedString(currencySettings: CurrencySettings) -> NSAttributedString {
+        let stockStatusAttributedString = createStockStatusAttributedString()
+        let variationStatusOrPriceAttributedString = createVariationStatusOrPriceAttributedString(currencySettings: currencySettings)
+
+        let detailsAttributedString = NSMutableAttributedString(attributedString: stockStatusAttributedString)
+        detailsAttributedString.append(NSAttributedString(string: " • ", attributes: [
+            .foregroundColor: UIColor.textSubtle,
+            .font: Style.detailsFont
+        ]))
+        detailsAttributedString.append(variationStatusOrPriceAttributedString)
+        return NSAttributedString(attributedString: detailsAttributedString)
+    }
+
+    func createStockStatusAttributedString() -> NSAttributedString {
+        let stockText = createStockText()
+        return NSAttributedString(string: stockText,
+                                  attributes: [
+                                    .foregroundColor: UIColor.textSubtle,
+                                    .font: Style.detailsFont
+        ])
+    }
+
+    func createVariationStatusOrPriceAttributedString(currencySettings: CurrencySettings) -> NSAttributedString {
         let currencyCode = currencySettings.currencyCode
         let currency = currencySettings.symbol(from: currencyCode)
 
@@ -35,14 +57,20 @@ private extension EditableProductVariationModel {
         let attributedString = NSMutableAttributedString(string: detailsText,
                                                          attributes: [
                                                             .foregroundColor: textColor,
-                                                            .font: StyleManager.footerLabelFont
-            ])
+                                                            .font: Style.detailsFont
+        ])
         return attributedString
     }
 
     func createPriceText(currency: String, currencySettings: CurrencySettings) -> String {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         return currencyFormatter.formatAmount(productVariation.price, with: currency) ?? ""
+    }
+}
+
+private extension EditableProductVariationModel {
+    enum Style {
+        static let detailsFont = StyleManager.footerLabelFont
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductFormDataModel+ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductFormDataModel+ProductsTabProductViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Helpers for `ProductsTabProductViewModel` from `ProductFormDataModel`.
+extension ProductFormDataModel {
+    /// Create a description text based on a product data model's stock status/quantity.
+    func createStockText() -> String {
+        switch stockStatus {
+        case .inStock:
+            if let stockQuantity = stockQuantity {
+                let format = NSLocalizedString("%ld in stock", comment: "Label about product's inventory stock status shown on Products tab")
+                return String.localizedStringWithFormat(format, stockQuantity)
+            } else {
+                return NSLocalizedString("In stock", comment: "Label about product's inventory stock status shown on Products tab")
+            }
+        default:
+            return stockStatus.description
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -29,13 +29,13 @@ struct ProductsTabProductViewModel {
         imageUrl = product.images.first?.src
         name = product.name
         self.isSelected = isSelected
-        detailsAttributedString = product.createDetailsAttributedString()
+        detailsAttributedString = EditableProductModel(product: product).createDetailsAttributedString()
 
         self.imageService = imageService
     }
 }
 
-private extension Product {
+private extension EditableProductModel {
     func createDetailsAttributedString() -> NSAttributedString {
         let statusText = createStatusText()
         let stockText = createStockText()
@@ -51,40 +51,26 @@ private extension Product {
                                                             .font: StyleManager.footerLabelFont
             ])
         if let statusText = statusText {
-            attributedString.addAttributes([.foregroundColor: productStatus.descriptionColor],
+            attributedString.addAttributes([.foregroundColor: status.descriptionColor],
                                            range: NSRange(location: 0, length: statusText.count))
         }
         return attributedString
     }
 
     func createStatusText() -> String? {
-        switch productStatus {
+        switch status {
         case .pending, .draft:
-            return productStatus.description
+            return status.description
         default:
             return nil
-        }
-    }
-
-    func createStockText() -> String? {
-        switch productStockStatus {
-        case .inStock:
-            if let stockQuantity = stockQuantity {
-                let format = NSLocalizedString("%ld in stock", comment: "Label about product's inventory stock status shown on Products tab")
-                return String.localizedStringWithFormat(format, stockQuantity)
-            } else {
-                return NSLocalizedString("In stock", comment: "Label about product's inventory stock status shown on Products tab")
-            }
-        default:
-            return productStockStatus.description
         }
     }
 
     func createVariationsText() -> String? {
-        guard !variations.isEmpty else {
+        guard !product.variations.isEmpty else {
             return nil
         }
-        let numberOfVariations = variations.count
+        let numberOfVariations = product.variations.count
         let singularFormat = NSLocalizedString("%ld variant", comment: "Label about one product variation shown on Products tab")
         let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
         let format = String.pluralize(numberOfVariations, singular: singularFormat, plural: pluralFormat)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */; };
 		025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */; };
 		025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1749237AA49D00C780B4 /* Product+ProductForm.swift */; };
+		025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025E32BB251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift */; };
 		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
 		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
@@ -1115,6 +1116,7 @@
 		025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+ObservablesTests.swift"; sourceTree = "<group>"; };
 		025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormSection+ReusableTableRow.swift"; sourceTree = "<group>"; };
 		025B1749237AA49D00C780B4 /* Product+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductForm.swift"; sourceTree = "<group>"; };
+		025E32BB251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormDataModel+ProductsTabProductViewModel.swift"; sourceTree = "<group>"; };
 		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
 		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
@@ -2024,6 +2026,7 @@
 			isa = PBXGroup;
 			children = (
 				020DD48C2322A617005822B1 /* ProductsTabProductViewModel.swift */,
+				025E32BB251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift */,
 			);
 			path = "View Models";
 			sourceTree = "<group>";
@@ -5331,6 +5334,7 @@
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
+				025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */,
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
 				B50911302049E27A007D25DC /* DashboardViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModel+VariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModel+VariationTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import Yosemite
 
 final class ProductsTabProductViewModel_VariationTests: XCTestCase {
+    // MARK: Status / price details
+
     func test_product_cell_view_model_shows_disabled_details_text_when_variation_is_disabled() {
         // Arrange
         let variation = MockProductVariation().productVariation().copy(status: .privateStatus)
@@ -12,7 +14,7 @@ final class ProductsTabProductViewModel_VariationTests: XCTestCase {
         let viewModel = ProductsTabProductViewModel(productVariationModel: model)
 
         // Assert
-        XCTAssertEqual(viewModel.detailsAttributedString.string, EditableProductVariationModel.DetailsLocalization.disabledText)
+        XCTAssertTrue(viewModel.detailsAttributedString.string.contains(EditableProductVariationModel.DetailsLocalization.disabledText))
     }
 
     func test_product_cell_view_model_shows_no_price_details_text_when_variation_is_enabled_but_missing_price() {
@@ -24,7 +26,7 @@ final class ProductsTabProductViewModel_VariationTests: XCTestCase {
         let viewModel = ProductsTabProductViewModel(productVariationModel: model)
 
         // Assert
-        XCTAssertEqual(viewModel.detailsAttributedString.string, EditableProductVariationModel.DetailsLocalization.noPriceText)
+        XCTAssertTrue(viewModel.detailsAttributedString.string.contains(EditableProductVariationModel.DetailsLocalization.noPriceText))
     }
 
     func test_product_cell_view_model_shows_price_details_text_when_variation_is_enabled_and_has_price() {
@@ -41,6 +43,47 @@ final class ProductsTabProductViewModel_VariationTests: XCTestCase {
         let viewModel = ProductsTabProductViewModel(productVariationModel: model, currencySettings: currencySettings)
 
         // Assert
-        XCTAssertEqual(viewModel.detailsAttributedString.string, "$6.000")
+        XCTAssertTrue(viewModel.detailsAttributedString.string.contains("$6.000"))
+    }
+
+    // MARK: Inventory details
+
+    func test_product_cell_view_model_shows_stock_status_when_variation_is_not_in_stock() {
+        // Arrange
+        let variation = MockProductVariation().productVariation().copy(stockStatus: .outOfStock)
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Action
+        let viewModel = ProductsTabProductViewModel(productVariationModel: model)
+
+        // Assert
+        XCTAssertTrue(viewModel.detailsAttributedString.string.contains(ProductStockStatus.outOfStock.description))
+    }
+
+    func test_product_cell_view_model_shows_stock_status_when_variation_is_in_stock_without_stock_quantity() {
+        // Arrange
+        let variation = MockProductVariation().productVariation().copy(stockQuantity: nil, stockStatus: .inStock)
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Action
+        let viewModel = ProductsTabProductViewModel(productVariationModel: model)
+
+        // Assert
+        XCTAssertTrue(viewModel.detailsAttributedString.string.contains(ProductStockStatus.inStock.description))
+    }
+
+    func test_product_cell_view_model_shows_stock_status_with_quantity_when_variation_is_in_stock_with_stock_quantity() {
+        // Arrange
+        let stockQuantity: Int64 = 6
+        let variation = MockProductVariation().productVariation().copy(stockQuantity: stockQuantity, stockStatus: .inStock)
+        let model = EditableProductVariationModel(productVariation: variation)
+
+        // Action
+        let viewModel = ProductsTabProductViewModel(productVariationModel: model)
+
+        // Assert
+        let format = NSLocalizedString("%ld in stock", comment: "Label about product's inventory stock status shown on Products tab")
+        let expectedStockDetails = String.localizedStringWithFormat(format, stockQuantity)
+        XCTAssertTrue(viewModel.detailsAttributedString.string.contains(expectedStockDetails))
     }
 }


### PR DESCRIPTION
Fixes #2863 

## Changes

- Moved `func createStockText() -> String` from a private `Product` extension to `ProductFormDataModel` protocol extension (which `EditableProductModel` and `EditableProductVariationModel` implement)
  - Updated the return value from an optional string to non-optional, since it's already returning non-nil value for all cases
- Updated `ProductsTabProductViewModel`'s initializer for `Product` to use `EditableProductModel` and `ProductFormDataModel`'s extensions
- Updated `ProductsTabProductViewModel`'s initializer for `EditableProductVariationModel` from just a status/price to `"\(stock status) • \(the original status or price)"`

## Testing

- Go to the Products tab --> each product cell should look the same as before
- Tap on a variable product
- Tap on the variations row --> each variation cell should show the stock status first

## Example screenshots

\ | before | after
-- | -- | --
variation list | ![Simulator Screen Shot - iPhone 11 - 2020-09-25 at 11 12 00](https://user-images.githubusercontent.com/1945542/94228564-d0368080-ff2f-11ea-8513-2215b84e66a2.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-25 at 11 14 15](https://user-images.githubusercontent.com/1945542/94228568-d4629e00-ff2f-11ea-8869-574bb52ef2dd.png)
product list (regression testing) | ![Simulator Screen Shot - iPhone 11 - 2020-09-25 at 11 11 51](https://user-images.githubusercontent.com/1945542/94228546-ca409f80-ff2f-11ea-875b-134186deaecb.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-25 at 11 14 08](https://user-images.githubusercontent.com/1945542/94228566-d298da80-ff2f-11ea-8648-9b0f5302780c.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
