### PR TITLE
[Issue Refunds] Products refunds cell

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -50,6 +50,19 @@ private extension RefundProductsTotalTableViewCell {
         productsRefundTitleLabel.font = .font(forStyle: .body, weight: .bold)
         productsRefundPriceLabel.applyBodyStyle()
         productsRefundPriceLabel.font = .font(forStyle: .body, weight: .bold)
+
+        taxTitleLabel.text = Localization.taxTitle
+        subtotalTitleLabel.text = Localization.subtotalTitle
+        productsRefundPriceLabel.text = Localization.totalTitle
+    }
+}
+
+// MARK: Constants
+private extension RefundProductsTotalTableViewCell {
+    enum Localization {
+        static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that lists the shipping tax cost")
+        static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that lists the shipping subtotal cost")
+        static let totalTitle = NSLocalizedString("Products Refund", comment: "Title on the refund screen that lists the shipping total cost")
     }
 }
 
@@ -93,7 +106,7 @@ struct RefundProductsTotalTableViewCell_Previews: PreviewProvider {
                 .previewDisplayName("Dark")
 
             makeStack()
-                .previewLayout(.fixed(width: 359, height: 180))
+                .previewLayout(.fixed(width: 359, height: 150))
                 .environment(\.sizeCategory, .accessibilityMedium)
                 .previewDisplayName("Large Font")
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+/// `TableViewCell` that displays the products amount to be refunded
+///
+final class RefundProductsTotalTableViewCell: UITableViewCell {
+
+    override class func awakeFromNib() {
+        super.awakeFromNib()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -53,7 +53,7 @@ private extension RefundProductsTotalTableViewCell {
 
         taxTitleLabel.text = Localization.taxTitle
         subtotalTitleLabel.text = Localization.subtotalTitle
-        productsRefundPriceLabel.text = Localization.totalTitle
+        productsRefundTitleLabel.text = Localization.totalTitle
     }
 }
 
@@ -72,9 +72,9 @@ extension RefundProductsTotalTableViewCell {
 // MARK: Constants
 private extension RefundProductsTotalTableViewCell {
     enum Localization {
-        static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that lists the shipping tax cost")
-        static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that lists the shipping subtotal cost")
-        static let totalTitle = NSLocalizedString("Products Refund", comment: "Title on the refund screen that lists the shipping total cost")
+        static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that lists the products refund tax cost")
+        static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that lists the products refund subtotal cost")
+        static let totalTitle = NSLocalizedString("Products Refund", comment: "Title on the refund screen that lists the products refudn total cost")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -4,6 +4,30 @@ import UIKit
 ///
 final class RefundProductsTotalTableViewCell: UITableViewCell {
 
+    /// Displays `Subtotal` title
+    ///
+    @IBOutlet private var subtotalTitleLabel: UILabel!
+
+    /// Displays the subtotal value
+    ///
+    @IBOutlet private var subtotalPriceLabel: UILabel!
+
+    /// Displays `Tax` title
+    ///
+    @IBOutlet private var taxTitleLabel: UILabel!
+
+    /// Displays the tax value
+    ///
+    @IBOutlet private var taxPriceLabel: UILabel!
+
+    /// Displays `Products Refund` title
+    ///
+    @IBOutlet private var productsRefundTitleLabel: UILabel!
+
+    /// Displays the total products costs to be refunded
+    ///
+    @IBOutlet private var productsRefundPriceLabel: UILabel!
+
     override class func awakeFromNib() {
         super.awakeFromNib()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -32,3 +32,52 @@ final class RefundProductsTotalTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
 }
+
+// MARK: - Previews
+#if canImport(SwiftUI) && DEBUG
+
+import SwiftUI
+
+private struct RefundProductsTotalTableViewCellRepresentable: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let nib = UINib(nibName: "RefundProductsTotalTableViewCell", bundle: nil)
+        guard let cell = nib.instantiate(withOwner: self, options: nil).first as? RefundProductsTotalTableViewCell else {
+            fatalError("Could not create RefundProductsTotalTableViewCell")
+        }
+        return cell
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        // no op
+    }
+}
+
+@available(iOS 13.0, *)
+struct RefundProductsTotalTableViewCell_Previews: PreviewProvider {
+
+    private static func makeStack() -> some View {
+        VStack {
+            RefundProductsTotalTableViewCellRepresentable()
+        }
+    }
+
+    static var previews: some View {
+        Group {
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 128))
+                .previewDisplayName("Light")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 128))
+                .environment(\.colorScheme, .dark)
+                .previewDisplayName("Dark")
+
+            makeStack()
+                .previewLayout(.fixed(width: 359, height: 200))
+                .environment(\.sizeCategory, .accessibilityMedium)
+                .previewDisplayName("Large Font")
+        }
+    }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -74,7 +74,7 @@ private extension RefundProductsTotalTableViewCell {
     enum Localization {
         static let taxTitle = NSLocalizedString("Tax", comment: "Title on the refunds screen that lists the products refund tax cost")
         static let subtotalTitle = NSLocalizedString("Subtotal", comment: "Title on the refund screen that lists the products refund subtotal cost")
-        static let totalTitle = NSLocalizedString("Products Refund", comment: "Title on the refund screen that lists the products refudn total cost")
+        static let totalTitle = NSLocalizedString("Products Refund", comment: "Title on the refund screen that lists the products refund total cost")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -57,6 +57,18 @@ private extension RefundProductsTotalTableViewCell {
     }
 }
 
+// MARK: ViewModel Rendering
+extension RefundProductsTotalTableViewCell {
+
+    /// Configure cell with the provided view model
+    ///
+    func configure(with viewModel: RefundProductsTotalViewModel) {
+        taxPriceLabel.text = viewModel.productsTax
+        subtotalPriceLabel.text = viewModel.productsSubtotal
+        productsRefundPriceLabel.text = viewModel.productsTotal
+    }
+}
+
 // MARK: Constants
 private extension RefundProductsTotalTableViewCell {
     enum Localization {
@@ -77,6 +89,9 @@ private struct RefundProductsTotalTableViewCellRepresentable: UIViewRepresentabl
         guard let cell = nib.instantiate(withOwner: self, options: nil).first as? RefundProductsTotalTableViewCell else {
             fatalError("Could not create RefundProductsTotalTableViewCell")
         }
+
+        let viewModel = RefundProductsTotalViewModel(productsTax: "$2.50", productsSubtotal: "$12.30", productsTotal: "$14.80")
+        cell.configure(with: viewModel)
         return cell
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -28,8 +28,28 @@ final class RefundProductsTotalTableViewCell: UITableViewCell {
     ///
     @IBOutlet private var productsRefundPriceLabel: UILabel!
 
-    override class func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
+        applyCellStyles()
+    }
+}
+
+// MARK: View Styles Configuration
+private extension RefundProductsTotalTableViewCell {
+    func applyCellStyles() {
+        applyDefaultBackgroundStyle()
+        applyLabelsStyles()
+    }
+
+    func applyLabelsStyles() {
+        subtotalTitleLabel.applyBodyStyle()
+        subtotalPriceLabel.applyBodyStyle()
+        taxTitleLabel.applyBodyStyle()
+        taxPriceLabel.applyBodyStyle()
+        productsRefundTitleLabel.applyBodyStyle()
+        productsRefundTitleLabel.font = .font(forStyle: .body, weight: .bold)
+        productsRefundPriceLabel.applyBodyStyle()
+        productsRefundPriceLabel.font = .font(forStyle: .body, weight: .bold)
     }
 }
 
@@ -73,7 +93,7 @@ struct RefundProductsTotalTableViewCell_Previews: PreviewProvider {
                 .previewDisplayName("Dark")
 
             makeStack()
-                .previewLayout(.fixed(width: 359, height: 200))
+                .previewLayout(.fixed(width: 359, height: 180))
                 .environment(\.sizeCategory, .accessibilityMedium)
                 .previewDisplayName("Large Font")
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.xib
@@ -4,19 +4,107 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="129" id="IYL-0L-bWR" customClass="RefundProductsTotalTableViewCell" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="129"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="117" id="Vz0-ss-WsR" customClass="RefundProductsTotalTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="125"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IYL-0L-bWR" id="W50-0W-6vJ">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="129"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Vz0-ss-WsR" id="gXm-6C-hxr">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="125"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="FaN-z6-unF">
+                        <rect key="frame" x="16" y="0.0" width="398" height="125"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="0sF-zp-IWD">
+                                <rect key="frame" x="0.0" y="0.0" width="398" height="72"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Lgn-wd-mXO">
+                                        <rect key="frame" x="0.0" y="16" width="382" height="15.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FyN-Fk-Ssc">
+                                                <rect key="frame" x="0.0" y="0.0" width="336" height="15.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WsN-zY-tB7">
+                                                <rect key="frame" x="340" y="0.0" width="42" height="15.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="I9r-UV-Uri">
+                                        <rect key="frame" x="0.0" y="35.5" width="382" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uIc-BF-raq">
+                                                <rect key="frame" x="0.0" y="0.0" width="336" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B2g-kz-Ibc">
+                                                <rect key="frame" x="340" y="0.0" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <directionalEdgeInsets key="directionalLayoutMargins" top="16" leading="0.0" bottom="16" trailing="16"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rX8-gX-awI">
+                                <rect key="frame" x="0.0" y="72" width="398" height="0.5"/>
+                                <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="0.5" id="bYG-dz-5ng"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="m8n-Ik-OIx">
+                                <rect key="frame" x="0.0" y="72.5" width="398" height="52.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-vV-2rs">
+                                        <rect key="frame" x="0.0" y="16" width="336" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hXJ-xj-1dI">
+                                        <rect key="frame" x="340" y="16" width="42" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <directionalEdgeInsets key="directionalLayoutMargins" top="16" leading="0.0" bottom="16" trailing="16"/>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="jan-6k-nbp"/>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="FaN-z6-unF" firstAttribute="leading" secondItem="gXm-6C-hxr" secondAttribute="leading" constant="16" id="IuI-Ry-vR5"/>
+                    <constraint firstItem="FaN-z6-unF" firstAttribute="top" secondItem="gXm-6C-hxr" secondAttribute="top" id="QRU-eF-FGi"/>
+                    <constraint firstAttribute="trailing" secondItem="FaN-z6-unF" secondAttribute="trailing" id="TIB-c5-wkg"/>
+                    <constraint firstAttribute="bottom" secondItem="FaN-z6-unF" secondAttribute="bottom" id="jyk-C2-8rB"/>
+                </constraints>
             </tableViewCellContentView>
-            <point key="canvasLocation" x="137.68115942028987" y="181.13839285714286"/>
+            <connections>
+                <outlet property="productsRefundPriceLabel" destination="hXJ-xj-1dI" id="wpd-Tn-LZn"/>
+                <outlet property="productsRefundTitleLabel" destination="7dg-vV-2rs" id="2e6-8v-TO2"/>
+                <outlet property="subtotalPriceLabel" destination="WsN-zY-tB7" id="Fh1-qs-ojt"/>
+                <outlet property="subtotalTitleLabel" destination="FyN-Fk-Ssc" id="OW4-gl-Nb0"/>
+                <outlet property="taxPriceLabel" destination="B2g-kz-Ibc" id="Zau-lE-sYu"/>
+                <outlet property="taxTitleLabel" destination="uIc-BF-raq" id="6n0-hw-W41"/>
+            </connections>
+            <point key="canvasLocation" x="40.579710144927539" y="93.415178571428569"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.xib
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="129" id="IYL-0L-bWR" customClass="RefundProductsTotalTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="129"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IYL-0L-bWR" id="W50-0W-6vJ">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="129"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <point key="canvasLocation" x="137.68115942028987" y="181.13839285714286"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalViewModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Represents products cost details for an order to be refunded. Meant to be rendered by `RefundProductsTotalTableViewCell`
+///
+struct RefundProductsTotalViewModel {
+    let productsTax: String
+    let productsSubtotal: String
+    let productsTotal: String
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		02FE89C9231FB31400E85EF8 /* FeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C8231FB31400E85EF8 /* FeatureFlagService.swift */; };
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
+		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */; };
@@ -1289,6 +1290,7 @@
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
@@ -2775,6 +2777,7 @@
 				26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */,
 				26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */,
 				26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */,
+				260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */,
 				26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */,
 				26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */,
 			);
@@ -5192,6 +5195,7 @@
 				B5AA7B3F20ED81C2004DA14F /* UserDefaults+Woo.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
+				260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */,
 				0286B27D23C7051F003D784B /* ProductImagesViewController.swift in Sources */,
 				D8149F532251CFE60006A245 /* EditableOrderTrackingTableViewCell.swift in Sources */,
 				024DF30B23742297006658FE /* AztecFormatBarCommand.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -336,6 +336,8 @@
 		26B119C024D0C69500FED5C7 /* SurveyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */; };
 		26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */; };
 		26B3D8A0252235C50054C319 /* RefundShippingDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */; };
