### PR TITLE
Adds type-safe TableView cell dequeue

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -551,19 +551,14 @@ extension StorePickerViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let site = state.site(at: indexPath) else {
             hideActionButton()
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: EmptyStoresTableViewCell.reuseIdentifier,
-                                                           for: indexPath) as? EmptyStoresTableViewCell else {
-                fatalError()
-            }
+            let cell = tableView.dequeueReusableCell(EmptyStoresTableViewCell.self, for: indexPath)
             cell.onJetpackSetupButtonTapped = { [weak self] in
                 let safariViewController = SFSafariViewController(url: WooConstants.URLs.emptyStoresJetpackSetup.asURL())
                 self?.present(safariViewController, animated: true, completion: nil)
             }
             return cell
         }
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: StoreTableViewCell.reuseIdentifier, for: indexPath) as? StoreTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(StoreTableViewCell.self, for: indexPath)
 
         cell.name = site.name
         cell.url = site.url

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -17,3 +17,19 @@ extension UITableView {
         return IndexPath(row: row, section: section)
     }
 }
+
+// MARK: Typesafe dequeue
+extension UITableView {
+
+    /// Dequeue a previously registered cell by it's class `reuseIdentifier` property.
+    /// Failing to dequeue the cell will throw a `fatalError`
+    ///
+    func dequeueReusableCell<T: UITableViewCell>(_ type: T.Type, for indexPath: IndexPath) -> T {
+        guard let cell = dequeueReusableCell(withIdentifier: T.reuseIdentifier, for: indexPath) as? T else {
+            let message = "Could not dequeue cell with identifier \(T.reuseIdentifier) at \(indexPath)"
+            DDLogError(message)
+            fatalError(message)
+        }
+        return cell
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -61,10 +61,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: rowType.reuseIdentifier,
-                                                       for: indexPath) as? Cell else {
-                                                        fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(Cell.self, for: indexPath)
         let model = command.data[indexPath.row]
         command.configureCell(cell: cell, model: model)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -212,11 +212,7 @@ extension TopPerformerDataViewController: UITableViewDataSource {
         guard let statsItem = statsItem(at: indexPath) else {
             return tableView.dequeueReusableCell(withIdentifier: NoPeriodDataTableViewCell.reuseIdentifier, for: indexPath)
         }
-
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? ProductTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(ProductTableViewCell.self, for: indexPath)
 
         cell.configure(statsItem, imageService: imageService)
         cell.hidesBottomBorder = tableView.lastIndexPathOfTheLastSection() == indexPath ? true : false

--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
@@ -88,10 +88,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: rowType.reuseIdentifier,
-                                                       for: indexPath) as? Cell else {
-                                                        fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(Cell.self, for: indexPath)
         let model = command.data[indexPath.row]
         // Configures the cell's `accessoryType` before calling `command.configureCell` so that the command could override the `accessoryType`.
         cell.accessoryType = command.isSelected(model: model) ? .checkmark: .none

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -175,10 +175,7 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: rowType.reuseIdentifier,
-                                                       for: indexPath) as? Cell else {
-                                                        fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(Cell.self, for: indexPath)
         let model = object(at: indexPath)
         dataSource.configureCell(cell: cell, model: model)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -235,10 +235,7 @@ extension OrderStatusListViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: StatusListTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? StatusListTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(StatusListTableViewCell.self, for: indexPath)
 
         let status = statusResultsController.object(at: indexPath)
         cell.textLabel?.text = status.name

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -73,10 +73,7 @@ extension ProductListViewController: UITableViewDataSource {
         let itemViewModel = ProductDetailsCellViewModel(item: item,
                                                         currency: viewModel.order.currency,
                                                         product: product)
-        let cellID = PickListTableViewCell.reuseIdentifier
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath) as? PickListTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(PickListTableViewCell.self, for: indexPath)
         cell.selectionStyle = .default
         cell.configure(item: itemViewModel, imageService: imageService)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -197,10 +197,7 @@ extension ShipmentProvidersViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: WooBasicTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? WooBasicTableViewCell else {
-                                                        fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(WooBasicTableViewCell.self, for: indexPath)
 
         cell.bodyLabel?.text = viewModel.titleForCellAt(indexPath)
         cell.applyListSelectorStyle()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -161,9 +161,7 @@ final class OrderListViewController: UIViewController {
     /// Returns a function that creates cells for `dataSource`.
     private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
         return { [weak self] tableView, indexPath, objectID in
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
-                fatalError("Failed to create cell \(OrderTableViewCell.reuseIdentifier)")
-            }
+            let cell = tableView.dequeueReusableCell(OrderTableViewCell.self, for: indexPath)
             guard let self = self else {
                 return cell
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -459,9 +459,7 @@ extension OrdersViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: OrderTableViewCell.reuseIdentifier, for: indexPath) as? OrderTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(OrderTableViewCell.self, for: indexPath)
 
         let detailsViewModel = viewModel.detailsViewModel(at: indexPath)
         let orderStatus = lookUpOrderStatus(for: detailsViewModel?.order)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -82,10 +82,7 @@ extension ProductParentCategoriesViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductCategoryTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? ProductCategoryTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(ProductCategoryTableViewCell.self, for: indexPath)
 
         if let categoryViewModel = categoryViewModels[safe: indexPath.row] {
             cell.configure(with: categoryViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -207,10 +207,7 @@ extension ProductCategoryListViewController: UITableViewDataSource, UITableViewD
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductCategoryTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? ProductCategoryTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(ProductCategoryTableViewCell.self, for: indexPath)
 
         if let categoryViewModel = viewModel.categoryViewModels[safe: indexPath.row] {
             cell.configure(with: categoryViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -114,9 +114,7 @@ extension ProductReviewsDataSource: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductReviewTableViewCell.reuseIdentifier) as? ProductReviewTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(ProductReviewTableViewCell.self, for: indexPath)
 
         configure(cell, at: indexPath)
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -491,10 +491,7 @@ extension ProductsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? ProductsTabProductTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(ProductsTabProductTableViewCell.self, for: indexPath)
 
         let product = resultsController.object(at: indexPath)
         let viewModel = ProductsTabProductViewModel(product: product)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -249,10 +249,7 @@ extension ProductVariationsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductsTabProductTableViewCell.reuseIdentifier,
-                                                       for: indexPath) as? ProductsTabProductTableViewCell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(ProductsTabProductTableViewCell.self, for: indexPath)
 
         let productVariation = resultsController.object(at: indexPath)
         let model = EditableProductVariationModel(productVariation: productVariation,

--- a/WooCommerce/Classes/ViewRelated/Reviews/DefaultReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/DefaultReviewsDataSource.swift
@@ -158,12 +158,8 @@ extension DefaultReviewsDataSource: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductReviewTableViewCell.reuseIdentifier) as? ProductReviewTableViewCell else {
-            fatalError()
-        }
-
+        let cell = tableView.dequeueReusableCell(ProductReviewTableViewCell.self, for: indexPath)
         configure(cell, at: indexPath)
-
         return cell
     }
 

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -62,11 +62,7 @@ extension OrderSearchStarterViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell =
-            tableView.dequeueReusableCell(withIdentifier: SettingTitleAndValueTableViewCell.reuseIdentifier,
-                                          for: indexPath) as? SettingTitleAndValueTableViewCell else {
-                                            fatalError("Unexpected or missing cell")
-        }
+        let cell = tableView.dequeueReusableCell(SettingTitleAndValueTableViewCell.self, for: indexPath)
 
         let cellViewModel = viewModel.cellViewModel(at: indexPath)
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -168,9 +168,7 @@ where Cell.SearchModel == Command.CellViewModel {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: Cell.reuseIdentifier, for: indexPath) as? Cell else {
-            fatalError()
-        }
+        let cell = tableView.dequeueReusableCell(Cell.self, for: indexPath)
 
         let model = resultsController.object(at: indexPath)
         let cellModel = searchUICommand.createCellViewModel(model: model)


### PR DESCRIPTION
# Why

_We deserve nice things_

----

While working on the refund screen #2890 I end up writing a lot of repeated code that looked like this:
```swift
guard let cell = tableView.dequeueReusableCell(withIdentifier: CellType.reuseIdentifier, for: indexPath) as? CellType else {
    fatalError("Cell could not be dequeed")
}
```

To mitigate this I've added a typesafe dequeue method on `TableView` that will shorten the code to:
```swift
let cell = tableView.dequeueReusableCell(CellType.self, for: indexPath)
```

In this PR I've also refactored all possible TableView dequeues to use this new method which gives us a bit of logging since most of the code only called fatal error without any message.


# Testing Steps.
- Making sure that the code compiles should be enough but doing a sanity check trough the app and see that all cells are working correctly doesn't hurt!


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
