### PR TITLE
Fix `OrderPaymentDetailsViewModelTests` that fail locally after running the app with different currency settings

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 final class OrderPaymentDetailsViewModel {
     private let order: Order
     private let refund: Refund?
-    private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+    private let currencyFormatter: CurrencyFormatter
 
     var subtotal: Decimal {
         let subtotal = order.items.reduce(Decimal(0)) { (output, item) in
@@ -146,9 +146,10 @@ final class OrderPaymentDetailsViewModel {
         return order.coupons
     }
 
-    init(order: Order, refund: Refund? = nil) {
+    init(order: Order, refund: Refund? = nil, currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.order = order
         self.refund = refund
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
     }
 
     private func summarizeCoupons(from lines: [OrderCouponLine]?) -> String? {

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -10,7 +10,9 @@ extension SessionManager {
     /// Returns a SessionManager instance with testing Keychain/UserDefaults
     ///
     static var testingInstance: SessionManager {
-        return SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
+        let sessionManager = SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
+        sessionManager.setStoreId(nil)
+        return sessionManager
     }
 
     /// Create an instance of unit testing.
@@ -20,6 +22,7 @@ extension SessionManager {
         // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
         // will be removed.
         manager.defaultCredentials = authenticated ? SessionSettings.credentials : nil
+        manager.setStoreId(nil)
         return manager
     }
 

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -10,9 +10,7 @@ extension SessionManager {
     /// Returns a SessionManager instance with testing Keychain/UserDefaults
     ///
     static var testingInstance: SessionManager {
-        let sessionManager = SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
-        sessionManager.setStoreId(nil)
-        return sessionManager
+        return SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
     }
 
     /// Create an instance of unit testing.
@@ -22,7 +20,6 @@ extension SessionManager {
         // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
         // will be removed.
         manager.defaultCredentials = authenticated ? SessionSettings.credentials : nil
-        manager.setStoreId(nil)
         return manager
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderPaymentDetailsViewModelTests.swift
@@ -16,7 +16,7 @@ final class OrderPaymentDetailsViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         order = MockOrders().sampleOrder()
-        viewModel = OrderPaymentDetailsViewModel(order: order!)
+        viewModel = OrderPaymentDetailsViewModel(order: order!, currencySettings: CurrencySettings())
 
         brokenOrder = MockOrders().brokenOrder()
         brokenOrderViewModel = OrderPaymentDetailsViewModel(order: brokenOrder)


### PR DESCRIPTION
Part of #1687 

Before this PR, some test cases failed locally if I ran the app with different currency settings before:

```
Test: testShippingValueMatchesExpectation() in OrderPaymentDetailsViewModelTests failed in Configuration 1 on iPhone 11
Assertions: XCTAssertEqual failed: ("Optional("$0.0")") is not equal to ("Optional("$0.00")")
File: OrderPaymentDetailsViewModelTests.swift:58

Test: testSubtotalValueMatchesExpectation() in OrderPaymentDetailsViewModelTests failed in Configuration 1 on iPhone 11
Assertions: XCTAssertEqual failed: ("$0.0") is not equal to ("$0.00")
File: OrderPaymentDetailsViewModelTests.swift:44

Test: testTaxesValueMatchesExpectation() in OrderPaymentDetailsViewModelTests failed in Configuration 1 on iPhone 11
Assertions: XCTAssertEqual failed: ("Optional("$1.2")") is not equal to ("Optional("$1.20")")
File: OrderPaymentDetailsViewModelTests.swift:63

Test: testTotalValueMatchedExpectation() in OrderPaymentDetailsViewModelTests failed in Configuration 1 on iPhone 11
Assertions: XCTAssertEqual failed: ("Optional("$31.2")") is not equal to ("Optional("$31.20")")
File: OrderPaymentDetailsViewModelTests.swift:69
```

This is because `OrderPaymentDetailsViewModel` uses the singleton `ServiceLocator.currencySettings` while the unit tests are expecting different currency settings (`CurrencySettings()`).

## Changes

- DI'ed `CurrencySettings` to `OrderPaymentDetailsViewModel` for unit testing.

## Testing

No user-facing changes are expected, feel free to confidence check on order details:

- Go to the Orders tab
- Open an order --> the payment details should be shown as before with the site currency settings

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
