### PR TITLE
[IssueRefund] Render order items

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemTableViewCell.swift
@@ -99,18 +99,23 @@ extension RefundItemTableViewCell {
 
     /// Configure cell with the provided view model
     ///
-    func configure(with viewModel: RefundItemViewModel) {
+    func configure(with viewModel: RefundItemViewModel, imageService: ImageService) {
         itemTitle.text = viewModel.productTitle
         itemCaption.text = viewModel.productQuantityAndPrice
         itemQuantityButton.setTitle(viewModel.quantityToRefund, for: .normal)
 
-        if let _ = viewModel.productImage {
-            // TODO: fill product image
-            placeholderImageView.image = nil
-        } else {
+        guard let productImage = viewModel.productImage else {
             itemImageView.image = nil
             placeholderImageView.image = .productPlaceholderImage
+            return
         }
+
+        placeholderImageView.image = nil
+        imageService.downloadAndCacheImageForImageView(itemImageView,
+                                                       with: productImage,
+                                                       placeholder: nil,
+                                                       progressBlock: nil,
+                                                       completion: nil)
     }
 }
 
@@ -146,7 +151,7 @@ private struct RefundItemTableViewCellRepresentable: UIViewRepresentable {
                                             productTitle: "Hoddie - Big",
                                             productQuantityAndPrice: "2 x $29.99 each",
                                             quantityToRefund: "1")
-        cell.configure(with: viewModel)
+        cell.configure(with: viewModel, imageService: ServiceLocator.imageService)
         return cell
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
@@ -1,9 +1,10 @@
 import Foundation
+import Yosemite
 
 /// Represents an order item to be refunded. Meant to be rendered by `RefundItemTableViewCell`
 ///
 struct RefundItemViewModel {
-    let productImage: URL?
+    let productImage: String?
     let productTitle: String
     let productQuantityAndPrice: String
     let quantityToRefund: String

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
@@ -9,3 +9,29 @@ struct RefundItemViewModel {
     let productQuantityAndPrice: String
     let quantityToRefund: String
 }
+
+// MARK: Convenience Initializers
+extension RefundItemViewModel {
+
+    /// Creates a `RefundItemViewModel` based on a `OrderItem`, it's related product and it's currency..
+    /// `QuantityToRefund` is set to 0.
+    ///
+    init(item: OrderItem, product: Product?, currency: String, currencySettings: CurrencySettings) {
+        productImage = product?.images.first?.src
+        productTitle = item.name
+        quantityToRefund = String(UInt.min)
+        productQuantityAndPrice = {
+            let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
+            let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+            let price = currencyFormatter.formatAmount(item.price, with: currency ) ?? ""
+            return String(format: Localization.quantityAndPriceFormat, quantity, price)
+        }()
+    }
+}
+
+// MARK: Constant
+private extension RefundItemViewModel {
+    enum Localization {
+        static let quantityAndPriceFormat = NSLocalizedString("%@ x %@ each", comment: "Refund item price and quantity format. EG: 2 x $10.00 each")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundItemViewModel.swift
@@ -13,7 +13,7 @@ struct RefundItemViewModel {
 // MARK: Convenience Initializers
 extension RefundItemViewModel {
 
-    /// Creates a `RefundItemViewModel` based on a `OrderItem`, it's related product and it's currency..
+    /// Creates a `RefundItemViewModel` based on an `OrderItem`, it's related product and it's currency..
     /// `QuantityToRefund` is set to 0.
     ///
     init(item: OrderItem, product: Product?, currency: String, currencySettings: CurrencySettings) {
@@ -23,7 +23,7 @@ extension RefundItemViewModel {
         productQuantityAndPrice = {
             let quantity = NumberFormatter.localizedString(from: item.quantity as NSDecimalNumber, number: .decimal)
             let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-            let price = currencyFormatter.formatAmount(item.price, with: currency ) ?? ""
+            let price = currencyFormatter.formatAmount(item.price, with: currency) ?? ""
             return String(format: Localization.quantityAndPriceFormat, quantity, price)
         }()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 /// Screen that allows the user to refund items (products and shipping) of an order
 ///
@@ -12,9 +13,10 @@ final class IssueRefundViewController: UIViewController {
     @IBOutlet private var nextButton: UIButton!
     @IBOutlet private var selectAllButton: UIButton!
 
-    private let viewModel = IssueRefundViewModel()
+    private let viewModel: IssueRefundViewModel
 
-    init() {
+    init(order: Order) {
+        self.viewModel = IssueRefundViewModel(order: order)
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -13,10 +13,15 @@ final class IssueRefundViewController: UIViewController {
     @IBOutlet private var nextButton: UIButton!
     @IBOutlet private var selectAllButton: UIButton!
 
+    private let imageService: ImageService
+
     private let viewModel: IssueRefundViewModel
 
-    init(order: Order) {
-        self.viewModel = IssueRefundViewModel(order: order)
+    init(order: Order,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         imageService: ImageService = ServiceLocator.imageService) {
+        self.imageService = imageService
+        self.viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -112,7 +117,7 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
         switch rowViewModel {
         case let viewModel as RefundItemViewModel:
             let cell = tableView.dequeueReusableCell(RefundItemTableViewCell.self, for: indexPath)
-            cell.configure(with: viewModel)
+            cell.configure(with: viewModel, imageService: imageService)
             return cell
         case let viewModel as RefundProductsTotalViewModel:
             let cell = tableView.dequeueReusableCell(RefundProductsTotalTableViewCell.self, for: indexPath)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -12,12 +12,12 @@ final class IssueRefundViewModel {
     /// Title for the navigation bar
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///
-    let title: String = "$35.45"
+    let title: String = "$0.00"
 
     /// String indicating how many items the user has selected to refund
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///
-    let selectedItemsTitle: String = "3 items selected"
+    let selectedItemsTitle: String = "0 items selected"
 
     /// The sections and rows to display in the `UITableView`.
     ///
@@ -89,7 +89,7 @@ extension IssueRefundViewModel {
         }
 
         // This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
-        let sumaryRow = RefundProductsTotalViewModel(productsTax: "$13.45", productsSubtotal: "$66.26", productsTotal: "$79.71")
+        let sumaryRow = RefundProductsTotalViewModel(productsTax: "$0.00", productsSubtotal: "$0.00", productsTotal: "$0.00")
 
         return Section(rows: itemsRows + [sumaryRow])
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -25,7 +25,7 @@ final class IssueRefundViewModel {
 
     /// Products related to this order. Needed to build `RefundItemViewModel` rows
     ///
-    lazy var products: [Product] = {
+    private lazy var products: [Product] = {
         let resultsController = createProductsResultsController()
         try? resultsController.performFetch()
         return resultsController.fetchedObjects
@@ -89,9 +89,9 @@ extension IssueRefundViewModel {
         }
 
         // This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
-        let sumaryRow = RefundProductsTotalViewModel(productsTax: "$0.00", productsSubtotal: "$0.00", productsTotal: "$0.00")
+        let summaryRow = RefundProductsTotalViewModel(productsTax: "$0.00", productsSubtotal: "$0.00", productsTotal: "$0.00")
 
-        return Section(rows: itemsRows + [sumaryRow])
+        return Section(rows: itemsRows + [summaryRow])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -1,8 +1,13 @@
 import Foundation
+import Yosemite
 
 /// ViewModel for presenting the issue refund screen to the user.
 ///
 final class IssueRefundViewModel {
+
+    /// Order to be refunded
+    ///
+    private let order: Order
 
     /// Title for the navigation bar
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
@@ -33,6 +38,10 @@ final class IssueRefundViewModel {
                                            shippingTotal: "$12.99")
         ])
     ]
+
+    init(order: Order) {
+        self.order = order
+    }
 }
 
 // MARK: Sections and Rows

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -55,9 +55,8 @@ private extension IssueRefundViewModel {
     /// Results controller that fetches the products related to this order
     ///
     func createProductsResultsController() -> ResultsController<StorageProduct> {
-        let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
         let itemsIDs = order.items.map { $0.productID }
-        let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", siteID, itemsIDs)
+        let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", order.siteID, itemsIDs)
         return ResultsController<StorageProduct>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -20,27 +20,45 @@ final class IssueRefundViewModel {
     let selectedItemsTitle: String = "3 items selected"
 
     /// The sections and rows to display in the `UITableView`.
-    /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///
-    let sections: [Section] = [
-        Section(rows: [
-            RefundItemViewModel(productImage: nil, productTitle: "Item 1", productQuantityAndPrice: "2 x $30.27 each", quantityToRefund: "1"),
-            RefundItemViewModel(productImage: nil, productTitle: "Item 2", productQuantityAndPrice: "4 x $20.00 each", quantityToRefund: "2"),
-            RefundItemViewModel(productImage: nil, productTitle: "Item 3", productQuantityAndPrice: "3 x $15.99 each", quantityToRefund: "0"),
-            RefundProductsTotalViewModel(productsTax: "$13.45", productsSubtotal: "$66.26", productsTotal: "$79.71")
-        ]),
-        Section(rows: [
-            ShippingSwitchViewModel(title: "Refund Shipping", isOn: true),
-            RefundShippingDetailsViewModel(carrierRate: "USPS Flat Rate",
-                                           carrierCost: "$10.0",
-                                           shippingTax: "$2.99",
-                                           shippingSubtotal: "$10.0",
-                                           shippingTotal: "$12.99")
-        ])
-    ]
+    private(set) var sections: [Section] = []
 
-    init(order: Order) {
+    /// Products related to this order. Needed to build `RefundItemViewModel` rows
+    ///
+    lazy var products: [Product] = {
+        let resultsController = createProductsResultsController()
+        try? resultsController.performFetch()
+        return resultsController.fetchedObjects
+    }()
+
+    init(order: Order, currencySettings: CurrencySettings) {
         self.order = order
+
+        // This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
+        sections = [
+            createItemsToRefundSection(currencySettings: currencySettings),
+            Section(rows: [
+                ShippingSwitchViewModel(title: "Refund Shipping", isOn: true),
+                RefundShippingDetailsViewModel(carrierRate: "USPS Flat Rate",
+                                               carrierCost: "$10.0",
+                                               shippingTax: "$2.99",
+                                               shippingSubtotal: "$10.0",
+                                               shippingTotal: "$12.99")
+            ])
+        ]
+    }
+}
+
+// MARK: Results Controller
+private extension IssueRefundViewModel {
+
+    /// Results controller that fetches the products related to this order
+    ///
+    func createProductsResultsController() -> ResultsController<StorageProduct> {
+        let siteID = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min
+        let itemsIDs = order.items.map { $0.productID }
+        let predicate = NSPredicate(format: "siteID == %lld AND productID IN %@", siteID, itemsIDs)
+        return ResultsController<StorageProduct>(storageManager: ServiceLocator.storageManager, matching: predicate, sortedBy: [])
     }
 }
 
@@ -60,6 +78,20 @@ extension IssueRefundViewModel {
     struct ShippingSwitchViewModel: IssueRefundRow {
         let title: String
         let isOn: Bool
+    }
+
+    /// Returns a section with the order items that can be refunded
+    ///
+    private func createItemsToRefundSection(currencySettings: CurrencySettings) -> Section {
+        let itemsRows = order.items.map { item -> RefundItemViewModel in
+            let product = products.filter { $0.productID == item.productID }.first
+            return RefundItemViewModel(item: item, product: product, currency: order.currency, currencySettings: currencySettings)
+        }
+
+        // This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
+        let sumaryRow = RefundProductsTotalViewModel(productsTax: "$13.45", productsSubtotal: "$66.26", productsTotal: "$79.71")
+
+        return Section(rows: itemsRows + [sumaryRow])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -333,7 +333,7 @@ private extension OrderDetailsViewController {
 
     func issueRefundWasPressed() {
         // TODO: Migrate to a CoordinatingController https://github.com/woocommerce/woocommerce-ios/issues/2844
-        let issueRefundViewController = IssueRefundViewController()
+        let issueRefundViewController = IssueRefundViewController(order: viewModel.order)
         let navigationController = WooNavigationController(rootViewController: issueRefundViewController)
         present(navigationController, animated: true)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -329,6 +329,8 @@
 		265BCA0E2430E771004E53EE /* ProductCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */; };
 		265D909B2446657B00D66F0F /* ProductCategoryViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */; };
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
+		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
+		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1310,6 +1312,8 @@
 		265BCA0B2430E741004E53EE /* ProductCategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryTableViewCell.swift; sourceTree = "<group>"; };
 		265BCA0D2430E771004E53EE /* ProductCategoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
+		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
+		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2748,6 +2752,14 @@
 			path = Cell;
 			sourceTree = "<group>";
 		};
+		2667BFD5252E5D4C008099D4 /* Issue Refund */ = {
+			isa = PBXGroup;
+			children = (
+				2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */,
+			);
+			path = "Issue Refund";
+			sourceTree = "<group>";
+		};
 		26B119B524D0B36700FED5C7 /* Survey */ = {
 			isa = PBXGroup;
 			children = (
@@ -3156,6 +3168,7 @@
 		57F34A9F2423D44000E38AFB /* Orders */ = {
 			isa = PBXGroup;
 			children = (
+				2667BFD5252E5D4C008099D4 /* Issue Refund */,
 				57F2C6C9246DEBB10074063B /* Order Details */,
 				570AAB042472FACB00516C0C /* OrderDetailsDataSourceTests.swift */,
 				57F34AA02423D45A00E38AFB /* OrdersViewModelTests.swift */,
@@ -3354,6 +3367,7 @@
 				D8C11A6122E24C4A00D4A88D /* LedgerTableViewCellTests.swift */,
 				D83F593C225B4B5000626E75 /* ManualTrackingViewControllerTests.swift */,
 				D8AB131D225DC25F002BB5D1 /* MockOrders.swift */,
+				2667BFDA252E659A008099D4 /* MockOrderItem.swift */,
 				D83A6A772379097A00419D48 /* MurielColorTests.swift */,
 				D8736B5022EB69E300A14A29 /* OrderDetailsViewModelTests.swift */,
 				D8C11A5F22E2479800D4A88D /* OrderPaymentDetailsViewModelTests.swift */,
@@ -5626,6 +5640,7 @@
 				02C2756D24F4EEBF00286C04 /* ProductShippingSettingsViewModelTests.swift in Sources */,
 				B53B898920D450AF00EDB467 /* SessionManagerTests.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
+				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
 				45F5A3C323DF31D2007D40E5 /* ShippingInputFormatterTests.swift in Sources */,
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
@@ -5662,6 +5677,7 @@
 				020BE77323B4A567007FE54C /* AztecInsertMoreFormatBarCommandTests.swift in Sources */,
 				B53A569D21123EEB000776C9 /* MockupStorage.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
+				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrderItem.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Yosemite
+
+/// Generates mock order items
+///
+public struct MockOrderItem {
+    public static func sampleItem(itemID: Int64 = 0,
+                                  name: String = "",
+                                  productID: Int64 = 0,
+                                  variationID: Int64 = 0,
+                                  quantity: Decimal = 0,
+                                  price: NSDecimalNumber = 0,
+                                  sku: String? = nil,
+                                  subtotal: String = "0",
+                                  subtotalTax: String = "0",
+                                  taxClass: String = "",
+                                  taxes: [OrderItemTax] = [],
+                                  total: String = "0",
+                                  totalTax: String = "0") -> OrderItem {
+        return OrderItem(itemID: itemID,
+                         name: name,
+                         productID: productID,
+                         variationID: variationID,
+                         quantity: quantity,
+                         price: price,
+                         sku: sku,
+                         subtotal: subtotal,
+                         subtotalTax: subtotalTax,
+                         taxClass: taxClass,
+                         taxes: taxes,
+                         total: total,
+                         totalTax: totalTax)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemViewModelTests.swift
@@ -3,11 +3,41 @@ import Yosemite
 
 @testable import WooCommerce
 
-
 /// Test cases for `RefundItemViewModel`
 ///
 final class RefundItemViewModelTests: XCTestCase {
-    func test_something() {
-        Mockor
+    func test_viewModel_is_created_with_correct_initial_values() {
+        // Given
+        let item = sampleItem()
+        let product = sampleProduct()
+        let currencySettings = CurrencySettings()
+
+        // Wgeb
+        let viewModel = RefundItemViewModel(item: item, product: product, currency: "usd", currencySettings: currencySettings)
+
+        // Then
+        XCTAssertEqual(viewModel.productImage, product.images.first?.src)
+        XCTAssertEqual(viewModel.productTitle, item.name)
+        XCTAssertEqual(viewModel.quantityToRefund, "0")
+
+        let localizedFormat = NSLocalizedString("%@ x $%@ each", comment: "")
+        XCTAssertEqual(viewModel.productQuantityAndPrice, String(format: localizedFormat, "\(item.quantity)", item.price))
+
+    }
+}
+
+// MARK: Sample Objects
+private extension RefundItemViewModelTests {
+
+    func sampleProduct() -> Product {
+        MockProduct().product(images: [sampleProductImage()])
+    }
+
+    func sampleItem() -> OrderItem {
+        MockOrderItem.sampleItem(name: "Sample Item", quantity: 2, price: 10.55)
+    }
+
+    func sampleProductImage() -> ProductImage {
+        ProductImage(imageID: 0, dateCreated: Date(), dateModified: nil, src: "https://www.woo.com/img.jpg", name: nil, alt: nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemViewModelTests.swift
@@ -12,7 +12,7 @@ final class RefundItemViewModelTests: XCTestCase {
         let product = sampleProduct()
         let currencySettings = CurrencySettings()
 
-        // Wgeb
+        // When
         let viewModel = RefundItemViewModel(item: item, product: product, currency: "usd", currencySettings: currencySettings)
 
         // Then
@@ -20,9 +20,8 @@ final class RefundItemViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productTitle, item.name)
         XCTAssertEqual(viewModel.quantityToRefund, "0")
 
-        let localizedFormat = NSLocalizedString("%@ x $%@ each", comment: "")
-        XCTAssertEqual(viewModel.productQuantityAndPrice, String(format: localizedFormat, "\(item.quantity)", item.price))
-
+        let localizedFormat = NSLocalizedString("%@ x %@ each", comment: "")
+        XCTAssertEqual(viewModel.productQuantityAndPrice, String(format: localizedFormat, "\(item.quantity)", "$\(item.price)"))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemViewModelTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+
+/// Test cases for `RefundItemViewModel`
+///
+final class RefundItemViewModelTests: XCTestCase {
+    func test_something() {
+        Mockor
+    }
+}


### PR DESCRIPTION
Part of #2842 

# Why

Previous PR #2925 focused on building the issue refund UI with static data.
This PR focuses on rendering the order items real data.

PS:
- The view is still read-only
- Shipping Section is still static data

# How
- Updated `IssueRefundViewModel` to create the items rows based on the `order.items` property.
- Updated `RefundItemViewModel` to add an initializer based on an an `OrderItem` and `Product`
- Updated `RefundItemTableViewCell` to download and show remote  images.
- Created tests for `RefundItemViewModel`

# Screenshot
<img width="385" alt="render items" src="https://user-images.githubusercontent.com/562080/95383903-762fa680-08b1-11eb-9ee4-502d7a28a883.png">

# Testing Steps
- Launch the app and navigate to an order that can be refunded
- Tap on the issue refund button
- See that all items from the order are listed on the screen with the correct information

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
