### PR TITLE
Adds RefundShippingDetailsTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -89,7 +89,7 @@ private extension RefundShippingDetailsTableViewCell {
         shippingImageView.image = .shippingImage
         shippingImageView.tintColor = .systemColor(.systemGray2)
         shippingBorderView.layer.cornerRadius = Constants.shippingBorderCornerRadius
-        shippingBorderView.layer.borderWidth = Constants.shippingBorderWitdh
+        shippingBorderView.layer.borderWidth = Constants.shippingBorderWidth
         shippingBorderView.layer.borderColor = UIColor.border.cgColor
     }
 }
@@ -125,14 +125,14 @@ private extension RefundShippingDetailsTableViewCell {
 // MARK: Constants
 private extension RefundShippingDetailsTableViewCell {
     enum Localization {
-        static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that list the shipping tax cost")
-        static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that list the shipping subtotal cost")
-        static let totalTitle = NSLocalizedString("Shipping Refund", comment: "Title on the refund screen that list the shipping total cost")
+        static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that lists the shipping tax cost")
+        static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that lists the shipping subtotal cost")
+        static let totalTitle = NSLocalizedString("Shipping Refund", comment: "Title on the refund screen that lists the shipping total cost")
     }
 
     enum Constants {
         static let shippingBorderCornerRadius: CGFloat = 2.0
-        static let shippingBorderWitdh: CGFloat = 0.5
+        static let shippingBorderWidth: CGFloat = 0.5
         static let shippingBorderViewHeight: CGFloat = 40.0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -72,7 +72,12 @@ private extension RefundShippingDetailsTableViewCell {
     }
 
     func applyShippingImageViewStyles() {
-
+        shippingImageView.contentMode = .center
+        shippingImageView.image = .shippingImage
+        shippingImageView.tintColor = .systemColor(.systemGray2)
+        shippingImageView.layer.cornerRadius = Constants.iconCornerRadius
+        shippingImageView.layer.borderWidth = Constants.iconBorderWitdh
+        shippingImageView.layer.borderColor = UIColor.border.cgColor
     }
 }
 
@@ -82,6 +87,11 @@ private extension RefundShippingDetailsTableViewCell {
         static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that list the shipping tax cost")
         static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that list the shipping subtotal cost")
         static let totalTitle = NSLocalizedString("Shipping Refund", comment: "Title on the refund screen that list the shipping total cost")
+    }
+
+    enum Constants {
+        static let iconCornerRadius: CGFloat = 2.0
+        static let iconBorderWitdh: CGFloat = 0.5
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -14,7 +14,7 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
 
     /// Display the shipping cost
     ///
-    @IBOutlet private var shippingPrice: UILabel!
+    @IBOutlet private var shippingPriceLabel: UILabel!
 
     /// Displays `Subtotal` title
     ///
@@ -70,7 +70,7 @@ private extension RefundShippingDetailsTableViewCell {
 
     func applyLabelsStyles() {
         carrierLabel.applyBodyStyle()
-        shippingPrice.applyFootnoteStyle()
+        shippingPriceLabel.applyFootnoteStyle()
         subtotalTitleLabel.applyBodyStyle()
         subtotalPriceLabel.applyBodyStyle()
         taxTitleLabel.applyBodyStyle()
@@ -101,7 +101,7 @@ extension RefundShippingDetailsTableViewCell {
     ///
     func configure(with viewModel: RefundShippingDetailsViewModel) {
         carrierLabel.text = viewModel.carrierRate
-        shippingPrice.text = viewModel.carrierCost
+        shippingPriceLabel.text = viewModel.carrierCost
         taxPriceLabel.text = viewModel.shippingTax
         subtotalPriceLabel.text = viewModel.shippingSubtotal
         shippingRefundPriceLabel.text = viewModel.shippingTotal

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -4,6 +4,42 @@ import UIKit
 ///
 final class RefundShippingDetailsTableViewCell: UITableViewCell {
 
+    /// Displays a truck image next to the carrier name
+    ///
+    @IBOutlet weak var shippingImageView: UIImageView!
+
+    /// Displays the carrier name and shipping rate
+    ///
+    @IBOutlet weak var carrierLabel: UILabel!
+
+    /// Display the shipping cost
+    ///
+    @IBOutlet weak var shippingPrice: UILabel!
+
+    /// Displays `Subtotal` title
+    ///
+    @IBOutlet weak var subtotalTitleLabel: UILabel!
+
+    /// Displays the subtotal value
+    ///
+    @IBOutlet weak var subtotalPriceLabel: UILabel!
+
+    /// Displays `Tax` title
+    ///
+    @IBOutlet weak var taxTitleLabel: UILabel!
+
+    /// Displays the tax value
+    ///
+    @IBOutlet weak var taxPriceLabel: UILabel!
+
+    /// Displays `Shipping Refund` title
+    ///
+    @IBOutlet weak var shippingRefundTitleLabel: UILabel!
+
+    /// Displays the total shipping cost to refund
+    ///
+    @IBOutlet weak var shippingRefundPriceLabel: UILabel!
+
     override func awakeFromNib() {
         super.awakeFromNib()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -81,6 +81,20 @@ private extension RefundShippingDetailsTableViewCell {
     }
 }
 
+// MARK: ViewModel Rendering
+extension RefundShippingDetailsTableViewCell {
+
+    /// Configure cell with the provided view model
+    ///
+    func configure(with viewModel: RefundShippingDetailsViewModel) {
+        carrierLabel.text = viewModel.carrierRate
+        shippingPrice.text = viewModel.carrierCost
+        taxPriceLabel.text = viewModel.shippingTax
+        subtotalPriceLabel.text = viewModel.shippingSubtotal
+        shippingRefundPriceLabel.text = viewModel.shippingTotal
+    }
+}
+
 // MARK: Constants
 private extension RefundShippingDetailsTableViewCell {
     enum Localization {
@@ -106,6 +120,13 @@ private struct RefundShippingDetailsTableViewCellRepresentable: UIViewRepresenta
         guard let cell = nib.instantiate(withOwner: self, options: nil).first as? RefundShippingDetailsTableViewCell else {
             fatalError("Could not create RefundShippingDetailsTableViewCell")
         }
+
+        let viewModel = RefundShippingDetailsViewModel(carrierRate: "USPS Flat Rate Shipping",
+                                                       carrierCost: "$7.50",
+                                                       shippingTax: "$3.00",
+                                                       shippingSubtotal: "$7.50",
+                                                       shippingTotal: "$10.50")
+        cell.configure(with: viewModel)
         return cell
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -42,6 +42,33 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        applyCellStyles()
+    }
+}
+
+// MARK: View Styles Configuration
+private extension RefundShippingDetailsTableViewCell {
+    func applyCellStyles() {
+        applyDefaultBackgroundStyle()
+        applyLabelsStyles()
+        applyShippingImageViewStyles()
+    }
+
+    func applyLabelsStyles() {
+        carrierLabel.applyBodyStyle()
+        shippingPrice.applyFootnoteStyle()
+        subtotalTitleLabel.applyBodyStyle()
+        subtotalPriceLabel.applyBodyStyle()
+        taxTitleLabel.applyBodyStyle()
+        taxPriceLabel.applyBodyStyle()
+        shippingRefundTitleLabel.applyBodyStyle()
+        shippingRefundTitleLabel.font = .font(forStyle: .body, weight: .bold)
+        shippingRefundPriceLabel.applyBodyStyle()
+        shippingRefundPriceLabel.font = .font(forStyle: .body, weight: .bold)
+    }
+
+    func applyShippingImageViewStyles() {
+
     }
 }
 
@@ -83,6 +110,11 @@ struct RefundShippingDetailsTableViewCell_Previews: PreviewProvider {
                 .previewLayout(.fixed(width: 359, height: 209))
                 .environment(\.colorScheme, .dark)
                 .previewDisplayName("Dark")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 209))
+                .environment(\.layoutDirection, .rightToLeft)
+                .previewDisplayName("RTL")
 
 //            makeStack()
 //                .previewLayout(.fixed(width: 359, height: 300))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -6,43 +6,43 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
 
     /// Displays a truck image next to the carrier name
     ///
-    @IBOutlet weak var shippingImageView: UIImageView!
+    @IBOutlet private var shippingImageView: UIImageView!
 
     /// Displays the carrier name and shipping rate
     ///
-    @IBOutlet weak var carrierLabel: UILabel!
+    @IBOutlet private var carrierLabel: UILabel!
 
     /// Display the shipping cost
     ///
-    @IBOutlet weak var shippingPrice: UILabel!
+    @IBOutlet private var shippingPrice: UILabel!
 
     /// Displays `Subtotal` title
     ///
-    @IBOutlet weak var subtotalTitleLabel: UILabel!
+    @IBOutlet private var subtotalTitleLabel: UILabel!
 
     /// Displays the subtotal value
     ///
-    @IBOutlet weak var subtotalPriceLabel: UILabel!
+    @IBOutlet private var subtotalPriceLabel: UILabel!
 
     /// Displays `Tax` title
     ///
-    @IBOutlet weak var taxTitleLabel: UILabel!
+    @IBOutlet private var taxTitleLabel: UILabel!
 
     /// Displays the tax value
     ///
-    @IBOutlet weak var taxPriceLabel: UILabel!
+    @IBOutlet private var taxPriceLabel: UILabel!
 
     /// Displays `Shipping Refund` title
     ///
-    @IBOutlet weak var shippingRefundTitleLabel: UILabel!
+    @IBOutlet private var shippingRefundTitleLabel: UILabel!
 
     /// Displays the total shipping cost to refund
     ///
-    @IBOutlet weak var shippingRefundPriceLabel: UILabel!
+    @IBOutlet private var shippingRefundPriceLabel: UILabel!
 
     /// Displays a border around the `shippingImageView`
     ///
-    @IBOutlet weak var shippingBorderView: UIView!
+    @IBOutlet private var shippingBorderView: UIView!
 
     /// Needed to make sure the `shippingImageView` grows at the same ratio as the dynamic fonts
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -44,3 +44,57 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
 }
+
+// MARK: - Previews
+#if canImport(SwiftUI) && DEBUG
+
+import SwiftUI
+
+private struct RefundShippingDetailsTableViewCellRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let nib = UINib(nibName: "RefundShippingDetailsTableViewCell", bundle: nil)
+        guard let cell = nib.instantiate(withOwner: self, options: nil).first as? RefundShippingDetailsTableViewCell else {
+            fatalError("Could not create RefundShippingDetailsTableViewCell")
+        }
+        return cell
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        // no op
+    }
+}
+
+@available(iOS 13.0, *)
+struct RefundShippingDetailsTableViewCell_Previews: PreviewProvider {
+
+    private static func makeStack() -> some View {
+        VStack {
+            RefundShippingDetailsTableViewCellRepresentable()
+        }
+    }
+
+    static var previews: some View {
+        Group {
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 209))
+                .previewDisplayName("Light")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 209))
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark")
+
+//            makeStack()
+//                .previewLayout(.fixed(width: 359, height: 300))
+//                .environment(\.sizeCategory, .accessibilityMedium)
+//                .previewDisplayName("Large Font")
+//
+//            makeStack()
+//                .previewLayout(.fixed(width: 359, height: 620))
+//                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+//                .previewDisplayName("Extra Large Font")
+        }
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -40,9 +40,23 @@ final class RefundShippingDetailsTableViewCell: UITableViewCell {
     ///
     @IBOutlet weak var shippingRefundPriceLabel: UILabel!
 
+    /// Displays a border around the `shippingImageView`
+    ///
+    @IBOutlet weak var shippingBorderView: UIView!
+
+    /// Needed to make sure the `shippingImageView` grows at the same ratio as the dynamic fonts
+    ///
+    @IBOutlet private var shippingBorderViewHeightConstraint: NSLayoutConstraint!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         applyCellStyles()
+        applyAccessibilityChanges()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applyAccessibilityChanges()
     }
 }
 
@@ -72,12 +86,11 @@ private extension RefundShippingDetailsTableViewCell {
     }
 
     func applyShippingImageViewStyles() {
-        shippingImageView.contentMode = .center
         shippingImageView.image = .shippingImage
         shippingImageView.tintColor = .systemColor(.systemGray2)
-        shippingImageView.layer.cornerRadius = Constants.iconCornerRadius
-        shippingImageView.layer.borderWidth = Constants.iconBorderWitdh
-        shippingImageView.layer.borderColor = UIColor.border.cgColor
+        shippingBorderView.layer.cornerRadius = Constants.shippingBorderCornerRadius
+        shippingBorderView.layer.borderWidth = Constants.shippingBorderWitdh
+        shippingBorderView.layer.borderColor = UIColor.border.cgColor
     }
 }
 
