### PR TITLE
Add site ID to `Order`, `OrderCoupon`, `OrderRefundCondensed`, and `ShippingLine` in storage lookup

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -30,8 +30,8 @@ public extension StorageType {
 
     /// Retrieves the Stored Order.
     ///
-    func loadOrder(orderID: Int64) -> Order? {
-        let predicate = NSPredicate(format: "orderID = %ld", orderID)
+    func loadOrder(siteID: Int64, orderID: Int64) -> Order? {
+        let predicate = NSPredicate(format: "orderID = %ld AND siteID = %ld", orderID, siteID)
         return firstObject(ofType: Order.self, matching: predicate)
     }
 
@@ -58,15 +58,15 @@ public extension StorageType {
 
     /// Retrieves the Stored Order Coupon.
     ///
-    func loadOrderCoupon(couponID: Int64) -> OrderCoupon? {
-        let predicate = NSPredicate(format: "couponID = %ld", couponID)
+    func loadOrderCoupon(siteID: Int64, couponID: Int64) -> OrderCoupon? {
+        let predicate = NSPredicate(format: "order.siteID = %ld AND couponID = %ld", siteID, couponID)
         return firstObject(ofType: OrderCoupon.self, matching: predicate)
     }
 
     /// Retrieves the Stored Order Refund Condensed.
     ///
-    func loadOrderRefundCondensed(refundID: Int64) -> OrderRefundCondensed? {
-        let predicate = NSPredicate(format: "refundID = %ld", refundID)
+    func loadOrderRefundCondensed(siteID: Int64, refundID: Int64) -> OrderRefundCondensed? {
+        let predicate = NSPredicate(format: "order.siteID = %ld AND refundID = %ld", siteID, refundID)
         return firstObject(ofType: OrderRefundCondensed.self, matching: predicate)
     }
 

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -72,8 +72,8 @@ public extension StorageType {
 
     /// Retrieves the Stored Order Shipping Line.
     ///
-    func loadShippingLine(shippingID: Int64) -> ShippingLine? {
-        let predicate = NSPredicate(format: "shippingID = %ld", shippingID)
+    func loadShippingLine(siteID: Int64, shippingID: Int64) -> ShippingLine? {
+        let predicate = NSPredicate(format: "order.siteID = %ld AND shippingID = %ld", siteID, shippingID)
         return firstObject(ofType: ShippingLine.self, matching: predicate)
     }
 

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -37,7 +37,7 @@ extension SelectedSiteSettings {
         resultsController.onDidChangeObject = { [weak self] (object, indexPath, type, newIndexPath) in
             guard let self = self else { return }
             ServiceLocator.currencySettings.updateCurrencyOptions(with: object)
-            self.siteSettings = self.resultsController.fetchedObjects ?? []
+            self.siteSettings = self.resultsController.fetchedObjects
         }
         refreshResultsPredicate()
     }

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -45,7 +45,8 @@ struct OrdersUpsertUseCase {
     }
 
     private func upsert(_ readOnlyOrder: Networking.Order, insertingSearchResults: Bool = false) -> Storage.Order {
-        let storageOrder = storage.loadOrder(orderID: readOnlyOrder.orderID) ?? storage.insertNewObject(ofType: Storage.Order.self)
+        let storageOrder = storage.loadOrder(siteID: readOnlyOrder.siteID, orderID: readOnlyOrder.orderID)
+            ?? storage.insertNewObject(ofType: Storage.Order.self)
         storageOrder.update(with: readOnlyOrder)
 
         // Are we caching Search Results? Did this order exist before?
@@ -120,7 +121,7 @@ struct OrdersUpsertUseCase {
     private func handleOrderCoupons(_ readOnlyOrder: Networking.Order, _ storageOrder: Storage.Order, _ storage: StorageType) {
         // Upsert the coupons from the read-only order
         for readOnlyCoupon in readOnlyOrder.coupons {
-            if let existingStorageCoupon = storage.loadOrderCoupon(couponID: readOnlyCoupon.couponID) {
+            if let existingStorageCoupon = storage.loadOrderCoupon(siteID: readOnlyOrder.siteID, couponID: readOnlyCoupon.couponID) {
                 existingStorageCoupon.update(with: readOnlyCoupon)
             } else {
                 let newStorageCoupon = storage.insertNewObject(ofType: Storage.OrderCoupon.self)
@@ -143,7 +144,7 @@ struct OrdersUpsertUseCase {
     private func handleOrderRefundsCondensed(_ readOnlyOrder: Networking.Order, _ storageOrder: Storage.Order, _ storage: StorageType) {
         // Upsert the refunds from the read-only order
         for readOnlyRefund in readOnlyOrder.refunds {
-            if let existingStorageRefund = storage.loadOrderRefundCondensed(refundID: readOnlyRefund.refundID) {
+            if let existingStorageRefund = storage.loadOrderRefundCondensed(siteID: readOnlyOrder.siteID, refundID: readOnlyRefund.refundID) {
                 existingStorageRefund.update(with: readOnlyRefund)
             } else {
                 let newStorageRefund = storage.insertNewObject(ofType: Storage.OrderRefundCondensed.self)

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -167,7 +167,7 @@ struct OrdersUpsertUseCase {
     private func handleOrderShippingLines(_ readOnlyOrder: Networking.Order, _ storageOrder: Storage.Order, _ storage: StorageType) {
         // Upsert the shipping lines from the read-only order
         for readOnlyShippingLine in readOnlyOrder.shippingLines {
-            if let existingStorageShippingLine = storage.loadShippingLine(shippingID: readOnlyShippingLine.shippingID) {
+            if let existingStorageShippingLine = storage.loadShippingLine(siteID: readOnlyOrder.siteID, shippingID: readOnlyShippingLine.shippingID) {
                 existingStorageShippingLine.update(with: readOnlyShippingLine)
             } else {
                 let newStorageShippingLine = storage.insertNewObject(ofType: Storage.ShippingLine.self)

--- a/Yosemite/Yosemite/Stores/OrderNoteStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderNoteStore.swift
@@ -50,7 +50,7 @@ private extension OrderNoteStore {
                 return
             }
 
-            self?.upsertStoredOrderNotesInBackground(readOnlyOrderNotes: orderNotes, orderID: orderID) {
+            self?.upsertStoredOrderNotesInBackground(readOnlyOrderNotes: orderNotes, orderID: orderID, siteID: siteID) {
                 onCompletion(orderNotes, nil)
             }
         }
@@ -66,7 +66,7 @@ private extension OrderNoteStore {
                 return
             }
 
-            self?.upsertStoredOrderNotesInBackground(readOnlyOrderNotes: [note], orderID: orderID) {
+            self?.upsertStoredOrderNotesInBackground(readOnlyOrderNotes: [note], orderID: orderID, siteID: siteID) {
                 onCompletion(note, nil)
             }
         }
@@ -80,10 +80,10 @@ extension OrderNoteStore {
 
     /// Updates (OR Inserts) the specified ReadOnly OrderNote Entity into the Storage Layer.
     ///
-    func upsertStoredOrderNoteInBackground(readOnlyOrderNote: Networking.OrderNote, orderID: Int64, onCompletion: @escaping () -> Void) {
+    func upsertStoredOrderNoteInBackground(readOnlyOrderNote: Networking.OrderNote, orderID: Int64, siteID: Int64, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
-            self.saveNote(derivedStorage, readOnlyOrderNote, orderID)
+            self.saveNote(derivedStorage, readOnlyOrderNote, orderID, siteID: siteID)
         }
 
         storageManager.saveDerivedType(derivedStorage: derivedStorage) {
@@ -93,11 +93,11 @@ extension OrderNoteStore {
 
     /// Updates (OR Inserts) the specified ReadOnly OrderNote Entities into the Storage Layer.
     ///
-    func upsertStoredOrderNotesInBackground(readOnlyOrderNotes: [Networking.OrderNote], orderID: Int64, onCompletion: @escaping () -> Void) {
+    func upsertStoredOrderNotesInBackground(readOnlyOrderNotes: [Networking.OrderNote], orderID: Int64, siteID: Int64, onCompletion: @escaping () -> Void) {
         let derivedStorage = sharedDerivedStorage
         derivedStorage.perform {
             for readOnlyOrderNote in readOnlyOrderNotes {
-                self.saveNote(derivedStorage, readOnlyOrderNote, orderID)
+                self.saveNote(derivedStorage, readOnlyOrderNote, orderID, siteID: siteID)
             }
         }
 
@@ -109,13 +109,13 @@ extension OrderNoteStore {
     /// Using the provided StorageType, update or insert a Storage.OrderNote using the provided ReadOnly
     /// OrderNote. This func does *not* persist any unsaved changes to storage.
     ///
-    private func saveNote(_ storage: StorageType, _ readOnlyOrderNote: OrderNote, _ orderID: Int64) {
+    private func saveNote(_ storage: StorageType, _ readOnlyOrderNote: OrderNote, _ orderID: Int64, siteID: Int64) {
         if let existingStorageNote = storage.loadOrderNote(noteID: readOnlyOrderNote.noteID) {
             existingStorageNote.update(with: readOnlyOrderNote)
             return
         }
 
-        guard let storageOrder = storage.loadOrder(orderID: orderID) else {
+        guard let storageOrder = storage.loadOrder(siteID: siteID, orderID: orderID) else {
             DDLogWarn("⚠️ Could not persist the OrderNote with ID \(readOnlyOrderNote.noteID) — unable to retrieve stored order with ID \(orderID).")
             return
         }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -218,7 +218,7 @@ private extension OrderStore {
         remote.loadOrder(for: siteID, orderID: orderID) { [weak self] (order, error) in
             guard let order = order else {
                 if case NetworkError.notFound? = error {
-                    self?.deleteStoredOrder(orderID: orderID)
+                    self?.deleteStoredOrder(siteID: siteID, orderID: orderID)
                 }
                 onCompletion(nil, error)
                 return
@@ -234,7 +234,7 @@ private extension OrderStore {
     ///
     func updateOrder(siteID: Int64, orderID: Int64, status: OrderStatusEnum, onCompletion: @escaping (Error?) -> Void) {
         /// Optimistically update the Status
-        let oldStatus = updateOrderStatus(orderID: orderID, statusKey: status)
+        let oldStatus = updateOrderStatus(siteID: siteID, orderID: orderID, statusKey: status)
 
         let remote = OrdersRemote(network: network)
         remote.updateOrder(from: siteID, orderID: orderID, statusKey: status) { [weak self] (_, error) in
@@ -245,7 +245,7 @@ private extension OrderStore {
             }
 
             /// Revert Optimistic Update
-            self?.updateOrderStatus(orderID: orderID, statusKey: oldStatus)
+            self?.updateOrderStatus(siteID: siteID, orderID: orderID, statusKey: oldStatus)
             onCompletion(error)
         }
     }
@@ -275,9 +275,9 @@ extension OrderStore {
 
     /// Deletes any Storage.Order with the specified OrderID
     ///
-    func deleteStoredOrder(orderID: Int64) {
+    func deleteStoredOrder(siteID: Int64, orderID: Int64) {
         let storage = storageManager.viewStorage
-        guard let order = storage.loadOrder(orderID: orderID) else {
+        guard let order = storage.loadOrder(siteID: siteID, orderID: orderID) else {
             return
         }
 
@@ -290,9 +290,9 @@ extension OrderStore {
     /// - Returns: Status, prior to performing the Update OP.
     ///
     @discardableResult
-    func updateOrderStatus(orderID: Int64, statusKey: OrderStatusEnum) -> OrderStatusEnum {
+    func updateOrderStatus(siteID: Int64, orderID: Int64, statusKey: OrderStatusEnum) -> OrderStatusEnum {
         let storage = storageManager.viewStorage
-        guard let order = storage.loadOrder(orderID: orderID) else {
+        guard let order = storage.loadOrder(siteID: siteID, orderID: orderID) else {
             return statusKey
         }
 
@@ -348,7 +348,7 @@ private extension OrderStore {
         searchResults.keyword = keyword
 
         for readOnlyOrder in readOnlyOrders {
-            guard let storedOrder = storage.loadOrder(orderID: readOnlyOrder.orderID) else {
+            guard let storedOrder = storage.loadOrder(siteID: readOnlyOrder.siteID, orderID: readOnlyOrder.orderID) else {
                 continue
             }
 

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -56,6 +56,25 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         let persistedOrder9001 = try XCTUnwrap(viewStorage.loadOrder(siteID: defaultSiteID, orderID: 9001))
         XCTAssertEqual(persistedOrder9001.toReadOnly(), orders.last)
     }
+
+    func test_it_persists_order_relationships_in_storage() throws {
+        // Given
+        let coupon = Networking.OrderCouponLine(couponID: 1, code: "", discount: "", discountTax: "")
+        let refund = Networking.OrderRefundCondensed(refundID: 122, reason: "", total: "1.6")
+        let order = makeOrder().copy(orderID: 98, number: "dignissimos", coupons: [coupon], refunds: [refund])
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+
+        // When
+        useCase.upsert([order])
+
+        // Then
+        let persistedOrder = try XCTUnwrap(viewStorage.loadOrder(siteID: defaultSiteID, orderID: 98))
+        XCTAssertEqual(persistedOrder.toReadOnly(), order)
+        let persistedCoupon = try XCTUnwrap(viewStorage.loadOrderCoupon(siteID: defaultSiteID, couponID: coupon.couponID))
+        XCTAssertEqual(persistedCoupon.toReadOnly(), coupon)
+        let persistedRefund = try XCTUnwrap(viewStorage.loadOrderRefundCondensed(siteID: defaultSiteID, refundID: refund.refundID))
+        XCTAssertEqual(persistedRefund.toReadOnly(), refund)
+    }
 }
 
 private extension OrdersUpsertUseCaseTests {

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -61,7 +61,8 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         // Given
         let coupon = Networking.OrderCouponLine(couponID: 1, code: "", discount: "", discountTax: "")
         let refund = Networking.OrderRefundCondensed(refundID: 122, reason: "", total: "1.6")
-        let order = makeOrder().copy(orderID: 98, number: "dignissimos", coupons: [coupon], refunds: [refund])
+        let shippingLine = Networking.ShippingLine(shippingID: 25, methodTitle: "dodo", methodID: "", total: "2.1", totalTax: "0.8")
+        let order = makeOrder().copy(orderID: 98, number: "dignissimos", shippingLines: [shippingLine], coupons: [coupon], refunds: [refund])
         let useCase = OrdersUpsertUseCase(storage: viewStorage)
 
         // When
@@ -74,6 +75,8 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         XCTAssertEqual(persistedCoupon.toReadOnly(), coupon)
         let persistedRefund = try XCTUnwrap(viewStorage.loadOrderRefundCondensed(siteID: defaultSiteID, refundID: refund.refundID))
         XCTAssertEqual(persistedRefund.toReadOnly(), refund)
+        let persistedShippingLine = try XCTUnwrap(viewStorage.loadShippingLine(siteID: defaultSiteID, shippingID: shippingLine.shippingID))
+        XCTAssertEqual(persistedShippingLine.toReadOnly(), shippingLine)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -7,6 +7,7 @@ import Networking
 
 final class OrdersUpsertUseCaseTests: XCTestCase {
 
+    private let defaultSiteID: Int64 = 10
     private var storageManager: StorageManagerType!
     private var viewStorage: StorageType {
         storageManager.viewStorage
@@ -49,17 +50,17 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         useCase.upsert(orders)
 
         // Then
-        let persistedOrder98 = try XCTUnwrap(viewStorage.loadOrder(orderID: 98))
+        let persistedOrder98 = try XCTUnwrap(viewStorage.loadOrder(siteID: defaultSiteID, orderID: 98))
         XCTAssertEqual(persistedOrder98.toReadOnly(), orders.first)
 
-        let persistedOrder9001 = try XCTUnwrap(viewStorage.loadOrder(orderID: 9001))
+        let persistedOrder9001 = try XCTUnwrap(viewStorage.loadOrder(siteID: defaultSiteID, orderID: 9001))
         XCTAssertEqual(persistedOrder9001.toReadOnly(), orders.last)
     }
 }
 
 private extension OrdersUpsertUseCaseTests {
     func makeOrder() -> Networking.Order {
-        Order(siteID: 0,
+        Order(siteID: defaultSiteID,
               orderID: 0,
               parentID: 0,
               customerID: 0,

--- a/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderNoteStoreTests.swift
@@ -148,12 +148,12 @@ class OrderNoteStoreTests: XCTestCase {
         let group = DispatchGroup()
 
         group.enter()
-        orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: sampleCustomerNote(), orderID: sampleOrderID) {
+        orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: sampleCustomerNote(), orderID: sampleOrderID, siteID: sampleSiteID) {
             group.leave()
         }
 
         group.enter()
-        orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: sampleCustomerNoteMutated(), orderID: sampleOrderID) {
+        orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: sampleCustomerNoteMutated(), orderID: sampleOrderID, siteID: sampleSiteID) {
             group.leave()
         }
 
@@ -181,7 +181,7 @@ class OrderNoteStoreTests: XCTestCase {
         XCTAssertNil(viewStorage.loadAccount(userID: remoteOrderNote.noteID))
 
         let expectation = self.expectation(description: "Stored Order Note")
-        orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: remoteOrderNote, orderID: sampleOrderID) {
+        orderNoteStore.upsertStoredOrderNoteInBackground(readOnlyOrderNote: remoteOrderNote, orderID: sampleOrderID, siteID: sampleSiteID) {
             let storageOrderNote = self.viewStorage.loadOrderNote(noteID: remoteOrderNote.noteID)
             XCTAssertEqual(storageOrderNote?.toReadOnly(), remoteOrderNote)
             XCTAssertTrue(Thread.isMainThread)

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 /// OrderStore Unit Tests
 ///
-class OrderStoreTests: XCTestCase {
+final class OrderStoreTests: XCTestCase {
 
     /// Mockup Dispatcher!
     ///
@@ -201,7 +201,8 @@ class OrderStoreTests: XCTestCase {
                                               keyword: defaultSearchKeyword,
                                               pageNumber: defaultPageNumber,
                                               pageSize: defaultPageSize) { error in
-            let readOnlyOrder = self.viewStorage.loadOrder(orderID: expectedOrder.orderID)?.toReadOnly()
+                                                let readOnlyOrder = self.viewStorage.loadOrder(siteID: self.sampleSiteID,
+                                                                                               orderID: expectedOrder.orderID)?.toReadOnly()
             XCTAssertEqual(readOnlyOrder, expectedOrder)
             XCTAssertNil(error)
 
@@ -347,7 +348,7 @@ class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 1)
 
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrderMutated(), in: viewStorage)
-        let storageOrder1 = viewStorage.loadOrder(orderID: sampleOrderMutated().orderID)
+        let storageOrder1 = viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderMutated().orderID)
         XCTAssertEqual(storageOrder1?.toReadOnly(), sampleOrderMutated())
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 3)
@@ -355,7 +356,7 @@ class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 2)
 
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrderMutated2(), in: viewStorage)
-        let storageOrder2 = viewStorage.loadOrder(orderID: sampleOrderMutated2().orderID)
+        let storageOrder2 = viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderMutated2().orderID)
         XCTAssertEqual(storageOrder2?.toReadOnly(), sampleOrderMutated2())
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 1)
@@ -369,10 +370,10 @@ class OrderStoreTests: XCTestCase {
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let remoteOrder = sampleOrder()
 
-        XCTAssertNil(viewStorage.loadOrder(orderID: remoteOrder.orderID))
+        XCTAssertNil(viewStorage.loadOrder(siteID: sampleSiteID, orderID: remoteOrder.orderID))
         orderStore.upsertStoredOrder(readOnlyOrder: remoteOrder, in: viewStorage)
 
-        let storageOrder = viewStorage.loadOrder(orderID: remoteOrder.orderID)
+        let storageOrder = viewStorage.loadOrder(siteID: sampleSiteID, orderID: remoteOrder.orderID)
         XCTAssertEqual(storageOrder?.toReadOnly(), remoteOrder)
     }
 
@@ -388,7 +389,7 @@ class OrderStoreTests: XCTestCase {
 
         orderStore.upsertStoredOrder(readOnlyOrder: remoteOrder, insertingSearchResults: true, in: viewStorage)
 
-        let storageOrder = viewStorage.loadOrder(orderID: remoteOrder.orderID)
+        let storageOrder = viewStorage.loadOrder(siteID: sampleSiteID, orderID: remoteOrder.orderID)
         XCTAssert(storageOrder?.exclusiveForSearch == false)
     }
 
@@ -404,7 +405,7 @@ class OrderStoreTests: XCTestCase {
         orderStore.upsertStoredOrder(readOnlyOrder: remoteOrder, insertingSearchResults: true, in: viewStorage)
         viewStorage.saveIfNeeded()
 
-        let storageOrder = viewStorage.loadOrder(orderID: remoteOrder.orderID)
+        let storageOrder = viewStorage.loadOrder(siteID: sampleSiteID, orderID: remoteOrder.orderID)
         XCTAssert(storageOrder?.exclusiveForSearch == true)
     }
 
@@ -420,7 +421,7 @@ class OrderStoreTests: XCTestCase {
         orderStore.upsertStoredOrder(readOnlyOrder: remoteOrder, insertingSearchResults: false, in: viewStorage)
         viewStorage.saveIfNeeded()
 
-        let storageOrder = viewStorage.loadOrder(orderID: remoteOrder.orderID)
+        let storageOrder = viewStorage.loadOrder(siteID: sampleSiteID, orderID: remoteOrder.orderID)
         XCTAssert(storageOrder?.exclusiveForSearch == false)
     }
 
@@ -437,7 +438,7 @@ class OrderStoreTests: XCTestCase {
         orderStore.upsertStoredResults(keyword: defaultSearchKeyword, readOnlyOrder: remoteOrder, in: viewStorage)
 
         let storageSearchResults = viewStorage.loadOrderSearchResults(keyword: defaultSearchKeyword)
-        let storageOrder = viewStorage.loadOrder(orderID: remoteOrder.orderID)
+        let storageOrder = viewStorage.loadOrder(siteID: sampleSiteID, orderID: remoteOrder.orderID)
 
         XCTAssertEqual(storageSearchResults?.keyword, defaultSearchKeyword)
         XCTAssertEqual(storageSearchResults?.orders?.count, 1)
@@ -524,7 +525,7 @@ class OrderStoreTests: XCTestCase {
         let action = OrderAction.updateOrder(siteID: sampleSiteID, orderID: sampleOrderID, status: OrderStatusEnum.processing) { error in
             XCTAssertNil(error)
 
-            let storageOrder = self.storageManager.viewStorage.loadOrder(orderID: self.sampleOrderID)
+            let storageOrder = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)
             XCTAssert(storageOrder?.statusKey == OrderStatusEnum.processing.rawValue)
 
             expectation.fulfill()
@@ -548,7 +549,7 @@ class OrderStoreTests: XCTestCase {
         let action = OrderAction.updateOrder(siteID: sampleSiteID, orderID: sampleOrderID, status: OrderStatusEnum.processing) { error in
             XCTAssertNotNil(error)
 
-            let storageOrder = self.storageManager.viewStorage.loadOrder(orderID: self.sampleOrderID)
+            let storageOrder = self.storageManager.viewStorage.loadOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID)
             XCTAssert(storageOrder?.statusKey == OrderStatusEnum.completed.rawValue)
 
             expectation.fulfill()


### PR DESCRIPTION
Fixes #279

There are not many details in the issue description #279, so I referred to a previous PR that linked to the issue https://github.com/woocommerce/woocommerce-ios/pull/831.

## Changes

- In `StorageType` extensions, added site ID to the lookup functions for `Order`, `OrderCoupon`, `OrderRefundCondensed`, and `ShippingLine`
- Updated its usage in `OrdersUpsertUseCase`
- Updated unit tests, and added a test case `test_it_persists_order_relationships_in_storage`
- Fixed a build warning from `develop`: https://github.com/woocommerce/woocommerce-ios/commit/104bd005387854592534b50980e7da75d38760ed

## Testing

Please do a confidence check on the Orders tab - especially refunded orders, order's shipping info, and orders with at least a coupon!

Here are screenshots of an order with coupon, and an order with refund info and shipping info:

order with a coupon | order with refund and shipping info
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-09-29 at 22 18 56](https://user-images.githubusercontent.com/1945542/94571320-6fe26e80-02a2-11eb-9ae8-2df383910a8c.png) | ![Simulator Screen Shot - iPhone 11 - 2020-09-29 at 22 19 22](https://user-images.githubusercontent.com/1945542/94571337-753fb900-02a2-11eb-8cdc-43d9449d1ec4.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
