### PR TITLE
Issue/2757 mark unmark a product as downloadable

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -710,7 +710,8 @@ extension ProductDetailsViewModel {
         case .productVariants:
             ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
             let variationsViewController = ProductVariationsViewController(product: product,
-                                                                           isEditProductsRelease3Enabled: false)
+                                                                           isEditProductsRelease3Enabled: false,
+                                                                           isEditProductsRelease5Enabled: false)
             sender.navigationController?.pushViewController(variationsViewController, animated: true)
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -55,18 +55,19 @@ private extension AddProductCoordinator {
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
         let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
                                                                   product: model)
+        let isEditProductsRelease5Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler,
                                              isEditProductsRelease3Enabled: true,
-                                             isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
+                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
                                                        isEditProductsRelease3Enabled: true,
-                                                       isEditProductsRelease5Enabled: true)
+                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -65,7 +65,8 @@ private extension AddProductCoordinator {
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
                                                        presentationStyle: .navigationStack,
-                                                       isEditProductsRelease3Enabled: true)
+                                                       isEditProductsRelease3Enabled: true,
+                                                       isEditProductsRelease5Enabled: true)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -185,6 +185,37 @@ enum ProductSettingsRows {
         let cellTypes: [UITableViewCell.Type] = [SwitchTableViewCell.self]
     }
 
+    struct DownloadableProduct: ProductSettingsRowMediator {
+        private let settings: ProductSettings
+
+        init(_ settings: ProductSettings) {
+            self.settings = settings
+        }
+
+        func configure(cell: UITableViewCell) {
+            guard let cell = cell as? SwitchTableViewCell else {
+                return
+            }
+
+            let title = NSLocalizedString("Downloadable Product", comment: "Downloadable Product label in Product Settings")
+
+            cell.title = title
+            cell.isOn = settings.downloadable
+            cell.onChange = { newValue in
+                //TODO: Add analytics
+                self.settings.downloadable = newValue
+            }
+        }
+
+        func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
+            // Empty because we don't need to handle the tap on this cell
+        }
+
+        let reuseIdentifier: String = SwitchTableViewCell.reuseIdentifier
+
+        let cellTypes: [UITableViewCell.Type] = [SwitchTableViewCell.self]
+    }
+
     struct ReviewsAllowed: ProductSettingsRowMediator {
         private let settings: ProductSettings
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,7 +8,7 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool)
+    init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool, isEditProductsRelease5Enabled: Bool)
 }
 
 // MARK: - Sections declaration for Product Settings
