### PR TITLE
Configure the same user-agent header for all the network requests made through the app

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		453305ED2459E1AA00264E50 /* site-post.json in Resources */ = {isa = PBXBuildFile; fileRef = 453305EC2459E1AA00264E50 /* site-post.json */; };
 		453305EF2459E46100264E50 /* SitePostsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453305EE2459E46000264E50 /* SitePostsRemoteTests.swift */; };
 		453305F52459ED2700264E50 /* site-post-update.json in Resources */ = {isa = PBXBuildFile; fileRef = 453305F42459ED2700264E50 /* site-post-update.json */; };
+		45551F122523E7F1007EF104 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45551F112523E7F1007EF104 /* UserAgent.swift */; };
+		45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45551F132523E7FF007EF104 /* UserAgentTests.swift */; };
 		4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4568E2212459ADC60007E478 /* SitePostsRemote.swift */; };
 		4568E2242459D3230007E478 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4568E2232459D3230007E478 /* Post.swift */; };
 		456F71D424CB1E2400472EC1 /* ProductTagFromBatchCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456F71D324CB1E2400472EC1 /* ProductTagFromBatchCreation.swift */; };
@@ -441,6 +443,8 @@
 		453305EC2459E1AA00264E50 /* site-post.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-post.json"; sourceTree = "<group>"; };
 		453305EE2459E46000264E50 /* SitePostsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostsRemoteTests.swift; sourceTree = "<group>"; };
 		453305F42459ED2700264E50 /* site-post-update.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-post-update.json"; sourceTree = "<group>"; };
+		45551F112523E7F1007EF104 /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
+		45551F132523E7FF007EF104 /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		4568E2212459ADC60007E478 /* SitePostsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePostsRemote.swift; sourceTree = "<group>"; };
 		4568E2232459D3230007E478 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		456F71D324CB1E2400472EC1 /* ProductTagFromBatchCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagFromBatchCreation.swift; sourceTree = "<group>"; };
@@ -892,6 +896,7 @@
 		B518663220A0A2E800037A38 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				45551F132523E7FF007EF104 /* UserAgentTests.swift */,
 				B518663320A0A2E800037A38 /* Constants.swift */,
 			);
 			path = Settings;
@@ -1019,6 +1024,7 @@
 			children = (
 				B557DA1720979D51005962F4 /* Credentials.swift */,
 				B557DA1920979D66005962F4 /* Settings.swift */,
+				45551F112523E7F1007EF104 /* UserAgent.swift */,
 				B557DA0A20975D7E005962F4 /* WooAPIVersion.swift */,
 				B557DA0C20975DB1005962F4 /* WordPressAPIVersion.swift */,
 			);
@@ -1759,6 +1765,7 @@
 				B572F69A21AC475C003EEFF0 /* DevicesRemote.swift in Sources */,
 				B518662420A099BF00037A38 /* AlamofireNetwork.swift in Sources */,
 				CE430676234BA7920073CBFF /* RefundListMapper.swift in Sources */,
+				45551F122523E7F1007EF104 /* UserAgent.swift in Sources */,
 				45CDAFAB2434CA9300F83C22 /* ProductCatalogVisibility.swift in Sources */,
 				B557DA1820979D51005962F4 /* Credentials.swift in Sources */,
 				CE583A0E2109154500D73C1C /* OrderNoteMapper.swift in Sources */,
@@ -1821,6 +1828,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */,
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,

--- a/Networking/Networking/Requests/AuthenticatedRequest.swift
+++ b/Networking/Networking/Requests/AuthenticatedRequest.swift
@@ -22,7 +22,7 @@ struct AuthenticatedRequest: URLRequestConvertible {
 
         authenticated.setValue("Bearer " + credentials.authToken, forHTTPHeaderField: "Authorization")
         authenticated.setValue("application/json", forHTTPHeaderField: "Accept")
-        authenticated.setValue(Settings.userAgent, forHTTPHeaderField: "User-Agent")
+        authenticated.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
         return authenticated
     }

