### PR TITLE
Orders tab: DI site ID to `OrdersRootViewController ` and its downstream classes

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -8,6 +8,7 @@ final class OrderDetailsResultsControllers {
     private let storageManager: StorageManagerType
 
     private let order: Order
+    private let siteID: Int64
 
     /// Shipment Tracking ResultsController.
     ///
@@ -23,7 +24,7 @@ final class OrderDetailsResultsControllers {
     /// Product ResultsController.
     ///
     private lazy var productResultsController: ResultsController<StorageProduct> = {
-        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -32,7 +33,7 @@ final class OrderDetailsResultsControllers {
     /// Status Results Controller.
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
-        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -76,6 +77,7 @@ final class OrderDetailsResultsControllers {
     init(order: Order,
          storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.order = order
+        self.siteID = order.siteID
         self.storageManager = storageManager
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsDataSource.swift
@@ -45,7 +45,7 @@ final class RefundDetailsDataSource: NSObject {
     /// The results controllers used to display a refund
     ///
     private lazy var resultsControllers: RefundDetailsResultController = {
-        return RefundDetailsResultController()
+        return RefundDetailsResultController(siteID: order.siteID)
     }()
 
     /// Set up results controllers

--- a/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsResultController.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refund Details/RefundDetailsResultController.swift
@@ -9,7 +9,7 @@ final class RefundDetailsResultController {
     ///
     private lazy var productResultsController: ResultsController<StorageProduct> = {
         let storageManager = ServiceLocator.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "name", ascending: true)
 
         return ResultsController<StorageProduct>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
@@ -19,6 +19,12 @@ final class RefundDetailsResultController {
     ///
     var products: [Product] {
         return productResultsController.fetchedObjects
+    }
+
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
     }
 
     /// Configure the result controller(s)

--- a/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Refunded Products/RefundedProductsDataSource.swift
@@ -29,7 +29,7 @@ final class RefundedProductsDataSource: NSObject {
     /// The results controllers used to display a refund
     ///
     private lazy var resultsControllers: RefundDetailsResultController = {
-        return RefundDetailsResultController()
+        return RefundDetailsResultController(siteID: order.siteID)
     }()
 
     /// Set up results controllers

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -8,6 +8,7 @@ import Yosemite
 /// - The providers corresponding to the store country should be shown first
 final class ShippingProvidersViewModel {
     let order: Order
+    private let predicateForAllProviders: NSPredicate
 
     /// Title of view displaying all available Shipment Tracking Providers
     let title = NSLocalizedString("Shipping Carriers",
@@ -61,7 +62,7 @@ final class ShippingProvidersViewModel {
         let storageManager = ServiceLocator.storageManager
         let groupNameKeyPath = ResultsControllerConstants.groupNameKeyPath
         let providerNameKeyPath = ResultsControllerConstants.providerNameKeyPath
-        let excludingStoreCountry = predicateExcludingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
+        let excludingStoreCountry = predicateExcludingStoreCountry(predicate: predicateForAllProviders)
 
         let providerGroupDescriptor = NSSortDescriptor(key: groupNameKeyPath,
                                                       ascending: true)
@@ -81,7 +82,7 @@ final class ShippingProvidersViewModel {
         let groupNameKeyPath = ResultsControllerConstants.groupNameKeyPath
         let providerNameKeyPath = ResultsControllerConstants.providerNameKeyPath
 
-        let matchingStoreCountry = predicateMatchingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
+        let matchingStoreCountry = predicateMatchingStoreCountry(predicate: predicateForAllProviders)
 
         let providerGroupDescriptor = NSSortDescriptor(key: groupNameKeyPath,
                                                        ascending: true)
@@ -112,6 +113,7 @@ final class ShippingProvidersViewModel {
     ///
     init(order: Order, selectedProvider: ShipmentTrackingProvider?, selectedProviderGroupName: String?) {
         self.order = order
+        self.predicateForAllProviders = NSPredicate(format: "siteID == %lld", order.siteID)
         self.selectedProvider = selectedProvider
         self.selectedProviderGroupName = selectedProviderGroupName
     }
@@ -152,9 +154,9 @@ final class ShippingProvidersViewModel {
     ///
     func clearFilters() {
         providersExcludingStoreCountry.predicate =
-            predicateExcludingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
+            predicateExcludingStoreCountry(predicate: predicateForAllProviders)
         providersForStoreCountry.predicate =
-            predicateMatchingStoreCountry(predicate: ResultsControllerConstants.predicateForAllProviders)
+            predicateMatchingStoreCountry(predicate: predicateForAllProviders)
     }
 
     private func dataWasUpdated() {
@@ -330,9 +332,6 @@ extension ShippingProvidersViewModel {
 // MARK: - Constants
 //
 private enum ResultsControllerConstants {
-    static let predicateForAllProviders =
-        NSPredicate(format: "siteID == %lld",
-                    ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
     static let groupNameKeyPath =
         #keyPath(StorageShipmentTrackingProvider.group.name)
     static let providerNameKeyPath = #keyPath(StorageShipmentTrackingProvider.name)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -372,7 +372,7 @@ private extension MainTabBarController {
         let dashboardViewController = createDashboardViewController(siteID: siteID)
         dashboardNavigationController.viewControllers = [dashboardViewController]
 
-        let ordersViewController = createOrdersViewController()
+        let ordersViewController = createOrdersViewController(siteID: siteID)
         ordersNavigationController.viewControllers = [ordersViewController]
 
         let productsViewController = createProductsViewController()
@@ -390,8 +390,8 @@ private extension MainTabBarController {
         DashboardViewController(siteID: siteID)
     }
 
-    func createOrdersViewController() -> UIViewController {
-        OrdersRootViewController()
+    func createOrdersViewController(siteID: Int64) -> UIViewController {
+        OrdersRootViewController(siteID: siteID)
     }
 
     func createProductsViewController() -> UIViewController {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Summary Section/Edit Order Status/OrderStatusListViewController.swift
@@ -13,7 +13,7 @@ final class OrderStatusListViewController: UIViewController {
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = ServiceLocator.storageManager
         let predicate = NSPredicate(format: "siteID == %lld && slug != %@",
-                                    ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min,
+                                    siteID,
                                     OrderStatusEnum.refunded.rawValue)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
@@ -39,9 +39,11 @@ final class OrderStatusListViewController: UIViewController {
     /// Order to be provided with a new status
     ///
     private let order: Order
+    private let siteID: Int64
 
     init(order: Order, currentStatus: OrderStatus?) {
         self.order = order
+        self.siteID = order.siteID
         self.selectedStatus = currentStatus
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -82,10 +82,7 @@ private extension ShipmentProvidersViewController {
     ///
     func fetchGroups() {
         footerSpinnerView.startAnimating()
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return
-        }
-
+        let siteID = viewModel.order.siteID
         let orderID = viewModel.order.orderID
 
         let loadGroupsAction = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -46,6 +46,8 @@ final class OrderListViewModel {
     ///
     private let includesFutureOrders: Bool
 
+    private let siteID: Int64
+
     /// Used for tracking whether the app was _previously_ in the background.
     ///
     private var isAppActive: Bool = true
@@ -57,11 +59,13 @@ final class OrderListViewModel {
         snapshotsProvider.snapshot
     }
 
-    init(storageManager: StorageManagerType = ServiceLocator.storageManager,
+    init(siteID: Int64,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
          statusFilter: OrderStatus?,
          includesFutureOrders: Bool = true) {
+        self.siteID = siteID
         self.storageManager = storageManager
         self.pushNotificationsManager = pushNotificationsManager
         self.notificationCenter = notificationCenter
@@ -142,15 +146,6 @@ final class OrderListViewModel {
 
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
-
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            assertionFailure("Trying to create a query for Order list without a site ID")
-            return FetchResultSnapshotsProvider<StorageOrder>.Query(
-                sortDescriptor: NSSortDescriptor(keyPath: \StorageOrder.dateCreated, ascending: false),
-                predicate: predicate,
-                sectionNameKeyPath: "\(#selector(StorageOrder.normalizedAgeAsString))"
-            )
-        }
 
         let siteIDPredicate = NSPredicate(format: "siteID = %lld", siteID)
         let queryPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [siteIDPredicate, predicate])

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewController.swift
@@ -11,9 +11,12 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
 
     private lazy var analytics = ServiceLocator.analytics
 
-    private lazy var viewModel = OrdersMasterViewModel()
+    private lazy var viewModel = OrdersMasterViewModel(siteID: siteID)
 
-    init() {
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
         super.init(nibName: Self.nibName, bundle: nil)
     }
 
@@ -58,14 +61,10 @@ final class OrdersMasterViewController: ButtonBarPagerTabStripViewController {
     /// Shows `SearchViewController`.
     ///
     @objc private func displaySearchOrders() {
-        guard let storeID = viewModel.siteID else {
-            return
-        }
-
         analytics.track(.ordersListSearchTapped)
 
-        let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(storeID: storeID,
-                                                                                                  command: OrderSearchUICommand(),
+        let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(storeID: siteID,
+                                                                                                  command: OrderSearchUICommand(siteID: siteID),
                                                                                                   cellType: OrderTableViewCell.self)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 
@@ -177,7 +176,7 @@ extension OrdersMasterViewController {
         // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.
         let processingOrderStatus = OrderStatus(
             name: OrderStatusEnum.processing.rawValue,
-            siteID: Int64.max,
+            siteID: siteID,
             slug: OrderStatusEnum.processing.rawValue,
             total: 0
         )
@@ -185,8 +184,9 @@ extension OrdersMasterViewController {
         // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
         // text in here. We want the string to be translated.
         let processingOrdersVC = OrderListViewController(
+            siteID: siteID,
             title: Localization.processingTitle,
-            viewModel: OrderListViewModel(statusFilter: processingOrderStatus),
+            viewModel: OrderListViewModel(siteID: siteID, statusFilter: processingOrderStatus),
             emptyStateConfig: .simple(
                 message: NSAttributedString(string: Localization.processingEmptyStateMessage),
                 image: .waitingForCustomersImage
@@ -195,8 +195,9 @@ extension OrdersMasterViewController {
         processingOrdersVC.delegate = self
 
         let allOrdersVC = OrderListViewController(
+            siteID: siteID,
             title: Localization.allOrdersTitle,
-            viewModel: OrderListViewModel(statusFilter: nil, includesFutureOrders: false),
+            viewModel: OrderListViewModel(siteID: siteID, statusFilter: nil, includesFutureOrders: false),
             emptyStateConfig: .withLink(
                 message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                 image: .emptyOrdersImage,
@@ -215,15 +216,16 @@ extension OrdersMasterViewController {
         // TODO This is fake. It's probably better to just pass the `slug` to `OrdersViewController`.
         let processingOrderStatus = OrderStatus(
             name: OrderStatusEnum.processing.rawValue,
-            siteID: Int64.max,
+            siteID: siteID,
             slug: OrderStatusEnum.processing.rawValue,
             total: 0
         )
         // We're intentionally not using `processingOrderStatus` as the source of the "Processing"
         // text in here. We want the string to be translated.
         let processingOrdersVC = OrdersViewController(
+            siteID: siteID,
             title: Localization.processingTitle,
-            viewModel: OrdersViewModel(statusFilter: processingOrderStatus),
+            viewModel: OrdersViewModel(siteID: siteID, statusFilter: processingOrderStatus),
             emptyStateConfig: .simple(
                 message: NSAttributedString(string: Localization.processingEmptyStateMessage),
                 image: .waitingForCustomersImage
@@ -232,8 +234,9 @@ extension OrdersMasterViewController {
         processingOrdersVC.delegate = self
 
         let allOrdersVC = OrdersViewController(
+            siteID: siteID,
             title: Localization.allOrdersTitle,
-            viewModel: OrdersViewModel(statusFilter: nil, includesFutureOrders: false),
+            viewModel: OrdersViewModel(siteID: siteID, statusFilter: nil, includesFutureOrders: false),
             emptyStateConfig: .withLink(
                 message: NSAttributedString(string: Localization.allOrdersEmptyStateMessage),
                 image: .emptyOrdersImage,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersMasterViewModel.swift
@@ -4,12 +4,6 @@ import Yosemite
 
 /// Encapsulates data management for `OrdersMasterViewController`.
 ///
-/// ## Always Active
-///
-/// The corresponding view, `OrdersMaterViewController`, is never deallocated even if the user has
-/// already logged out. There are some considerations in this class like `refreshStatusPredicate` to
-/// accommodate this behavior.
-///
 final class OrdersMasterViewModel {
 
     private lazy var storageManager = ServiceLocator.storageManager
@@ -20,13 +14,18 @@ final class OrdersMasterViewModel {
     ///
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
-        return ResultsController<StorageOrderStatus>(storageManager: storageManager, sortedBy: [descriptor])
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        return ResultsController<StorageOrderStatus>(storageManager: storageManager,
+                                                     matching: predicate,
+                                                     sortedBy: [descriptor])
     }()
 
     /// The current `Site` `siteID`.
     ///
-    var siteID: Int64? {
-        sessionManager.defaultStoreID
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
     }
 
     /// Start all the operations that this `ViewModel` is responsible for.
@@ -34,25 +33,12 @@ final class OrdersMasterViewModel {
     /// This should only be called once in the lifetime of `OrdersMasterViewController`.
     ///
     func activate() {
-        // Initialize `statusResultsController`
-        refreshStatusPredicate()
         try? statusResultsController.performFetch()
-
-        // Listen to notifications
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(defaultAccountWasUpdated), name: .defaultAccountWasUpdated, object: nil)
     }
 
     /// Fetch all `OrderStatus` from the API
     ///
     func syncOrderStatuses() {
-        guard let siteID = siteID else {
-            return
-        }
-
-        // First, let's verify our FRC predicate is up to date
-        refreshStatusPredicate()
-
         let action = OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { (_, error) in
             if let error = error {
                 DDLogError("⛔️ Order List — Error synchronizing order statuses: \(error)")
@@ -60,27 +46,5 @@ final class OrdersMasterViewModel {
         }
 
         stores.dispatch(action)
-    }
-
-    /// Runs whenever the default Account is updated.
-    ///
-    @objc private func defaultAccountWasUpdated() {
-        refreshStatusPredicate()
-    }
-
-    /// Update the `siteID` predicate of `statusResultsController` to the current `siteID`.
-    ///
-    private func refreshStatusPredicate() {
-        // Bugfix for https://github.com/woocommerce/woocommerce-ios/issues/751.
-        // Because we are listening for default account changes,
-        // this will also fire upon logging out, when the account
-        // is set to nil. So let's protect against multi-threaded
-        // access attempts if the account is indeed nil.
-        guard stores.isAuthenticated,
-            stores.needsDefaultStore == false else {
-                return
-        }
-
-        statusResultsController.predicate = NSPredicate(format: "siteID == %lld", siteID ?? Int.min)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -17,7 +17,7 @@ final class OrdersRootViewController: UIViewController {
 
     // MARK: Child view controller
 
-    private lazy var ordersViewController = OrdersMasterViewController()
+    private lazy var ordersViewController = OrdersMasterViewController(siteID: siteID)
 
     // MARK: Subviews
 
@@ -25,18 +25,20 @@ final class OrdersRootViewController: UIViewController {
         return UIView(frame: .zero)
     }()
 
+    private let siteID: Int64
+
     // MARK: View Lifecycle
 
-    init() {
+    init(siteID: Int64) {
+        self.siteID = siteID
         super.init(nibName: nil, bundle: nil)
 
         configureTitle()
         configureTabBarItem()
     }
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        tabBarItem.image = .statsAltImage
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersViewModel.swift
@@ -65,14 +65,17 @@ final class OrdersViewModel {
         resultsController.isEmpty
     }
 
+    private let siteID: Int64
     private let stores: StoresManager
 
-    init(storageManager: StorageManagerType = ServiceLocator.storageManager,
+    init(siteID: Int64,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
          pushNotificationsManager: PushNotesManager = ServiceLocator.pushNotesManager,
          notificationCenter: NotificationCenter = .default,
          statusFilter: OrderStatus?,
          includesFutureOrders: Bool = true,
          stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
         self.storageManager = storageManager
         self.pushNotificationsManager = pushNotificationsManager
         self.notificationCenter = notificationCenter
@@ -127,11 +130,6 @@ final class OrdersViewModel {
 
             return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }()
-
-        guard let siteID = stores.sessionManager.defaultStoreID else {
-            assertionFailure("Trying to create results controller without a site ID")
-            return predicate
-        }
 
         let siteIDPredicate = NSPredicate(format: "siteID = %lld", siteID)
         return NSCompoundPredicate(andPredicateWithSubpredicates: [siteIDPredicate, predicate])

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewController.swift
@@ -12,7 +12,7 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
 
     @IBOutlet private var tableView: UITableView!
 
-    private lazy var viewModel = OrderSearchStarterViewModel()
+    private lazy var viewModel = OrderSearchStarterViewModel(siteID: siteID)
 
     private lazy var keyboardFrameObserver: KeyboardFrameObserver = {
         KeyboardFrameObserver { [weak self] keyboardFrame in
@@ -23,7 +23,10 @@ final class OrderSearchStarterViewController: UIViewController, KeyboardFrameAdj
     /// Required implementation for `KeyboardFrameAdjustmentProvider`.
     var additionalKeyboardFrameHeight: CGFloat = 0
 
-    init() {
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -129,14 +132,16 @@ private extension OrderSearchStarterViewController {
 
         if #available(iOS 13, *) {
             return OrderListViewController(
+                siteID: siteID,
                 title: title,
-                viewModel: .init(statusFilter: cellViewModel.orderStatus),
+                viewModel: .init(siteID: siteID, statusFilter: cellViewModel.orderStatus),
                 emptyStateConfig: emptyStateConfig
             )
         } else {
             return OrdersViewController(
+                siteID: siteID,
                 title: title,
-                viewModel: .init(statusFilter: cellViewModel.orderStatus),
+                viewModel: .init(siteID: siteID, statusFilter: cellViewModel.orderStatus),
                 emptyStateConfig: emptyStateConfig
             )
         }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchStarterViewModel.swift
@@ -42,7 +42,7 @@ final class OrderSearchStarterViewModel {
                                                      sortedBy: [descriptor])
     }()
 
-    init(siteID: Int64 = ServiceLocator.stores.sessionManager.defaultStoreID ?? Int64.min,
+    init(siteID: Int64,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          locale: Locale = .current) {
         self.siteID = siteID

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -16,13 +16,16 @@ final class OrderSearchUICommand: SearchUICommand {
 
     private lazy var statusResultsController: ResultsController<StorageOrderStatus> = {
         let storageManager = ServiceLocator.storageManager
-        let predicate = NSPredicate(format: "siteID == %lld", ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
         let descriptor = NSSortDescriptor(key: "slug", ascending: true)
 
         return ResultsController<StorageOrderStatus>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
-    init() {
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
         configureResultsController()
     }
 
@@ -33,7 +36,7 @@ final class OrderSearchUICommand: SearchUICommand {
     }
 
     func createStarterViewController() -> UIViewController? {
-        OrderSearchStarterViewController()
+        OrderSearchStarterViewController(siteID: siteID)
     }
 
     func configureEmptyStateViewControllerBeforeDisplay(viewController: EmptyStateViewController,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrdersViewModelTests.swift
@@ -45,7 +45,8 @@ final class OrdersViewModelTests: XCTestCase {
 
     func test_given_a_filter_it_loads_the_orders_matching_that_filter_from_the_DB() {
         // Arrange
-        let viewModel = OrdersViewModel(storageManager: storageManager,
+        let viewModel = OrdersViewModel(siteID: siteID,
+                                        storageManager: storageManager,
                                         statusFilter: orderStatus(with: .processing),
                                         stores: stores)
 
@@ -66,7 +67,7 @@ final class OrdersViewModelTests: XCTestCase {
 
     func test_given_no_filter_it_loads_all_the_today_and_past_orders_from_the_DB() {
         // Arrange
-        let viewModel = OrdersViewModel(storageManager: storageManager, statusFilter: nil, stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, stores: stores)
 
         let allInsertedOrders = [
             (0..<10).map { insertOrder(id: $0, status: .processing) },
@@ -90,7 +91,8 @@ final class OrdersViewModelTests: XCTestCase {
     /// be fetched.
     func test_given_including_future_orders_it_also_loads_future_orders_from_the_DB() {
         // Arrange
-        let viewModel = OrdersViewModel(storageManager: storageManager,
+        let viewModel = OrdersViewModel(siteID: siteID,
+                                        storageManager: storageManager,
                                         statusFilter: orderStatus(with: .pending),
                                         includesFutureOrders: true,
                                         stores: stores)
@@ -122,7 +124,7 @@ final class OrdersViewModelTests: XCTestCase {
     /// midnight are included.
     func test_given_excluding_future_orders_it_only_loads_orders_up_to_midnight_from_the_DB() {
         // Arrange
-        let viewModel = OrdersViewModel(storageManager: storageManager, statusFilter: nil, includesFutureOrders: false, stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, storageManager: storageManager, statusFilter: nil, includesFutureOrders: false, stores: stores)
 
         let ignoredOrders = [
             // Orders in the future
@@ -153,7 +155,7 @@ final class OrdersViewModelTests: XCTestCase {
     /// Orders with dateCreated in the future should be grouped in an "Upcoming" section.
     func test_it_groups_future_orders_in_upcoming_section() {
         // Arrange
-        let viewModel = OrdersViewModel(storageManager: storageManager, statusFilter: orderStatus(with: .failed), stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, storageManager: storageManager, statusFilter: orderStatus(with: .failed), stores: stores)
 
         let expectedOrders = (
             future: [
@@ -182,7 +184,7 @@ final class OrdersViewModelTests: XCTestCase {
     func test_it_requests_a_resynchronization_when_the_app_is_activated() {
         // Arrange
         let notificationCenter = NotificationCenter()
-        let viewModel = OrdersViewModel(notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {
@@ -202,7 +204,7 @@ final class OrdersViewModelTests: XCTestCase {
     func test_given_no_previous_deactivation_it_does_not_request_a_resynchronization_when_the_app_is_activated() {
         // Arrange
         let notificationCenter = NotificationCenter()
-        let viewModel = OrdersViewModel(notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, notificationCenter: notificationCenter, statusFilter: nil, stores: stores)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {
@@ -223,7 +225,7 @@ final class OrdersViewModelTests: XCTestCase {
     func test_given_a_new_order_notification_it_requests_a_resynchronization() {
         // Arrange
         let pushNotificationsManager = MockPushNotificationsManager()
-        let viewModel = OrdersViewModel(pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {
@@ -243,7 +245,7 @@ final class OrdersViewModelTests: XCTestCase {
     func test_given_a_non_order_notification_it_does_not_request_a_resynchronization() {
         // Arrange
         let pushNotificationsManager = MockPushNotificationsManager()
-        let viewModel = OrdersViewModel(pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
+        let viewModel = OrdersViewModel(siteID: siteID, pushNotificationsManager: pushNotificationsManager, statusFilter: nil, stores: stores)
 
         var resynchronizeRequested = false
         viewModel.onShouldResynchronizeIfViewIsVisible = {


### PR DESCRIPTION
Part of #1838 

## Changes

- DI'ed `siteID: Int64` to `OrdersRootViewController` and its related classes, including refund, search, and shipping. Also removed unnecessary observation for `defaultAccountWasUpdated` notification
- Updated unit tests

## Testing

For confidence check on the Orders tab:

(I tested tapping a new order push notification)

Prerequisite: the site has at least one refunded order

- Log out from the app
- Log in to a site
- Go to the Orders tab --> the orders should load on both sub-tabs as before
- Tap on the search icon --> it should display the order statuses available in the selected site
- Tap on the Refunded order status, and tap on a refunded order --> the refund UI should be shown as before
- Tap on a "Refunded" row that contains at least a product --> the product should be shown in the refund details as before
- Switch to another site and repeat the steps above, making sure the Orders tab only shows data from the selected site

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
