### PR TITLE
[Issue Refund] Render products refund summary

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents an Order's Item Entity.
 ///
-public struct OrderItem: Decodable {
+public struct OrderItem: Decodable, Hashable {
     public let itemID: Int64
     public let name: String
     public let productID: Int64

--- a/Networking/Networking/Model/OrderItemTax.swift
+++ b/Networking/Networking/Model/OrderItemTax.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Represents the Taxes for a specific Order Item.
 ///
-public struct OrderItemTax: Codable {
+public struct OrderItemTax: Codable, Hashable {
 
     /// Tax ID for line item
     ///

--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -244,4 +244,14 @@ public class CurrencyFormatter {
 
         return formattedAmount
     }
+
+    /// Applies currency option settings to the amount for the given currency.
+    /// - Parameters:
+    ///     - amount: a Decimal representation of the amount, from the API, with no formatting applied. e.g. "19.87"
+    ///     - currency: a 3-letter country code for currencies that are supported in the API. e.g. "USD"
+    ///     - locale: the locale that is used to format the currency amount string.
+    ///
+    func formatAmount(_ amount: Decimal, with currency: String? = nil, locale: Locale = .current) -> String? {
+        formatAmount(amount as NSDecimalNumber, with: currency, locale: locale)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yosemite
 
 /// Represents products cost details for an order to be refunded. Meant to be rendered by `RefundProductsTotalTableViewCell`
 ///
@@ -6,4 +7,59 @@ struct RefundProductsTotalViewModel {
     let productsTax: String
     let productsSubtotal: String
     let productsTotal: String
+}
+
+// MARK: Convenience Initializers
+extension RefundProductsTotalViewModel {
+
+    /// Tuple to group an order item with its refund quantity
+    ///
+    struct RefundItem {
+        let item: OrderItem
+        let quantity: Int
+    }
+
+    /// Tuple to store calculations results
+    ///
+    private struct RefundValues {
+        let subtotal: Decimal
+        let tax: Decimal
+        var total: Decimal {
+            return subtotal + tax
+        }
+    }
+
+    /// Creates a `RefundProductsTotalViewModel` based on a list of items to refund.
+    ///
+    init(refundItems: [RefundItem], currency: String, currencySettings: CurrencySettings) {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        let values = Self.calculateRefundValues(refundItems: refundItems, currencyFormatter: currencyFormatter)
+
+        self.productsTax = currencyFormatter.formatAmount(values.tax, with: currency) ?? ""
+        self.productsSubtotal = currencyFormatter.formatAmount(values.subtotal, with: currency) ?? ""
+        self.productsTotal = currencyFormatter.formatAmount(values.total, with: currency) ?? ""
+    }
+
+    /// Calculates the items subtotal, taxes and total to refund
+    ///
+    static private func calculateRefundValues(refundItems: [RefundItem], currencyFormatter: CurrencyFormatter) -> RefundValues {
+        let zero = RefundValues(subtotal: 0, tax: 0)
+        return refundItems.reduce(zero) { previousValues, refundItem -> RefundValues in
+
+            let itemPrice = refundItem.item.price as Decimal
+            let quantityToRefund = Decimal(refundItem.quantity)
+
+            // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
+            let itemTax: Decimal = {
+                let totalTax = currencyFormatter.convertToDecimal(from: refundItem.item.totalTax) ?? 0
+                return (totalTax as Decimal) / refundItem.item.quantity
+            }()
+
+            // Acumulate the evaluated item values
+            let subtotal = previousValues.subtotal + (itemPrice * quantityToRefund)
+            let tax = previousValues.tax + (itemTax * quantityToRefund)
+
+            return RefundValues(subtotal: subtotal, tax: tax)
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundProductsTotalViewModel.swift
@@ -11,55 +11,15 @@ struct RefundProductsTotalViewModel {
 
 // MARK: Convenience Initializers
 extension RefundProductsTotalViewModel {
-
-    /// Tuple to group an order item with its refund quantity
-    ///
-    struct RefundItem {
-        let item: OrderItem
-        let quantity: Int
-    }
-
-    /// Tuple to store calculations results
-    ///
-    private struct RefundValues {
-        let subtotal: Decimal
-        let tax: Decimal
-        var total: Decimal {
-            return subtotal + tax
-        }
-    }
-
     /// Creates a `RefundProductsTotalViewModel` based on a list of items to refund.
     ///
-    init(refundItems: [RefundItem], currency: String, currencySettings: CurrencySettings) {
+    init(refundItems: [RefundItemsValuesCalculationUseCase.RefundItem], currency: String, currencySettings: CurrencySettings) {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
-        let values = Self.calculateRefundValues(refundItems: refundItems, currencyFormatter: currencyFormatter)
+        let useCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: currencyFormatter)
+        let values = useCase.calculateRefundValues()
 
         self.productsTax = currencyFormatter.formatAmount(values.tax, with: currency) ?? ""
         self.productsSubtotal = currencyFormatter.formatAmount(values.subtotal, with: currency) ?? ""
         self.productsTotal = currencyFormatter.formatAmount(values.total, with: currency) ?? ""
-    }
-
-    /// Calculates the items subtotal, taxes and total to refund
-    ///
-    static private func calculateRefundValues(refundItems: [RefundItem], currencyFormatter: CurrencyFormatter) -> RefundValues {
-        let zero = RefundValues(subtotal: 0, tax: 0)
-        return refundItems.reduce(zero) { previousValues, refundItem -> RefundValues in
-
-            let itemPrice = refundItem.item.price as Decimal
-            let quantityToRefund = Decimal(refundItem.quantity)
-
-            // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
-            let itemTax: Decimal = {
-                let totalTax = currencyFormatter.convertToDecimal(from: refundItem.item.totalTax) ?? 0
-                return (totalTax as Decimal) / refundItem.item.quantity
-            }()
-
-            // Acumulate the evaluated item values
-            let subtotal = previousValues.subtotal + (itemPrice * quantityToRefund)
-            let tax = previousValues.tax + (itemTax * quantityToRefund)
-
-            return RefundValues(subtotal: subtotal, tax: tax)
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -162,7 +162,7 @@ extension IssueRefundViewModel {
                                        currencySettings: state.currencySettings)
         }
 
-        let refundItems = state.refundQuantityStore.map { RefundProductsTotalViewModel.RefundItem(item: $0, quantity: $1) }
+        let refundItems = state.refundQuantityStore.map { RefundItemsValuesCalculationUseCase.RefundItem(item: $0, quantity: $1) }
         let summaryRow = RefundProductsTotalViewModel(refundItems: refundItems, currency: state.order.currency, currencySettings: state.currencySettings)
 
         return Section(rows: itemsRows + [summaryRow])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundItemsValuesCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundItemsValuesCalculationUseCase.swift
@@ -5,7 +5,7 @@ import Yosemite
 ///
 struct RefundItemsValuesCalculationUseCase {
 
-    /// Items and their cuantities to be refunded
+    /// Items and their quantities to be refunded
     ///
     let refundItems: [RefundItem]
 
@@ -28,7 +28,7 @@ struct RefundItemsValuesCalculationUseCase {
                 return (totalTax as Decimal) / refundItem.item.quantity
             }()
 
-            // Acumulate the evaluated item values
+            // Accumulate the evaluated item values
             let subtotal = previousValues.subtotal + (itemPrice * quantityToRefund)
             let tax = previousValues.tax + (itemTax * quantityToRefund)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundItemsValuesCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundItemsValuesCalculationUseCase.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Yosemite
+
+/// Calculates the values(subtotal, total and tax) to be refunded.
+///
+struct RefundItemsValuesCalculationUseCase {
+
+    /// Items and their cuantities to be refunded
+    ///
+    let refundItems: [RefundItem]
+
+    /// Formatter to convert string values to decimal values
+    ///
+    let currencyFormatter: CurrencyFormatter
+
+    /// Calculates the values(subtotal, total and tax) to be refunded.
+    ///
+    func calculateRefundValues() -> RefundValues {
+        let zero = RefundValues(subtotal: 0, tax: 0)
+        return refundItems.reduce(zero) { previousValues, refundItem -> RefundValues in
+
+            let itemPrice = refundItem.item.price as Decimal
+            let quantityToRefund = Decimal(refundItem.quantity)
+
+            // Figure out `itemTax` by dividing `totalTax` by the purchased `quantity`.
+            let itemTax: Decimal = {
+                let totalTax = currencyFormatter.convertToDecimal(from: refundItem.item.totalTax) ?? 0
+                return (totalTax as Decimal) / refundItem.item.quantity
+            }()
+
+            // Acumulate the evaluated item values
+            let subtotal = previousValues.subtotal + (itemPrice * quantityToRefund)
+            let tax = previousValues.tax + (itemTax * quantityToRefund)
+
+            return RefundValues(subtotal: subtotal, tax: tax)
+        }
+    }
+}
+
+// MARK: Helper types
+extension RefundItemsValuesCalculationUseCase {
+    /// Tuple to group an order item with its refund quantity
+    ///
+    struct RefundItem {
+        let item: OrderItem
+        let quantity: Int
+    }
+
+    /// Tuple to return calculations results
+    ///
+    struct RefundValues {
+        let subtotal: Decimal
+        let tax: Decimal
+        var total: Decimal {
+            return subtotal + tax
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -335,6 +335,7 @@
 		2667BFDF252F762E008099D4 /* IssueRefundViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFDE252F762E008099D4 /* IssueRefundViewModelTests.swift */; };
 		2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE0252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift */; };
 		2667BFE3252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */; };
+		2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1323,6 +1324,7 @@
 		2667BFDE252F762E008099D4 /* IssueRefundViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRefundViewModelTests.swift; sourceTree = "<group>"; };
 		2667BFE0252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemQuantityListSelectorCommand.swift; sourceTree = "<group>"; };
 		2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemQuantityListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCase.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2806,6 +2808,7 @@
 				260C315F2524ECA900157BC2 /* IssueRefundViewController.swift */,
 				2667BFE0252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift */,
 				260C31612524EEB200157BC2 /* IssueRefundViewController.xib */,
+				2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */,
 			);
 			path = "Issue Refunds";
 			sourceTree = "<group>";
@@ -5566,6 +5569,7 @@
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
+				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,
 				B56C721221B5B44000E5E85B /* PushNotificationsConfiguration.swift in Sources */,
 				26FE09DF24DB871100B9BDF5 /* SurveyViewControllersFactory.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		2667BFE3252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */; };
 		2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */; };
 		2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */; };
+		2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1327,6 +1328,7 @@
 		2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemQuantityListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCase.swift; sourceTree = "<group>"; };
 		2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCaseTests.swift; sourceTree = "<group>"; };
+		2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModelTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2771,6 +2773,7 @@
 			children = (
 				2667BFDE252F762E008099D4 /* IssueRefundViewModelTests.swift */,
 				2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */,
+				2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */,
 				2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */,
 				2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */,
 				2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */,
@@ -5754,6 +5757,7 @@
 				02404EE02314FE5900FF1170 /* DashboardUIFactoryTests.swift in Sources */,
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				57F34AA12423D45A00E38AFB /* OrdersViewModelTests.swift in Sources */,
+				2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */,
 				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
 				570AAB052472FACB00516C0C /* OrderDetailsDataSourceTests.swift in Sources */,
 				B517EA1A218B2D2600730EC4 /* StringFormatterTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE0252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift */; };
 		2667BFE3252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */; };
 		2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */; };
+		2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1325,6 +1326,7 @@
 		2667BFE0252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemQuantityListSelectorCommand.swift; sourceTree = "<group>"; };
 		2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemQuantityListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCase.swift; sourceTree = "<group>"; };
+		2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCaseTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2771,6 +2773,7 @@
 				2667BFD6252E5DBF008099D4 /* RefundItemViewModelTests.swift */,
 				2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */,
 				2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */,
+				2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */,
 			);
 			path = "Issue Refund";
 			sourceTree = "<group>";
@@ -5766,6 +5769,7 @@
 				B541B2132189E7FD008FE7C1 /* ScannerWooTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
+				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,
 				D89E0C31226EFB0900DF9DE6 /* EditableOrderTrackingTableViewCellTests.swift in Sources */,
 				02B296A922FA6E0000FD7A4C /* DateStartAndEndTests.swift in Sources */,
 				02B653AC2429F7BF00A9C839 /* MockTaxClassStoresManager.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -40,7 +40,7 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     }
 
     func testSubtotalValueMatchesExpectation() {
-        let expectedValue = CurrencyFormatter(currencySettings: CurrencySettings()).formatAmount(0, with: order.currency) ?? String()
+        let expectedValue = CurrencyFormatter(currencySettings: CurrencySettings()).formatAmount(.zero, with: order.currency) ?? String()
         XCTAssertEqual(viewModel.subtotalValue, expectedValue)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemsValuesCalculationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundItemsValuesCalculationUseCaseTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Test cases for `RefundItemsValuesCalculationUseCase`
+///
+final class RefundItemsValuesCalculationUseCaseTests: XCTestCase {
+    func test_useCase_correctly_calculates_values_from_regular_items() {
+        // Given
+        let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let refundItems: [RefundItemsValuesCalculationUseCase.RefundItem] = [
+            .init(item: MockOrderItem.sampleItem(quantity: 1, price: 10.50, totalTax: "1.20"), quantity: 1),
+            .init(item: MockOrderItem.sampleItem(quantity: 2, price: 15.00, totalTax: "4.20"), quantity: 2),
+            .init(item: MockOrderItem.sampleItem(quantity: 3, price: 7.99, totalTax: "3.30"), quantity: 2),
+        ]
+
+        // When
+        let useCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: formatter)
+        let values = useCase.calculateRefundValues()
+
+        // Then
+        // Subtotal = 1 x 10.50(item1 price) + 2 x 15.00(item2 price) + 2 * 7.99(item3 price) = 56.48
+        // Tax = 1 x 1.28(item1 tax) + 2 x 1.10(item2 tax) + 2 * 1.10(item3 tax) = 7.60
+        XCTAssertEqual(values.subtotal, 56.48)
+        XCTAssertEqual(values.tax, 7.60)
+        XCTAssertEqual(values.total, 64.08)
+    }
+
+    func test_useCase_correctly_ignores_0_quantity_values() {
+        // Given
+        let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let refundItems: [RefundItemsValuesCalculationUseCase.RefundItem] = [
+            .init(item: MockOrderItem.sampleItem(quantity: 1, price: 10.50, totalTax: "1.20"), quantity: 1),
+            .init(item: MockOrderItem.sampleItem(quantity: 2, price: 15.00, totalTax: "4.20"), quantity: 0),
+            .init(item: MockOrderItem.sampleItem(quantity: 3, price: 7.99, totalTax: "3.30"), quantity: 0),
+        ]
+
+        // When
+        let useCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: formatter)
+        let values = useCase.calculateRefundValues()
+
+        // Then
+        XCTAssertEqual(values.subtotal, 10.50)
+        XCTAssertEqual(values.tax, 1.20)
+        XCTAssertEqual(values.total, 11.70)
+    }
+
+    func test_useCase_correctly_calculates_no_items() {
+        // Given
+        let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let refundItems: [RefundItemsValuesCalculationUseCase.RefundItem] = []
+
+        // When
+        let useCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: formatter)
+        let values = useCase.calculateRefundValues()
+
+        // Then
+        XCTAssertEqual(values.subtotal, 0.0)
+        XCTAssertEqual(values.tax, 0.0)
+        XCTAssertEqual(values.total, 0.0)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundProductsTotalViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundProductsTotalViewModelTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Test cases for `RefundProductsTotalViewModel`
+///
+final class RefundProductsTotalViewModelTests: XCTestCase {
+    func test_viewModel_is_created_with_correct_initial_values() {
+        // Given
+        let refundItems: [RefundItemsValuesCalculationUseCase.RefundItem] = [
+            .init(item: MockOrderItem.sampleItem(quantity: 1, price: 10.50, totalTax: "1.20"), quantity: 1),
+            .init(item: MockOrderItem.sampleItem(quantity: 2, price: 15.00, totalTax: "4.20"), quantity: 2),
+            .init(item: MockOrderItem.sampleItem(quantity: 3, price: 7.99, totalTax: "3.30"), quantity: 2),
+        ]
+
+        // When
+        let viewModel = RefundProductsTotalViewModel(refundItems: refundItems, currency: "USD", currencySettings: CurrencySettings())
+
+        // Then
+        XCTAssertEqual(viewModel.productsSubtotal, "$56.48")
+        XCTAssertEqual(viewModel.productsTax, "$7.60")
+        XCTAssertEqual(viewModel.productsTotal, "$64.08")
+    }
+}


### PR DESCRIPTION
part of #2842

# Why
This PR takes care of updating the values summary view of the issue refund screen.
<img width="300" alt="Screen Shot 2020-10-09 at 2 34 25 PM" src="https://user-images.githubusercontent.com/562080/95624576-ba02e700-0a3c-11eb-92a6-4cd1eeaddf9a.png">

# How
- Made `OrderItem` hashable to it can be stored in `RefundQuantityStore`. This is to avoid having to do extra computing work when mapping from `itemID` to `OrderItem`

- Added a method on `CurrencyFormatter` to accept `Decimal` types. This is because doing arithmetic with `Decimal` is nicer than with `NSDecimalNumber`

- Created `RefundItemsValuesCalculationUseCase` to help me calculate the amount of money to be refunded as well as give me subtotal and tax as separate values.

- Updated `createSections` method on `IssueRefundViewModel` to pass the real refund items to `RefundProductsTotalViewModel` which is the cell that is rendered on screen 

# Demo
![select-items](https://user-images.githubusercontent.com/562080/95624395-6d1f1080-0a3c-11eb-8dcf-5157da83c576.gif)


# Testing Steps
- Launch app and navigate to a non-refunded order
- Tap on any of the item quantity buttons and select a different quantity
- See that the summary view updates appropriately.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