--- a/Networking/Networking/Settings/Settings.swift
+++ b/Networking/Networking/Settings/Settings.swift
@@ -5,10 +5,6 @@ import Foundation
 ///
 public struct Settings {
 
-    /// UserAgent to be used for every Networking Request
-    ///
-    public static var userAgent = "WooCommerce iOS"
-
     /// WordPress.com API Base URL
     ///
     public static var wordpressApiBaseURL: String = {

--- a/Networking/Networking/Settings/UserAgent.swift
+++ b/Networking/Networking/Settings/UserAgent.swift
@@ -1,28 +1,25 @@
-import Foundation
-import UIKit
 import WebKit
-
 
 /// WooCommerce User Agent!
 ///
-class UserAgent {
+public class UserAgent {
 
     /// Private: NO-OP
     ///
     private init() { }
 
 
-    /// Returns the WooCommerce User Agent
+    /// Returns the default WooCommerce iOS User Agent
     ///
-    static var defaultUserAgent: String = {
+    public static var defaultUserAgent: String = {
         return webkitUserAgent + " " + Constants.woocommerceIdentifier + "/" + bundleShortVersion
     }()
 
     /// Returns the WebKit User Agent
     ///
-    static var webkitUserAgent: String {
+    public static var webkitUserAgent: String {
         guard let userAgent = WKWebView().value(forKey: Constants.userAgentKey) as? String,
-            userAgent.isNotEmpty else {
+            !userAgent.isEmpty else {
                 return ""
         }
         return userAgent
@@ -30,7 +27,7 @@ class UserAgent {
 
     /// Returns the Bundle Version ID
     ///
-    static var bundleShortVersion: String {
+    public static var bundleShortVersion: String {
         let version = Bundle.main.object(forInfoDictionaryKey: Constants.shortVersionKey) as? String
         return version ?? String()
     }

--- a/Networking/Networking/Settings/UserAgent.swift
+++ b/Networking/Networking/Settings/UserAgent.swift
@@ -12,7 +12,7 @@ public class UserAgent {
 
     /// Returns the WebKit User Agent
     ///
-    public static var webkitUserAgent: String {
+    static var webkitUserAgent: String {
         guard let userAgent = WKWebView().value(forKey: Constants.userAgentKey) as? String,
             !userAgent.isEmpty else {
                 return ""

--- a/Networking/Networking/Settings/UserAgent.swift
+++ b/Networking/Networking/Settings/UserAgent.swift
@@ -4,11 +4,6 @@ import WebKit
 ///
 public class UserAgent {
 
-    /// Private: NO-OP
-    ///
-    private init() { }
-
-
     /// Returns the default WooCommerce iOS User Agent
     ///
     public static var defaultUserAgent: String = {

--- a/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
+++ b/Networking/NetworkingTests/Requests/AuthenticatedRequestTests.swift
@@ -36,6 +36,6 @@ class AuthenticatedRequestTests: XCTestCase {
         let output = try! authenticated.asURLRequest()
 
         let generated = output.allHTTPHeaderFields?["User-Agent"]
-        XCTAssertEqual(generated, Settings.userAgent)
+        XCTAssertEqual(generated, UserAgent.defaultUserAgent)
     }
 }

--- a/Networking/NetworkingTests/Settings/UserAgentTests.swift
+++ b/Networking/NetworkingTests/Settings/UserAgentTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import WooCommerce
+@testable import Networking
 
 /// UserAgent Unit Tests
 ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,9 @@
 - [*] Enhancement: for variable products, the stock status is now shown in its variation list.
 - [*] Sign In With Apple: if the Apple ID has been disconnected from the WordPress app (e.g. in Settings > Apple ID > Password & Security > Apps using Apple ID), the app is logged out on app launch or app switch.
 - [internal] #2881 Upgraded WPAuth from 1.24 to 1.26-beta.12. Regressions may happen in login flows.
- 
+- [internal] #2896 Configured the same user agent header for all the network requests made through the app.
+
+
 5.1
 -----
 - [*] bugfix: now reviews are refreshed correctly. If you try to delete or to set as spam a review from the web, the result will match in the product reviews list.

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CoreData
 import Storage
+import class Networking.UserAgent
 
 import CocoaLumberjack
 import KeychainAccess

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import KeychainAccess
 import WordPressAuthenticator
 import Yosemite
+import class Networking.UserAgent
 import struct Networking.Settings
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/LicensesViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WebKit
 import SafariServices
-
+import class Networking.UserAgent
 
 class LicensesViewController: UIViewController {
 
@@ -56,6 +56,7 @@ private extension LicensesViewController {
         webView.navigationDelegate = self
         webView.backgroundColor = .clear
         webView.isOpaque = false
+        webView.customUserAgent = UserAgent.defaultUserAgent
         webView.loadFileURL(licenseURL, allowingReadAccessTo: licenseURL)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WebKit
+import class Networking.UserAgent
 
 /// Outputs of the the SurveyViewController
 ///
@@ -51,6 +52,7 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
         title = survey.title
 
         let request = URLRequest(url: survey.url)
+        webView.customUserAgent = UserAgent.defaultUserAgent
         webView.load(request)
         webView.navigationDelegate = self
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -400,7 +400,6 @@
 		45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4221924ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift */; };
 		45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */; };
 		45AE150324A23F03005AA948 /* ProductParentCategoriesViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */; };
-		45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */; };
 		45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */; };
 		45AE582D230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */; };
 		45B9C63E23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */; };
@@ -589,7 +588,6 @@
 		B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55BC1F221A8790F0011A0C0 /* StringHTMLTests.swift */; };
 		B55D4BFD20B5CDE700D7A50F /* replace_secrets.rb in Resources */ = {isa = PBXBuildFile; fileRef = B55D4BFB20B5CDE600D7A50F /* replace_secrets.rb */; };
 		B55D4C0620B6027200D7A50F /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55D4C0520B6027100D7A50F /* AuthenticationManager.swift */; };
-		B55D4C2720B717C000D7A50F /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55D4C2620B717C000D7A50F /* UserAgent.swift */; };
 		B560D68A2195BD100027BB7E /* NoteDetailsCommentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B560D6892195BD100027BB7E /* NoteDetailsCommentTableViewCell.xib */; };
 		B560D68C2195BD1E0027BB7E /* NoteDetailsCommentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B560D68B2195BD1D0027BB7E /* NoteDetailsCommentTableViewCell.swift */; };
 		B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56BBD15214820A70053A32D /* SyncCoordinatorTests.swift */; };
@@ -1376,7 +1374,6 @@
 		45A4221924ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreNoticePresenter.swift; sourceTree = "<group>"; };
 		45AE150024A23F03005AA948 /* ProductParentCategoriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductParentCategoriesViewController.swift; sourceTree = "<group>"; };
 		45AE150124A23F03005AA948 /* ProductParentCategoriesViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductParentCategoriesViewController.xib; sourceTree = "<group>"; };
-		45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
 		45AE582A230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		45AE582B230D9D35001901E3 /* OrderNoteHeaderTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderNoteHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		45B9C63C23A8E50D007FC4C5 /* ProductPriceSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewController.swift; sourceTree = "<group>"; };
@@ -1573,7 +1570,6 @@
 		B55D4BFB20B5CDE600D7A50F /* replace_secrets.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = replace_secrets.rb; sourceTree = "<group>"; };
 		B55D4C0520B6027100D7A50F /* AuthenticationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
 		B55D4C1920B6193000D7A50F /* InfoPlist.tpl */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; path = InfoPlist.tpl; sourceTree = "<group>"; };
-		B55D4C2620B717C000D7A50F /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		B560D6892195BD100027BB7E /* NoteDetailsCommentTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NoteDetailsCommentTableViewCell.xib; sourceTree = "<group>"; };
 		B560D68B2195BD1D0027BB7E /* NoteDetailsCommentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailsCommentTableViewCell.swift; sourceTree = "<group>"; };
 		B56BBD15214820A70053A32D /* SyncCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -3343,7 +3339,6 @@
 				B517EA19218B2D2600730EC4 /* StringFormatterTests.swift */,
 				B56BBD15214820A70053A32D /* SyncCoordinatorTests.swift */,
 				D83A6A7923792B2400419D48 /* UIColor+Muriel-Tests.swift */,
-				45AE1B9B2417C10C00A9E8BD /* UserAgentTests.swift */,
 				CE50345621B1F26C007573C6 /* ZendeskManagerTests.swift */,
 			);
 			path = Tools;
@@ -3430,7 +3425,6 @@
 				74B5713521CD7604008F9B8E /* SharingHelper.swift */,
 				D8C62470227AE0030011A7D6 /* SiteCountry.swift */,
 				B5D6DC53214802740003E48A /* SyncCoordinator.swift */,
-				B55D4C2620B717C000D7A50F /* UserAgent.swift */,
 				CE22709E2293052700C0626C /* WebviewHelper.swift */,
 				45D685FD23D0FB25005F87D0 /* Throttler.swift */,
 			);
