### PR TITLE
[Issue Refunds] Shipping Switch Handling

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// Represents shipping details for an order to be refunded. Meant to be rendered by `RefundShippingDetailsTableViewCell`
 ///
@@ -8,4 +9,31 @@ struct RefundShippingDetailsViewModel {
     let shippingTax: String
     let shippingSubtotal: String
     let shippingTotal: String
+}
+
+// MARK: Convenience Initializers
+extension RefundShippingDetailsViewModel {
+    /// Creates a `RefundShippingDetailsViewModel` based on a `ShippingLine`
+    ///
+    init(shippingLine: ShippingLine, currency: String, currencySettings: CurrencySettings) {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.carrierRate = shippingLine.methodTitle
+        self.carrierCost = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? ""
+        self.shippingTax = currencyFormatter.formatAmount(shippingLine.totalTax, with: currency) ?? ""
+        self.shippingSubtotal = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? ""
+        self.shippingTotal = {
+            let calculatedTotal = Self.calculateShippingTotal(of: shippingLine, using: currencyFormatter)
+            return currencyFormatter.formatAmount(calculatedTotal, with: currency) ?? ""
+        }()
+    }
+
+    /// Calculates the shipping total by adding the shipping cost + the shipping tax
+    ///
+    private static func calculateShippingTotal(of shippingLine: ShippingLine, using currencyFormatter: CurrencyFormatter) -> String {
+        guard let cost = currencyFormatter.convertToDecimal(from: shippingLine.total),
+            let tax = currencyFormatter.convertToDecimal(from: shippingLine.totalTax) else {
+                return ""
+        }
+        return cost.adding(tax).stringValue
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
@@ -29,11 +29,11 @@ extension RefundShippingDetailsViewModel {
 
     /// Calculates the shipping total by adding the shipping cost + the shipping tax
     ///
-    private static func calculateShippingTotal(of shippingLine: ShippingLine, using currencyFormatter: CurrencyFormatter) -> String {
+    private static func calculateShippingTotal(of shippingLine: ShippingLine, using currencyFormatter: CurrencyFormatter) -> NSDecimalNumber {
         guard let cost = currencyFormatter.convertToDecimal(from: shippingLine.total),
             let tax = currencyFormatter.convertToDecimal(from: shippingLine.totalTax) else {
-                return ""
+                return .zero
         }
-        return cost.adding(tax).stringValue
+        return cost.adding(tax)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -34,7 +34,7 @@ final class IssueRefundViewController: UIViewController {
         configureNavigationBar()
         configureTableView()
         observeViewModel()
-        updateVithViewModelContent()
+        updateWithViewModelContent()
     }
 
     override func viewWillLayoutSubviews() {
@@ -48,11 +48,11 @@ final class IssueRefundViewController: UIViewController {
 private extension IssueRefundViewController {
     func observeViewModel() {
         viewModel.onChange = { [weak self] in
-            self?.updateVithViewModelContent()
+            self?.updateWithViewModelContent()
         }
     }
 
-    func updateVithViewModelContent() {
+    func updateWithViewModelContent() {
         title = viewModel.title
         itemsSelectedLabel.text = viewModel.selectedItemsTitle
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -33,12 +33,29 @@ final class IssueRefundViewController: UIViewController {
         super.viewDidLoad()
         configureNavigationBar()
         configureTableView()
+        observeViewModel()
+        updateVithViewModelContent()
     }
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         tableView.updateHeaderHeight()
         tableView.updateFooterHeight()
+    }
+}
+
+// MARK: ViewModel observation
+private extension IssueRefundViewController {
+    func observeViewModel() {
+        viewModel.onChange = { [weak self] in
+            self?.updateVithViewModelContent()
+        }
+    }
+
+    func updateVithViewModelContent() {
+        title = viewModel.title
+        itemsSelectedLabel.text = viewModel.selectedItemsTitle
+        tableView.reloadData()
     }
 }
 
@@ -61,7 +78,6 @@ private extension IssueRefundViewController {
 private extension IssueRefundViewController {
 
     func configureNavigationBar() {
-        title = viewModel.title
         addCloseNavigationBarButton(title: Localization.cancelTitle)
     }
 
@@ -89,7 +105,6 @@ private extension IssueRefundViewController {
         selectAllButton.setTitle(Localization.selectAllTitle, for: .normal)
 
         itemsSelectedLabel.applySecondaryBodyStyle()
-        itemsSelectedLabel.text = viewModel.selectedItemsTitle
     }
 
     func configureFooterView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -51,6 +51,10 @@ private extension IssueRefundViewController {
     @IBAction func selectAllButtonWasPressed(_ sender: Any) {
         print("Select All button pressed")
     }
+
+    func shippingSwitchChanged() {
+        viewModel.toggleRefundShipping()
+    }
 }
 
 // MARK: View Configuration
@@ -127,6 +131,9 @@ extension IssueRefundViewController: UITableViewDelegate, UITableViewDataSource 
             let cell = tableView.dequeueReusableCell(SwitchTableViewCell.self, for: indexPath)
             cell.title = viewModel.title
             cell.isOn = viewModel.isOn
+            cell.onChange = { [weak self] _ in
+                self?.shippingSwitchChanged()
+            }
             return cell
         case let viewModel as RefundShippingDetailsViewModel:
             let cell = tableView.dequeueReusableCell(RefundShippingDetailsTableViewCell.self, for: indexPath)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -5,7 +5,7 @@ import Yosemite
 ///
 final class IssueRefundViewModel {
 
-    /// Struct to hold the necesary state to perform the refund and update the view model
+    /// Struct to hold the necessary state to perform the refund and update the view model
     ///
     private struct State {
         /// Order to be refunded

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -57,6 +57,13 @@ final class IssueRefundViewModel {
     }
 }
 
+// MARK: User Actions
+extension IssueRefundViewModel {
+    func toggleRefundShipping() {
+        state.shouldRefundShipping.toggle()
+    }
+}
+
 // MARK: Results Controller
 private extension IssueRefundViewModel {
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -22,9 +22,12 @@ final class IssueRefundViewModel {
     }
 
     /// Current ViewModel state
-    /// TODO: Var or let?
     ///
-    private var state: State
+    private var state: State {
+        didSet {
+            sections = createSections()
+        }
+    }
 
     /// Title for the navigation bar
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
@@ -122,8 +125,12 @@ extension IssueRefundViewModel {
             return nil
         }
 
-        // `true` is hardcoded, will be dynamic after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
-        let switchRow = ShippingSwitchViewModel(title: Localization.refundShippingTitle, isOn: true)
+        // If `shouldRefundShipping` is disabled, return only the `switchRow`
+        let switchRow = ShippingSwitchViewModel(title: Localization.refundShippingTitle, isOn: state.shouldRefundShipping)
+        guard state.shouldRefundShipping else {
+            return Section(rows: [switchRow])
+        }
+
         let detailsRow = RefundShippingDetailsViewModel(shippingLine: shippingLine, currency: state.order.currency, currencySettings: state.currencySettings)
         return Section(rows: [switchRow, detailsRow])
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -26,6 +26,7 @@ final class IssueRefundViewModel {
     private var state: State {
         didSet {
             sections = createSections()
+            onChange?()
         }
     }
 
@@ -38,6 +39,10 @@ final class IssueRefundViewModel {
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///
     let selectedItemsTitle: String = "0 items selected"
+
+    /// Closured to notify the `ViewController` when the view model properties change
+    ///
+    var onChange: (() -> (Void))?
 
     /// The sections and rows to display in the `UITableView`.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -39,11 +39,7 @@ final class IssueRefundViewModel {
             createItemsToRefundSection(currencySettings: currencySettings),
             Section(rows: [
                 ShippingSwitchViewModel(title: "Refund Shipping", isOn: true),
-                RefundShippingDetailsViewModel(carrierRate: "USPS Flat Rate",
-                                               carrierCost: "$10.0",
-                                               shippingTax: "$2.99",
-                                               shippingSubtotal: "$10.0",
-                                               shippingTotal: "$12.99")
+                RefundShippingDetailsViewModel(shippingLine: order.shippingLines[0], currency: order.currency, currencySettings: currencySettings)
             ])
         ]
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		265D909D2446688C00D66F0F /* ProductCategoryViewModelBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */; };
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
+		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1314,6 +1315,7 @@
 		265D909A2446657A00D66F0F /* ProductCategoryViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilder.swift; sourceTree = "<group>"; };
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
+		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2756,6 +2758,7 @@
 			isa = PBXGroup;
 			children = (
 				2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */,
+				2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */,
 			);
 			path = "Issue Refund";
 			sourceTree = "<group>";
@@ -5718,6 +5721,7 @@
 				4535001E2509455100CDE072 /* SiteCountryTests.swift in Sources */,
 				5798191324526FE8000817F8 /* PublishSubjectTests.swift in Sources */,
 				746791632108D7C0007CF1DC /* WooAnalyticsTests.swift in Sources */,
+				2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */,
 				021FAFCD2355621E00B99241 /* UIView+SubviewsAxisTests.swift in Sources */,
 				74F3015A2200EC0800931B9E /* NSDecimalNumberWooTests.swift in Sources */,
 				D85136CD231E15B800DD0539 /* MockReviews.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */; };
 		2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDA252E659A008099D4 /* MockOrderItem.swift */; };
 		2667BFDD252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */; };
+		2667BFDF252F762E008099D4 /* IssueRefundViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDE252F762E008099D4 /* IssueRefundViewModelTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1316,6 +1317,7 @@
 		2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFDA252E659A008099D4 /* MockOrderItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOrderItem.swift; sourceTree = "<group>"; };
 		2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsViewModelTests.swift; sourceTree = "<group>"; };
+		2667BFDE252F762E008099D4 /* IssueRefundViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModelTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2757,6 +2759,7 @@
 		2667BFD5252E5D4C008099D4 /* Issue Refund */ = {
 			isa = PBXGroup;
 			children = (
+				2667BFDE252F762E008099D4 /* IssueRefundViewModelTests.swift */,
 				2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */,
 				2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */,
 			);
@@ -5728,6 +5731,7 @@
 				D8053BCE231F98DA00CE60C2 /* ReviewAgeTests.swift in Sources */,
 				5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */,
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,
+				2667BFDF252F762E008099D4 /* IssueRefundViewModelTests.swift in Sources */,
 				02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */,
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -4,7 +4,7 @@ final class MockOrders {
     let siteID: Int64 = 1234
     let orderID: Int64 = 5678
 
-    func makeOrder(status: OrderStatusEnum = .processing, items: [OrderItem] = []) -> Order {
+    func makeOrder(status: OrderStatusEnum = .processing, items: [OrderItem] = [], shippingLines: [ShippingLine] = sampleShippingLines()) -> Order {
         return Order(siteID: siteID,
                      orderID: orderID,
                      parentID: 0,
@@ -26,7 +26,7 @@ final class MockOrders {
                      items: items,
                      billingAddress: sampleAddress(),
                      shippingAddress: sampleAddress(),
-                     shippingLines: sampleShippingLines(),
+                     shippingLines: shippingLines,
                      coupons: [],
                      refunds: [])
     }
@@ -57,12 +57,12 @@ final class MockOrders {
                      items: [],
                      billingAddress: sampleAddress(),
                      shippingAddress: sampleAddress(),
-                     shippingLines: sampleShippingLines(),
+                     shippingLines: Self.sampleShippingLines(),
                      coupons: [],
                      refunds: [])
     }
 
-    func sampleShippingLines() -> [ShippingLine] {
+    static func sampleShippingLines() -> [ShippingLine] {
         return [ShippingLine(shippingID: 123,
         methodTitle: "International Priority Mail Express Flat Rate",
         methodID: "usps",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -7,4 +7,48 @@ import Yosemite
 ///
 final class IssueRefundViewModelTests: XCTestCase {
 
+    func test_viewModel_does_not_have_shippping_section_on_order_without_shipping() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder(shippingLines: [])
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+
+        // Then
+        let rows = viewModel.sections.flatMap { $0.rows }
+        XCTAssertFalse(rows.isEmpty)
+        rows.forEach { viewModel in
+            XCTAssertFalse(viewModel is IssueRefundViewModel.ShippingSwitchViewModel)
+            XCTAssertFalse(viewModel is RefundShippingDetailsViewModel)
+        }
+    }
+
+    func test_viewModel_does_have_shipping_section_on_order_with_shipping() throws {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder(shippingLines: MockOrders.sampleShippingLines())
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+
+        // Then
+        let shippingSwitchRow = try XCTUnwrap(viewModel.sections[safe: 1]?.rows[safe: 0])
+        XCTAssertTrue(shippingSwitchRow is IssueRefundViewModel.ShippingSwitchViewModel)
+    }
+
+    func test_viewModel_inserts_shipping_details_after_toggling_switch() throws {
+        // Given
+        let currencySettings = CurrencySettings()
+        let order = MockOrders().makeOrder(shippingLines: MockOrders.sampleShippingLines())
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+        XCTAssertNil(viewModel.sections[safe: 1]?.rows[safe: 1]) // No shipping details
+
+        // When
+        viewModel.toggleRefundShipping()
+
+        // Then
+        let shippingDetailsRow = try XCTUnwrap(viewModel.sections[safe: 1]?.rows[safe: 1])
+        XCTAssertTrue(shippingDetailsRow is RefundShippingDetailsViewModel)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Test cases for `IssueRefundViewModel`
+///
+final class IssueRefundViewModelTests: XCTestCase {
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -7,7 +7,7 @@ import Yosemite
 ///
 final class IssueRefundViewModelTests: XCTestCase {
 
-    func test_viewModel_does_not_have_shippping_section_on_order_without_shipping() {
+    func test_viewModel_does_not_have_shipping_section_on_order_without_shipping() {
         // Given
         let currencySettings = CurrencySettings()
         let order = MockOrders().makeOrder(shippingLines: [])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundShippingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundShippingDetailsViewModelTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Test cases for `RefundShippingDetailsViewModel`
+///
+final class RefundShippingDetailsViewModelTests: XCTestCase {
+    func test_viewModel_is_created_with_correct_initial_values() {
+        // Given
+        let shippingLine = ShippingLine(shippingID: 0, methodTitle: "USPS Flat Rate", methodID: "USPS", total: "10.20", totalTax: "1.30")
+        let currencySettings = CurrencySettings()
+
+        // When
+        let viewModel = RefundShippingDetailsViewModel(shippingLine: shippingLine, currency: "usd", currencySettings: currencySettings)
+
+        // Then
+        XCTAssertEqual(viewModel.carrierRate, "USPS Flat Rate")
+        XCTAssertEqual(viewModel.carrierCost, "$10.20")
+        XCTAssertEqual(viewModel.shippingTax, "$1.30")
+        XCTAssertEqual(viewModel.shippingSubtotal, "$10.20")
+        XCTAssertEqual(viewModel.shippingTotal, "$11.50")
+    }
+}


### PR DESCRIPTION
part of #2842

# Why
This PR takes care of two things:
1. Render the shipping details to refund.
2. Show/Hide the shipping detail when the user enables/disables the "Refund Shipping" switch.

# How
1. Update `RefundShippingDetailsViewModel` to include a new initializer that will format its fields appropriately.
2. Added a `State` struct in `IssueRefundViewController` to hold on to the state generated by the users. 
   Modify that state when the user toggles the shipping switch. 
   Recreate the table view sections everything that states changes.

# Screenshots
No Shipping | Shipping Disabled | Shipping Enabled
--- | --- | ---
<img width="387" alt="no-shipping" src="https://user-images.githubusercontent.com/562080/95498394-5d82c780-0969-11eb-9638-07cf1012309c.png"> | <img width="395" alt="shipping-disabled" src="https://user-images.githubusercontent.com/562080/95498387-5a87d700-0969-11eb-9ab8-55ef24968880.png"> | <img width="388" alt="shipping-enabled" src="https://user-images.githubusercontent.com/562080/95498393-5c519a80-0969-11eb-9a88-bca6fda995c1.png">


# Testing steps

## No shipping
- Launch app and navigate to an underfunded order that does not have shipping
- Tap on the "Issue refund" button
- See that the issue refund screen does not show a shipping section

## Shipping
- Launch app and navigate to an underfunded order that does have shipping
- Tap on the "Issue refund" button
- See that the screen shows a disabled switch to refund shipping
- Enable the switch
- See that the screen shows the shipping details to refund


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
