### PR TITLE
Fix `DashboardViewController` retained after logging out

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,9 +32,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 1.24.0'
+  # pod 'WordPressAuthenticator', '~> 1.24.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'wcios-2884/authenticator-presentation-completion'
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.11'

--- a/Podfile
+++ b/Podfile
@@ -32,9 +32,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  # pod 'WordPressAuthenticator', '~> 1.24.0'
+  pod 'WordPressAuthenticator', '~> 1.26.0-beta'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'wcios-2884/authenticator-presentation-completion'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'WordPressShared', '~> 1.11'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.26.0-beta.13):
+  - WordPressAuthenticator (1.26.0-beta.14):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `wcios-2884/authenticator-presentation-completion`)
+  - WordPressAuthenticator (~> 1.26.0-beta)
   - WordPressShared (~> 1.11)
   - WordPressUI (~> 1.7.2-beta)
   - Wormholy (~> 1.6.2)
@@ -141,6 +141,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -155,16 +156,6 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
-
-EXTERNAL SOURCES:
-  WordPressAuthenticator:
-    :branch: wcios-2884/authenticator-presentation-completion
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-
-CHECKOUT OPTIONS:
-  WordPressAuthenticator:
-    :commit: f41960e64124c30a74c9ccba3978a6374d5679a7
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -191,7 +182,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: e44d5f80a6f02c3491414d24c5e09ef0dc666b40
+  WordPressAuthenticator: aac1312fd60a8563583f7d10765e835cea65eb17
   WordPressKit: 35574a223dd23320866813677d908cf81c8a4750
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
   WordPressUI: 1765e695563562da513b0dd5ddb95dcf59d9f604
@@ -207,6 +198,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 1108a760ab4432ce92ccee6832098ff446310295
+PODFILE CHECKSUM: 7c356eafb9a0e5726aec58c67acd0f65cc9f308d
 
 COCOAPODS: 1.9.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
   - WordPress-Aztec-iOS (1.11.0)
   - WordPress-Editor-iOS (1.11.0):
     - WordPress-Aztec-iOS (= 1.11.0)
-  - WordPressAuthenticator (1.24.0):
+  - WordPressAuthenticator (1.26.0-beta.13):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -63,23 +63,23 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.16-beta)
+    - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.11-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.16.0):
+  - WordPressKit (4.18.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.10-beta)
-    - wpxmlrpc (= 0.8.5)
+    - wpxmlrpc (~> 0.9.0-beta)
   - WordPressShared (1.11.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.2-beta.1)
   - Wormholy (1.6.2)
   - WPMediaPicker (1.7.1)
-  - wpxmlrpc (0.8.5)
+  - wpxmlrpc (0.9.0-beta.1)
   - XLPagerTabStrip (9.0.0)
   - ZendeskCommonUISDK (4.2.0):
     - ZendeskSDKConfigurationsSDK (~> 1.1.2)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Kingfisher (~> 5.11.0)
   - Sourcery (~> 0.18)
   - WordPress-Editor-iOS (~> 1.11.0)
-  - WordPressAuthenticator (~> 1.24.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `wcios-2884/authenticator-presentation-completion`)
   - WordPressShared (~> 1.11)
   - WordPressUI (~> 1.7.2-beta)
   - Wormholy (~> 1.6.2)
@@ -141,7 +141,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -156,6 +155,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :branch: wcios-2884/authenticator-presentation-completion
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: f41960e64124c30a74c9ccba3978a6374d5679a7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -182,13 +191,13 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
-  WordPressAuthenticator: a9497866f5d480974988312c92d61c9db70f91d6
-  WordPressKit: 48d56b8d3d25619e32d3a8ae4e934547eb684856
+  WordPressAuthenticator: e44d5f80a6f02c3491414d24c5e09ef0dc666b40
+  WordPressKit: 35574a223dd23320866813677d908cf81c8a4750
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
   WordPressUI: 1765e695563562da513b0dd5ddb95dcf59d9f604
   Wormholy: 5a186f877829e7d488963b09f204e0186b40c9a8
   WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2
