### PR TITLE
Issue/2756 update downloadable file info for a product - part 2

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/FIle List/ProductDownloadListViewController.swift
@@ -125,6 +125,7 @@ extension ProductDownloadListViewController {
 
     @objc private func downloadSettingsButtonTapped() {
         // TODO: - add analytics
+        showDownloadSettings()
     }
 
     @objc private func addButtonTapped() {
@@ -157,6 +158,36 @@ extension ProductDownloadListViewController {
         guard hasUnsavedChanges else {
             return
         }
+    }
+}
+
+// MARK: Action - Downloaded Settings
+//
+extension ProductDownloadListViewController {
+    func showDownloadSettings() {
+        let viewController = ProductDownloadSettingsViewController(product: product) { [weak self]
+            (downloadLimit, downloadExpiry, hasUnsavedChanges) in
+            self?.onDownloadSettingsCompletion(downloadLimit: downloadLimit,
+                                               downloadExpiry: downloadExpiry,
+                                               hasUnsavedChanges: hasUnsavedChanges)
+        }
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func onDownloadSettingsCompletion(downloadLimit: Int64,
+                                      downloadExpiry: Int64,
+                                      hasUnsavedChanges: Bool) {
+        defer {
+            navigationController?.popViewController(animated: true)
+        }
+
+        guard hasUnsavedChanges else {
+            return
+        }
+
+        viewModel.handleDownloadLimitChange(downloadLimit)
+        viewModel.handleDownloadExpiryChange(downloadExpiry)
+        viewModel.completeUpdating(onCompletion: onCompletion)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/Product+DownloadSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/Product+DownloadSettingsViewModels.swift
@@ -1,0 +1,25 @@
+import Yosemite
+
+extension Product {
+    static func createDownloadLimitViewModel(downloadLimit: Int64,
+                                                onTextChange: @escaping (_ text: String?) -> Void) -> TitleAndTextFieldTableViewCell.ViewModel {
+        let text = downloadLimit >= 0 ? String(downloadLimit) : nil
+        return TitleAndTextFieldTableViewCell.ViewModel(title: ProductDownloadSettingsViewModel.Strings.downloadLimitTitle,
+                                                        text: text,
+                                                        placeholder: ProductDownloadSettingsViewModel.Strings.downloadLimitPlaceholder,
+                                                        keyboardType: .numberPad,
+                                                        textFieldAlignment: .trailing,
+                                                        onTextChange: onTextChange)
+    }
+
+    static func createDownloadExpiryViewModel(downloadExpiry: Int64,
+                                               onTextChange: @escaping (_ text: String?) -> Void) -> TitleAndTextFieldTableViewCell.ViewModel {
+        let text = downloadExpiry >= 0 ? String(downloadExpiry) : nil
+        return TitleAndTextFieldTableViewCell.ViewModel(title: ProductDownloadSettingsViewModel.Strings.downloadExpiryTitle,
+                                                        text: text,
+                                                        placeholder: ProductDownloadSettingsViewModel.Strings.downloadExpiryPlaceholder,
+                                                        keyboardType: .numberPad,
+                                                        textFieldAlignment: .trailing,
+                                                        onTextChange: onTextChange)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.swift
@@ -1,0 +1,292 @@
+import UIKit
+import Yosemite
+
+// MARK: - ProductDownloadSettingsViewController
+//
+final class ProductDownloadSettingsViewController: UIViewController {
+
+    @IBOutlet weak var tableView: UITableView!
+
+    private let viewModel: ProductDownloadSettingsViewModelOutput & ProductDownloadSettingsActionHandler
+    private var sections: [Section] = []
+    private var error: String?
+
+    // Completion callback
+    //
+    typealias Completion = (_ downloadLimit: Int64, _ downloadExpiry: Int64, _ hasUnsavedChanges: Bool) -> Void
+    private let onCompletion: Completion
+
+    private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
+        let keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
+            self?.handleKeyboardFrameUpdate(keyboardFrame: keyboardFrame)
+        }
+        return keyboardFrameObserver
+    }()
+
+    /// Init
+    ///
+    init(product: ProductFormDataModel, completion: @escaping Completion) {
+        viewModel = ProductDownloadSettingsViewModel(product: product)
+        onCompletion = completion
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        startListeningToNotifications()
+        configureNavigationBar()
+        configureMainView()
+        configureSections()
+        configureTableView()
+        handleSwipeBackGesture()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        configureTextFieldAsFirstResponder()
+    }
+}
+
+// MARK: - Navigation actions handling
+//
+extension ProductDownloadSettingsViewController {
+
+    override func shouldPopOnBackButton() -> Bool {
+        guard viewModel.hasUnsavedChanges() else {
+            return true
+        }
+        presentBackNavigationActionSheet()
+        return false
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+
+    @objc private func completeUpdating() {
+        viewModel.completeUpdating() { [weak self] (downloadLimit, downloadExpiry, hasUnsavedChanges) in
+            self?.onCompletion(downloadLimit, downloadExpiry, hasUnsavedChanges)
+        }
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        })
+    }
+}
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension ProductDownloadSettingsViewController: UITableViewDataSource {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections[section].rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reuseIdentifier, for: indexPath)
+        configure(cell, for: row, at: indexPath)
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footer
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension ProductDownloadSettingsViewController {
+
+    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+
+    func configureSections() {
+        sections = viewModel.sections
+    }
+
+    func getDownloadLimitCell() -> TitleAndTextFieldTableViewCell? {
+        guard let indexPath = sections.indexPathForRow(.limit) else {
+            return nil
+        }
+        return tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell
+    }
+
+    func getDownloadExpiryCell() -> TitleAndTextFieldTableViewCell? {
+        guard let indexPath = sections.indexPathForRow(.expiry) else {
+            return nil
+        }
+        return tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell
+    }
+}
+
+
+// MARK: - Cell configuration
+//
+private extension ProductDownloadSettingsViewController {
+    /// Cells currently configured in the order they appear on screen
+    ///
+    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+        switch cell {
+        case let cell as TitleAndTextFieldTableViewCell where row == .limit:
+            configureLimit(cell: cell)
+        case let cell as TitleAndTextFieldTableViewCell where row == .expiry:
+            configureExpiry(cell: cell)
+        default:
+            fatalError()
+            break
+        }
+    }
+
+    func configureLimit(cell: TitleAndTextFieldTableViewCell) {
+        let cellViewModel = Product.createDownloadLimitViewModel(downloadLimit: viewModel.downloadLimit) { [weak self] value in
+            self?.viewModel.handleDownloadLimitChange(value) { [weak self] (isValid, shouldBringUpKeyboard) in
+                self?.enableDoneButton(isValid)
+                if shouldBringUpKeyboard {
+                    self?.getDownloadLimitCell()?.textFieldBecomeFirstResponder()
+                }
+            }
+        }
+        cell.configure(viewModel: cellViewModel)
+    }
+
+    func configureExpiry(cell: TitleAndTextFieldTableViewCell) {
+        let cellViewModel = Product.createDownloadExpiryViewModel(downloadExpiry: viewModel.downloadExpiry) { [weak self] value in
+            self?.viewModel.handleDownloadExpiryChange(value) { [weak self] (isValid, shouldBringUpKeyboard) in
+                self?.enableDoneButton(isValid)
+                if shouldBringUpKeyboard {
+                    self?.getDownloadExpiryCell()?.textFieldBecomeFirstResponder()
+                }
+            }
+        }
+        cell.configure(viewModel: cellViewModel)
+    }
+}
+
+// MARK: - View Configuration
+//
+private extension ProductDownloadSettingsViewController {
+
+    func configureNavigationBar() {
+        title = NSLocalizedString("Download Settings",
+                                  comment: "Download file settings navigation title")
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                            target: self,
+                                                            action: #selector(completeUpdating))
+        removeNavigationBackBarButtonText()
+        self.enableDoneButton(false)
+    }
+
+    func configureMainView() {
+        view.backgroundColor = .listBackground
+    }
+
+    func configureTableView() {
+        tableView.dataSource = self
+
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.backgroundColor = .listBackground
+        tableView.removeLastCellSeparator()
+
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(tableView)
+
+        registerTableViewCells()
+        registerTableViewHeaderFooters()
+    }
+
+    /// The limit text field becomes the first responder immediately when the view did appear
+    ///
+    func configureTextFieldAsFirstResponder() {
+        if let indexPath = sections.indexPathForRow(.limit) {
+            let cell = tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell
+            cell?.textFieldBecomeFirstResponder()
+        }
+    }
+
+    func registerTableViewCells() {
+        for row in Row.allCases {
+            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+        }
+    }
+
+    func registerTableViewHeaderFooters() {
+        let headersAndFooters = [ ErrorSectionHeaderView.self ]
+
+        for kind in headersAndFooters {
+            tableView.register(kind.loadNib(), forHeaderFooterViewReuseIdentifier: kind.reuseIdentifier)
+        }
+    }
+
+    private func enableDoneButton(_ enabled: Bool) {
+        navigationItem.rightBarButtonItem?.isEnabled = enabled
+    }
+}
+
+// MARK: - Keyboard management
+//
+extension ProductDownloadSettingsViewController: KeyboardScrollable {
+    var scrollable: UIScrollView {
+        return tableView
+    }
+}
+
+private extension ProductDownloadSettingsViewController {
+    /// Registers for all of the related Notifications
+    ///
+    func startListeningToNotifications() {
+        keyboardFrameObserver.startObservingKeyboardFrame()
+    }
+}
+
+extension ProductDownloadSettingsViewController {
+
+    struct Section: RowIterable, Equatable {
+        let errorTitle: String?
+        let footer: String?
+        let rows: [Row]
+
+        init(errorTitle: String? = nil, footer: String? = nil, rows: [Row]) {
+            self.errorTitle = errorTitle
+            self.footer = footer
+            self.rows = rows
+        }
+    }
+
+    enum Row: CaseIterable {
+        case limit
+        case expiry
+
+        fileprivate var type: UITableViewCell.Type {
+            switch self {
+            case .limit, .expiry:
+                return TitleAndTextFieldTableViewCell.self
+            }
+        }
+
+        fileprivate var reuseIdentifier: String {
+            return type.reuseIdentifier
+        }
+    }
+}
+
+private extension ProductDownloadSettingsViewController {
+    enum Constants {
+        static let sectionHeight = CGFloat(44)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.xib
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ProductDownloadSettingsViewController" customModule="WooCommerce" customModuleProvider="target">
+            <connections>
+                <outlet property="tableView" destination="1Vz-Zp-cOV" id="7rW-ve-g9E"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="1Vz-Zp-cOV">
+                    <rect key="frame" x="0.0" y="39" width="414" height="818"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <point key="canvasLocation" x="137.68115942028987" y="120.53571428571428"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewModel.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Yosemite
+
+/// Provides data needed for download settings.
+///
+protocol ProductDownloadSettingsViewModelOutput {
+    typealias Section = ProductDownloadSettingsViewController.Section
+    typealias Row = ProductDownloadSettingsViewController.Row
+    var sections: [Section] { get }
+
+    var downloadLimit: Int64 { get }
+    var downloadExpiry: Int64 { get }
+}
+
+/// Handles actions related to the download settings data.
+///
+protocol ProductDownloadSettingsActionHandler {
+    // Input field actions
+    func handleDownloadLimitChange(_ downloadLimit: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void)
+    func handleDownloadExpiryChange(_ downloadExpiry: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void)
+
+    // Navigation actions
+    func completeUpdating(onCompletion: ProductDownloadSettingsViewController.Completion)
+    func hasUnsavedChanges() -> Bool
+}
+
+/// Provides view data for downloadable file download, and handles init/UI/navigation actions needed in product download settings.
+///
+final class ProductDownloadSettingsViewModel: ProductDownloadSettingsViewModelOutput {
+    private let product: ProductFormDataModel
+
+    // Editable data
+    //
+    private(set) var downloadLimit: Int64
+    private(set) var downloadExpiry: Int64
+
+    // Validation
+    private var downloadLimitIsValid: Bool = false
+    private var downloadExpiryIsValid: Bool = false
+    private lazy var throttler: Throttler = Throttler(seconds: 0.5)
+
+    init(product: ProductFormDataModel) {
+        self.product = product
+        self.downloadLimit = product.downloadLimit
+        self.downloadExpiry = product.downloadExpiry
+        downloadLimitIsValid = self.downloadLimit >= 0 ? true : false
+        downloadExpiryIsValid = self.downloadExpiry >= 0 ? true : false
+    }
+
+    var sections: [Section] {
+        let limitSection = Section(footer: Strings.downloadLimitFooter, rows: [.limit])
+        let expirySection = Section(footer: Strings.downloadExpiryFooter, rows: [.expiry])
+
+        switch product {
+        case is EditableProductModel:
+            return [
+                limitSection,
+                expirySection
+            ]
+        default:
+            fatalError("Unsupported product type: \(product)")
+        }
+    }
+}
+
+// MARK: - UI changes
+//
+extension ProductDownloadSettingsViewModel: ProductDownloadSettingsActionHandler {
+    func handleDownloadLimitChange(_ downloadLimit: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void) {
+        guard let downloadLimit = downloadLimit, let downloadLimit_unwrapped = Int64(downloadLimit), downloadLimit_unwrapped >= 0 else {
+            downloadLimitIsValid = false
+            self.downloadLimit = -1
+            onValidation(isChangesValid(), true)
+            return
+        }
+        self.downloadLimit = downloadLimit_unwrapped
+        let newValue = self.downloadLimit
+        let oldValue = product.downloadLimit
+
+        guard newValue != oldValue else {
+            downloadLimitIsValid = false
+            onValidation(isChangesValid(), true)
+            return
+        }
+        downloadLimitIsValid = true
+        onValidation(isChangesValid(), false)
+    }
+
+    func handleDownloadExpiryChange(_ downloadExpiry: String?, onValidation: @escaping (_ isValid: Bool, _ shouldBringUpKeyboard: Bool) -> Void) {
+        guard let downloadExpiry = downloadExpiry, let downloadExpiry_unwrapped = Int64(downloadExpiry), downloadExpiry_unwrapped >= 0 else {
+            downloadExpiryIsValid = false
+            self.downloadExpiry = -1
+            onValidation(isChangesValid(), true)
+            return
+        }
+        self.downloadExpiry = downloadExpiry_unwrapped
+        let newValue = self.downloadExpiry
+        let oldValue = product.downloadExpiry
+
+        guard newValue != oldValue else {
+            downloadExpiryIsValid = false
+            onValidation(isChangesValid(), true)
+            return
+        }
+        downloadExpiryIsValid = true
+        onValidation(isChangesValid(), false)
+    }
+
+    // MARK: - Navigation actions
+
+    func completeUpdating(onCompletion: ProductDownloadSettingsViewController.Completion) {
+        if isChangesValid() {
+            onCompletion(downloadLimit, downloadExpiry, hasUnsavedChanges())
+        }
+        return
+    }
+
+    func hasUnsavedChanges() -> Bool {
+        return isChangesValid()
+    }
+}
+
+// MARK: - Convenience Methods
+//
+private extension ProductDownloadSettingsViewModel {
+    func isChangesValid() -> Bool {
+        return downloadLimitIsValid || downloadExpiryIsValid
+    }
+}
+
+extension ProductDownloadSettingsViewModel {
+    enum Strings {
+        static let downloadLimitTitle = NSLocalizedString("Download limit",
+                                                          comment: "Title of the cell in Product Download limit > Download limit")
+        static let downloadLimitPlaceholder = NSLocalizedString("No limit",
+                                                                comment: "Placeholder of the cell text field in Download limit")
+        static let downloadLimitFooter = NSLocalizedString("Enter the number of time file can be downloaded or leave blank for unlimited downloads",
+                                                           comment: "Footer text for Downloadable Limit")
+        static let downloadExpiryTitle = NSLocalizedString("Download expiration",
+                                                     comment: "Title of the cell in Product Download Expiration > Download expiration")
+        static let downloadExpiryPlaceholder = NSLocalizedString("No expiration",
+                                                           comment: "Placeholder of the cell text field in Download expiration")
+        static let downloadExpiryFooter = NSLocalizedString("Enter the number of days before a download link expires, or leave blank if never it expires",
+                                                            comment: "Footer text for Download Expiration")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -525,6 +525,11 @@
 		74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F301592200EC0800931B9E /* NSDecimalNumberWooTests.swift */; };
 		74F9E9CD214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */; };
 		74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */; };
+		77307804251EA06100178696 /* Product+DownloadSettingsViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77307800251EA06000178696 /* Product+DownloadSettingsViewModels.swift */; };
+		77307805251EA06100178696 /* ProductDownloadSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77307801251EA06000178696 /* ProductDownloadSettingsViewController.swift */; };
+		77307806251EA06100178696 /* ProductDownloadSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77307802251EA06000178696 /* ProductDownloadSettingsViewModel.swift */; };
+		77307807251EA06100178696 /* ProductDownloadSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77307803251EA06000178696 /* ProductDownloadSettingsViewController.xib */; };
+		77307809251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77307808251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift */; };
 		77423F17251CF77E0016A083 /* ProductDownloadListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */; };
 		77E53EB8250E6A4E003D385F /* ProductDownloadListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E53EB6250E6A4E003D385F /* ProductDownloadListViewController.swift */; };
 		77E53EB9250E6A4E003D385F /* ProductDownloadListViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77E53EB7250E6A4E003D385F /* ProductDownloadListViewController.xib */; };
