### PR TITLE
Shorter TableView register nib method

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -189,15 +189,8 @@ private extension StorePickerViewController {
     }
 
     func setupTableView() {
-        let cells = [
-            EmptyStoresTableViewCell.reuseIdentifier: EmptyStoresTableViewCell.loadNib(),
-            StoreTableViewCell.reuseIdentifier: StoreTableViewCell.loadNib()
-        ]
-
-        for (reuseIdentifier, nib) in cells {
-            tableView.register(nib, forCellReuseIdentifier: reuseIdentifier)
-        }
-
+        tableView.registerNib(for: EmptyStoresTableViewCell.self)
+        tableView.registerNib(for: StoreTableViewCell.self)
         tableView.backgroundColor = .listBackground
     }
 

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -27,7 +27,7 @@ extension UITableView {
         register(type, forCellReuseIdentifier: type.reuseIdentifier)
     }
 
-    /// Registers a `UITableViewCell`nib  using its `reuseIdentifier` property as the reuse identifier.
+    /// Registers a `UITableViewCell` nib  using its `reuseIdentifier` property as the reuse identifier.
     ///
     func registerNib(for type: UITableViewCell.Type) {
         register(type.loadNib(), forCellReuseIdentifier: type.reuseIdentifier)

--- a/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableView+Helpers.swift
@@ -18,8 +18,20 @@ extension UITableView {
     }
 }
 
