### PR TITLE
Dashboard tab: DI site ID to `DashboardViewController` and its related classes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -10,9 +10,9 @@ final class DashboardViewController: UIViewController {
 
     // MARK: Properties
 
-    private var siteID: Int64?
+    private let siteID: Int64
 
-    private var dashboardUIFactory: DashboardUIFactory?
+    private let dashboardUIFactory: DashboardUIFactory
     private var dashboardUI: DashboardUI?
 
     // MARK: Subviews
@@ -23,9 +23,10 @@ final class DashboardViewController: UIViewController {
 
     // MARK: View Lifecycle
 
-    init() {
+    init(siteID: Int64) {
+        self.siteID = siteID
+        dashboardUIFactory = DashboardUIFactory(siteID: siteID)
         super.init(nibName: nil, bundle: nil)
-        startListeningToNotifications()
         configureTabBarItem()
     }
 
@@ -77,10 +78,6 @@ private extension DashboardViewController {
         navigationItem.title = ServiceLocator.stores.sessionManager.defaultSite?.name ?? Localization.title
     }
 
-    func resetTitle() {
-        navigationItem.title = Localization.title
-    }
-
     private func configureNavigationItem() {
         let rightBarButton = UIBarButtonItem(image: .cogImage,
                                              style: .plain,
@@ -114,15 +111,7 @@ private extension DashboardViewController {
     }
 
     func reloadDashboardUIStatsVersion() {
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return
-        }
-        if siteID != self.siteID {
-            dashboardUIFactory = DashboardUIFactory(siteID: siteID)
-            self.siteID = siteID
-        }
-
-        dashboardUIFactory?.reloadDashboardUI(onUIUpdate: { [weak self] dashboardUI in
+        dashboardUIFactory.reloadDashboardUI(onUIUpdate: { [weak self] dashboardUI in
             self?.onDashboardUIUpdate(updatedDashboardUI: dashboardUI)
         })
     }
@@ -160,29 +149,6 @@ private extension DashboardViewController {
         updatedDashboardUI.displaySyncingErrorNotice = { [weak self] in
             self?.displaySyncingErrorNotice()
         }
-    }
-}
-
-// MARK: - Notifications
-//
-extension DashboardViewController {
-
-    /// Wires all of the Notification Hooks
-    ///
-    func startListeningToNotifications() {
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
-    }
-
-    /// Runs whenever the default Account is updated.
-    ///
-    @objc func defaultAccountWasUpdated() {
-        guard isViewLoaded, ServiceLocator.stores.isAuthenticated == false else {
-            return
-        }
-
-        resetTitle()
-        dashboardUI?.defaultAccountDidUpdate()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/DashboardUIFactory.swift
@@ -11,9 +11,6 @@ protocol DashboardUI: UIViewController {
     /// Called when the user pulls to refresh
     var onPullToRefresh: () -> Void { get set }
 
-    /// Called when the default account was updated
-    func defaultAccountDidUpdate()
-
     /// Reloads data in Dashboard
     ///
     /// - Parameter completion: called when Dashboard data reload finishes
@@ -45,7 +42,7 @@ final class DashboardUIFactory {
         if let lastStatsV4DashboardUI = lastStatsV4DashboardUI {
             return lastStatsV4DashboardUI
         }
-        let dashboardUI = StoreStatsAndTopPerformersViewController(nibName: nil, bundle: nil)
+        let dashboardUI = StoreStatsAndTopPerformersViewController(siteID: siteID)
         lastStatsV4DashboardUI = dashboardUI
         return dashboardUI
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -11,6 +11,7 @@ final class TopPerformerDataViewController: UIViewController {
     // MARK: - Properties
 
     private let granularity: StatGranularity
+    private let siteID: Int64
 
     var hasTopEarnerStatsItems: Bool {
         return (topEarnerStats?.items?.count ?? 0) > 0
@@ -60,7 +61,8 @@ final class TopPerformerDataViewController: UIViewController {
 
     /// Designated Initializer
     ///
-    init(granularity: StatGranularity) {
+    init(siteID: Int64, granularity: StatGranularity) {
+        self.siteID = siteID
         self.granularity = granularity
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
@@ -223,7 +225,7 @@ extension TopPerformerDataViewController: UITableViewDataSource {
 extension TopPerformerDataViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard let statsItem = statsItem(at: indexPath), let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+        guard let statsItem = statsItem(at: indexPath) else {
             return
         }
         presentProductDetails(for: statsItem.productID, siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -56,7 +56,6 @@ extension DeprecatedDashboardStatsViewController: DashboardUI {
         set {}
     }
 
-    func defaultAccountDidUpdate() {}
     func remindStatsUpgradeLater() {}
     func reloadData(completion: @escaping () -> Void) {}
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -72,7 +72,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     private lazy var inAppFeedbackCardViewsForStackView: [UIView] = createInAppFeedbackCardViewsForStackView()
 
     private lazy var topPerformersPeriodViewController: TopPerformerDataViewController = {
-        return TopPerformerDataViewController(granularity: timeRange.topEarnerStatsGranularity)
+        return TopPerformerDataViewController(siteID: siteID, granularity: timeRange.topEarnerStatsGranularity)
     }()
 
     // MARK: Internal Properties
@@ -83,6 +83,8 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     private let viewModel: StoreStatsAndTopPerformersPeriodViewModel
 
+    private let siteID: Int64
+
     /// Subscriptions that should be cancelled on `deinit`.
     private var cancellables = [ObservationToken]()
 
@@ -92,9 +94,11 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
     ///     The in-app feedback card may still not be presented depending on the constraints. But
     ///     setting this to `false`, will ensure that it will never be presented.
     ///
-    init(timeRange: StatsTimeRangeV4,
+    init(siteID: Int64,
+         timeRange: StatsTimeRangeV4,
          currentDate: Date,
          canDisplayInAppFeedbackCard: Bool) {
+        self.siteID = siteID
         self.timeRange = timeRange
         self.granularity = timeRange.intervalGranularity
         self.currentDate = currentDate

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -369,7 +369,7 @@ private extension MainTabBarController {
         }
 
         // Initialize each tab's root view controller
-        let dashboardViewController = createDashboardViewController()
+        let dashboardViewController = createDashboardViewController(siteID: siteID)
         dashboardNavigationController.viewControllers = [dashboardViewController]
 
         let ordersViewController = createOrdersViewController()
@@ -386,8 +386,8 @@ private extension MainTabBarController {
         selectedIndex = WooTab.myStore.visibleIndex()
     }
 
-    func createDashboardViewController() -> UIViewController {
-        DashboardViewController()
+    func createDashboardViewController(siteID: Int64) -> UIViewController {
+        DashboardViewController(siteID: siteID)
     }
 
     func createOrdersViewController() -> UIViewController {


### PR DESCRIPTION
Part of #1838 

## Changes

- DI'ed `siteID: Int64` to `DashboardViewController` and its related classes (`DashboardUIFactory` and its child view controllers). Also removed unnecessary observation for `defaultAccountWasUpdated` notification

## Testing

For confidence check on the dashboard tab:

- Log out from the app
- Log in to a site --> the dashboard tab should load as before
- Switch to another site --> the dashboard tab should load data for the new site

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