@@ -95,6 +108,20 @@ extension RefundShippingDetailsTableViewCell {
     }
 }
 
+// MARK: Accessibility
+private extension RefundShippingDetailsTableViewCell {
+    func applyAccessibilityChanges() {
+        adjustShippingImageViewHeight()
+    }
+
+    /// Changes the shipping image view height acording to the current trait collection
+    ///
+    func adjustShippingImageViewHeight() {
+        shippingBorderViewHeightConstraint.constant = UIFontMetrics.default.scaledValue(for: Constants.shippingBorderViewHeight,
+                                                                                        compatibleWith: traitCollection)
+    }
+}
+
 // MARK: Constants
 private extension RefundShippingDetailsTableViewCell {
     enum Localization {
@@ -104,8 +131,9 @@ private extension RefundShippingDetailsTableViewCell {
     }
 
     enum Constants {
-        static let iconCornerRadius: CGFloat = 2.0
-        static let iconBorderWitdh: CGFloat = 0.5
+        static let shippingBorderCornerRadius: CGFloat = 2.0
+        static let shippingBorderWitdh: CGFloat = 0.5
+        static let shippingBorderViewHeight: CGFloat = 40.0
     }
 }
 
@@ -155,20 +183,15 @@ struct RefundShippingDetailsTableViewCell_Previews: PreviewProvider {
                 .environment(\.colorScheme, .dark)
                 .previewDisplayName("Dark")
 
-//            makeStack()
-//                .previewLayout(.fixed(width: 359, height: 209))
-//                .environment(\.layoutDirection, .rightToLeft)
-//                .previewDisplayName("RTL")
-//
-//            makeStack()
-//                .previewLayout(.fixed(width: 359, height: 300))
-//                .environment(\.sizeCategory, .accessibilityMedium)
-//                .previewDisplayName("Large Font")
-//
-//            makeStack()
-//                .previewLayout(.fixed(width: 359, height: 620))
-//                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
-//                .previewDisplayName("Extra Large Font")
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 300))
+                .environment(\.sizeCategory, .accessibilityMedium)
+                .previewDisplayName("Large Font")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 600))
+                .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+                .previewDisplayName("Extra Large Font")
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -65,10 +65,23 @@ private extension RefundShippingDetailsTableViewCell {
         shippingRefundTitleLabel.font = .font(forStyle: .body, weight: .bold)
         shippingRefundPriceLabel.applyBodyStyle()
         shippingRefundPriceLabel.font = .font(forStyle: .body, weight: .bold)
+
+        taxTitleLabel.text = Localization.taxTitle
+        subtotalTitleLabel.text = Localization.subtotalTitle
+        shippingRefundTitleLabel.text = Localization.totalTitle
     }
 
     func applyShippingImageViewStyles() {
 
+    }
+}
+
+// MARK: Constants
+private extension RefundShippingDetailsTableViewCell {
+    enum Localization {
+        static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that list the shipping tax cost")
+        static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that list the shipping subtotal cost")
+        static let totalTitle = NSLocalizedString("Shipping Refund", comment: "Title on the refund screen that list the shipping total cost")
     }
 }
 