@@ -1500,6 +1505,11 @@
 		74F301592200EC0800931B9E /* NSDecimalNumberWooTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDecimalNumberWooTests.swift; sourceTree = "<group>"; };
 		74F9E9CB214C036400A3F2D2 /* NoPeriodDataTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoPeriodDataTableViewCell.xib; sourceTree = "<group>"; };
 		74F9E9CC214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoPeriodDataTableViewCell.swift; sourceTree = "<group>"; };
+		77307800251EA06000178696 /* Product+DownloadSettingsViewModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Product+DownloadSettingsViewModels.swift"; sourceTree = "<group>"; };
+		77307801251EA06000178696 /* ProductDownloadSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDownloadSettingsViewController.swift; sourceTree = "<group>"; };
+		77307802251EA06000178696 /* ProductDownloadSettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDownloadSettingsViewModel.swift; sourceTree = "<group>"; };
+		77307803251EA06000178696 /* ProductDownloadSettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductDownloadSettingsViewController.xib; sourceTree = "<group>"; };
+		77307808251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDownloadSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadListViewModelTests.swift; sourceTree = "<group>"; };
 		77E53EB6250E6A4E003D385F /* ProductDownloadListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDownloadListViewController.swift; sourceTree = "<group>"; };
 		77E53EB7250E6A4E003D385F /* ProductDownloadListViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductDownloadListViewController.xib; sourceTree = "<group>"; };
@@ -3256,9 +3266,21 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		773077FF251EA06000178696 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				77307800251EA06000178696 /* Product+DownloadSettingsViewModels.swift */,
+				77307801251EA06000178696 /* ProductDownloadSettingsViewController.swift */,
+				77307802251EA06000178696 /* ProductDownloadSettingsViewModel.swift */,
+				77307803251EA06000178696 /* ProductDownloadSettingsViewController.xib */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		77423F14251CF59D0016A083 /* Downloadable Files */ = {
 			isa = PBXGroup;
 			children = (
+				77307808251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift */,
 				77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */,
 			);
 			path = "Downloadable Files";
@@ -3267,6 +3289,7 @@
 		77E53EB5250E6972003D385F /* Downloadable Files */ = {
 			isa = PBXGroup;
 			children = (
+				773077FF251EA06000178696 /* Settings */,
 				77E53EC62510C3F4003D385F /* FIle List */,
 			);
 			path = "Downloadable Files";
@@ -4840,6 +4863,7 @@
 				020BE74E23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.xib in Resources */,
 				4580BA7523F192D400B5F764 /* ProductSettingsViewController.xib in Resources */,
 				74A95B5821C403EA00FEE953 /* pure-min.css in Resources */,
+				77307807251EA06100178696 /* ProductDownloadSettingsViewController.xib in Resources */,
 				0262DA5423A238460029AF30 /* UnitInputTableViewCell.xib in Resources */,
 				B5BE75DD213F1D3D00909A14 /* OverlayMessageView.xib in Resources */,
 				57C503DE23E8CE0D00EC0790 /* OrdersMasterViewController.xib in Resources */,
@@ -5299,6 +5323,7 @@
 				02C0CD2A23B5BB1C00F880B1 /* ImageService.swift in Sources */,
 				26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */,
 				02482A8B237BE8C7007E73ED /* LinkSettingsViewController.swift in Sources */,
+				77307806251EA06100178696 /* ProductDownloadSettingsViewModel.swift in Sources */,
 				CE227097228F152400C0626C /* WooBasicTableViewCell.swift in Sources */,
 				45B9C64323A91CB6007FC4C5 /* PriceInputFormatter.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
@@ -5324,6 +5349,7 @@
 				D82DFB4A225F22D400EFE2CB /* UISearchBar+Appearance.swift in Sources */,
 				571B850224CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift in Sources */,
 				7441E1D221503F77004E6ECE /* IntrinsicTableView.swift in Sources */,
+				77307805251EA06100178696 /* ProductDownloadSettingsViewController.swift in Sources */,
 				B517EA1D218B41F200730EC4 /* String+Woo.swift in Sources */,
 				02564A8C246CE38E00D6DB2A /* SwappableSubviewContainerView.swift in Sources */,
 				024DF31223742B18006658FE /* AztecItalicFormatBarCommand.swift in Sources */,
@@ -5551,6 +5577,7 @@
 				02E262C9238D0AD300B79588 /* ProductStockStatusListSelectorCommand.swift in Sources */,
 				CE2A9FC823C3D2D4002BEC1C /* RefundedProductsDataSource.swift in Sources */,
 				CECC759523D6057E00486676 /* OrderItem+Woo.swift in Sources */,
+				77307804251EA06100178696 /* Product+DownloadSettingsViewModels.swift in Sources */,
 				0235595924496D70004BE2B8 /* ProductsSortOrderBottomSheetListSelectorCommand.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */,
@@ -5681,6 +5708,7 @@
 				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
 				570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,
+				77307809251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift in Sources */,
 				02EA6BFC2435EC3500FFF90A /* MockImageDownloader.swift in Sources */,
 				57C9A8FC24C21BFB001E1C2F /* ReviewsCoordinatorTests.swift in Sources */,
 				45B9C64523A945C0007FC4C5 /* PriceInputFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadSettingsViewModelTests.swift
@@ -1,0 +1,259 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class ProductDownloadSettingsViewModelTests: XCTestCase {
+
+    // MARK: - Initialization
+
+    func test_readonly_values_are_as_expected_after_initializing_download_settings() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+
+        // Act
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Assert
+        XCTAssertEqual(viewModel.downloadLimit, 1)
+        XCTAssertEqual(viewModel.downloadExpiry, 1)
+    }
+
+    func test_section_and_row_values_are_as_expected_after_initializing_download_settings() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Act
+        let expectedSections: [ProductDownloadSettingsViewController.Section] = [
+            .init(footer: ProductDownloadSettingsViewModel.Strings.downloadLimitFooter, rows: [ProductDownloadSettingsViewController.Row.limit]),
+            .init(footer: ProductDownloadSettingsViewModel.Strings.downloadExpiryFooter, rows: [ProductDownloadSettingsViewController.Row.expiry])
+        ]
+
+        // Assert
+        XCTAssertEqual(viewModel.sections, expectedSections)
+    }
+
+    // MARK: - `handleDownloadLimitChange`
+
+    func test_handling_empty_downloadLimit_updates_with_default_value() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+        let defaultLimit: Int64 = -1
+
+        // Act
+        var isValidResult: Bool?
+        var shouldBringUpKeyboard: Bool?
+        waitForExpectation { exp in
+            viewModel.handleDownloadLimitChange("") { (isValid, shouldBringUpKeyboardValue) in
+                isValidResult = isValid
+                shouldBringUpKeyboard = shouldBringUpKeyboardValue
+                exp.fulfill()
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(isValidResult, true)
+        XCTAssertEqual(shouldBringUpKeyboard, true)
+        XCTAssertEqual(viewModel.downloadLimit, defaultLimit)
+    }
+
+    func test_handling_non_empty_downloadLimit_updates_with_success() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+        let expectedLimit: Int64 = 100
+
+        // Act
+        var isValidResult: Bool?
+        var shouldBringUpKeyboard: Bool?
+        waitForExpectation { exp in
+            viewModel.handleDownloadLimitChange("100") { (isValid, shouldBringUpKeyboardValue) in
+                isValidResult = isValid
+                shouldBringUpKeyboard = shouldBringUpKeyboardValue
+                exp.fulfill()
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(isValidResult, true)
+        XCTAssertEqual(shouldBringUpKeyboard, false)
+        XCTAssertEqual(viewModel.downloadLimit, expectedLimit)
+    }
+
+    func test_handling_invalid_downloadLimit_updates_with_default_value() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+        let defaultLimit: Int64 = -1
+
+        // Act
+        var isValidResult: Bool?
+        var shouldBringUpKeyboard: Bool?
+        waitForExpectation { exp in
+            viewModel.handleDownloadLimitChange("-100") { (isValid, shouldBringUpKeyboardValue) in
+                isValidResult = isValid
+                shouldBringUpKeyboard = shouldBringUpKeyboardValue
+                exp.fulfill()
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(isValidResult, true)
+        XCTAssertEqual(shouldBringUpKeyboard, true)
+        XCTAssertEqual(viewModel.downloadLimit, defaultLimit)
+    }
+
+    // MARK: - `handleDownloadExpiryChange`
+
+    func test_handling_empty_downloadExpiry_updates_with_default_value() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+        let defaultExpiry: Int64 = -1
+
+        // Act
+        var isValidResult: Bool?
+        var shouldBringUpKeyboard: Bool?
+        waitForExpectation { exp in
+            viewModel.handleDownloadExpiryChange("") { (isValid, shouldBringUpKeyboardValue) in
+                isValidResult = isValid
+                shouldBringUpKeyboard = shouldBringUpKeyboardValue
+                exp.fulfill()
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(isValidResult, true)
+        XCTAssertEqual(shouldBringUpKeyboard, true)
+        XCTAssertEqual(viewModel.downloadExpiry, defaultExpiry)
+    }
+
+    func test_handling_non_empty_downloadExpiry_updates_with_success() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+        let expectedExpiry: Int64 = 100
+
+        // Act
+        var isValidResult: Bool?
+        var shouldBringUpKeyboard: Bool?
+        waitForExpectation { exp in
+            viewModel.handleDownloadExpiryChange("100") { (isValid, shouldBringUpKeyboardValue) in
+                isValidResult = isValid
+                shouldBringUpKeyboard = shouldBringUpKeyboardValue
+                exp.fulfill()
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(isValidResult, true)
+        XCTAssertEqual(shouldBringUpKeyboard, false)
+        XCTAssertEqual(viewModel.downloadExpiry, expectedExpiry)
+    }
+
+    func test_handling_invalid_downloadExpiry_updates_with_default_value() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+        let defaultExpiry: Int64 = -1
+
+        // Act
+        var isValidResult: Bool?
+        var shouldBringUpKeyboard: Bool?
+        waitForExpectation { exp in
+            viewModel.handleDownloadExpiryChange("-100") { (isValid, shouldBringUpKeyboardValue) in
+                isValidResult = isValid
+                shouldBringUpKeyboard = shouldBringUpKeyboardValue
+                exp.fulfill()
+            }
+        }
+
+        // Assert
+        XCTAssertEqual(isValidResult, true)
+        XCTAssertEqual(shouldBringUpKeyboard, true)
+        XCTAssertEqual(viewModel.downloadExpiry, defaultExpiry)
+    }
+
+    // MARK: - `hasUnsavedChanges`
+
+    func test_viewModel_has_unsaved_changes_after_updating_validD_downloadLimit() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Act
+        let expected = "100"
+        viewModel.handleDownloadLimitChange(expected) { _, _ in }
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+
+    }
+
+    func test_viewModel_has_unsaved_changes_with_default_value_after_updating_invalid_downloadLimit() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Act
+        let expected = "-100"
+        viewModel.handleDownloadLimitChange(expected) { _, _ in }
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_viewModel_has_unsaved_changes_after_updating_valid_downloadExpiry() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Act
+        let expected = "100"
+        viewModel.handleDownloadExpiryChange(expected) { _, _ in }
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+
+    }
+
+    func test_viewModel_has_unsaved_changes_with_default_value_after_updating_invalid_downloadExpiry() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Act
+        let expected = "-100"
+        viewModel.handleDownloadExpiryChange(expected) { _, _ in }
+
+        // Assert
+        XCTAssertTrue(viewModel.hasUnsavedChanges())
+    }
+
+    func test_viewModel_has_no_unsaved_changes_after_updating_with_the_original_values() {
+        // Arrange
+        let product = MockProduct().product(downloadable: true)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadSettingsViewModel(product: model)
+
+        // Act
+        viewModel.handleDownloadLimitChange("1") { _, _ in }
+        viewModel.handleDownloadExpiryChange("1") { _, _ in }
+
+        // Assert
+        XCTAssertFalse(viewModel.hasUnsavedChanges())
+    }
+}


### PR DESCRIPTION
Fixes: #2756 
Depends on: https://github.com/woocommerce/woocommerce-ios/pull/2872 for its actually remote API call implementation.
Part 1: https://github.com/woocommerce/woocommerce-ios/pull/2872

## Description
This PR allows updating the downloadable files info with their details. This PR implements the following capabilities.
- Add/Edit downloadable file limit and expiry in a separate scene when tapped from downloadable file list navigation right bar button item

## Changes
- Add `ProductDownloadSettingsViewController` and related files to show downloadable files' settings to add/edit when tappen from `ProductDownloadListViewController`s' right bar button

## Test Cases
Test cases have been included with this PR

## Screenshots

<img width="584" alt="Screen Shot 2020-09-25 at 1 51 24 AM" src="https://user-images.githubusercontent.com/1577598/94198002-65a62600-fed8-11ea-8188-5790737f54b3.png">


## Testing

#### Prerequisites
- Create a downloadable product from wp-admin
- Then navigate to the downloadable files' list scene on the app

#### Cases
- Tap on any downloadable file's settings button on the rightmost navigation bar button item, which will take you to the following scene
- Change the Limit and/or Expiry, and tap done. It should update the settings
- Done button should only be enabled if and only if there is any change/update on the Limit and/or Expiry value
- Removing any of the value should reset Limit and/or Expiry value to default

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
