### PR TITLE
Products M4 analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -259,6 +259,15 @@ public enum WooAnalyticsStat: String {
     case productListPulledToRefresh             = "product_list_pulled_to_refresh"
     case productListSearched                    = "product_list_searched"
     case productListMenuSearchTapped            = "product_list_menu_search_tapped"
+    case productListAddProductTapped            = "product_list_add_product_button_tapped"
+
+    // MARK: Add Product Events
+    //
+    case addProductTypeSelected                 = "add_product_product_type_selected"
+    case addProductPublishTapped                = "add_product_publish_tapped"
+    case addProductSaveAsDraftTapped            = "add_product_save_as_draft_tapped"
+    case addProductSuccess                      = "add_product_success"
+    case addProductFailed                       = "add_product_failed"
 
     // MARK: Edit Product Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -35,6 +35,7 @@ private extension AddProductCoordinator {
                                       comment: "Message title of bottom sheet for selecting a product type to create a product")
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let command = ProductTypeBottomSheetListSelectorCommand(selected: nil) { selectedProductType in
+            ServiceLocator.analytics.track(.addProductTypeSelected, withProperties: ["product_type": selectedProductType.rawValue])
             self.navigationController.dismiss(animated: true)
             self.presentProductForm(productType: selectedProductType)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -28,17 +28,17 @@ final class ProductFormRemoteActionUseCase {
         addProductRemotely(product: product) { productResult in
             switch productResult {
             case .failure(let error):
-                // TODO-2766: M4 analytics
+                ServiceLocator.analytics.track(.addProductFailed, withError: error)
                 onCompletion(.failure(error))
             case .success(let product):
                 // `self` is retained because the use case is not usually strongly held.
                 self.updatePasswordRemotely(product: product, password: password) { passwordResult in
                     switch passwordResult {
-                    case .failure:
-                        // TODO-2766: M4 analytics
+                    case .failure(let error):
+                        ServiceLocator.analytics.track(.addProductFailed, withError: error)
                         onCompletion(.failure(.passwordCannotBeUpdated))
                     case .success(let password):
-                        // TODO-2766: M4 analytics
+                        ServiceLocator.analytics.track(.addProductSuccess)
                         onCompletion(.success(ResultData(product: product, password: password)))
                     }
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -169,11 +169,16 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     }
 
     @objc func publishProduct() {
-        // TODO-2766: M4 analytics
+        if viewModel.formType == .add {
+            ServiceLocator.analytics.track(.addProductPublishTapped, withProperties: ["product_type": product.productType.rawValue])
+        }
         saveProduct()
     }
 
     func saveProductAsDraft() {
+        if viewModel.formType == .add {
+            ServiceLocator.analytics.track(.addProductSaveAsDraftTapped, withProperties: ["product_type": product.productType.rawValue])
+        }
         saveProduct(status: .draft)
     }
 
@@ -197,7 +202,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
         if viewModel.canSaveAsDraft() {
             actionSheet.addDefaultActionWithTitle(ActionSheetStrings.saveProductAsDraft) { [weak self] _ in
-                // TODO-2766: M4 analytics
                 self?.saveProductAsDraft()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -242,6 +242,9 @@ private extension ProductsViewController {
         guard let navigationController = navigationController else {
             return
         }
+
+        ServiceLocator.analytics.track(.productListAddProductTapped)
+
         guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             assertionFailure("No site ID for creating a product")
             return


### PR DESCRIPTION
Fixes #2766 

## Changes

- Added new events to `WooAnalyticsStat`
- Tracked each event

## Testing

I’d recommend testing on a device to disconnect from the internet more easily.

### Publish product
- Go to the Products tab
- Tap “+” in the navigation bar —> should see `🔵 Tracked product_list_add_product_button_tapped` in the console
- Tap a product type in the bottom sheet —> should see `🔵 Tracked add_product_product_type_selected` with a property `”product_type”: \(selectedProductType)` in the console
- Enter some product details
- Tap “Publish” in the navigation bar —> should see `🔵 Tracked add_product_publish_tapped` with a property `”product_type”: \(selectedProductType)` in the console. After the product is added remotely, should see `🔵 Tracked add_product_success` in the console

### Save as draft from discard changes action sheet
- Go back to the Products tab
- Tap “+” in the navigation bar, and select a product type
- Enter some product details
- Swipe back or tap “< Products” to leave the product form (one of these gestures sometimes does not work in iOS 13+ debug build) --> should see a discard changes action sheet
- Tap “Save as Draft” —> should see `🔵 Tracked add_product_save_as_draft_tapped` with a property `”product_type”: \(selectedProductType)` in the console. After the product is added remotely, should see `🔵 Tracked add_product_success` in the console

### Save as draft from the more menu
- Go back to the Products tab
- Tap “+” in the navigation bar, and select a product type
- Enter some product details
- Tap “…” in the navigation bar
- Tap “Save as draft” —> should see `🔵 Tracked add_product_save_as_draft_tapped` with a property `”product_type”: \(selectedProductType)` in the console. After the product is added remotely, should see `🔵 Tracked add_product_success` in the console

### Failed to add a product
- Turn off internet connection (offline mode)
- Go back to the Products tab
- Tap “+” in the navigation bar, and select a product type
- Enter some product details
- Tap “Publish” in the navigation bar —> should see `🔵 Tracked add_product_publish_tapped` with a property `”product_type”: \(selectedProductType)` followed by `🔵 Tracked add_product_failed` with properties of the error

💬  I noticed that the error isn't very descriptive for this offline error, because we show "Unexpected error" for `.unknown(error: AnyError)` case's description. If we want to track the associated error, we could probably create an extension for `ProductUpdateError` to return another error like `var errorForLogging: Error` that either returns self or its associated error?

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