@@ -5193,7 +5187,6 @@
 				740987B321B87760000E4C80 /* FancyAnimatedButton+Woo.swift in Sources */,
 				B511ED27218A660E005787DC /* StringDescriptor.swift in Sources */,
 				B5F355EF21CD500200A7077A /* SearchViewController.swift in Sources */,
-				B55D4C2720B717C000D7A50F /* UserAgent.swift in Sources */,
 				0273708024C0094500167204 /* ProductListMultiSelectorDataSource.swift in Sources */,
 				02B1AFEC24BC5AE5005DB1E3 /* GroupedProductListSelectorDataSource.swift in Sources */,
 				451A04EC2386D2B300E368C9 /* ProductImagesCollectionViewDataSource.swift in Sources */,
@@ -5671,7 +5664,6 @@
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
-				45AE1B9C2417C10C00A9E8BD /* UserAgentTests.swift in Sources */,
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
 				5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */,


### PR DESCRIPTION
Fixes #2895 

## Description
As discussed here pau2Xa-1OO and here C6H8C3G23/p1601048110035500 I aligned all the user agents sent through the app to be a combination of `webkitUserAgent + "wc-ios" + bundle short version`.

## Changes
- Moved the class `UserAgent` under Networking.
- Moved the class `UserAgentTests` under Networking.
- The `userAgent` variable was removed from `Settings`.
- In all the `WKWebView` (the one in Licenses and the one in Surveys) now we pass the new user agent.

## Testing
Just CI and a confidence check: login, API requests and `WKWebView's should continue to work as before.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
