### PR TITLE
Store picker: fix a retain issue and `didSelectStore`'s completion block

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -333,6 +333,10 @@ private extension StorePickerViewController {
             })
         }
 
+        dismiss()
+    }
+
+    func dismiss() {
         switch configuration {
         case .switchingStores:
             dismiss(animated: true)
@@ -517,7 +521,7 @@ extension StorePickerViewController {
             }
 
             delegate.didSelectStore(with: site.siteID) { [weak self] in
-                self?.cleanupAndDismiss()
+                self?.dismiss()
             }
         }
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -203,7 +203,12 @@ private extension StorePickerViewController {
         accountHeaderView.fullname = defaultAccount.displayName
         accountHeaderView.downloadGravatar(with: defaultAccount.email)
         accountHeaderView.isHelpButtonEnabled = configuration == .login || configuration == .standard
-        accountHeaderView.onHelpRequested = { ServiceLocator.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin) }
+        accountHeaderView.onHelpRequested = { [weak self] in
+            guard let self = self else {
+                return
+            }
+            ServiceLocator.authenticationManager.presentSupport(from: self, sourceTag: .generalLogin)
+        }
     }
 
     func setupNavigation() {


### PR DESCRIPTION
Related to #2920 

While testing switching stores for #2920, I encountered some issues in the store picker:

- After switching stores `n` times, there are `n` `StorePickerViewController` instances strongly retained by `AccountHeaderView` in the memory
- In `StorePickerViewController.actionWasPressed` > `delegate.didSelectStore(with: site.siteID)`'s completion block, it's calling `cleanupAndDismiss` which could call `delegate?.didSelectStore` again whereas it can just dismiss itself

## Changes

In `StorePickerViewController`:
- Updated to use weak self in `AccountHeaderView.onHelpRequested` completion block
- Separated the dismiss part of `func cleanupAndDismiss` to its own function `func dismiss` and called this in `actionWasPressed` > `delegate.didSelectStore(with: site.siteID)`'s completion block

## Testing

- Go to "My store" tab
- Tap on the ⚙️ icon and switch to another store --> the store switch should work as before. after store picker is dismissed and the app is back to the dashboard, there should be no `StorePickerViewController` instance in Xcode memory debugger

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