@@ -20,8 +20,8 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool) {
-            if isEditProductsRelease3Enabled && productType == .simple {
+        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool, isEditProductsRelease5Enabled: Bool) {
+            if (isEditProductsRelease3Enabled || isEditProductsRelease5Enabled) && productType == .simple {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
@@ -41,7 +41,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool) {
+        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool, isEditProductsRelease5Enabled: Bool) {
             if isEditProductsRelease3Enabled {
                 rows = [ProductSettingsRows.ReviewsAllowed(settings),
                         ProductSettingsRows.Slug(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -25,7 +25,8 @@ enum ProductSettingsSections {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
-                        ProductSettingsRows.VirtualProduct(settings)]
+                        ProductSettingsRows.VirtualProduct(settings),
+                        ProductSettingsRows.DownloadableProduct(settings)]
             } else {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -18,15 +18,18 @@ enum ProductSettingsSections {
     struct PublishSettings: ProductSettingsSectionMediator {
         let title = NSLocalizedString("Publish Settings", comment: "Title of the Publish Settings section on Product Settings screen")
 
-        let rows: [ProductSettingsRowMediator]
+        var rows: [ProductSettingsRowMediator]
 
         init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool, isEditProductsRelease5Enabled: Bool) {
-            if (isEditProductsRelease3Enabled || isEditProductsRelease5Enabled) && productType == .simple {
+            if isEditProductsRelease3Enabled && productType == .simple {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
-                        ProductSettingsRows.VirtualProduct(settings),
-                        ProductSettingsRows.DownloadableProduct(settings)]
+                        ProductSettingsRows.VirtualProduct(settings)]
+
+                if isEditProductsRelease5Enabled {
+                    rows.append(ProductSettingsRows.DownloadableProduct(settings))
+                }
             } else {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -25,12 +25,14 @@ final class ProductSettingsViewController: UIViewController {
          password: String?,
          formType: ProductFormType,
          isEditProductsRelease3Enabled: Bool,
+         isEditProductsRelease5Enabled: Bool,
          completion: @escaping Completion,
          onPasswordRetrieved: @escaping PasswordRetrievedCompletion) {
         viewModel = ProductSettingsViewModel(product: product,
                                              password: password,
                                              formType: formType,
-                                             isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                             isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         onCompletion = completion
         onPasswordCompletion = onPasswordRetrieved
         super.init(nibName: nil, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -11,7 +11,10 @@ final class ProductSettingsViewModel {
 
     var productSettings: ProductSettings {
         didSet {
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         }
     }
 
@@ -28,20 +31,28 @@ final class ProductSettingsViewModel {
     var onPasswordRetrieved: ((_ password: String) -> Void)?
 
     private let isEditProductsRelease3Enabled: Bool
+    private let isEditProductsRelease5Enabled: Bool
 
-    init(product: Product, password: String?, formType: ProductFormType, isEditProductsRelease3Enabled: Bool) {
+    init(product: Product, password: String?, formType: ProductFormType, isEditProductsRelease3Enabled: Bool, isEditProductsRelease5Enabled: Bool) {
         self.product = product
         self.password = password
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         productSettings = ProductSettings(from: product, password: password)
 
         switch formType {
         case .add:
             self.password = ""
             productSettings.password = ""
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         case .edit:
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             /// If nil, we fetch the password from site post API because it was never fetched
             if password == nil {
                 retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
@@ -56,7 +67,8 @@ final class ProductSettingsViewModel {
                     self.productSettings.password = password
                     self.sections = Self.configureSections(self.productSettings,
                                                            productType: product.productType,
-                                                           isEditProductsRelease3Enabled: self.isEditProductsRelease3Enabled)
+                                                           isEditProductsRelease3Enabled: self.isEditProductsRelease3Enabled,
+                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
                 }
             }
         }
@@ -103,9 +115,16 @@ private extension ProductSettingsViewModel {
 private extension ProductSettingsViewModel {
     static func configureSections(_ settings: ProductSettings,
                                   productType: ProductType,
-                                  isEditProductsRelease3Enabled: Bool) -> [ProductSettingsSectionMediator] {
-        return [ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled),
-                ProductSettingsSections.MoreOptions(settings, productType: productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                  isEditProductsRelease3Enabled: Bool,
+                                  isEditProductsRelease5Enabled: Bool) -> [ProductSettingsSectionMediator] {
+        return [ProductSettingsSections.PublishSettings(settings,
+                                                        productType: productType,
+                                                        isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                        isEditProductsRelease5Enabled: isEditProductsRelease5Enabled),
+                ProductSettingsSections.MoreOptions(settings,
+                                                    productType: productType,
+                                                    isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                    isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -326,7 +326,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                     return
                 }
                 let variationsViewController = ProductVariationsViewController(product: product.product,
-                                                                               isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                                                               isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                                               isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
                 show(variationsViewController, sender: self)
             case .status, .noPriceWarning:
                 break

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -41,6 +41,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     private let currency: String
     private let isEditProductsRelease3Enabled: Bool
+    private let isEditProductsRelease5Enabled: Bool
 
     private lazy var exitForm: () -> Void = {
         presentationStyle.createExitForm(viewController: self)
@@ -60,12 +61,14 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
          presentationStyle: ProductFormPresentationStyle,
-         isEditProductsRelease3Enabled: Bool) {
+         isEditProductsRelease3Enabled: Bool,
+         isEditProductsRelease5Enabled: Bool) {
         self.viewModel = viewModel
         self.eventLogger = eventLogger
         self.currency = currency
         self.presentationStyle = presentationStyle
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.productImageActionHandler = productImageActionHandler
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
@@ -645,6 +648,7 @@ private extension ProductFormViewController {
                                                            password: password,
                                                            formType: viewModel.formType,
                                                            isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                                            completion: { [weak self] (productSettings) in
             guard let self = self else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -227,6 +227,7 @@ extension ProductFormViewModel {
                                                                      featured: settings.featured,
                                                                      catalogVisibilityKey: settings.catalogVisibility.rawValue,
                                                                      virtual: settings.virtual,
+                                                                     downloadable: settings.downloadable,
                                                                      reviewsAllowed: settings.reviewsAllowed,
                                                                      purchaseNote: settings.purchaseNote,
                                                                      menuOrder: settings.menuOrder))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -56,7 +56,8 @@ private extension ProductDetailsFactory {
                                            eventLogger: ProductFormEventLogger(),
                                            productImageActionHandler: productImageActionHandler,
                                            presentationStyle: presentationStyle,
-                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
             vc.hidesBottomBarWhenPushed = true
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -83,13 +83,17 @@ final class ProductVariationsViewController: UIViewController {
 
     private let imageService: ImageService = ServiceLocator.imageService
     private let isEditProductsRelease3Enabled: Bool
+    private let isEditProductsRelease5Enabled: Bool
 
-    init(product: Product, isEditProductsRelease3Enabled: Bool) {
+    init(product: Product,
+         isEditProductsRelease3Enabled: Bool,
+         isEditProductsRelease5Enabled: Bool) {
         self.siteID = product.siteID
         self.productID = product.productID
         self.allAttributes = product.attributes
         self.parentProductSKU = product.sku
         self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -306,7 +310,7 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                            currency: currency,
                                                            presentationStyle: .navigationStack,
                                                            isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
-                                                           isEditProductsRelease5Enabled: false)
+                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -305,7 +305,8 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                            productImageActionHandler: productImageActionHandler,
                                                            currency: currency,
                                                            presentationStyle: .navigationStack,
-                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
+                                                           isEditProductsRelease5Enabled: false)
             navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -253,6 +253,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let password = ""
         let catalogVisibility = "search"
         let virtual = true
+        let downloadable = true
         let reviewsAllowed = true
         let slug = "this-is-a-test"
         let purchaseNote = "This is a purchase note"
@@ -265,7 +266,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
                                               reviewsAllowed: reviewsAllowed,
                                               slug: slug,
                                               purchaseNote: purchaseNote,
-                                              menuOrder: menuOrder)
+                                              menuOrder: menuOrder,
+                                              downloadable: downloadable)
         viewModel.updateProductSettings(productSettings)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
@@ -13,14 +13,15 @@ final class ProductSettingsRowsTests: XCTestCase {
 
         // Given
         originalSettings = ProductSettings(status: .draft,
-                                       featured: false,
-                                       password: nil,
-                                       catalogVisibility: .catalog,
-                                       virtual: false,
-                                       reviewsAllowed: false,
-                                       slug: "",
-                                       purchaseNote: nil,
-                                       menuOrder: 0)
+                                           featured: false,
+                                           password: nil,
+                                           catalogVisibility: .catalog,
+                                           virtual: false,
+                                           reviewsAllowed: false,
+                                           slug: "",
+                                           purchaseNote: nil,
+                                           menuOrder: 0,
+                                           downloadable: false)
     }
 
     override func tearDown() {
@@ -57,5 +58,21 @@ final class ProductSettingsRowsTests: XCTestCase {
 
         // Then
         XCTAssertEqual(settings.reviewsAllowed, true)
+    }
+
+    func test_downloadable_product_row_changed_when_updated() throws {
+        let settings = try XCTUnwrap(originalSettings)
+
+        // Given
+        let downloadableProduct = ProductSettingsRows.DownloadableProduct(settings)
+
+        let cell = SwitchTableViewCell()
+        downloadableProduct.configure(cell: cell)
+
+        // When
+        cell.onChange?(true)
+
+        // Then
+        XCTAssertEqual(settings.downloadable, true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -21,7 +21,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.grouped
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: false)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -44,7 +44,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.simple
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: false)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {
@@ -67,7 +67,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.grouped
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: true)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -90,7 +90,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.simple
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: true)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -21,7 +21,10 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.grouped
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: false)
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease3Enabled: true,
+                                                              isEditProductsRelease5Enabled: false)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -44,7 +47,10 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.simple
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: false)
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease3Enabled: true,
+                                                              isEditProductsRelease5Enabled: false)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {
@@ -67,7 +73,10 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.grouped
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease3Enabled: true,
+                                                              isEditProductsRelease5Enabled: true)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -90,7 +99,10 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.simple
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease3Enabled: true,
+                                                              isEditProductsRelease5Enabled: true)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -16,7 +16,8 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        reviewsAllowed: false,
                                        slug: "",
                                        purchaseNote: nil,
-                                       menuOrder: 0)
+                                       menuOrder: 0,
+                                       downloadable: false)
         let productType = ProductType.grouped
 
         // When
@@ -38,7 +39,8 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        reviewsAllowed: false,
                                        slug: "",
                                        purchaseNote: nil,
-                                       menuOrder: 0)
+                                       menuOrder: 0,
+                                       downloadable: false)
         let productType = ProductType.simple
 
         // When
@@ -47,6 +49,52 @@ final class ProductSettingsSectionsTests: XCTestCase {
         // Then
         XCTAssertNotNil(section.rows.first(where: {
             $0 is ProductSettingsRows.VirtualProduct
+        }))
+    }
+
+    func test_given_a_non_simple_product_then_it_does_not_show_the_downloadable_product_option() {
+        // Given
+        let settings = ProductSettings(status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
+        let productType = ProductType.grouped
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+
+        // Then
+        XCTAssertNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.DownloadableProduct
+        }))
+    }
+
+    func test_given_a_simple_product_then_it_shows_the_downloadable_product_option() {
+        // Given
+        let settings = ProductSettings(status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
+        let productType = ProductType.simple
+
+        // When
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+
+        // Then
+        XCTAssertNotNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.DownloadableProduct
         }))
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -68,6 +68,6 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
 private extension ProductSettingsViewModel {
     convenience init(product: Product, password: String?) {
-        self.init(product: product, password: password, formType: .edit, isEditProductsRelease3Enabled: true)
+        self.init(product: product, password: password, formType: .edit, isEditProductsRelease3Enabled: true, isEditProductsRelease5Enabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -6,7 +6,8 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
     func testOnReloadClosure() {
 
-        let product = MockProduct().product(virtual: true,
+        let product = MockProduct().product(downloadable: false,
+                                            virtual: true,
                                             status: .publish,
                                             featured: true,
                                             catalogVisibility: .search,
@@ -31,7 +32,8 @@ final class ProductSettingsViewModelTests: XCTestCase {
                                                     reviewsAllowed: true,
                                                     slug: "this-is-a-slug",
                                                     purchaseNote: "This is a purchase note",
-                                                    menuOrder: 1)
+                                                    menuOrder: 1,
+                                                    downloadable: true)
 
         waitForExpectations(timeout: 1.5, handler: nil)
     }

--- a/Yosemite/Yosemite/Model/Products/ProductSettings.swift
+++ b/Yosemite/Yosemite/Model/Products/ProductSettings.swift
@@ -13,6 +13,7 @@ public final class ProductSettings {
     public var slug: String
     public var purchaseNote: String?
     public var menuOrder: Int
+    public var downloadable: Bool
 
     public init(status: ProductStatus,
                 featured: Bool,
@@ -22,7 +23,8 @@ public final class ProductSettings {
                 reviewsAllowed: Bool,
                 slug: String,
                 purchaseNote: String?,
-                menuOrder: Int) {
+                menuOrder: Int,
+                downloadable: Bool) {
         self.status = status
         self.featured = featured
         self.password = password
@@ -32,6 +34,7 @@ public final class ProductSettings {
         self.slug = slug
         self.purchaseNote = purchaseNote
         self.menuOrder = menuOrder
+        self.downloadable = downloadable
     }
 
     public convenience init(from product: Product, password: String?) {
@@ -43,7 +46,8 @@ public final class ProductSettings {
                   reviewsAllowed: product.reviewsAllowed,
                   slug: product.slug,
                   purchaseNote: product.purchaseNote,
-                  menuOrder: product.menuOrder)
+                  menuOrder: product.menuOrder,
+                  downloadable: product.downloadable)
     }
 }
 
@@ -59,6 +63,7 @@ extension ProductSettings: Equatable {
             lhs.reviewsAllowed == rhs.reviewsAllowed &&
             lhs.slug == rhs.slug &&
             lhs.purchaseNote == rhs.purchaseNote &&
-            lhs.menuOrder == rhs.menuOrder
+            lhs.menuOrder == rhs.menuOrder &&
+            lhs.downloadable == rhs.downloadable
     }
 }


### PR DESCRIPTION
Fixes: #2757 
Depends on: https://github.com/woocommerce/woocommerce-ios/pull/2872 for its actually remote API call implementation.

## Description
This PR allows the capability for a product to mark/unmark it as downloadable, from `Product Settings` on product details

## Changes
- Add `downloadable ` property to `ProductSettings` model
- Add a new row for downloadable product settings on `ProductSettingsRows `
- Add `isEditProductsRelease5Enabled` feature flag of `Product Settings` related places

## Test Cases
Test cases have been included with this PR

## Screenshots
<img width="584" alt="Screen Shot 2020-09-26 at 12 47 36 PM" src="https://user-images.githubusercontent.com/1577598/94332371-7a78db80-fff6-11ea-921c-ba779d63861b.png">

## Testing

### Cases

#### Case 1 
- From the `Products` tab, select any `Simple` product, and show details.
- Tap on the top right navigation bar button >> "Product Settings"
- You should be able to see a new switchable row, titled `Downloadable Product`
- Make any changes on the downloadable switch and update the product.
- Come back again to this page to verify that your changes are reflected properly (Currently the remote API depends on https://github.com/woocommerce/woocommerce-ios/pull/2872 . So that PR needs to be merged for the API to work properly]

#### Case 2 
- From the same `Products` tab, select a `non-simple` product
- Go to the product settings and the Downloadable Product row shouldn't be visible

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