@@ -111,11 +124,11 @@ struct RefundShippingDetailsTableViewCell_Previews: PreviewProvider {
                 .environment(\.colorScheme, .dark)
                 .previewDisplayName("Dark")
 
-            makeStack()
-                .previewLayout(.fixed(width: 359, height: 209))
-                .environment(\.layoutDirection, .rightToLeft)
-                .previewDisplayName("RTL")
-
+//            makeStack()
+//                .previewLayout(.fixed(width: 359, height: 209))
+//                .environment(\.layoutDirection, .rightToLeft)
+//                .previewDisplayName("RTL")
+//
 //            makeStack()
 //                .previewLayout(.fixed(width: 359, height: 300))
 //                .environment(\.sizeCategory, .accessibilityMedium)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+/// TableViewCell that displays all information regarding shipping refunds
+///
+final class RefundShippingDetailsTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
@@ -133,6 +133,17 @@
                     <constraint firstAttribute="bottom" secondItem="JDF-j9-Gh4" secondAttribute="bottom" id="w6m-RO-5ZW"/>
                 </constraints>
             </tableViewCellContentView>
+            <connections>
+                <outlet property="carrierLabel" destination="YcK-wh-psM" id="hbq-Sb-tAf"/>
+                <outlet property="shippingImageView" destination="chZ-Nd-oWh" id="UI2-cb-BJk"/>
+                <outlet property="shippingPrice" destination="StO-ND-1uB" id="fY1-vi-El1"/>
+                <outlet property="shippingRefundPriceLabel" destination="URn-4h-z0y" id="e41-c5-Iux"/>
+                <outlet property="shippingRefundTitleLabel" destination="E7R-DR-yWr" id="A2w-Uk-6ab"/>
+                <outlet property="subtotalPriceLabel" destination="hhl-06-gXM" id="AzJ-1s-JyY"/>
+                <outlet property="subtotalTitleLabel" destination="t4R-J0-otV" id="VAK-s4-vDa"/>
+                <outlet property="taxPriceLabel" destination="QLc-wt-CbB" id="4Ej-7b-CLV"/>
+                <outlet property="taxTitleLabel" destination="9vh-Ay-6m1" id="HtJ-Eo-5Ug"/>
+            </connections>
             <point key="canvasLocation" x="108.69565217391305" y="80.022321428571431"/>
         </tableViewCell>
     </objects>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
@@ -4,19 +4,136 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="252" id="oBT-Z9-cJd" customClass="RefundShippingDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="252"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="201" id="oBT-Z9-cJd" customClass="RefundShippingDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="209"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oBT-Z9-cJd" id="Mly-TP-AMG">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="252"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="209"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="JDF-j9-Gh4">
+                        <rect key="frame" x="16" y="0.0" width="398" height="209"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="aS0-yn-0bT">
+                                <rect key="frame" x="0.0" y="0.0" width="398" height="78.5"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="chZ-Nd-oWh">
+                                        <rect key="frame" x="0.0" y="20" width="39" height="39"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="39" id="NrA-04-VpI"/>
+                                            <constraint firstAttribute="width" secondItem="chZ-Nd-oWh" secondAttribute="height" multiplier="1:1" id="sgR-W3-obP"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="QuX-dZ-8Yf">
+                                        <rect key="frame" x="55" y="17" width="327" height="45"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YcK-wh-psM">
+                                                <rect key="frame" x="0.0" y="0.0" width="327" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="StO-ND-1uB">
+                                                <rect key="frame" x="0.0" y="24.5" width="327" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <directionalEdgeInsets key="directionalLayoutMargins" top="16" leading="0.0" bottom="16" trailing="16"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4by-7O-T7E">
+                                <rect key="frame" x="0.0" y="78.5" width="398" height="0.5"/>
+                                <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="0.5" id="ywx-aM-oGX"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="maY-Zz-sH8">
+                                <rect key="frame" x="0.0" y="79" width="398" height="77"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="gGp-Tm-i7s">
+                                        <rect key="frame" x="0.0" y="16" width="382" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t4R-J0-otV">
+                                                <rect key="frame" x="0.0" y="0.0" width="336" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hhl-06-gXM">
+                                                <rect key="frame" x="340" y="0.0" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="YBq-NT-Dwu">
+                                        <rect key="frame" x="0.0" y="40.5" width="382" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9vh-Ay-6m1">
+                                                <rect key="frame" x="0.0" y="0.0" width="336" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLc-wt-CbB">
+                                                <rect key="frame" x="340" y="0.0" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <directionalEdgeInsets key="directionalLayoutMargins" top="16" leading="0.0" bottom="16" trailing="16"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2eP-YU-ZoX">
+                                <rect key="frame" x="0.0" y="156" width="398" height="0.5"/>
+                                <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="0.5" id="oxV-cz-6M5"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="AsH-ce-Yq8">
+                                <rect key="frame" x="0.0" y="156.5" width="398" height="52.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E7R-DR-yWr">
+                                        <rect key="frame" x="0.0" y="16" width="336" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="URn-4h-z0y">
+                                        <rect key="frame" x="340" y="16" width="42" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <directionalEdgeInsets key="directionalLayoutMargins" top="16" leading="0.0" bottom="16" trailing="16"/>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="qCH-VN-qlL"/>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="JDF-j9-Gh4" firstAttribute="top" secondItem="Mly-TP-AMG" secondAttribute="top" id="2GR-Qr-Jx6"/>
+                    <constraint firstAttribute="trailing" secondItem="JDF-j9-Gh4" secondAttribute="trailing" id="DOu-h1-5Ce"/>
+                    <constraint firstItem="JDF-j9-Gh4" firstAttribute="leading" secondItem="Mly-TP-AMG" secondAttribute="leading" constant="16" id="Sjx-xb-d3j"/>
+                    <constraint firstAttribute="bottom" secondItem="JDF-j9-Gh4" secondAttribute="bottom" id="w6m-RO-5ZW"/>
+                </constraints>
             </tableViewCellContentView>
-            <point key="canvasLocation" x="110" y="113"/>
+            <point key="canvasLocation" x="108.69565217391305" y="80.022321428571431"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="252" id="oBT-Z9-cJd" customClass="RefundShippingDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="252"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oBT-Z9-cJd" id="Mly-TP-AMG">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="252"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="110" y="113"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
@@ -23,24 +23,25 @@
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="aS0-yn-0bT">
                                 <rect key="frame" x="0.0" y="0.0" width="398" height="78.5"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="chZ-Nd-oWh">
-                                        <rect key="frame" x="0.0" y="20" width="39" height="39"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UIO-C5-NbR">
+                                        <rect key="frame" x="0.0" y="19.5" width="40" height="40"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="39" id="NrA-04-VpI"/>
-                                            <constraint firstAttribute="width" secondItem="chZ-Nd-oWh" secondAttribute="height" multiplier="1:1" id="sgR-W3-obP"/>
+                                            <constraint firstAttribute="width" secondItem="UIO-C5-NbR" secondAttribute="height" multiplier="1:1" id="QkD-0l-2wr"/>
+                                            <constraint firstAttribute="height" constant="40" id="v2s-3t-84S"/>
                                         </constraints>
-                                    </imageView>
+                                    </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="QuX-dZ-8Yf">
-                                        <rect key="frame" x="55" y="17" width="327" height="45"/>
+                                        <rect key="frame" x="56" y="17" width="326" height="45"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YcK-wh-psM">
-                                                <rect key="frame" x="0.0" y="0.0" width="327" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="326" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="StO-ND-1uB">
-                                                <rect key="frame" x="0.0" y="24.5" width="327" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="24.5" width="326" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -125,16 +126,25 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="qCH-VN-qlL"/>
                     </stackView>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="chZ-Nd-oWh">
+                        <rect key="frame" x="24" y="27" width="24" height="24"/>
+                    </imageView>
                 </subviews>
                 <constraints>
                     <constraint firstItem="JDF-j9-Gh4" firstAttribute="top" secondItem="Mly-TP-AMG" secondAttribute="top" id="2GR-Qr-Jx6"/>
+                    <constraint firstItem="UIO-C5-NbR" firstAttribute="bottom" secondItem="chZ-Nd-oWh" secondAttribute="bottom" constant="8.5" id="7LA-X9-A7f"/>
                     <constraint firstAttribute="trailing" secondItem="JDF-j9-Gh4" secondAttribute="trailing" id="DOu-h1-5Ce"/>
+                    <constraint firstItem="UIO-C5-NbR" firstAttribute="trailing" secondItem="chZ-Nd-oWh" secondAttribute="trailing" constant="8" id="FO4-aj-x7c"/>
+                    <constraint firstItem="chZ-Nd-oWh" firstAttribute="top" secondItem="UIO-C5-NbR" secondAttribute="top" constant="7.5" id="PjL-g1-hR6"/>
                     <constraint firstItem="JDF-j9-Gh4" firstAttribute="leading" secondItem="Mly-TP-AMG" secondAttribute="leading" constant="16" id="Sjx-xb-d3j"/>
+                    <constraint firstItem="chZ-Nd-oWh" firstAttribute="leading" secondItem="UIO-C5-NbR" secondAttribute="leading" constant="8" id="tp7-6b-GI4"/>
                     <constraint firstAttribute="bottom" secondItem="JDF-j9-Gh4" secondAttribute="bottom" id="w6m-RO-5ZW"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="carrierLabel" destination="YcK-wh-psM" id="hbq-Sb-tAf"/>
+                <outlet property="shippingBorderView" destination="UIO-C5-NbR" id="N6j-Du-QU6"/>
+                <outlet property="shippingBorderViewHeightConstraint" destination="v2s-3t-84S" id="nku-Qw-WS3"/>
                 <outlet property="shippingImageView" destination="chZ-Nd-oWh" id="UI2-cb-BJk"/>
                 <outlet property="shippingPrice" destination="StO-ND-1uB" id="fY1-vi-El1"/>
                 <outlet property="shippingRefundPriceLabel" destination="URn-4h-z0y" id="e41-c5-Iux"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
@@ -146,7 +146,7 @@
                 <outlet property="shippingBorderView" destination="UIO-C5-NbR" id="N6j-Du-QU6"/>
                 <outlet property="shippingBorderViewHeightConstraint" destination="v2s-3t-84S" id="nku-Qw-WS3"/>
                 <outlet property="shippingImageView" destination="chZ-Nd-oWh" id="UI2-cb-BJk"/>
-                <outlet property="shippingPrice" destination="StO-ND-1uB" id="fY1-vi-El1"/>
+                <outlet property="shippingPriceLabel" destination="StO-ND-1uB" id="aaX-D3-EGa"/>
                 <outlet property="shippingRefundPriceLabel" destination="URn-4h-z0y" id="e41-c5-Iux"/>
                 <outlet property="shippingRefundTitleLabel" destination="E7R-DR-yWr" id="A2w-Uk-6ab"/>
                 <outlet property="subtotalPriceLabel" destination="hhl-06-gXM" id="AzJ-1s-JyY"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Represents shipping detailsf for an order to be refunded. Meant to be rendered by `RefundShippingDetailsTableViewCell`
+/// Represents shipping details for an order to be refunded. Meant to be rendered by `RefundShippingDetailsTableViewCell`
 ///
 struct RefundShippingDetailsViewModel {
     let carrierRate: String

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Represents shipping detailsf for an order to be refunded. Meant to be rendered by `RefundShippingDetailsTableViewCell`
+///
+struct RefundShippingDetailsViewModel {
+    let carrierRate: String
+    let carrierCost: String
+    let shippingTax: String
+    let shippingSubtotal: String
+    let shippingTotal: String
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -328,6 +328,8 @@
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
 		26ABCE532518EAF300721CB0 /* IssueRefundTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ABCE522518EAF300721CB0 /* IssueRefundTableViewCell.swift */; };
 		26ABCE552518EB0600721CB0 /* IssueRefundTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26ABCE542518EB0600721CB0 /* IssueRefundTableViewCell.xib */; };
+		26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */; };
+		26AE31B2251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */; };
 		26B119B924D0B38F00FED5C7 /* SurveyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */; };
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
@@ -1298,6 +1300,8 @@
 		2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCoordinatingController.swift; sourceTree = "<group>"; };
 		26ABCE522518EAF300721CB0 /* IssueRefundTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundTableViewCell.swift; sourceTree = "<group>"; };
 		26ABCE542518EB0600721CB0 /* IssueRefundTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundTableViewCell.xib; sourceTree = "<group>"; };
+		26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsTableViewCell.swift; sourceTree = "<group>"; };
+		26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundShippingDetailsTableViewCell.xib; sourceTree = "<group>"; };
 		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
@@ -2759,6 +2763,8 @@
 				26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */,
 				26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */,
 				26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */,