-  wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
+  wpxmlrpc: 54196a1c23d1298f05895cc375a8f91385106fd0
   XLPagerTabStrip: 61c57fd61f611ee5f01ff1495ad6fbee8bf496c5
   ZendeskCommonUISDK: afbee7c58c04cf88012a48c079599ec0d1590d16
   ZendeskCoreSDK: 86513e62c1ab68913416c9044463d9b687ca944f
@@ -198,6 +207,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: e183d32abac888c448469e2005c4a5a8c3ed73f0
   ZendeskSupportSDK: e52f37fa8bcba91f024b81025869fe5a2860f741
 
-PODFILE CHECKSUM: 2dfad9e9dd47d30db57ea8a3fe620bdc97cf676b
+PODFILE CHECKSUM: 1108a760ab4432ce92ccee6832098ff446310295
 
 COCOAPODS: 1.9.1

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -354,22 +354,24 @@ extension AppDelegate {
 
     /// Whenever there is no default WordPress.com Account, let's display the Authentication UI.
     ///
-    func displayAuthenticatorIfNeeded() {
+    private func displayAuthenticatorIfNeeded() {
         guard ServiceLocator.stores.isAuthenticated == false else {
             return
         }
 
-        displayAuthenticator()
+        displayAuthenticator(animated: false)
     }
 
     /// Displays the WordPress.com Authentication UI.
     ///
-    func displayAuthenticator() {
+    func displayAuthenticator(animated: Bool) {
         guard let rootViewController = window?.rootViewController else {
             fatalError()
         }
 
-        ServiceLocator.authenticationManager.displayAuthentication(from: rootViewController)
+        ServiceLocator.authenticationManager.displayAuthentication(from: rootViewController, animated: animated) { [weak self] in
+            self?.tabBarController?.removeViewControllers()
+        }
     }
 
     /// Whenever the app is authenticated but there is no Default StoreID: Let's display the Store Picker.
@@ -388,13 +390,13 @@ extension AppDelegate {
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .standard)
         storePickerCoordinator?.start()
         storePickerCoordinator?.onDismiss = { [weak self] in
-            self?.displayAuthenticator()
+            self?.displayAuthenticator(animated: false)
         }
     }
 
     /// Whenever we're in an Authenticated state, let's Sync all of the WC-Y entities.
     ///
-    func synchronizeEntitiesIfPossible() {
+    private func synchronizeEntitiesIfPossible() {
         guard ServiceLocator.stores.isAuthenticated else {
             return
         }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -99,10 +99,10 @@ class AuthenticationManager: Authentication {
 
     /// Displays the Login Flow using the specified UIViewController as presenter.
     ///
-    func displayAuthentication(from presenter: UIViewController) {
-        WordPressAuthenticator.showLogin(from: presenter, animated: true, onLoginButtonTapped: {
+    func displayAuthentication(from presenter: UIViewController, animated: Bool, onCompletion: @escaping () -> Void) {
+        WordPressAuthenticator.showLogin(from: presenter, animated: animated, onLoginButtonTapped: {
             ServiceLocator.analytics.track(.loginPrologueContinueTapped)
-        })
+        }, onCompletion: onCompletion)
     }
 
     /// Handles an Authentication URL Callback. Returns *true* on success.

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -16,7 +16,7 @@ protocol Authentication {
 
     /// Displays the Login Flow using the specified UIViewController as presenter.
     ///
-    func displayAuthentication(from presenter: UIViewController)
+    func displayAuthentication(from presenter: UIViewController, animated: Bool, onCompletion: @escaping () -> Void)
 
     /// Initializes the WordPress Authenticator.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -26,7 +26,7 @@ final class DashboardViewController: UIViewController {
     init() {
         super.init(nibName: nil, bundle: nil)
         startListeningToNotifications()
-        tabBarItem.image = .statsAltImage
+        configureTabBarItem()
     }
 
     required init?(coder: NSCoder) {
@@ -67,23 +67,18 @@ private extension DashboardViewController {
         configureNavigationItem()
     }
 
-    private func configureTitle() {
-        let myStore = NSLocalizedString(
-            "My store",
-            comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
-        )
-        title = ServiceLocator.stores.sessionManager.defaultSite?.name ?? myStore
-        tabBarItem.title = myStore
+    func configureTabBarItem() {
+        tabBarItem.image = .statsAltImage
+        tabBarItem.title = Localization.title
         tabBarItem.accessibilityIdentifier = "tab-bar-my-store-item"
     }
 
-    private func resetTitle() {
-        let myStore = NSLocalizedString(
-            "My store",
-            comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
-        )
-        title = myStore
-        tabBarItem.title = myStore
+    func configureTitle() {
+        navigationItem.title = ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.title
+    }
+
+    func resetTitle() {
+        navigationItem.title = Localization.title
     }
 
     private func configureNavigationItem() {
@@ -237,5 +232,14 @@ private extension DashboardViewController {
         dashboardUI?.reloadData(completion: { [weak self] in
             self?.configureTitle()
         })
+    }
+}
+
+private extension DashboardViewController {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "My store",
+            comment: "Title of the bottom tab item that presents the user's store dashboard, and default title for the store dashboard"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -138,6 +138,16 @@ final class ProductsViewController: UIViewController {
 
     // MARK: - View Lifecycle
 
+    init() {
+        super.init(nibName: nil, bundle: nil)
+
+        configureTabBarItem()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -248,7 +258,7 @@ private extension ProductsViewController {
     /// Set the title.
     ///
     func configureNavigationBar() {
-        title = NSLocalizedString(
+        navigationItem.title = NSLocalizedString(
             "Products",
             comment: "Title that appears on top of the Product List screen (plural form of the word Product)."
         )
@@ -308,6 +318,12 @@ private extension ProductsViewController {
     ///
     func configureMainView() {
         view.backgroundColor = .listBackground
+    }
+
+    func configureTabBarItem() {
+        tabBarItem.title = NSLocalizedString("Products", comment: "Title of the Products tab — plural form of Product")
+        tabBarItem.image = .productImage
+        tabBarItem.accessibilityIdentifier = "tab-bar-products-item"
     }
 
     /// Configure common table properties.

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsCoordinator.swift
@@ -20,6 +20,7 @@ final class ReviewsCoordinator: Coordinator {
     private let willPresentReviewDetailsFromPushNotification: () -> Void
 
     init(siteID: Int64,
+         navigationController: UINavigationController,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          storesManager: StoresManager = ServiceLocator.stores,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
@@ -32,12 +33,14 @@ final class ReviewsCoordinator: Coordinator {
         self.switchStoreUseCase = switchStoreUseCase
         self.willPresentReviewDetailsFromPushNotification = willPresentReviewDetailsFromPushNotification
 
-        self.navigationController = WooNavigationController(rootViewController: ReviewsViewController(siteID: siteID))
+        self.navigationController = navigationController
+        navigationController.viewControllers = [ReviewsViewController(siteID: siteID)]
     }
 
-    convenience init(siteID: Int64, willPresentReviewDetailsFromPushNotification: @escaping () -> Void) {
+    convenience init(siteID: Int64, navigationController: UINavigationController, willPresentReviewDetailsFromPushNotification: @escaping () -> Void) {
         let storesManager = ServiceLocator.stores
         self.init(siteID: siteID,
+                  navigationController: navigationController,
                   storesManager: storesManager,
                   switchStoreUseCase: SwitchStoreUseCase(stores: storesManager),
                   willPresentReviewDetailsFromPushNotification: willPresentReviewDetailsFromPushNotification)

--- a/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
@@ -10,7 +10,7 @@ class DeauthenticatedState: StoresManagerState {
     /// This method should run only when the app got deauthenticated.
     ///
     func didEnter() {
-        AppDelegate.shared.displayAuthenticator()
+        AppDelegate.shared.displayAuthenticator(animated: true)
     }
 
     /// NO-OP: Executed before the current state is deactivated.

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -43,31 +43,16 @@ final class MainTabBarControllerTests: XCTestCase {
                    isAnInstanceOf: ReviewsViewController.self)
     }
 
-    func test_tab_view_controllers_are_empty_after_deauthentication() {
-        // Arrange
-        // Trigger `viewDidLoad`
-        XCTAssertNotNil(tabBarController.view)
-        let siteID: Int64 = 134
-        stores.updateDefaultStore(storeID: siteID)
-        XCTAssertEqual(tabBarController.viewControllers?.count, 4)
-
-        // Action
-        stores.deauthenticate()
-
-        // Assert
-        XCTAssertEqual(tabBarController.viewControllers?.count, 0)
-    }
-
-    func test_viewControllers_are_replaced_after_updating_to_a_different_site() throws {
+    func test_tab_root_viewControllers_are_replaced_after_updating_to_a_different_site() throws {
         // Arrange
         // Trigger `viewDidLoad`
         XCTAssertNotNil(tabBarController.view)
 
         // Action
         stores.updateDefaultStore(storeID: 134)
-        let viewControllersBeforeSiteChange = try XCTUnwrap(tabBarController.viewControllers)
+        let viewControllersBeforeSiteChange = tabBarController.tabRootViewControllers
         stores.updateDefaultStore(storeID: 630)
-        let viewControllersAfterSiteChange = try XCTUnwrap(tabBarController.viewControllers)
+        let viewControllersAfterSiteChange = tabBarController.tabRootViewControllers
 
         // Assert
         XCTAssertEqual(viewControllersBeforeSiteChange.count, viewControllersAfterSiteChange.count)
@@ -108,5 +93,11 @@ final class MainTabBarControllerTests: XCTestCase {
         // Assert
         XCTAssertEqual(selectedTabIndexBeforeSiteChange, WooTab.products.visibleIndex())
         XCTAssertEqual(selectedTabIndexAfterSiteChange, WooTab.myStore.visibleIndex())
+    }
+}
+
+private extension MainTabBarController {
+    var tabRootViewControllers: [UIViewController] {
+        viewControllers?.compactMap { $0 as? UINavigationController }.compactMap { $0.viewControllers.first } ?? []
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Notifications/ReviewsCoordinatorTests.swift
@@ -179,6 +179,7 @@ final class ReviewsCoordinatorTests: XCTestCase {
 private extension ReviewsCoordinatorTests {
     func makeReviewsCoordinator(willPresentReviewDetailsFromPushNotification: (@escaping () -> Void) = { }) -> ReviewsCoordinator {
         return ReviewsCoordinator(siteID: 1,
+                                  navigationController: UINavigationController(),
                                   pushNotificationsManager: pushNotificationsManager,
                                   storesManager: storesManager,
                                   noticePresenter: noticePresenter,

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -179,7 +179,8 @@ extension DefaultStoresManager {
 final class MockAuthenticationManager: AuthenticationManager {
     private(set) var displayAuthenticationInvoked: Bool = false
 
-    override func displayAuthentication(from presenter: UIViewController) {
+    override func displayAuthentication(from presenter: UIViewController, animated: Bool, onCompletion: @escaping () -> Void) {
         displayAuthenticationInvoked = true
+        onCompletion()
     }
 }


### PR DESCRIPTION
Fixes #2884 
Based on https://github.com/woocommerce/woocommerce-ios/pull/2850

- [x] ⚠️ Update `Podfile` to point `WordPressAuthenticator` to production version after https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/488 is merged and deployed ⚠️ 

## The challenge of resetting `MainTabBarController`'s `viewControllers`

The last tab (`DashboardViewController`) before logging out is retained by `MainTabBarController` because once a `UITabBarController`'s `selectedViewController` has been set, it cannot be set to nil or it crashes the app. I tried replacing `MainTabBarController`'s `viewControllers` to a single placeholder navigation controller and set it to its `selectedViewController`, but `DashboardViewController` is still retained because of an internal strong reference `_selectedViewControllerDuringWillAppear` 😨 My guess is because `DashboardViewController` is still present when `MainTabBarController` presents the authentication UI, and I could not find a way to fix this internal strong reference nor find much information about it online.

<img width="1676" alt="Screen Shot 2020-09-29 at 11 41 50 AM" src="https://user-images.githubusercontent.com/1945542/94532360-59232400-0270-11eb-8079-7cc0faff184f.png">

In order to fix this, I think it'd better to keep `MainTabBarController`'s `viewControllers` the same throughout its lifetime. In this PR, I updated the original implementation (mutating `viewControllers` after site ID changes) to replace each tab navigation controller's `viewControllers` instead. This deallocates all the tab root view controllers after logging out.

In `MainTabBarController`, its `viewControllers` are now fixed to the same `UINavigationController`s and we update each navigation controller's `viewControllers` when site ID changes.

Note: I noticed that `StoreStatsV4PeriodViewController`s are still lingering after `DashboardViewController` is deallocated. It looks like it's from `ChartYAxis` from the charting library. I created a separate issue https://github.com/woocommerce/woocommerce-ios/issues/2887 to track this.

<img width="1482" alt="Screen Shot 2020-09-29 at 4 32 27 PM" src="https://user-images.githubusercontent.com/1945542/94533194-6f7daf80-0271-11eb-89e4-0013daa9e99d.png">

## Other changes

### Tear down the tab root view controllers after authentication UI is presented

When the user logs out, it triggers `AppDelegate`'s `displayAuthenticator` to show the authentication UI. However, now that the dashboard tab is torn down and deallocated on `nil` site ID (when `displayAuthenticator` is triggered), the blank dashboard tab is shown for a split second before the authentication is presented. Before this PR, this issue doesn't occur because `DashboardViewController` was still retained. To fix this UI issue, I made a PR https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/488 to add a completion block for authentication UI presentation completion and tear down the tab root view controllers there.

### Authentication UI presentation animation

Another UI issue I noticed from https://github.com/woocommerce/woocommerce-ios/pull/2850 is when launching the app in logged out state where the authentication UI is presented from a black screen (since the tab root view controllers aren't set up when logged out). The desired behavior is to animate the authentication UI presentation only after logging out from the app (logged in --> logged out). To fix this, I added an `animated: Bool` parameter to allow animation only when transitioning from logged in to logged out state (`DeauthenticatedState`'s `didEnter`).

## Future tasks

(I created an issue for these two https://github.com/woocommerce/woocommerce-ios/issues/2888)

- I'd like to refactor the app navigation to a coordinator (maybe not a subclass of `Coordinator` because the main window is using a `UITabBarController` instead of a `UINavigationController`). I have some WIP code for this but thought it's better leaving them for a separate task.
- I noticed a glitch for store picker flow when the app is previously logged in but the user hasn't selected a site, and we present a store picker on launch. Because the main tab bar isn't set up yet since the app is still logged out, the store picker is presented from a tab bar with a black screen. I tried updating its presentation to try presenting from the tab bar controller, but `StorePickerCoordinator` currently takes in a `UINavigationController` only and it uses the tab bar's `selecteViewController` right now 🤨 (feels a bit hacky to me to grab a `UINavigationController` from the tab bar's selected tab) I think this is not a major flow, but I'd like to fix it sometime soon.

## Testing

### Logging in / switching stores

- Log out from the app
- Log in to an account with multiple sites, select a site to continue and navigate to each tab --> all the tabs should load as before
- Navigate to the My Store tab, tap Settings, then switch to the same store --> nothing should happen
- Tap Settings, then switch to a different store --> all the tabs should be updated to load data for the selected site
- Log out from the app --> in Xcode memory debugger, all tab root view controllers should be deallocated (before this PR, `DashboardViewController` stays around after logging out)

### Confidence check for Review push notifications

- Enable dev push notifications on sandbox p99K0U-1qz-p2
- Log in and navigate to a tab that is not Reviews
- Place the app in the background
- Submit a product review on the web
- Wait for the push notification
- Tap on the push notification
- Wait for a second --> the app should navigate to the Reviews tab and show the review details

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
