### PR TITLE
Add Unit Test To Help Prevent Core Data Migration Mistakes

### DIFF
--- a/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -288,9 +288,8 @@ private extension CoreDataIterativeMigrator {
 
     func models(for modelVersions: [ManagedObjectModelsInventory.ModelVersion]) throws -> [NSManagedObjectModel] {
         let models = try modelVersions.map { version -> NSManagedObjectModel in
-            guard let url = urlForModel(name: version.name, in: nil),
-                let model = NSManagedObjectModel(contentsOf: url) else {
-                    let description = "No model found for \(version.name)"
+            guard let model = self.modelsInventory.model(for: version) else {
+                let description = "No model found for \(version.name)"
                 throw NSError(domain: "IterativeMigrator", code: 110, userInfo: [NSLocalizedDescriptionKey: description])
             }
 
@@ -298,24 +297,5 @@ private extension CoreDataIterativeMigrator {
         }
 
         return models
-    }
-
-    func urlForModel(name: String, in directory: String?) -> URL? {
-        let bundle = Bundle(for: CoreDataManager.self)
-        var url = bundle.url(forResource: name, withExtension: "mom", subdirectory: directory)
-
-        if url != nil {
-            return url
-        }
-
-        let momdPaths = bundle.paths(forResourcesOfType: "momd", inDirectory: directory)
-        momdPaths.forEach { (path) in
-            if url != nil {
-                return
-            }
-            url = bundle.url(forResource: name, withExtension: "mom", subdirectory: URL(fileURLWithPath: path).lastPathComponent)
-        }
-
-        return url
     }
 }

--- a/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
+++ b/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
@@ -81,6 +81,11 @@ struct ManagedObjectModelsInventory {
                                             versions: modelVersions)
     }
 
+    /// Load the corresponding `NSManagedObjectModel` for the given `version`.
+    ///
+    /// This is intentionally not part of `ModelVersion` itself because this involves a file
+    /// access and we usually would not need all of the `NSManagedObjectModel` instances.
+    ///
     func model(for version: ModelVersion) -> NSManagedObjectModel? {
         let expectedMomURL = packageURL.appendingPathComponent(version.name).appendingPathExtension("mom")
         return NSManagedObjectModel(contentsOf: expectedMomURL)

--- a/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
+++ b/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
@@ -80,6 +80,11 @@ struct ManagedObjectModelsInventory {
                                             currentModel: currentModel,
                                             versions: modelVersions)
     }
+
+    func model(for version: ModelVersion) -> NSManagedObjectModel? {
+        let expectedMomURL = packageURL.appendingPathComponent(version.name).appendingPathExtension("mom")
+        return NSManagedObjectModel(contentsOf: expectedMomURL)
+    }
 }
 
 // MARK: - Utils

