### PR TITLE
Always enable M3 features in product details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -16,24 +16,13 @@ struct ProductDetailsFactory {
                                stores: StoresManager = ServiceLocator.stores,
                                forceReadOnly: Bool,
                                onCompletion: @escaping (UIViewController) -> Void) {
-        let action = AppSettingsAction.loadProductsFeatureSwitch { isFeatureSwitchOn in
-            let isEditProductsEnabled: Bool
-            switch product.productType {
-            case .simple:
-                isEditProductsEnabled = true
-            default:
-                isEditProductsEnabled = true
-            }
-
-            let vc = productDetails(product: product,
-                                    presentationStyle: presentationStyle,
-                                    currencySettings: currencySettings,
-                                    isEditProductsEnabled: forceReadOnly ? false : isEditProductsEnabled,
-                                    isEditProductsRelease3Enabled: isFeatureSwitchOn,
-                                    isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
-            onCompletion(vc)
-        }
-        stores.dispatch(action)
+        let vc = productDetails(product: product,
+                                presentationStyle: presentationStyle,
+                                currencySettings: currencySettings,
+                                isEditProductsEnabled: forceReadOnly ? false: true,
+                                isEditProductsRelease3Enabled: true,
+                                isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
+        onCompletion(vc)
     }
 }
 


### PR DESCRIPTION
Fixes #2927 

## Changes

Before this PR, `ProductDetailsFactory` determines whether M3 features are enabled by reading the value from `AppSettingsAction.loadProductsFeatureSwitch` that could be previously set under Settings > Experimental Features. If the feature switch was previously off, M3 features are disabled and there is no way to enable them since we removed the feature switch in release 5.2. To fix this, I set `isEditProductsRelease3Enabled` to be `true` now that we're launching M3 features to all users. 

## Testing

- Launch the app with [release 5.1](https://github.com/woocommerce/woocommerce-ios/releases/tag/5.1) or TestFlight 5.1 build
- Go to Settings > Experimental Features, and turn off the products feature switch
- Launch the app from `develop`
- Go to the products tab
- Tap on a variable/external/grouped/non-core product --> the product should be editable with M3 features like product reviews, product type, etc.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