+				26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */,
+				26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -4879,6 +4885,7 @@
 				CE85FD5320F677770080B73E /* Dashboard.storyboard in Resources */,
 				B56DB3CF2049BFAA00D4AA8E /* Main.storyboard in Resources */,
 				02C8876E24501FAC00E4470F /* FilterListViewController.xib in Resources */,
+				26AE31B2251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib in Resources */,
 				CE21B3D820FE669A00A259D5 /* BasicTableViewCell.xib in Resources */,
 				74334F37214AB130006D6AC5 /* ProductTableViewCell.xib in Resources */,
 				26ABCE552518EB0600721CB0 /* IssueRefundTableViewCell.xib in Resources */,
@@ -5456,6 +5463,7 @@
 				74EC34A8225FE69C004BBC2E /* ProductDetailsViewController.swift in Sources */,
 				26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
+				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,
 				57EBC92024EEE61800C1D45B /* WooAnalyticsEvent.swift in Sources */,
 				B55401692170D5E10067DC90 /* ChartPlaceholderView.swift in Sources */,
 				02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		26B119BB24D0B62E00FED5C7 /* SurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */; };
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
+		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
@@ -1306,6 +1307,7 @@
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
+		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
@@ -2763,6 +2765,7 @@
 				26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */,
 				26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */,
 				26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */,
