### PR TITLE
Opening of the Product Detail in read-only mode if it will be opened from an Order Detail

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,10 @@
 -----
 - [*] Enhancement: for variable products, the stock status is now shown in its variation list.
 - [*] Sign In With Apple: if the Apple ID has been disconnected from the WordPress app (e.g. in Settings > Apple ID > Password & Security > Apps using Apple ID), the app is logged out on app launch or app switch.
+- [*] Now from an Order Detail it's only possible to open a Product in read-only mode.
 - [internal] #2881 Upgraded WPAuth from 1.24 to 1.26-beta.12. Regressions may happen in login flows.
- 
+
+
 5.1
 -----
 - [*] bugfix: now reviews are refreshed correctly. If you try to delete or to set as spam a review from the web, the result will match in the product reviews list.

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -213,14 +213,16 @@ extension OrderDetailsViewModel {
         case .orderItem:
             let item = items[indexPath.row]
             let loaderViewController = ProductLoaderViewController(productID: item.productOrVariationID,
-                                                                   siteID: order.siteID)
+                                                                   siteID: order.siteID,
+                                                                   forceReadOnly: true)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .aggregateOrderItem:
             let item = dataSource.aggregateOrderItems[indexPath.row]
             let productID = item.variationID == 0 ? item.productID : item.variationID
             let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: order.siteID)
+                                                                   siteID: order.siteID,
+                                                                   forceReadOnly: true)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
         case .billingDetail:

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsViewModel.swift
@@ -136,7 +136,8 @@ extension RefundDetailsViewModel {
             let item = refund.items[indexPath.row]
             let productID = item.variationID == 0 ? item.productID : item.variationID
             let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                                   siteID: refund.siteID)