--- a/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
+++ b/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift
@@ -26,7 +26,7 @@ struct ManagedObjectModelsInventory {
     /// This is intentionally a `struct` with a single property instead of a `String` because I
     /// foresee that this will be used to contain the `NSManagedObjectModel` in the near future.
     ///
-    struct ModelVersion {
+    struct ModelVersion: Equatable {
         /// The name excluding the extension.
         ///
         /// For example, if the model file name is "Model 10.mom", then this would be "Model 10".

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -27,7 +27,7 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString)?
             .appendingPathExtension("sqlite"))
 
-        try modelsInventory.versions.forEach { currentVersion in
+        for (currentVersionIndex, currentVersion) in modelsInventory.versions.enumerated() {
             // Given
             let currentModel = try XCTUnwrap(modelsInventory.model(for: currentVersion))
 
@@ -56,10 +56,9 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
             XCTAssertTrue(currentModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: persistentStore.metadata),
                           "Current model “\(currentVersion.name)” should be compatible with the persistentStore.")
 
-            // All other models should not be compatible with the current persistentStore
-            try modelsInventory.versions.filter {
-                $0 != currentVersion
-            }.forEach { version in
+            // Higher version models should not be compatible with the current persistentStore
+            let higherVersions = modelsInventory.versions.dropFirst(currentVersionIndex + 1)
+            try higherVersions.forEach { version in
                 let model = try XCTUnwrap(modelsInventory.model(for: version))
                 XCTAssertFalse(model.isConfiguration(withName: nil, compatibleWithStoreMetadata: persistentStore.metadata),
                                "Model “\(version.name)” should not be compatible with the persistentStore whose version is “\(currentVersion.name)”.")

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -19,8 +19,13 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         super.tearDown()
     }
 
-    /// Tests that given a store with an old version, higher model versions are not compatible with
-    /// it.
+    /// Tests that model versions are not compatible with each other.
+    ///
+    /// This protects us from mistakes like adding a new model version that has **no structural
+    /// changes** and not setting the Hash Modifier. An example of that is creating a new model
+    /// but only renaming the entity classes. If we forget to change the model's Hash Modifier,
+    /// then the `CoreDataManager.migrateDataModelIfNecessary` will (correctly) **skip** the
+    /// migration. See here for more information: https://tinyurl.com/yxzpwp7t.
     ///
     /// This loops through **all NSManagedObjectModels**, performs a migration, and checks for
     /// compatibility with all the other versions. For example, for "Model 3":
@@ -29,20 +34,16 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
     /// 2. Check that Model 3 is compatible with the _migrated_ store. This verifies the migration.
     /// 3. Check that Models 1, 2, 4, 5, 6, 7, and so on are **not** compatible with the _migrated_ store.
     ///
-    /// This test protects us from mistakes like adding a new model version **without** structural
-    /// changes. An example of that is creating a new model but only renaming the entity classes.
-    /// If we forget to change the model's Hash Modifier, then the
-    /// `CoreDataManager.migrateDataModelIfNecessary` will actually **skip** the migration. See
-    /// here for more information: https://tinyurl.com/yxzpwp7t.
+    /// ## Testing
     ///
     /// You can make this test fail by:
     ///
-    /// 1. Creating a new model for `WooCommerce.xcdatamodeld`, copying the latest version.
+    /// 1. Creating a new model version for `WooCommerce.xcdatamodeld`, copying the latest version.
     /// 2. Running this test.
     ///
     /// And then make this pass again by setting a Hash Modifier value for the new model.
     ///
-    func test_when_migrating_through_all_versions_then_higher_versions_are_not_compatible() throws {
+    func test_all_model_versions_are_not_compatible_with_each_other() throws {
         // Given
         // Use in-memory type or else this would be too slow.
         let storeType = NSInMemoryStoreType

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -19,6 +19,54 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_all_model_versions_are_incompatible_with_each_other() throws {
+        // Given
+        // Use in-memory type or else this would be too slow.
+        let storeType = NSInMemoryStoreType
+        let storeURL = try XCTUnwrap(NSURL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)?
+            .appendingPathExtension("sqlite"))
+
+        try modelsInventory.versions.forEach { currentVersion in
+            // Given
+            let currentModel = try XCTUnwrap(modelsInventory.model(for: currentVersion))
+
+            // When
+            // Migrate to the currentVersion if this is not the first version in the list.
+            if modelsInventory.versions.first != currentVersion {
+                let migrator = CoreDataIterativeMigrator(modelsInventory: modelsInventory)
+                let (isMigrationSuccessful, _) = try migrator.iterativeMigrate(sourceStore: storeURL, storeType: storeType, to: currentModel)
+                XCTAssertTrue(isMigrationSuccessful)
+            }
+
+            // Load the persistent container
+            let persistentContainer = makePersistentContainer(storeURL: storeURL, storeType: storeType, model: currentModel)
+            let loadingError: Error? = try waitFor { promise in
+                persistentContainer.loadPersistentStores { _, error in
+                    promise(error)
+                }
+            }
+            XCTAssertNil(loadingError)
+
+            let persistentStoreCoordinator = persistentContainer.persistentStoreCoordinator
+            let persistentStore = try XCTUnwrap(persistentStoreCoordinator.persistentStores.first)
+
+            // Then
+            // The current model should be compatible with the current persistent store
+            XCTAssertTrue(currentModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: persistentStore.metadata),
+                          "Current model “\(currentVersion.name)” should be compatible with the persistentStore.")
+
+            // All other models should not be compatible with the current persistentStore
+            try modelsInventory.versions.filter {
+                $0 != currentVersion
+            }.forEach { version in
+                let model = try XCTUnwrap(modelsInventory.model(for: version))
+                XCTAssertFalse(model.isConfiguration(withName: nil, compatibleWithStoreMetadata: persistentStore.metadata),
+                               "Model “\(version.name)” should not be compatible with the persistentStore whose version is “\(currentVersion.name)”.")
+            }
+        }
+    }
+
     func test_it_will_not_migrate_if_the_database_file_does_not_exist() throws {
         // Given
         let targetModel = try managedObjectModel(for: "Model 28")
@@ -346,53 +394,6 @@ final class CoreDataIterativeMigratorTests: XCTestCase {
         XCTAssertEqual(persistedAttribute.options, attributeOptions)
     }
 
-    func test_all_model_versions_are_incompatible_with_each_other() throws {
-        // Given
-        // Use in-memory type or else this would be too slow.
-        let storeType = NSInMemoryStoreType
-        let storeURL = try XCTUnwrap(NSURL(fileURLWithPath: NSTemporaryDirectory())
-                                        .appendingPathComponent(UUID().uuidString)?
-                                        .appendingPathExtension("sqlite"))
-
-        try modelsInventory.versions.forEach { currentVersion in
-            // Given
-            let currentModel = try XCTUnwrap(modelsInventory.model(for: currentVersion))
-
-            // When
-            // Migrate to the currentVersion if this is not the first version in the list.
-            if modelsInventory.versions.first != currentVersion {
-                let migrator = CoreDataIterativeMigrator(modelsInventory: modelsInventory)
-                let (isMigrationSuccessful, _) = try migrator.iterativeMigrate(sourceStore: storeURL, storeType: storeType, to: currentModel)
-                XCTAssertTrue(isMigrationSuccessful)
-            }
-
-            // Load the persistent container
-            let persistentContainer = makePersistentContainer(storeURL: storeURL, storeType: storeType, model: currentModel)
-            let loadingError: Error? = try waitFor { promise in
-                persistentContainer.loadPersistentStores { _, error in
-                    promise(error)
-                }
-            }
-            XCTAssertNil(loadingError)
-
-            let persistentStoreCoordinator = persistentContainer.persistentStoreCoordinator
-            let persistentStore = try XCTUnwrap(persistentStoreCoordinator.persistentStores.first)
-
-            // Then
-            // The current model should be compatible with the current persistent store
-            XCTAssertTrue(currentModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: persistentStore.metadata),
-                          "Current model “\(currentVersion.name)” should be compatible with the persistentStore.")
-
-            // All other models should not be compatible with the current persistentStore
-            try modelsInventory.versions.filter {
-                $0 != currentVersion
-            }.forEach { version in
-                let model = try XCTUnwrap(modelsInventory.model(for: version))
-                XCTAssertFalse(model.isConfiguration(withName: nil, compatibleWithStoreMetadata: persistentStore.metadata),
-                              "Model “\(version.name)” should not be compatible with the persistentStore whose version is “\(currentVersion.name)”.")
-            }
-        }
-    }
 }
 
 /// Helpers for generating data in migration tests

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -424,9 +424,11 @@ private extension CoreDataIterativeMigratorTests {
     }
 
     func managedObjectModel(for modelName: String) throws -> NSManagedObjectModel {
-        try XCTUnwrap(NSManagedObjectModel(contentsOf: urlForModel(name: modelName)))
+        let modelVersion = ManagedObjectModelsInventory.ModelVersion(name: modelName)
+        return try XCTUnwrap(modelsInventory.model(for: modelVersion))
     }
 
+    /// Prefer using `managedObjectModel(for:)` directly. 
     func urlForModel(name: String) -> URL {
 
         let bundle = Bundle(for: CoreDataManager.self)

--- a/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
+++ b/Storage/StorageTests/CoreData/CoreDataIterativeMigratorTests.swift
@@ -7,10 +7,10 @@ import CoreData
 final class CoreDataIterativeMigratorTests: XCTestCase {
     private var modelsInventory: ManagedObjectModelsInventory!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         DDLog.add(DDOSLogger.sharedInstance)
-        modelsInventory = try! .from(packageName: "WooCommerce", bundle: Bundle(for: CoreDataManager.self))
+        modelsInventory = try .from(packageName: "WooCommerce", bundle: Bundle(for: CoreDataManager.self))
     }
 
     override func tearDown() {

--- a/Storage/StorageTests/CoreData/ManagedObjectModelsInventoryTests.swift
+++ b/Storage/StorageTests/CoreData/ManagedObjectModelsInventoryTests.swift
@@ -59,6 +59,7 @@ final class ManagedObjectModelsInventoryTests: XCTestCase {
             "Model 28",
             "Model 29",
             "Model 30",
+            "Model 31"
         ]
 
         // When


### PR DESCRIPTION
## Problem

I'm about to add another migration to fix the Xcode 12 build. And from my experience, I always felt uneasy because I'm never sure if I'm doing things right or I forgot something. 

As @astralbodies also mentioned, when we create a new model but don't make any structural changes, we should always make sure to change the Hash Modifier value. If we don't, then this will pass and `CoreDataManager` will just _skip_ the migration:

https://github.com/woocommerce/woocommerce-ios/blob/365f2c7c64c1cdf74097e5913c2b934ffdf9606e/Storage/Storage/CoreData/CoreDataManager.swift#L188-L191

That can lead to unknown consequences. 

This fact is also mentioned in this [Core Data documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CoreDataVersioning/Articles/vmUnderstandingVersions.html). 

> There may, however, be some situations in which you have two versions of a model that Core Data would normally treat as equivalent that you want to be recognized as being different. For example, you might change the name of the class used to represent an entity, or more subtly you might keep the model the same but change the internal format of an attribute such as a BLOB—this is irrelevant to Core Data, but it is crucial for the integrity of your data. To support this, Core Data allows you to set a hash modifier for an entity or property see versionHashModifier (NSEntityDescription) and versionHashModifier (NSPropertyDescription).

## Solution

This PR adds an automated test that ensures that all the Core Data model versions are **not compatible with each other**. This helps prevent us from creating new Core Data model versions that `CoreDataManager.migrateDataModelIfNecessary()` will just ignore. 

### Other Changes

I organized some of the `NSManagedObjectModel` creation to use [`ManagedObjectModelsInventory`](https://github.com/woocommerce/woocommerce-ios/blob/add/unit-test-for-core-data-migrations/Storage/Storage/CoreData/ManagedObjectModelsInventory.swift) so there is less repetition in how we read these objects. 

https://github.com/woocommerce/woocommerce-ios/blob/be33b0678990493cc4b9f8d2a7ec39d2b58443aa/Storage/Storage/CoreData/CoreDataIterativeMigrator.swift#L291-L294


## Testing

1. Run the `test_all_model_versions_are_not_compatible_with_each_other` unit test. We expect this to pass.
2. Add a new Model Version to `WooCommerce.xcdatamodeld`. Use the last model version as the base. This is probably named “Model 32”.
3. In “Model 32”, change the class name of the `Attribute` entity to `GenericAttribute`. 
4. Set “Model 32” as the current model version. 
5. Run the `test_all_model_versions_are_not_compatible_with_each_other` again. It should fail now. This is the “feature” of this unit test. 
6. Back to “Model 32”, add a value for the Hash Modifier.

    ![image](https://user-images.githubusercontent.com/198826/94292928-d66e3200-ff1a-11ea-892b-3f30188b0365.png)

7. Run the `test_all_model_versions_are_not_compatible_with_each_other` again. It should pass. 

Run `git reset --hard HEAD` to discard all the changes above. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

