### PR TITLE
Add/Edit Product: update copy on the waiting UI based on product status

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 5.3
 -----
-- [*] Enhancement: when saving a product as draft, the in-progress modal now shows title and message like "saving your product" instead of "publishing your product".
+- [*] Enhancement: when not saving a product as "published", the in-progress modal now shows title and message like "saving your product" instead of "publishing your product".
 - [internal] #2883 Renamed a product database table (Attribute) to GenericAttribute. This adds a new database migration. 
 
  

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 5.3
 -----
+- [*] Enhancement: when saving a product as draft, the in-progress modal now shows title and message like "saving your product" instead of "publishing your product".
 - [internal] #2883 Renamed a product database table (Attribute) to GenericAttribute. This adds a new database migration. 
 
  

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -523,9 +523,19 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func saveProduct(status: ProductStatus? = nil) {
-        let title = NSLocalizedString("Publishing your product...", comment: "Title of the in-progress UI while updating the Product remotely")
-        let message = NSLocalizedString("Please wait while we publish this product to your store",
+        let productStatus = status ?? product.status
+        let title: String
+        let message: String
+        switch productStatus {
+        case .draft:
+            title = NSLocalizedString("Saving your product...", comment: "Title of the in-progress UI while saving a Product as draft remotely")
+            message = NSLocalizedString("Please wait while we save this product to your store",
+                                        comment: "Message of the in-progress UI while saving a Product as draft remotely")
+        default:
+            title = NSLocalizedString("Publishing your product...", comment: "Title of the in-progress UI while updating the Product remotely")
+            message = NSLocalizedString("Please wait while we publish this product to your store",
                                         comment: "Message of the in-progress UI while updating the Product remotely")
+        }
         displayInProgressView(title: title, message: message)
 
         saveImagesAndProductRemotely(status: status)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -527,14 +527,14 @@ private extension ProductFormViewController {
         let title: String
         let message: String
         switch productStatus {
-        case .draft:
-            title = NSLocalizedString("Saving your product...", comment: "Title of the in-progress UI while saving a Product as draft remotely")
-            message = NSLocalizedString("Please wait while we save this product to your store",
-                                        comment: "Message of the in-progress UI while saving a Product as draft remotely")
-        default:
+        case .publish:
             title = NSLocalizedString("Publishing your product...", comment: "Title of the in-progress UI while updating the Product remotely")
             message = NSLocalizedString("Please wait while we publish this product to your store",
                                         comment: "Message of the in-progress UI while updating the Product remotely")
+        default:
+            title = NSLocalizedString("Saving your product...", comment: "Title of the in-progress UI while saving a Product as draft remotely")
+            message = NSLocalizedString("Please wait while we save this product to your store",
+                                        comment: "Message of the in-progress UI while saving a Product as draft remotely")
         }
         displayInProgressView(title: title, message: message)
 


### PR DESCRIPTION
Fixes #2950 

## Changes

- In `ProductFormViewController`, updated the title and message of the in-progress modal to say "saving your product" instead of "publishing your product" when saving a product with status that is not "published"

## Testing

### Save a new product as draft

- Go to the Products tab
- Tap on "+" CTA in the navigation bar
- Tap "Simple product"
- Enter some product details
- Tap "..." in the navigation bar
- Tap "Save as draft" --> the waiting modal should show title and message like "Saving your product"

### Publish a new product

- Go to the Products tab
- Tap on "+" CTA in the navigation bar
- Tap "Simple product"
- Enter some product details
- Tap "Publish" in the navigation bar --> the waiting modal should show title and message like like before ("Publishing your product")

### Save an existing product as draft or pending review

- Go to the Products tab
- Tap on a product that has "published" status
- Tap "..." in the navigation bar, then "Product Settings"
- Tap on the status row
- Update the status to "Draft" or "Pending review"
- Go back to product settings and tap "Done"
- Tap "Update" --> the waiting modal should show title and message like "Saving your product"

### Save an existing product as "published"

- Go to the Products tab
- Tap on a product that does not have "published" status
- Tap "..." in the navigation bar, then "Product Settings"
- Tap on the status row
- Update the status to "Published"
- Go back to product settings and tap "Done"
- Tap "Update" --> the waiting modal should show title and message like like before ("Publishing your product")


## Example screenshots

Saving a product as draft or pending review | Saving a product as "published"
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-10-09 at 17 17 14](https://user-images.githubusercontent.com/1945542/95567562-b16ada80-0a55-11eb-98c9-7802bb1c23f6.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-09 at 17 17 22](https://user-images.githubusercontent.com/1945542/95567577-b465cb00-0a55-11eb-9906-3b96e7deb86f.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
