### PR TITLE
Upgrade WPAuth from 1.24.0 to 1.26.0-beta.12

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.24.0'
+  pod 'WordPressAuthenticator', '~> 1.26.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.26.0-beta.11):
+  - WordPressAuthenticator (1.26.0-beta.12):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -63,23 +63,23 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.17)
+    - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.11-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.17.0):
+  - WordPressKit (4.18.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.10-beta)
-    - wpxmlrpc (= 0.8.5)
+    - wpxmlrpc (~> 0.9.0-beta)
   - WordPressShared (1.11.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.2-beta.1)
   - Wormholy (1.6.2)
   - WPMediaPicker (1.7.1)
-  - wpxmlrpc (0.8.5)
+  - wpxmlrpc (0.9.0-beta.1)
   - XLPagerTabStrip (9.0.0)
   - ZendeskCommonUISDK (4.2.0):
     - ZendeskSDKConfigurationsSDK (~> 1.1.2)
@@ -182,13 +182,13 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: a2692a1318e85ff8d6a31943d1fb183c98c1ec98
-  WordPressKit: f1a9e32cf7f46f7eb19d944591aad88b108d90e7
+  WordPressAuthenticator: abf28d3086000389c2bd0eb481c9d2de18cbbde2
+  WordPressKit: 35574a223dd23320866813677d908cf81c8a4750
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
   WordPressUI: 1765e695563562da513b0dd5ddb95dcf59d9f604
   Wormholy: 5a186f877829e7d488963b09f204e0186b40c9a8
   WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2
-  wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
+  wpxmlrpc: 54196a1c23d1298f05895cc375a8f91385106fd0
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskCommonUISDK: afbee7c58c04cf88012a48c079599ec0d1590d16
   ZendeskCoreSDK: 86513e62c1ab68913416c9044463d9b687ca944f

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.24.0):
+  - WordPressAuthenticator (1.26.0-beta.11):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -63,10 +63,10 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.16-beta)
+    - WordPressKit (~> 4.17)
     - WordPressShared (~> 1.11-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.16.0):
+  - WordPressKit (4.17.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.24.0)
+  - WordPressAuthenticator (~> 1.26.0-beta)
   - WordPressShared (~> 1.11)
   - WordPressUI (~> 1.7.2-beta)
   - Wormholy (~> 1.6.2)
@@ -182,8 +182,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: a9497866f5d480974988312c92d61c9db70f91d6
-  WordPressKit: 48d56b8d3d25619e32d3a8ae4e934547eb684856
+  WordPressAuthenticator: a2692a1318e85ff8d6a31943d1fb183c98c1ec98
+  WordPressKit: f1a9e32cf7f46f7eb19d944591aad88b108d90e7
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
   WordPressUI: 1765e695563562da513b0dd5ddb95dcf59d9f604
   Wormholy: 5a186f877829e7d488963b09f204e0186b40c9a8
@@ -198,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 2dfad9e9dd47d30db57ea8a3fe620bdc97cf676b
+PODFILE CHECKSUM: 7c356eafb9a0e5726aec58c67acd0f65cc9f308d
 
 COCOAPODS: 1.9.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 - [*] Enhancement: for variable products, the stock status is now shown in its variation list.
 - [*] Sign In With Apple: if the Apple ID has been disconnected from the WordPress app (e.g. in Settings > Apple ID > Password & Security > Apps using Apple ID), the app is logged out on app launch or app switch.
-- [internal] #2881 Upgraded WPAuth from 1.24 to 1.26-beta.11. Regressions may happen in login flows.
+- [internal] #2881 Upgraded WPAuth from 1.24 to 1.26-beta.12. Regressions may happen in login flows.
  
 5.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - [*] Enhancement: for variable products, the stock status is now shown in its variation list.
 - [*] Sign In With Apple: if the Apple ID has been disconnected from the WordPress app (e.g. in Settings > Apple ID > Password & Security > Apps using Apple ID), the app is logged out on app launch or app switch.
+- [internal] #2881 Upgraded WPAuth from 1.24 to 1.26-beta.11. Regressions may happen in login flows.
  
 5.1
 -----


### PR DESCRIPTION
Ref #2880. 

This is part of fixing the build errors when compiling with Xcode 12. This PR fixes this error in WPKit:

<img width="582" alt="WordPressKit error" src="https://user-images.githubusercontent.com/198826/94459839-1f212780-0175-11eb-96cc-c1472441f4b6.png">
 
That error was fixed in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/280. And WPKit was subsequently updated in WPAuth in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/475. 

## Changes in WPAuth

Here is a [diff between 1.24.0 and 1.26.0-beta.12](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/compare/1.24.0...1.26.0-beta.12). I don't see anything that might cause a regression. But please double-check. 

## Testing

### Xcode 12

1. Compile with Xcode 12.
2. Confirm that the build error above is no longer shown. 

There are still some more build errors that will be taken care of in upcoming PRs.

### Test for Regression

Using Xcode 11, please test different methods of logging in like:

- Log in with Google
- SIWA
- Log in with site address
- Log in with WP

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