-// MARK: Typesafe dequeue
+// MARK: Typesafe Register & Dequeue
 extension UITableView {
+
+    /// Registers a `UITableViewCell` using its `reuseIdentifier` property as the reuse identifier.
+    ///
+    func register(_ type: UITableViewCell.Type) {
+        register(type, forCellReuseIdentifier: type.reuseIdentifier)
+    }
+
+    /// Registers a `UITableViewCell`nib  using its `reuseIdentifier` property as the reuse identifier.
+    ///
+    func registerNib(for type: UITableViewCell.Type) {
+        register(type.loadNib(), forCellReuseIdentifier: type.reuseIdentifier)
+    }
 
     /// Dequeue a previously registered cell by it's class `reuseIdentifier` property.
     /// Failing to dequeue the cell will throw a `fatalError`

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -74,8 +74,7 @@ protocol ManualTrackingViewModel {
 extension ManualTrackingViewModel {
     func registerCells(for tableView: UITableView) {
         for row in AddEditTrackingRow.allCases {
-            tableView.register(row.type.loadNib(),
-                               forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -162,8 +162,8 @@ extension OrderDetailsViewModel {
             IssueRefundTableViewCell.self
         ]
 
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        for cellClass in cells {
+            tableView.registerNib(for: cellClass)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsViewModel.swift
@@ -54,13 +54,7 @@ extension RefundedProductsViewModel {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells(_ tableView: UITableView) {
-        let cells = [
-            ProductDetailsTableViewCell.self
-        ]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: ProductDetailsTableViewCell.self)
     }
 
     /// Registers all of the available TableViewHeaderFooters

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -117,7 +117,7 @@ private extension BottomSheetListSelectorViewController {
     }
 
     func registerTableViewCells() {
-        tableView.register(rowType.loadNib(), forCellReuseIdentifier: rowType.reuseIdentifier)
+        tableView.registerNib(for: rowType)
     }
 
     func registerTableViewHeaderFooters() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -159,11 +159,8 @@ private extension TopPerformerDataViewController {
     }
 
     func registerTableViewCells() {
-        let cells = [ProductTableViewCell.self, NoPeriodDataTableViewCell.self]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: ProductTableViewCell.self)
+        tableView.registerNib(for: NoPeriodDataTableViewCell.self)
     }
 
     func registerTableViewHeaderFooters() {
@@ -313,9 +310,7 @@ private extension TopPerformerDataViewController {
             tableView.separatorStyle = .none
             tableView.estimatedRowHeight = Constants.estimatedRowHeight
             tableView.applyFooterViewForHidingExtraRowPlaceholders()
-
-            tableView.register(ProductTableViewCell.loadNib(),
-                               forCellReuseIdentifier: ProductTableViewCell.reuseIdentifier)
+            tableView.registerNib(for: ProductTableViewCell.self)
         }
 
         /// Activate the ghost if this view is added to the parent.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/About/AboutViewController.swift
@@ -133,7 +133,7 @@ private extension AboutViewController {
     ///
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -95,7 +95,7 @@ private extension BetaFeaturesViewController {
     ///
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -120,7 +120,7 @@ class ApplicationLogViewController: UIViewController {
     ///
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -110,7 +110,7 @@ private extension HelpAndSupportViewController {
     ///
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacySettingsViewController.swift
@@ -128,7 +128,7 @@ private extension PrivacySettingsViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -164,7 +164,7 @@ private extension SettingsViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/LinkSettings/LinkSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/LinkSettings/LinkSettingsViewController.swift
@@ -208,7 +208,7 @@ private extension LinkSettingsViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/ListSelectorViewController.swift
@@ -138,6 +138,6 @@ private extension ListSelectorViewController {
     }
 
     func registerTableViewCells() {
-        tableView.register(rowType.loadNib(), forCellReuseIdentifier: rowType.reuseIdentifier)
+        tableView.registerNib(for: rowType)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -286,10 +286,10 @@ private extension PaginatedListSelectorViewController {
 
     func registerTableViewCells() {
         guard Bundle.main.path(forResource: rowType.classNameWithoutNamespaces, ofType: "nib") != nil else {
-            tableView.register(rowType.self, forCellReuseIdentifier: rowType.reuseIdentifier)
+            tableView.register(rowType)
             return
         }
-        tableView.register(rowType.loadNib(), forCellReuseIdentifier: rowType.reuseIdentifier)
+        tableView.registerNib(for: rowType)
     }
 
     func configureScrollWatcher() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -28,7 +28,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     @IBOutlet weak var contentStackView: UIStackView!
 
     static func register(for tableView: UITableView) {
-        tableView.register(loadNib(), forCellReuseIdentifier: reuseIdentifier)
+        tableView.registerNib(for: self)
     }
 
     func configureCell(searchModel: OrderSearchCellViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -76,14 +76,8 @@ private extension BillingInformationViewController {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
-        let cells = [
-            BillingAddressTableViewCell.self,
-            WooBasicTableViewCell.self
-        ]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: BillingAddressTableViewCell.self)
+        tableView.registerNib(for: WooBasicTableViewCell.self)
     }
 
     /// Registers all of the available TableViewHeaderFooters

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -96,14 +96,8 @@ private extension NewNoteViewController {
     /// Registers all of the available TableViewCells
     ///
     private func registerTableViewCells() {
-        let cells = [
-            TextViewTableViewCell.self,
-            SwitchTableViewCell.self
-        ]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: TextViewTableViewCell.self)
+        tableView.registerNib(for: SwitchTableViewCell.self)
     }
 
     /// Setup: Sections

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -85,11 +85,7 @@ final class OrderStatusListViewController: UIViewController {
     /// Registers all of the available TableViewCells
     ///
     private func registerTableViewCells() {
-        let cells = [StatusListTableViewCell.self]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: StatusListTableViewCell.self)
     }
 
     /// Setup: TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
@@ -131,8 +131,8 @@ extension RefundDetailsViewModel {
             TopLeftImageTableViewCell.self
         ]
 
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        for cellClass in cells {
+            tableView.registerNib(for: cellClass)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Fulfillment/FulfillViewController.swift
@@ -169,8 +169,8 @@ private extension FulfillViewController {
             PickListTableViewCell.self
         ]
 
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        for cellClass in cells {
+            tableView.registerNib(for: cellClass)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/ProductListViewController.swift
@@ -45,9 +45,7 @@ private extension ProductListViewController {
         tableView.sectionHeaderHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
-
-        let nib = PickListTableViewCell.loadNib()
-        tableView.register(nib, forCellReuseIdentifier: PickListTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: PickListTableViewCell.self)
 
         let headerNib = UINib(nibName: TwoColumnSectionHeaderView.reuseIdentifier, bundle: nil)
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: TwoColumnSectionHeaderView.reuseIdentifier)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -141,11 +141,7 @@ private extension ShipmentProvidersViewController {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
-        let cells = [WooBasicTableViewCell.self]
-
-        for cell in cells {
-            table.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        table.registerNib(for: WooBasicTableViewCell.self)
     }
 
     func styleTableView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -273,12 +273,8 @@ private extension OrderListViewController {
     /// Registers all of the available table view cells and headers
     ///
     func registerTableViewHeadersAndCells() {
-        let cells = [ OrderTableViewCell.self ]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-            ghostableTableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: OrderTableViewCell.self)
+        ghostableTableView.registerNib(for: OrderTableViewCell.self)
 
         let headerType = TwoColumnSectionHeaderView.self
         tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewController.swift
@@ -225,12 +225,8 @@ private extension OrdersViewController {
     /// Registers all of the available table view cells and headers
     ///
     func registerTableViewHeadersAndCells() {
-        let cells = [ OrderTableViewCell.self ]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-            ghostableTableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: OrderTableViewCell.self)
+        ghostableTableView.registerNib(for: OrderTableViewCell.self)
 
         let headerType = TwoColumnSectionHeaderView.self
         tableView.register(headerType.loadNib(), forHeaderFooterViewReuseIdentifier: headerType.reuseIdentifier)

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -52,7 +52,7 @@ extension ProductsTabProductTableViewCell: SearchResultCell {
     }
 
     static func register(for tableView: UITableView) {
-        tableView.register(self, forCellReuseIdentifier: reuseIdentifier)
+        tableView.register(self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -108,7 +108,7 @@ private extension AddProductCategoryViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/ProductParentCategoriesViewController.swift
@@ -60,7 +60,7 @@ private extension ProductParentCategoriesViewController {
     }
 
     func registerTableViewCells() {
-        tableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: ProductCategoryTableViewCell.self)
     }
 
     func configureTableView() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/ProductCategoryListViewController.swift
@@ -48,8 +48,8 @@ final class ProductCategoryListViewController: UIViewController {
 //
 private extension ProductCategoryListViewController {
     func registerTableViewCells() {
-        tableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
-        ghostTableView.register(ProductCategoryTableViewCell.loadNib(), forCellReuseIdentifier: ProductCategoryTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: ProductCategoryTableViewCell.self)
+        ghostTableView.registerNib(for: ProductCategoryTableViewCell.self)
     }
 
     func configureAddButton() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit External Link/ProductExternalLinkViewController.swift
@@ -229,7 +229,7 @@ private extension ProductExternalLinkViewController {
     }
 
     func registerTableViewCells() {
-        tableView.register(TitleAndTextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TitleAndTextFieldTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: TitleAndTextFieldTableViewCell.self)
     }
 
     func registerTableViewHeaderFooters() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -111,7 +111,7 @@ private extension ProductPriceSettingsViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -153,7 +153,7 @@ private extension ProductTagsViewController {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells() {
-        tableView.register(BasicTableViewCell.loadNib(), forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: BasicTableViewCell.self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -115,7 +115,7 @@ private extension ProductInventorySettingsViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Catalog Visibility/ProductCatalogVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Catalog Visibility/ProductCatalogVisibilityViewController.swift
@@ -60,8 +60,8 @@ private extension ProductCatalogVisibilityViewController {
     }
 
     func configureTableView() {
-        tableView.register(SwitchTableViewCell.loadNib(), forCellReuseIdentifier: SwitchTableViewCell.reuseIdentifier)
-        tableView.register(BasicTableViewCell.loadNib(), forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: SwitchTableViewCell.self)
+        tableView.registerNib(for: BasicTableViewCell.self)
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Menu Order/ProductMenuOrderViewController.swift
@@ -64,7 +64,7 @@ private extension ProductMenuOrderViewController {
     }
 
     func configureTableView() {
-        tableView.register(TextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TextFieldTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: TextFieldTableViewCell.self)
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -120,7 +120,7 @@ extension ProductSettingsViewModel {
         sections.flatMap {
             $0.rows.flatMap { $0.cellTypes }
         }.forEach {
-            tableView.register($0.loadNib(), forCellReuseIdentifier: $0.reuseIdentifier)
+            tableView.registerNib(for: $0)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -72,7 +72,7 @@ private extension ProductPurchaseNoteViewController {
     }
 
     func configureTableView() {
-        tableView.register(TextViewTableViewCell.loadNib(), forCellReuseIdentifier: TextViewTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: TextViewTableViewCell.self)
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -62,7 +62,7 @@ private extension ProductSlugViewController {
     }
 
     func configureTableView() {
-        tableView.register(TextFieldTableViewCell.loadNib(), forCellReuseIdentifier: TextFieldTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: TextFieldTableViewCell.self)
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -96,8 +96,8 @@ private extension ProductVisibilityViewController {
     }
 
     func configureTableView() {
-        tableView.register(BasicTableViewCell.loadNib(), forCellReuseIdentifier: BasicTableViewCell.reuseIdentifier)
-        tableView.register(TitleAndTextFieldWithImageTableViewCell.loadNib(), forCellReuseIdentifier: TitleAndTextFieldWithImageTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: BasicTableViewCell.self)
+        tableView.registerNib(for: TitleAndTextFieldWithImageTableViewCell.self)
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -387,13 +387,13 @@ private extension ProductFormViewController {
             case .primaryFields(let rows):
                 rows.forEach { row in
                     row.cellTypes.forEach { cellType in
-                        tableView.register(cellType.loadNib(), forCellReuseIdentifier: cellType.reuseIdentifier)
+                        tableView.registerNib(for: cellType)
                     }
                 }
             case .settings(let rows):
                 rows.forEach { row in
                     row.cellTypes.forEach { cellType in
-                        tableView.register(cellType.loadNib(), forCellReuseIdentifier: cellType.reuseIdentifier)
+                        tableView.registerNib(for: cellType)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -59,11 +59,7 @@ final class ProductReviewsViewModel {
     /// Setup: TableViewCells
     ///
     func configureTableViewCells(tableView: UITableView) {
-        let cells = [ProductReviewTableViewCell.self]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: ProductReviewTableViewCell.self)
     }
 
     func containsMorePages(_ highestVisibleReview: Int) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -72,7 +72,7 @@ private extension ProductShippingSettingsViewController {
 
     func registerTableViewCells() {
         for row in Row.allCases {
-            tableView.register(row.type.loadNib(), forCellReuseIdentifier: row.reuseIdentifier)
+            tableView.registerNib(for: row.type)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsViewController.swift
@@ -159,8 +159,8 @@ private extension ProductDetailsViewController {
             ReadMoreTableViewCell.self
         ]
 
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
+        for cellClass in cells {
+            tableView.registerNib(for: cellClass)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -393,7 +393,7 @@ private extension ProductsViewController {
     /// Register table cells.
     ///
     func registerTableViewCells() {
-        tableView.register(ProductsTabProductTableViewCell.self, forCellReuseIdentifier: ProductsTabProductTableViewCell.reuseIdentifier)
+        tableView.register(ProductsTabProductTableViewCell.self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -168,7 +168,7 @@ private extension ProductVariationsViewController {
     /// Register table cells.
     ///
     func registerTableViewCells() {
-        tableView.register(ProductsTabProductTableViewCell.self, forCellReuseIdentifier: ProductsTabProductTableViewCell.reuseIdentifier)
+        tableView.register(ProductsTabProductTableViewCell.self)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -130,14 +130,8 @@ private extension ReviewDetailsViewController {
     /// Registers all of the available TableViewCells.
     ///
     func registerTableViewCells() {
-        let cells = [
-            NoteDetailsHeaderPlainTableViewCell.self,
-            NoteDetailsCommentTableViewCell.self
-        ]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: NoteDetailsHeaderPlainTableViewCell.self)
+        tableView.registerNib(for: NoteDetailsCommentTableViewCell.self)
     }
 
     func reloadRows() {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -72,11 +72,7 @@ final class ReviewsViewModel {
     /// Setup: TableViewCells
     ///
     func configureTableViewCells(tableView: UITableView) {
-        let cells = [ProductReviewTableViewCell.self]
-
-        for cell in cells {
-            tableView.register(cell.loadNib(), forCellReuseIdentifier: cell.reuseIdentifier)
-        }
+        tableView.registerNib(for: ProductReviewTableViewCell.self)
     }
 
     func markAllAsRead(onCompletion: @escaping (Error?) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -43,8 +43,7 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
     }
 
     private func configureTableView() {
-        tableView.register(SettingTitleAndValueTableViewCell.loadNib(),
-                           forCellReuseIdentifier: SettingTitleAndValueTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: SettingTitleAndValueTableViewCell.self)
 
         tableView.backgroundColor = .listBackground
         tableView.delegate = self


### PR DESCRIPTION
# Why 

@shiki while reviewing #2908 suggested that we should apply the same strategy to the `tableView.register(...` method

I think this is good because:
- It's less code to write
- We guarantee that we always use the class `reuseIdentifier` and avoid any possible typo.

# How
Added
```swift
func register(_ type: UITableViewCell.Type)
```
and 

```swift
 func registerNib(for type: UITableViewCell.Type) 
```
methods, additionally I've refactored the existing code to use these new methods.

# Testing steps
- Making sure that the code compiles should be enough but doing a sanity check trough the app and see that all cells are working correctly doesn't hurt!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