+                                                                   siteID: refund.siteID,
+                                                                   forceReadOnly: true)
             let navController = WooNavigationController(rootViewController: loaderViewController)
             viewController.present(navController, animated: true, completion: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -254,7 +254,8 @@ private extension TopPerformerDataViewController {
     ///
     func presentProductDetails(for productID: Int64, siteID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                               siteID: siteID)
+                                                               siteID: siteID,
+                                                               forceReadOnly: false)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -266,7 +266,8 @@ private extension FulfillViewController {
     ///
     func productWasPressed(for productID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                               siteID: order.siteID)
+                                                               siteID: order.siteID,
+                                                               forceReadOnly: true)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -126,7 +126,8 @@ private extension ProductListViewController {
     ///
     func productWasPressed(for productID: Int64) {
         let loaderViewController = ProductLoaderViewController(productID: productID,
-                                                               siteID: viewModel.order.siteID)
+                                                               siteID: viewModel.order.siteID,
+                                                               forceReadOnly: false)
         let navController = WooNavigationController(rootViewController: loaderViewController)
         present(navController, animated: true, completion: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -8,11 +8,13 @@ struct ProductDetailsFactory {
     ///   - presentationStyle: how the product details are presented.
     ///   - currencySettings: site currency settings.
     ///   - stores: where the Products feature switch value can be read.
+    ///   - forceReadOnly: force the product detail to be presented in read only mode
     ///   - onCompletion: called when the view controller is created and ready for display.
     static func productDetails(product: Product,
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings = ServiceLocator.currencySettings,
                                stores: StoresManager = ServiceLocator.stores,
+                               forceReadOnly: Bool,
                                onCompletion: @escaping (UIViewController) -> Void) {
         let action = AppSettingsAction.loadProductsFeatureSwitch { isFeatureSwitchOn in
             let isEditProductsEnabled: Bool
@@ -26,7 +28,7 @@ struct ProductDetailsFactory {
             let vc = productDetails(product: product,
                                     presentationStyle: presentationStyle,
                                     currencySettings: currencySettings,
-                                    isEditProductsEnabled: isEditProductsEnabled,
+                                    isEditProductsEnabled: forceReadOnly ? false : isEditProductsEnabled,
                                     isEditProductsRelease3Enabled: isFeatureSwitchOn)
             onCompletion(vc)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -20,6 +20,10 @@ final class ProductLoaderViewController: UIViewController {
     ///
     private let siteID: Int64
 
+    /// Force the product detail to be presented in read only mode
+    ///
+    private let forceReadOnly: Bool
+
     /// UI Active State
     ///
     private var state: State = .loading {
@@ -31,9 +35,10 @@ final class ProductLoaderViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(productID: Int64, siteID: Int64) {
+    init(productID: Int64, siteID: Int64, forceReadOnly: Bool) {
         self.productID = productID
         self.siteID = siteID
+        self.forceReadOnly = forceReadOnly
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -152,7 +157,9 @@ private extension ProductLoaderViewController {
     /// Presents the ProductDetailsViewController or the ProductFormViewController, as a childViewController, for a given Product.
     ///
     func presentProductDetails(for product: Product) {
-        ProductDetailsFactory.productDetails(product: product, presentationStyle: .contained(containerViewController: self)) { [weak self] viewController in
+        ProductDetailsFactory.productDetails(product: product,
+                                             presentationStyle: .contained(containerViewController: self),
+                                             forceReadOnly: forceReadOnly) { [weak self] viewController in
             self?.attachProductDetailsChildViewController(viewController)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -542,7 +542,7 @@ extension ProductsViewController: UITableViewDelegate {
 
 private extension ProductsViewController {
     func didSelectProduct(product: Product) {
-        ProductDetailsFactory.productDetails(product: product, presentationStyle: .navigationStack) { [weak self] viewController in
+        ProductDetailsFactory.productDetails(product: product, presentationStyle: .navigationStack, forceReadOnly: false) { [weak self] viewController in
             self?.navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -67,7 +67,7 @@ final class ProductSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Product, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        ProductDetailsFactory.productDetails(product: model, presentationStyle: .navigationStack) { [weak viewController] vc in
+        ProductDetailsFactory.productDetails(product: model, presentationStyle: .navigationStack, forceReadOnly: false) { [weak viewController] vc in
             viewController?.navigationController?.pushViewController(vc, animated: true)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductDetailsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductDetailsFactoryTests.swift
@@ -14,7 +14,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
                                                 expectation.fulfill()
@@ -32,7 +33,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
                                                 expectation.fulfill()
@@ -52,7 +54,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
                                                 expectation.fulfill()
@@ -69,7 +72,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductDetailsViewController)
                                                 expectation.fulfill()
@@ -88,7 +92,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
                                                 expectation.fulfill()
@@ -105,7 +110,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductDetailsViewController)
                                                 expectation.fulfill()
@@ -124,7 +130,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
                                                 expectation.fulfill()
@@ -141,7 +148,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         // Action
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             stores: mockStoresManager) { viewController in
+                                             stores: mockStoresManager,
+                                             forceReadOnly: false) { viewController in
                                                 // Assert
                                                 XCTAssertTrue(viewController is ProductDetailsViewController)
                                                 expectation.fulfill()
@@ -160,7 +168,8 @@ final class ProductDetailsFactoryTests: XCTestCase {
         waitForExpectation { expectation in
             ProductDetailsFactory.productDetails(product: product,
                                                  presentationStyle: .navigationStack,
-                                                 stores: mockStoresManager) { viewController in
+                                                 stores: mockStoresManager,
+                                                 forceReadOnly: false) { viewController in
                                                     // Assert
                                                     XCTAssertTrue(viewController is ProductFormViewController<ProductFormViewModel>)
                                                     expectation.fulfill()
@@ -177,7 +186,26 @@ final class ProductDetailsFactoryTests: XCTestCase {
         waitForExpectation { expectation in
             ProductDetailsFactory.productDetails(product: product,
                                                  presentationStyle: .navigationStack,
-                                                 stores: mockStoresManager) { viewController in
+                                                 stores: mockStoresManager,
+                                                 forceReadOnly: false) { viewController in
+                                                    // Assert
+                                                    XCTAssertTrue(viewController is ProductDetailsViewController)
+                                                    expectation.fulfill()
+            }
+        }
+    }
+
+    func test_factory_creates_readonly_product_details_for_product_when_forceReadOnly_is_on() {
+        // Arrange
+        let mockStoresManager = MockProductsAppSettingsStoresManager(isProductsFeatureSwitchEnabled: false, sessionManager: SessionManager.testingInstance)
+        let product = MockProduct().product(productType: .simple)
+
+        // Action
+        waitForExpectation { expectation in
+            ProductDetailsFactory.productDetails(product: product,
+                                                 presentationStyle: .navigationStack,
+                                                 stores: mockStoresManager,
+                                                 forceReadOnly: true) { viewController in
                                                     // Assert
                                                     XCTAssertTrue(viewController is ProductDetailsViewController)
                                                     expectation.fulfill()


### PR DESCRIPTION
Fixes #2899 
Fixes #2894 

## Changes
- Added the parameter `forceReadOnly` in `ProductDetailsFactory` that forces the product detail to be presented in the read-only mode without taking care of other things (feature flags).
- Added the parameter `forceReadOnly` also in `ProductLoaderViewController`.
- Adapted the code where it was used `ProductDetailsFactory`.
- Updated tests.

## Testing
1. Navigate to an order detail from Order List or Order Search.
2. Open an Order Detail.
3. Tap one of the products.
4. Make sure that the Product Screen opened is read-only.

**Confidence check:** confirm that the other entry points from where it's possible to open a Product (Products tab and Top Performers Products in Dashboard) they work like before.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
