### PR TITLE
[Issue Refund] Add Issue Refund View Controller

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -451,10 +451,9 @@ private extension OrderDetailsDataSource {
         }
     }
 
-    // TODO: Change: actions
     private func configureIssueRefundButton(cell: IssueRefundTableViewCell) {
-        cell.onIssueRefundTouchUp = {
-            print("Issue refund pressed")
+        cell.onIssueRefundTouchUp = { [weak self] in
+            self?.onCellAction?(.issueRefund, nil)
         }
     }
 
@@ -1010,6 +1009,7 @@ extension OrderDetailsDataSource {
         case fulfill
         case tracking
         case summary
+        case issueRefund
     }
 
     struct Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -46,10 +46,8 @@ private extension RefundProductsTotalTableViewCell {
         subtotalPriceLabel.applyBodyStyle()
         taxTitleLabel.applyBodyStyle()
         taxPriceLabel.applyBodyStyle()
-        productsRefundTitleLabel.applyBodyStyle()
-        productsRefundTitleLabel.font = .font(forStyle: .body, weight: .semibold)
-        productsRefundPriceLabel.applyBodyStyle()
-        productsRefundPriceLabel.font = .font(forStyle: .body, weight: .semibold)
+        productsRefundTitleLabel.applyHeadlineStyle()
+        productsRefundPriceLabel.applyHeadlineStyle()
 
         taxTitleLabel.text = Localization.taxTitle
         subtotalTitleLabel.text = Localization.subtotalTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.swift
@@ -47,9 +47,9 @@ private extension RefundProductsTotalTableViewCell {
         taxTitleLabel.applyBodyStyle()
         taxPriceLabel.applyBodyStyle()
         productsRefundTitleLabel.applyBodyStyle()
-        productsRefundTitleLabel.font = .font(forStyle: .body, weight: .bold)
+        productsRefundTitleLabel.font = .font(forStyle: .body, weight: .semibold)
         productsRefundPriceLabel.applyBodyStyle()
-        productsRefundPriceLabel.font = .font(forStyle: .body, weight: .bold)
+        productsRefundPriceLabel.font = .font(forStyle: .body, weight: .semibold)
 
         taxTitleLabel.text = Localization.taxTitle
         subtotalTitleLabel.text = Localization.subtotalTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="117" id="Vz0-ss-WsR" customClass="RefundProductsTotalTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="117" id="Vz0-ss-WsR" customClass="RefundProductsTotalTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="125"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Vz0-ss-WsR" id="gXm-6C-hxr">

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -75,10 +75,8 @@ private extension RefundShippingDetailsTableViewCell {
         subtotalPriceLabel.applyBodyStyle()
         taxTitleLabel.applyBodyStyle()
         taxPriceLabel.applyBodyStyle()
-        shippingRefundTitleLabel.applyBodyStyle()
-        shippingRefundTitleLabel.font = .font(forStyle: .body, weight: .semibold)
-        shippingRefundPriceLabel.applyBodyStyle()
-        shippingRefundPriceLabel.font = .font(forStyle: .body, weight: .semibold)
+        shippingRefundTitleLabel.applyHeadlineStyle()
+        shippingRefundPriceLabel.applyHeadlineStyle()
 
         taxTitleLabel.text = Localization.taxTitle
         subtotalTitleLabel.text = Localization.subtotalTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.swift
@@ -76,9 +76,9 @@ private extension RefundShippingDetailsTableViewCell {
         taxTitleLabel.applyBodyStyle()
         taxPriceLabel.applyBodyStyle()
         shippingRefundTitleLabel.applyBodyStyle()
-        shippingRefundTitleLabel.font = .font(forStyle: .body, weight: .bold)
+        shippingRefundTitleLabel.font = .font(forStyle: .body, weight: .semibold)
         shippingRefundPriceLabel.applyBodyStyle()
-        shippingRefundPriceLabel.font = .font(forStyle: .body, weight: .bold)
+        shippingRefundPriceLabel.font = .font(forStyle: .body, weight: .semibold)
 
         taxTitleLabel.text = Localization.taxTitle
         subtotalTitleLabel.text = Localization.subtotalTitle

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="201" id="oBT-Z9-cJd" customClass="RefundShippingDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="201" id="oBT-Z9-cJd" customClass="RefundShippingDetailsTableViewCell" customModule="WooCommerce" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="209"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oBT-Z9-cJd" id="Mly-TP-AMG">

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -16,15 +16,65 @@ final class IssueRefundViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureTableView()
     }
 }
 
 // MARK: View Configuration
 private extension IssueRefundViewController {
+    func configureTableView() {
+        registerCells()
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+
     func registerCells() {
-        tableView.register(RefundItemTableViewCell.loadNib(), forCellReuseIdentifier: RefundItemTableViewCell.reuseIdentifier)
-        tableView.register(RefundProductsTotalTableViewCell.loadNib(), forCellReuseIdentifier: RefundProductsTotalTableViewCell.reuseIdentifier)
-        tableView.register(RefundShippingDetailsTableViewCell.loadNib(), forCellReuseIdentifier: RefundShippingDetailsTableViewCell.reuseIdentifier)
-        tableView.register(SwitchTableViewCell.loadNib(), forCellReuseIdentifier: SwitchTableViewCell.reuseIdentifier)
+        tableView.registerNib(for: RefundItemTableViewCell.self)
+        tableView.registerNib(for: RefundProductsTotalTableViewCell.self)
+        tableView.registerNib(for: RefundShippingDetailsTableViewCell.self)
+        tableView.registerNib(for: SwitchTableViewCell.self)
+    }
+}
+
+// MARK: TableView Delegate & DataSource
+extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 6
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: UITableViewCell?
+        switch indexPath.row {
+        case 0...2:
+            let  itemCell = tableView.dequeueReusableCell(RefundItemTableViewCell.self, for: indexPath)
+            let viewModel = RefundItemViewModel(productImage: nil,
+                                                productTitle: "Sample Product",
+                                                productQuantityAndPrice: "2 x $10.00 each",
+                                                quantityToRefund: "1")
+            itemCell.configure(with: viewModel)
+            cell = itemCell
+        case 3:
+            let totalCell = tableView.dequeueReusableCell(RefundProductsTotalTableViewCell.self, for: indexPath)
+            let viewModel = RefundProductsTotalViewModel(productsTax: "$3.40", productsSubtotal: "$10.00", productsTotal: "$13.40")
+            totalCell.configure(with: viewModel)
+            cell = totalCell
+        case 4:
+            let switchCell = tableView.dequeueReusableCell(SwitchTableViewCell.self, for: indexPath)
+            switchCell.title = "Refund Shipping"
+            cell = switchCell
+        case 5:
+            let shippingCell = tableView.dequeueReusableCell(RefundShippingDetailsTableViewCell.self, for: indexPath)
+            let viewModel = RefundShippingDetailsViewModel(carrierRate: "USPS Flat Rate",
+                                                           carrierCost: "$7.40",
+                                                           shippingTax: "$2.0",
+                                                           shippingSubtotal: "$7.40",
+                                                           shippingTotal: "$9.40")
+            shippingCell.configure(with: viewModel)
+            cell = shippingCell
+        default:
+            fatalError("Cell creation error")
+        }
+        return cell!
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -5,6 +5,8 @@ import UIKit
 final class IssueRefundViewController: UIViewController {
 
     @IBOutlet private var tableView: UITableView!
+    @IBOutlet private var tableFooterView: UIView!
+    @IBOutlet private var nextButton: UIButton!
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -16,7 +18,20 @@ final class IssueRefundViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNextButton()
         configureTableView()
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        tableView.updateFooterHeight()
+    }
+}
+
+// MARK: Actions
+private extension IssueRefundViewController {
+    @IBAction func nextButtonWasPressed(_ sender: Any) {
+        print("Next button pressed")
     }
 }
 
@@ -26,6 +41,7 @@ private extension IssueRefundViewController {
         registerCells()
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.tableFooterView = tableFooterView
     }
 
     func registerCells() {
@@ -33,6 +49,11 @@ private extension IssueRefundViewController {
         tableView.registerNib(for: RefundProductsTotalTableViewCell.self)
         tableView.registerNib(for: RefundShippingDetailsTableViewCell.self)
         tableView.registerNib(for: SwitchTableViewCell.self)
+    }
+
+    func configureNextButton() {
+        nextButton.applyPrimaryButtonStyle()
+        nextButton.setTitle(Localization.nextTitle, for: .normal)
     }
 }
 
@@ -76,5 +97,12 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
             fatalError("Cell creation error")
         }
         return cell!
+    }
+}
+
+// MARK: Constants
+private extension IssueRefundViewController {
+    enum Localization {
+        static let nextTitle = NSLocalizedString("Next", comment: "Title of the next button in the issue refund screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -20,7 +20,7 @@ final class IssueRefundViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureTitle()
+        configureNavigationBar()
         configureNextButton()
         configureTableView()
     }
@@ -41,8 +41,9 @@ private extension IssueRefundViewController {
 // MARK: View Configuration
 private extension IssueRefundViewController {
 
-    func configureTitle() {
+    func configureNavigationBar() {
         title = viewModel.title
+        addCloseNavigationBarButton(title: Localization.cancelTitle)
     }
 
     func configureTableView() {
@@ -114,5 +115,6 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
 private extension IssueRefundViewController {
     enum Localization {
         static let nextTitle = NSLocalizedString("Next", comment: "Title of the next button in the issue refund screen")
+        static let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title in the issue refund screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+final class IssueRefundViewControlle: UIViewController {
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -41,6 +41,7 @@ private extension IssueRefundViewController {
         registerCells()
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.backgroundColor = .listBackground
         tableView.tableFooterView = tableFooterView
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -18,3 +18,13 @@ final class IssueRefundViewController: UIViewController {
         super.viewDidLoad()
     }
 }
+
+// MARK: View Configuration
+private extension IssueRefundViewController {
+    func registerCells() {
+        tableView.register(RefundItemTableViewCell.loadNib(), forCellReuseIdentifier: RefundItemTableViewCell.reuseIdentifier)
+        tableView.register(RefundProductsTotalTableViewCell.loadNib(), forCellReuseIdentifier: RefundProductsTotalTableViewCell.reuseIdentifier)
+        tableView.register(RefundShippingDetailsTableViewCell.loadNib(), forCellReuseIdentifier: RefundShippingDetailsTableViewCell.reuseIdentifier)
+        tableView.register(SwitchTableViewCell.loadNib(), forCellReuseIdentifier: SwitchTableViewCell.reuseIdentifier)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -1,6 +1,10 @@
 import UIKit
 
-final class IssueRefundViewControlle: UIViewController {
+/// Screen that allows the user to refund items (products and shipping) of an order
+///
+final class IssueRefundViewController: UIViewController {
+
+    @IBOutlet private var tableView: UITableView!
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -6,6 +6,10 @@ final class IssueRefundViewController: UIViewController {
 
     @IBOutlet private var tableView: UITableView!
 
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -6,7 +6,11 @@ final class IssueRefundViewController: UIViewController {
 
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var tableFooterView: UIView!
+    @IBOutlet private var tableHeaderView: UIView!
+
+    @IBOutlet private var itemsSelectedLabel: UILabel!
     @IBOutlet private var nextButton: UIButton!
+    @IBOutlet private var selectAllButton: UIButton!
 
     private let viewModel = IssueRefundViewModel()
 
@@ -21,12 +25,12 @@ final class IssueRefundViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationBar()
-        configureNextButton()
         configureTableView()
     }
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
+        tableView.updateHeaderHeight()
         tableView.updateFooterHeight()
     }
 }
@@ -35,6 +39,10 @@ final class IssueRefundViewController: UIViewController {
 private extension IssueRefundViewController {
     @IBAction func nextButtonWasPressed(_ sender: Any) {
         print("Next button pressed")
+    }
+
+    @IBAction func selectAllButtonWasPressed(_ sender: Any) {
+        print("Select All button pressed")
     }
 }
 
@@ -51,7 +59,10 @@ private extension IssueRefundViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.backgroundColor = .listBackground
+        tableView.tableHeaderView = tableHeaderView
         tableView.tableFooterView = tableFooterView
+        configureFooterView()
+        configureHeaderView()
     }
 
     func registerCells() {
@@ -61,7 +72,16 @@ private extension IssueRefundViewController {
         tableView.registerNib(for: SwitchTableViewCell.self)
     }
 
-    func configureNextButton() {
+    func configureHeaderView() {
+        selectAllButton.applyLinkButtonStyle()
+        selectAllButton.contentEdgeInsets = .zero
+        selectAllButton.setTitle(Localization.selectAllTitle, for: .normal)
+
+        itemsSelectedLabel.applySecondaryBodyStyle()
+        itemsSelectedLabel.text = viewModel.selectedItemsTitle
+    }
+
+    func configureFooterView() {
         nextButton.applyPrimaryButtonStyle()
         nextButton.setTitle(Localization.nextTitle, for: .normal)
     }
@@ -116,5 +136,6 @@ private extension IssueRefundViewController {
     enum Localization {
         static let nextTitle = NSLocalizedString("Next", comment: "Title of the next button in the issue refund screen")
         static let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel button title in the issue refund screen")
+        static let selectAllTitle = NSLocalizedString("Select All", comment: "Select all button title in the issue refund screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -11,6 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController">
             <connections>
                 <outlet property="tableView" destination="Lf6-TH-48I" id="z2d-Ga-udY"/>
+                <outlet property="view" destination="iN0-l3-epB" id="J4r-V6-Ueu"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="104" y="30"/>
+        </view>
+    </objects>
+</document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -10,8 +10,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController">
             <connections>
+                <outlet property="itemsSelectedLabel" destination="Xkm-ge-1e1" id="1mf-3u-V0q"/>
                 <outlet property="nextButton" destination="omw-71-nel" id="Sgb-5r-DTF"/>
+                <outlet property="selectAllButton" destination="vQB-qj-G36" id="Rhx-j4-fi3"/>
                 <outlet property="tableFooterView" destination="dRH-Gh-qht" id="xP8-Ad-2WG"/>
+                <outlet property="tableHeaderView" destination="KQd-59-N09" id="hrf-ig-8WM"/>
                 <outlet property="tableView" destination="Lf6-TH-48I" id="z2d-Ga-udY"/>
                 <outlet property="view" destination="iN0-l3-epB" id="J4r-V6-Ueu"/>
             </connections>
@@ -36,7 +39,7 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="102.89855072463769" y="29.464285714285712"/>
         </view>
-        <view contentMode="scaleToFill" id="dRH-Gh-qht">
+        <view contentMode="scaleToFill" id="dRH-Gh-qht" userLabel="FooterView">
             <rect key="frame" x="0.0" y="0.0" width="417" height="67"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
@@ -60,6 +63,42 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="aKJ-SC-KN2"/>
             <point key="canvasLocation" x="-699.27536231884062" y="77.34375"/>
+        </view>
+        <view contentMode="scaleToFill" id="KQd-59-N09" userLabel="HeaderView">
+            <rect key="frame" x="0.0" y="0.0" width="417" height="71"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tz4-uY-TGt">
+                    <rect key="frame" x="16" y="10" width="385" height="51"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xkm-ge-1e1">
+                            <rect key="frame" x="0.0" y="0.0" width="339" height="51"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vQB-qj-G36">
+                            <rect key="frame" x="339" y="0.0" width="46" height="51"/>
+                            <state key="normal" title="Button"/>
+                            <connections>
+                                <action selector="selectAllButtonWasPressed:" destination="-1" eventType="touchUpInside" id="9cN-nV-u4d"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="Tz4-uY-TGt" firstAttribute="leading" secondItem="KQd-59-N09" secondAttribute="leading" constant="16" id="KHf-fF-Dae"/>
+                <constraint firstAttribute="trailing" secondItem="Tz4-uY-TGt" secondAttribute="trailing" constant="16" id="M9W-fJ-mIq"/>
+                <constraint firstItem="Tz4-uY-TGt" firstAttribute="bottom" secondItem="KQd-59-N09" secondAttribute="bottom" constant="-10" id="P34-kc-jlD"/>
+                <constraint firstAttribute="top" secondItem="Tz4-uY-TGt" secondAttribute="top" constant="-10" id="wXt-80-mZw"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="XWY-UK-OeP"/>
+            <point key="canvasLocation" x="-699.27536231884062" y="187.16517857142856"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -8,14 +8,30 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController">
+            <connections>
+                <outlet property="tableView" destination="Lf6-TH-48I" id="z2d-Ga-udY"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Lf6-TH-48I">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                </tableView>
+            </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="Lf6-TH-48I" secondAttribute="bottom" id="0Nd-zr-sv0"/>
+                <constraint firstItem="Lf6-TH-48I" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="3l3-sh-hkW"/>
+                <constraint firstAttribute="trailing" secondItem="Lf6-TH-48I" secondAttribute="trailing" id="ICh-vm-D8Y"/>
+                <constraint firstItem="Lf6-TH-48I" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="zPp-4d-0da"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <point key="canvasLocation" x="104" y="30"/>
+            <point key="canvasLocation" x="102.89855072463769" y="29.464285714285712"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -10,6 +10,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueRefundViewController">
             <connections>
+                <outlet property="nextButton" destination="omw-71-nel" id="Sgb-5r-DTF"/>
+                <outlet property="tableFooterView" destination="dRH-Gh-qht" id="xP8-Ad-2WG"/>
                 <outlet property="tableView" destination="Lf6-TH-48I" id="z2d-Ga-udY"/>
                 <outlet property="view" destination="iN0-l3-epB" id="J4r-V6-Ueu"/>
             </connections>
@@ -19,7 +21,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Lf6-TH-48I">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="Lf6-TH-48I">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                 </tableView>
@@ -33,6 +35,31 @@
             </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="102.89855072463769" y="29.464285714285712"/>
+        </view>
+        <view contentMode="scaleToFill" id="dRH-Gh-qht">
+            <rect key="frame" x="0.0" y="0.0" width="417" height="67"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omw-71-nel">
+                    <rect key="frame" x="16" y="16" width="385" height="35"/>
+                    <state key="normal" title="Button"/>
+                    <connections>
+                        <action selector="nextButtonWasPressed:" destination="-1" eventType="touchUpInside" id="Apt-3K-Oby"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="omw-71-nel" secondAttribute="trailing" constant="16" id="Iuh-aM-xBR"/>
+                <constraint firstItem="omw-71-nel" firstAttribute="top" secondItem="dRH-Gh-qht" secondAttribute="top" constant="16" id="OpE-fY-xG4"/>
+                <constraint firstItem="omw-71-nel" firstAttribute="leading" secondItem="dRH-Gh-qht" secondAttribute="leading" constant="16" id="TXj-Nj-G5h"/>
+                <constraint firstAttribute="bottom" secondItem="omw-71-nel" secondAttribute="bottom" constant="16" id="mR7-xj-5tk"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="aKJ-SC-KN2"/>
+            <point key="canvasLocation" x="-699.27536231884062" y="77.34375"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.xib
@@ -41,19 +41,19 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="omw-71-nel">
-                    <rect key="frame" x="16" y="16" width="385" height="35"/>
+                    <rect key="frame" x="16" y="0.0" width="385" height="67"/>
                     <state key="normal" title="Button"/>
                     <connections>
                         <action selector="nextButtonWasPressed:" destination="-1" eventType="touchUpInside" id="Apt-3K-Oby"/>
                     </connections>
                 </button>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="omw-71-nel" secondAttribute="trailing" constant="16" id="Iuh-aM-xBR"/>
-                <constraint firstItem="omw-71-nel" firstAttribute="top" secondItem="dRH-Gh-qht" secondAttribute="top" constant="16" id="OpE-fY-xG4"/>
+                <constraint firstItem="omw-71-nel" firstAttribute="top" secondItem="dRH-Gh-qht" secondAttribute="top" id="OpE-fY-xG4"/>
                 <constraint firstItem="omw-71-nel" firstAttribute="leading" secondItem="dRH-Gh-qht" secondAttribute="leading" constant="16" id="TXj-Nj-G5h"/>
-                <constraint firstAttribute="bottom" secondItem="omw-71-nel" secondAttribute="bottom" constant="16" id="mR7-xj-5tk"/>
+                <constraint firstAttribute="bottom" secondItem="omw-71-nel" secondAttribute="bottom" id="mR7-xj-5tk"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -9,6 +9,11 @@ final class IssueRefundViewModel {
     ///
     let title: String = "$35.45"
 
+    /// String indicating how many items the user has selected to refund
+    /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
+    ///
+    let selectedItemsTitle: String = "3 items selected"
+
     /// The sections and rows to display in the `UITableView`.
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// ViewModel for presenting the issue refund screen to the user.
+///
+final class IssueRefundViewModel {
+
+    /// Title for the navigation bar
+    /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
+    ///
+    let title: String = "$35.45"
+
+    /// The sections and rows to display in the `UITableView`.
+    /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
+    ///
+    let sections: [Section] = [
+        Section(rows: [
+            RefundItemViewModel(productImage: nil, productTitle: "Item 1", productQuantityAndPrice: "2 x $30.27 each", quantityToRefund: "1"),
+            RefundItemViewModel(productImage: nil, productTitle: "Item 2", productQuantityAndPrice: "4 x $20.00 each", quantityToRefund: "2"),
+            RefundItemViewModel(productImage: nil, productTitle: "Item 3", productQuantityAndPrice: "3 x $15.99 each", quantityToRefund: "0"),
+            RefundProductsTotalViewModel(productsTax: "$13.45", productsSubtotal: "$66.26", productsTotal: "$79.71")
+        ]),
+        Section(rows: [
+            ShippingSwitchViewModel(title: "Refund Shipping", isOn: true),
+            RefundShippingDetailsViewModel(carrierRate: "USPS Flat Rate",
+                                           carrierCost: "$10.0",
+                                           shippingTax: "$2.99",
+                                           shippingSubtotal: "$10.0",
+                                           shippingTotal: "$12.99")
+        ])
+    ]
+}
+
+// MARK: Sections and Rows
+
+/// Protocol that any `Section` item  should conform to.
+///
+protocol IssueRefundRow {}
+
+extension IssueRefundViewModel {
+
+    struct Section {
+        let rows: [IssueRefundRow]
+    }
+
+    /// ViewModel that represents the shipping switch row.
+    struct ShippingSwitchViewModel: IssueRefundRow {
+        let title: String
+        let isOn: Bool
+    }
+}
+
+extension RefundItemViewModel: IssueRefundRow {}
+
+extension RefundProductsTotalViewModel: IssueRefundRow {}
+
+extension RefundShippingDetailsViewModel: IssueRefundRow {}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -302,6 +302,8 @@ private extension OrderDetailsViewController {
                 break
             }
             trackingWasPressed(at: indexPath)
+        case .issueRefund:
+            issueRefundWasPressed()
         }
     }
 
@@ -327,6 +329,13 @@ private extension OrderDetailsViewController {
 
         ServiceLocator.analytics.track(.orderDetailTrackPackageButtonTapped)
         displayWebView(url: url)
+    }
+
+    func issueRefundWasPressed() {
+        // TODO: Migrate to a CoordinatingController https://github.com/woocommerce/woocommerce-ios/issues/2844
+        let issueRefundViewController = IssueRefundViewController()
+        let navigationController = WooNavigationController(rootViewController: issueRefundViewController)
+        present(navigationController, animated: true)
     }
 
     func displayWebView(url: URL) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -314,6 +314,8 @@
 		02FE89CB231FB36600E85EF8 /* DefaultFeatureFlagService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89CA231FB36600E85EF8 /* DefaultFeatureFlagService.swift */; };
 		24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C4F2502AEE200F49B68 /* EventLogging.swift */; };
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
+		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
+		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */; };
@@ -1290,6 +1292,8 @@
 		24F98C4F2502AEE200F49B68 /* EventLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogging.swift; sourceTree = "<group>"; };
 		25D00C97936D2C6589F8ECE9 /* Pods-WooCommerce.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerce.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerce/Pods-WooCommerce.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
+		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
+		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
@@ -2763,6 +2767,8 @@
 			isa = PBXGroup;
 			children = (
 				26E1BEC8251BE5270096D0A1 /* Cells */,
+				260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */,
+				260C31612524EEB200157BC2 /* IssueRefundViewController.xib */,
 			);
 			path = "Issue Refunds";
 			sourceTree = "<group>";
@@ -4891,6 +4897,7 @@
 				45C8B2672316AB460002FA77 /* BillingAddressTableViewCell.xib in Resources */,
 				B557652D20F6827900185843 /* StoreTableViewCell.xib in Resources */,
 				02E8B17823E2C49000A43403 /* InProgressProductImageCollectionViewCell.xib in Resources */,
+				260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */,
 				7493BB8F2149852A003071A9 /* TopPerformersHeaderView.xib in Resources */,
 				CE21B3E120FFC59700A259D5 /* ProductDetailsTableViewCell.xib in Resources */,
 				CE35F11C2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.xib in Resources */,
@@ -5496,6 +5503,7 @@
 				B57C744E20F56E3800EEFC87 /* UITableViewCell+Helpers.swift in Sources */,
 				0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
+				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,
 				CEEC9B5C21E79B3E0055EEF0 /* FeatureFlag.swift in Sources */,
 				26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */,
 				457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		260C315E2523CC4000157BC2 /* RefundProductsTotalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */; };
 		260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */; };
 		260C31622524EEB200157BC2 /* IssueRefundViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 260C31612524EEB200157BC2 /* IssueRefundViewController.xib */; };
+		260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		263EB409242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */; };
@@ -1294,6 +1295,7 @@
 		260C315D2523CC4000157BC2 /* RefundProductsTotalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModel.swift; sourceTree = "<group>"; };
 		260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewController.swift; sourceTree = "<group>"; };
 		260C31612524EEB200157BC2 /* IssueRefundViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueRefundViewController.xib; sourceTree = "<group>"; };
+		260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModel.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		263EB408242C58EA00F3A15F /* ProductFormActionsFactory+EditProductsM3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormActionsFactory+EditProductsM3Tests.swift"; sourceTree = "<group>"; };
@@ -2767,6 +2769,7 @@
 			isa = PBXGroup;
 			children = (
 				26E1BEC8251BE5270096D0A1 /* Cells */,
+				260C32BD2527A2DE00157BC2 /* IssueRefundViewModel.swift */,
 				260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */,
 				260C31612524EEB200157BC2 /* IssueRefundViewController.xib */,
 			);
@@ -5513,6 +5516,7 @@
 				02BA12852461674B008D8325 /* Optional+String.swift in Sources */,
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				0282DD96233C960C006A5FDB /* SearchResultCell.swift in Sources */,
+				260C32BE2527A2DE00157BC2 /* IssueRefundViewModel.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,


### PR DESCRIPTION
#closes #2890 

# Why

This PR implements the full(and static) UI of the funds screen.
<img width="313" alt="old-style" src="https://user-images.githubusercontent.com/562080/95095685-f78c0b00-06f0-11eb-844f-80d02adc2462.png">

PS: That design has legacy app styles.

# How

- Created `IssueRefundsViewController` that renders all previously created cells #2871 #2882 #2892 
- Created `IssueRefundsViewModel` to provide what information to render, this info is static at the moment
- Launch `IssueRefundsViewController` from "issue refund" button on the Order Detail screen
- Updated some cell fonts from `body` to `semibold`.

# Screenshots

Light(Up) | Light(Down)
---- | ----
<img width="392" alt="light-upZ" src="https://user-images.githubusercontent.com/562080/95096467-e8f22380-06f1-11eb-9446-3323c126833a.png"> | <img width="394" alt="light-down" src="https://user-images.githubusercontent.com/562080/95096473-eb547d80-06f1-11eb-9b17-ec4338d3f315.png">


Dark(Up) | Dark(Down)
---- | ----
<img width="400" alt="dark-up" src="https://user-images.githubusercontent.com/562080/95096534-fe674d80-06f1-11eb-8719-f67389c8f811.png"> | <img width="394" alt="dark-down" src="https://user-images.githubusercontent.com/562080/95096542-00c9a780-06f2-11eb-9965-bb8b01fcedfd.png">



# Testing Steps

- Launch the app and navigate to a non-refunded order
- Tap on the issue refund button
- See static content being rendered correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