+		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
+		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26E1BECA251BE5390096D0A1 /* RefundItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */; };
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
@@ -1310,6 +1312,8 @@
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
 		26B119C124D1CD3500FED5C7 /* WooConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooConstantsTests.swift; sourceTree = "<group>"; };
 		26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModel.swift; sourceTree = "<group>"; };
+		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
+		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BEC9251BE5390096D0A1 /* RefundItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemTableViewCell.swift; sourceTree = "<group>"; };
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
@@ -2771,6 +2775,8 @@
 				26B3D89F252235C50054C319 /* RefundShippingDetailsViewModel.swift */,
 				26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */,
 				26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */,
+				26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */,
+				26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -4880,6 +4886,7 @@
 				0286B27C23C7051F003D784B /* ProductImagesViewController.xib in Resources */,
 				02F49ADE23BF3A4100FA0BFA /* ErrorSectionHeaderView.xib in Resources */,
 				B554016B2170D6010067DC90 /* ChartPlaceholderView.xib in Resources */,
+				26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */,
 				CE32B11620BF8779006FBCF4 /* FulfillButtonTableViewCell.xib in Resources */,
 				45C8B2672316AB460002FA77 /* BillingAddressTableViewCell.xib in Resources */,
 				B557652D20F6827900185843 /* StoreTableViewCell.xib in Resources */,
