### PR TITLE
Update coding-style-guide to allow one liner guard self

### DIFF
--- a/docs/coding-style-guide.md
+++ b/docs/coding-style-guide.md
@@ -30,6 +30,11 @@ guard condition else { return }
 if condition { } else { }
 ```
 
+**As an exception to this rule,** guarding for a safe `self` is allowed to be expressed in one line.
+```swift
+guard let self = self else { return }
+```
+
 ## Parentheses
 
 Parentheses around conditionals are not required and should be omitted.


### PR DESCRIPTION
# Why

Update the style guide to allow one-liner `guard let self = self else { return }`

Ref: CGPNUU63E-p1601997825048400-slack

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