+				26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */,
 				26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */,
 				26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */,
 			);
@@ -5317,6 +5320,7 @@
 				571B850224CF7E3100CF58A7 /* InAppFeedbackCardViewController.swift in Sources */,
 				7441E1D221503F77004E6ECE /* IntrinsicTableView.swift in Sources */,
 				B517EA1D218B41F200730EC4 /* String+Woo.swift in Sources */,
+				26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */,
 				02564A8C246CE38E00D6DB2A /* SwappableSubviewContainerView.swift in Sources */,
 				024DF31223742B18006658FE /* AztecItalicFormatBarCommand.swift in Sources */,
 				02EAB6D92480AA4900FD873C /* SentryCrashLogger.swift in Sources */,


### PR DESCRIPTION
closes #2834 

# Why
The end goal is to build the refund UI, but this PR focuses on building the shipping details section (enclosed in the blue rectangle).

<img width="316" alt="end-goal" src="https://user-images.githubusercontent.com/562080/94473225-89e05c00-0191-11eb-8054-849392c9a6f9.png">

# How
- Created `RefundShippingDetailsTableViewCell` backed up by its xib.
- Created simple `RefundShippingDetailsViewModel` to aid rendering content on `RefundShippingDetailsTableViewCell`. This just declares properties for now. More logic will be added as the development progresses.

# Screenshots

Light | Dark | XXL | RTL
---- | ---- | ---- | ---- 
<img width="378" alt="normal" src="https://user-images.githubusercontent.com/562080/94474464-50105500-0193-11eb-98d4-74b88c936fe2.png"> |  <img width="384" alt="dark" src="https://user-images.githubusercontent.com/562080/94474468-51418200-0193-11eb-8796-0547e8c032e1.png"> |  <img width="375" alt="big-font" src="https://user-images.githubusercontent.com/562080/94474470-51da1880-0193-11eb-8a54-14849e3c28ca.png"> |  <img width="376" alt="rtl" src="https://user-images.githubusercontent.com/562080/94474473-5272af00-0193-11eb-9cd8-01089f062d7b.png">


# Testing Steps
- Nothing, as the cell is not yet integrated into any screen

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
