### PR TITLE
SIWA: fix the app not logging out after Apple credential is revoked when account has 2FA

### DIFF
--- a/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
+++ b/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
@@ -33,6 +33,7 @@ final class AppleIDCredentialChecker {
             if isLoggedIn {
                 self?.startObservingAppleIDCredentialRevoked()
             } else {
+                self?.removeAppleIDFromKeychain()
                 self?.stopObservingAppleIDCredentialRevoked()
             }
         }

--- a/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
+++ b/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
@@ -91,7 +91,9 @@ private extension AppleIDCredentialChecker {
             guard let self = self else {
                 return
             }
-            if self.isLoggedIn() {
+            // The user could have SIWA'ed earlier then changed to authenticate with another method, and thus the app still receives notifications on
+            // revoked Apple credentials. We only want to log out the app when the app is currently signed in with Apple (Apple ID saved in Keychain).
+            if self.isLoggedIn() && self.keychain.wooAppleID != nil {
                 DDLogInfo("Apple credentialRevokedNotification received. User signed out.")
                 self.logOutRevokedAppleAccount()
             }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -109,7 +109,7 @@ class AuthenticationManager: Authentication {
             guard let self = self else { return }
             // Resets Apple ID at the beginning of the authentication.
             self.appleUserID = nil
-            
+
             ServiceLocator.analytics.track(.loginPrologueContinueTapped)
         }, onCompletion: onCompletion)
     }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -18,6 +18,10 @@ class AuthenticationManager: Authentication {
     ///
     private lazy var keychain = Keychain(service: WooConstants.keychainServiceName)
 
+    /// Apple ID is temporarily stored in memory until we can save it to Keychain when the authentication is complete.
+    ///
+    private var appleUserID: String?
+
     /// Initializes the WordPress Authenticator.
     ///
     func initialize() {
@@ -101,7 +105,11 @@ class AuthenticationManager: Authentication {
     /// Displays the Login Flow using the specified UIViewController as presenter.
     ///
     func displayAuthentication(from presenter: UIViewController, animated: Bool, onCompletion: @escaping () -> Void) {
-        WordPressAuthenticator.showLogin(from: presenter, animated: animated, onLoginButtonTapped: {
+        WordPressAuthenticator.showLogin(from: presenter, animated: animated, onLoginButtonTapped: { [weak self] in
+            guard let self = self else { return }
+            // Resets Apple ID at the beginning of the authentication.
+            self.appleUserID = nil
+            
             ServiceLocator.analytics.track(.loginPrologueContinueTapped)
         }, onCompletion: onCompletion)
     }
@@ -130,7 +138,7 @@ class AuthenticationManager: Authentication {
 //
 extension AuthenticationManager: WordPressAuthenticatorDelegate {
     func userAuthenticatedWithAppleUserID(_ appleUserID: String) {
-        keychain.wooAppleID = appleUserID
+        self.appleUserID = appleUserID
     }
 
     var allowWPComLogin: Bool {
@@ -258,6 +266,12 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         guard let wpcom = credentials.wpcom else {
             fatalError("Self Hosted sites are not supported. Please review the Authenticator settings!")
         }
+
+        // If Apple ID is previously set, saves it to Keychain now that authentication is complete.
+        if let appleUserID = appleUserID {
+            keychain.wooAppleID = appleUserID
+        }
+        appleUserID = nil
 
         ServiceLocator.stores.authenticate(credentials: .init(authToken: wpcom.authToken))
         let action = AccountAction.synchronizeAccount { (account, error) in

--- a/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginPrologueViewController.swift
@@ -177,13 +177,3 @@ private extension LoginPrologueViewController {
         return disclaimerAttrText
     }
 }
-
-
-// MARK: - (Private) Constants!
-//
-private enum Settings {
-
-    /// Login Button's Corner Radius
-    ///
-    static let buttonCornerRadius = CGFloat(8.0)
-}


### PR DESCRIPTION
Fixes #2960 

## Changes

- Saved Apple ID to Keychain only when authentication is complete (more details in [this comment](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/499#issuecomment-707453062)). Reset local Apple ID when tapping on the login CTA in case the user changes to sign in with another method
- In `AppleIDCredentialChecker`, handled some edge cases:
  - Removed Apple ID from Keychain on logout
  - On `credentialRevokedNotification` from Apple, only log out the app if Apple ID is saved in Keychain (currently signed in with Apple)
- Removed unused code in `LoginPrologueViewController` that I noticed from debugging

## Testing

### SIWA with 2FA

- Start with a WordPress.com account with 2FA that is connected to Apple **and** linked to at least one WC store with Jetpack
- Log in to the app with SIWA to a store, wait for some data to load
- Close the app
- Go to Settings app > Apple ID > Password & Security > Apps using Apple ID and revoke access for WordPress
- Open the app again --> the app should be logged out

### SIWA, restart authentication with another method, revoke credentials

- Start with a WordPress.com account with 2FA that is connected to Apple **and** linked to at least one WC store with Jetpack
- Log in to the app with SIWA to a store, wait for some data to load
- On the One-Time Password screen, tap "<" in the navigation bar to go back to login prologue
- Log in with another method (Google or username/password) and wait for the app to load some data
- Go to Settings app > Apple ID > Password & Security > Apps using Apple ID and revoke access for WordPress
- Open the app again --> the app should **not** be logged out

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
