### PR TITLE
Products tab: DI site ID to `ProductsViewController` and its downstream classes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -375,7 +375,7 @@ private extension MainTabBarController {
         let ordersViewController = createOrdersViewController(siteID: siteID)
         ordersNavigationController.viewControllers = [ordersViewController]
 
-        let productsViewController = createProductsViewController()
+        let productsViewController = createProductsViewController(siteID: siteID)
         productsNavigationController.viewControllers = [productsViewController]
 
         let reviewsTabCoordinator = createReviewsTabCoordinator(siteID: siteID)
@@ -394,8 +394,8 @@ private extension MainTabBarController {
         OrdersRootViewController(siteID: siteID)
     }
 
-    func createProductsViewController() -> UIViewController {
-        ProductsViewController()
+    func createProductsViewController(siteID: Int64) -> UIViewController {
+        ProductsViewController(siteID: siteID)
     }
 
     func createReviewsTabCoordinator(siteID: Int64) -> Coordinator {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddProductCategoryViewController.swift
@@ -123,11 +123,11 @@ extension AddProductCategoryViewController {
         titleCategoryTextFieldResignFirstResponder()
         configureRightButtonItemAsSpinner()
 
-        guard let categoryName = newCategoryTitle, let defaultStoreID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+        guard let categoryName = newCategoryTitle else {
             return
         }
 
-        let action = ProductCategoryAction.addProductCategory(siteID: defaultStoreID,
+        let action = ProductCategoryAction.addProductCategory(siteID: siteID,
                                                               name: categoryName,
                                                               parentID: selectedParentCategory?.categoryID) { [weak self] (result) in
             self?.configureRightBarButtomitemAsSave()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsDataSource.swift
@@ -31,6 +31,7 @@ final class ProductReviewsDataSource: NSObject, ReviewsDataSource {
     /// Product for which we show the reviews.
     ///
     private let product: Product
+    private let siteID: Int64
 
     /// Boolean indicating if there are reviews
     ///
@@ -58,8 +59,8 @@ final class ProductReviewsDataSource: NSObject, ReviewsDataSource {
         return reviewsResultsController.numberOfObjects
     }
 
-
     init(product: Product) {
+        self.siteID = product.siteID
         self.product = product
         super.init()
     }
@@ -77,8 +78,7 @@ final class ProductReviewsDataSource: NSObject, ReviewsDataSource {
     /// Predicate to entities that belong to the current store
     ///
     private func sitePredicate() -> NSPredicate {
-        return NSPredicate(format: "siteID == %lld",
-                          ServiceLocator.stores.sessionManager.defaultStoreID ?? Int.min)
+        NSPredicate(format: "siteID == %lld", siteID)
     }
 
     /// Initializes observers for incoming reviews

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -53,7 +53,7 @@ final class ProductReviewsViewController: UIViewController {
     // MARK: - View Lifecycle
     init(product: Product) {
         self.product = product
-        viewModel = ProductReviewsViewModel(data: ProductReviewsDataSource(product: product))
+        viewModel = ProductReviewsViewModel(siteID: product.siteID, data: ProductReviewsDataSource(product: product))
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -20,7 +20,10 @@ final class ProductReviewsViewModel {
         return data
     }
 
-    init(data: ReviewsDataSource) {
+    private let siteID: Int64
+
+    init(siteID: Int64, data: ReviewsDataSource) {
+        self.siteID = siteID
         self.data = data
     }
 
@@ -77,10 +80,6 @@ extension ProductReviewsViewModel {
                             pageSize: Int,
                             productID: Int64,
                             onCompletion: (() -> Void)? = nil) {
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return
-        }
-
         let action = ProductReviewAction.synchronizeProductReviews(siteID: siteID,
                                                                    pageNumber: pageNumber,
                                                                    pageSize: pageSize,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
@@ -11,7 +11,7 @@ final class ProductReviewsViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockDataSource = MockProductReviewsDataSource()
-        viewModel = ProductReviewsViewModel(data: mockDataSource)
+        viewModel = ProductReviewsViewModel(siteID: 2, data: mockDataSource)
     }
 
     override func tearDown() {


### PR DESCRIPTION
Part of #1838 

## Changes

- DI'ed `siteID: Int64` to `OrdersRootViewController` and its related classes, including refund, search, and shipping. Also removed unnecessary observation for `defaultAccountWasUpdated` notification
- Updated unit tests

## Testing

For confidence check on the Products tab:

- Log out from the app
- Log in to a site
- Go to the Products tab --> the products should load as before
- Go to the Dashboard tab, and tap settings to switch to a different store
- Go to the Products tab --> the products of the selected site should load
- Tap on the search icon and search for some products --> the search results should load as before
- Tap on a product with reviews
- Tap on the reviews row --> the product reviews should load as before
- Add a category to the product, then tap "Update" --> the product should be saved remotely with the new category
- Go back to the Products tab, and tap "+" in the navigation bar
- Fill in some details, and tap "Publish" --> the product should be published remotely

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