@@ -5540,6 +5547,7 @@
 				CEEC9B5E21E79C330055EEF0 /* BuildConfiguration.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				02ADC7CC239762E0008D4BED /* PaginatedListSelectorViewProperties.swift in Sources */,
+				26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */,
 				CE1CCB4B20570B1F000EE3AC /* OrderTableViewCell.swift in Sources */,
 				748AD087219F481B00023535 /* UIView+Animation.swift in Sources */,
 				02564A8A246CDF6100D6DB2A /* ProductsTopBannerFactory.swift in Sources */,


### PR DESCRIPTION
closes #2767 

# Why 

End goal is to build the refunds UI, this PR focus on building the products refund costs detail cell(the blue rectangle).
<img width="402" alt="Screen Shot 2020-09-29 at 3 36 53 PM" src="https://user-images.githubusercontent.com/562080/94613134-b5367a00-0269-11eb-90f0-a3213bbb722e.png">

# How
- Created `RefundProductsTotalTableViewCell` which it's backed up by it's xib
- Created `RefundProductsTotalViewModel` to help to decouple the rendering content duties.

# Screenshots
 Regular |  Large
---- | ----
<img width="398" alt="regular" src="https://user-images.githubusercontent.com/562080/94612918-6852a380-0269-11eb-8d73-0fe95eff0ded.png"> | <img width="391" alt="large" src="https://user-images.githubusercontent.com/562080/94612922-6983d080-0269-11eb-8b8a-caff6e3cbd80.png">


# Testing Steps
Nothing as this is not yet visible on any screen.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
