### PR TITLE
Refactor `ProductAction.retrieveProduct` to return `Result<Product, Error>` instead of `(Product?, Error?)`

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -724,15 +724,17 @@ extension ProductDetailsViewModel {
 
     func syncProduct(onCompletion: ((Error?) -> ())? = nil) {
         let action = ProductAction.retrieveProduct(siteID: product.siteID,
-                                                   productID: product.productID) { [weak self] (product, error) in
-            guard let self = self, let product = product else {
-                DDLogError("⛔️ Error synchronizing Product: \(error.debugDescription)")
-                onCompletion?(error)
-                return
-            }
+                                                   productID: product.productID) { [weak self] result in
+                                                    guard let self = self else { return }
 
-            self.product = product
-            onCompletion?(nil)
+                                                    switch result {
+                                                    case .failure(let error):
+                                                        DDLogError("⛔️ Error synchronizing Product: \(error)")
+                                                        onCompletion?(error)
+                                                    case .success(let product):
+                                                        self.product = product
+                                                        onCompletion?(nil)
+                                                    }
         }
 
         ServiceLocator.stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductLoaderViewController.swift
@@ -96,18 +96,18 @@ private extension ProductLoaderViewController {
     /// Loads (and displays) the specified Product.
     ///
     func loadProduct() {
-        let action = ProductAction.retrieveProduct(siteID: siteID, productID: productID) { [weak self] (product, error) in
+        let action = ProductAction.retrieveProduct(siteID: siteID, productID: productID) { [weak self] result in
             guard let self = self else {
                 return
             }
 
-            guard let product = product else {
-                DDLogError("⛔️ Error loading Product for siteID: \(self.siteID) productID:\(self.productID) error:\(error.debugDescription)")
+            switch result {
+            case .success(let product):
+                self.state = .success(product: product)
+            case .failure(let error):
+                DDLogError("⛔️ Error loading Product for siteID: \(self.siteID) productID:\(self.productID) error:\(error)")
                 self.state = .failure
-                return
             }
-
-            self.state = .success(product: product)
         }
 
         state = .loading

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -27,7 +27,7 @@ public enum ProductAction: Action {
 
     /// Retrieves the specified Product.
     ///
-    case retrieveProduct(siteID: Int64, productID: Int64, onCompletion: (Product?, Error?) -> Void)
+    case retrieveProduct(siteID: Int64, productID: Int64, onCompletion: (Result<Product, Error>) -> Void)
 
     /// Retrieves a specified list of Products.
     ///

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -233,8 +233,7 @@ private extension ProductStore {
             case .success(let product):
                 self.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
                     guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: siteID, productID: productID) else {
-                        onCompletion(.failure(ProductLoadError.notFoundInStorage))
-                        return
+                        return onCompletion(.failure(ProductLoadError.notFoundInStorage))
                     }
                     onCompletion(.success(storageProduct.toReadOnly()))
                 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -218,7 +218,7 @@ private extension ProductStore {
 
     /// Retrieves the product associated with a given siteID + productID (if any!).
     ///
-    func retrieveProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Networking.Product?, Error?) -> Void) {
+    func retrieveProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Product, Error>) -> Void) {
         remote.loadProduct(for: siteID, productID: productID) { [weak self] result in
             guard let self = self else {
                 return
@@ -229,11 +229,14 @@ private extension ProductStore {
                 if case NetworkError.notFound = error {
                     self.deleteStoredProduct(siteID: siteID, productID: productID)
                 }
-                onCompletion(nil, error)
+                onCompletion(.failure(error))
             case .success(let product):
                 self.upsertStoredProductsInBackground(readOnlyProducts: [product]) { [weak self] in
-                    let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: siteID, productID: productID)
-                    onCompletion(storageProduct?.toReadOnly(), nil)
+                    guard let storageProduct = self?.storageManager.viewStorage.loadProduct(siteID: siteID, productID: productID) else {
+                        onCompletion(.failure(ProductLoadError.notFoundInStorage))
+                        return
+                    }
+                    onCompletion(.success(storageProduct.toReadOnly()))
                 }
             }
 
@@ -651,4 +654,8 @@ public enum ProductUpdateError: Error, Equatable {
             }
         }
     }
+}
+
+public enum ProductLoadError: Error, Equatable {
+    case notFoundInStorage
 }


### PR DESCRIPTION
Prep for #2904 

This PR is not meant to introduce user-facing changes, and is to simplify the logic for the main PR for #2904.

## Changes

- Updated `ProductAction.retrieveProduct` to return `Result<Product, Error>` instead of `(Product?, Error?)`
- Refactored affected unit tests to follow Arrange/Action/Assert style with non-nil result

## Testing

Confidence check on affected screens:

- Go to the Orders tab
- Tap on an order
- Tap on a product on order details --> it should open the readonly product details successfully
- Pull down to refresh the product details --> it should refresh the product successfully

(I tested the case when the device has no network connection, and the error in the console shows the error details)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
