### PR TITLE
Consolidate auth-based navigation to `AppCoordinator`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -6,14 +6,18 @@ import UIKit
 final class AppCoordinator {
     private let tabBarController: MainTabBarController
     private let stores: StoresManager
+    private let authenticationManager: Authentication
 
     private var storePickerCoordinator: StorePickerCoordinator?
     private var cancellable: ObservationToken?
     private var isLoggedIn: Bool = false
 
-    init(tabBarController: MainTabBarController, stores: StoresManager = ServiceLocator.stores) {
+    init(tabBarController: MainTabBarController,
+         stores: StoresManager = ServiceLocator.stores,
+         authenticationManager: Authentication = ServiceLocator.authenticationManager) {
         self.tabBarController = tabBarController
         self.stores = stores
+        self.authenticationManager = authenticationManager
     }
 
     func start() {
@@ -32,11 +36,13 @@ final class AppCoordinator {
             self.isLoggedIn = isLoggedIn
         }
     }
+}
 
+private extension AppCoordinator {
     /// Displays the WordPress.com Authentication UI.
     ///
     func displayAuthenticator(animated: Bool) {
-        ServiceLocator.authenticationManager.displayAuthentication(from: tabBarController, animated: animated) { [weak self] in
+        authenticationManager.displayAuthentication(from: tabBarController, animated: animated) { [weak self] in
             guard let self = self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+/// Coordinates app navigation based on authentication state: tab bar UI is shown when the app is logged in, and authentication UI is shown
+/// when the app is logged out.
+///
+final class AppCoordinator {
+    private let tabBarController: MainTabBarController
+    private let stores: StoresManager
+
+    private var storePickerCoordinator: StorePickerCoordinator?
+    private var cancellable: ObservationToken?
+    private var isLoggedIn: Bool = false
+
+    init(tabBarController: MainTabBarController, stores: StoresManager = ServiceLocator.stores) {
+        self.tabBarController = tabBarController
+        self.stores = stores
+    }
+
+    func start() {
+        cancellable = stores.isLoggedIn.subscribe { [weak self] isLoggedIn in
+            guard let self = self else {
+                return
+            }
+
+            if isLoggedIn == false {
+                let animated = self.isLoggedIn == true
+                self.displayAuthenticator(animated: animated)
+            } else if self.stores.needsDefaultStore {
+                self.displayStorePicker()
+            }
+
+            self.isLoggedIn = isLoggedIn
+        }
+    }
+
+    /// Displays the WordPress.com Authentication UI.
+    ///
+    func displayAuthenticator(animated: Bool) {
+        ServiceLocator.authenticationManager.displayAuthentication(from: tabBarController, animated: animated) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.tabBarController.removeViewControllers()
+        }
+    }
+
+    /// Whenever the app is authenticated but there is no Default StoreID: Let's display the Store Picker.
+    ///
+    func displayStorePicker() {
+        guard let navigationController = tabBarController.selectedViewController as? UINavigationController else {
+            DDLogError("⛔️ Unable to locate navigationController in order to launch the store picker.")
+            return
+        }
+
+        DDLogInfo("💬 Authenticated user does not have a Woo store selected — launching store picker.")
+        storePickerCoordinator = StorePickerCoordinator(navigationController, config: .standard)
+        storePickerCoordinator?.start()
+        storePickerCoordinator?.onDismiss = { [weak self] in
+            self?.displayAuthenticator(animated: false)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -22,9 +22,7 @@ final class AppCoordinator {
 
     func start() {
         cancellable = stores.isLoggedIn.subscribe { [weak self] isLoggedIn in
-            guard let self = self else {
-                return
-            }
+            guard let self = self else { return }
 
             if isLoggedIn == false {
                 let animated = self.isLoggedIn == true
@@ -43,9 +41,7 @@ private extension AppCoordinator {
     ///
     func displayAuthenticator(animated: Bool) {
         authenticationManager.displayAuthentication(from: tabBarController, animated: animated) { [weak self] in
-            guard let self = self else {
-                return
-            }
+            guard let self = self else { return }
             self.tabBarController.removeViewControllers()
         }
     }

--- a/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/DeauthenticatedState.swift
@@ -7,11 +7,9 @@ import Yosemite
 //
 class DeauthenticatedState: StoresManagerState {
 
-    /// This method should run only when the app got deauthenticated.
+    /// NO-OP: Executed when current state is activated.
     ///
-    func didEnter() {
-        AppDelegate.shared.displayAuthenticator(animated: true)
-    }
+    func didEnter() { }
 
     /// NO-OP: Executed before the current state is deactivated.
     ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */; };
 		025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1749237AA49D00C780B4 /* Product+ProductForm.swift */; };
 		025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025E32BB251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift */; };
+		025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FA38A2522CB4D0054CA57 /* AppCoordinator.swift */; };
 		025FDD3223717D2900824006 /* EditorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3123717D2900824006 /* EditorFactory.swift */; };
 		025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025FDD3323717D4900824006 /* AztecEditorViewController.swift */; };
 		0260F40123224E8100EDA10A /* ProductsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0260F40023224E8100EDA10A /* ProductsViewController.swift */; };
@@ -1146,6 +1147,7 @@
 		025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormSection+ReusableTableRow.swift"; sourceTree = "<group>"; };
 		025B1749237AA49D00C780B4 /* Product+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductForm.swift"; sourceTree = "<group>"; };
 		025E32BB251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormDataModel+ProductsTabProductViewModel.swift"; sourceTree = "<group>"; };
+		025FA38A2522CB4D0054CA57 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		025FDD3123717D2900824006 /* EditorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFactory.swift; sourceTree = "<group>"; };
 		025FDD3323717D4900824006 /* AztecEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecEditorViewController.swift; sourceTree = "<group>"; };
 		0260F40023224E8100EDA10A /* ProductsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsViewController.swift; sourceTree = "<group>"; };
@@ -3606,6 +3608,7 @@
 				B56DB3CD2049BFAA00D4AA8E /* Main.storyboard */,
 				CE263DE7206ACE3E0015A693 /* MainTabBarController.swift */,
 				D8736B5222EF4F5900A14A29 /* NotificationsBadgeController.swift */,
+				025FA38A2522CB4D0054CA57 /* AppCoordinator.swift */,
 			);
 			path = ViewRelated;
 			sourceTree = "<group>";
@@ -5189,6 +5192,7 @@
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */,
 				CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */,
+				025FA38B2522CB4D0054CA57 /* AppCoordinator.swift in Sources */,
 				02CEBB8024C9869E002EDF35 /* ProductFormActionsFactoryProtocol.swift in Sources */,
 				CE21B3E020FFC59700A259D5 /* ProductDetailsTableViewCell.swift in Sources */,
 				B509FED121C041DF000076A9 /* Locale+Woo.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0295355A245ADF8100BDC42B /* FilterType+Products.swift */; };
 		029700EC24FE38C900D242F8 /* ScrollWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EB24FE38C900D242F8 /* ScrollWatcher.swift */; };
 		029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */; };
+		029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */; };
 		029B0F57234197B80010C1F3 /* ProductSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */; };
 		029BFD4F24597D4B00FDDEEC /* UIButton+TitleAndImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029BFD4E24597D4B00FDDEEC /* UIButton+TitleAndImage.swift */; };
 		029D444922F13F8A00DEFA8A /* DashboardUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */; };
@@ -1215,6 +1216,7 @@
 		0295355A245ADF8100BDC42B /* FilterType+Products.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilterType+Products.swift"; sourceTree = "<group>"; };
 		029700EB24FE38C900D242F8 /* ScrollWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcher.swift; sourceTree = "<group>"; };
 		029700EE24FE38F000D242F8 /* ScrollWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollWatcherTests.swift; sourceTree = "<group>"; };
+		029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
 		029B0F56234197B80010C1F3 /* ProductSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSearchUICommand.swift; sourceTree = "<group>"; };
 		029BFD4E24597D4B00FDDEEC /* UIButton+TitleAndImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+TitleAndImage.swift"; sourceTree = "<group>"; };
 		029D444822F13F8A00DEFA8A /* DashboardUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardUIFactory.swift; sourceTree = "<group>"; };
@@ -3578,6 +3580,7 @@
 				B56DB3E32049BFAA00D4AA8E /* Info.plist */,
 				9379E1A4225536AD006A6BE4 /* TestAssets.xcassets */,
 				6856D6E9B1C3C89938DCAD5C /* Testing */,
+				029A9C662535873000BECEC5 /* AppCoordinatorTests.swift */,
 			);
 			path = WooCommerceTests;
 			sourceTree = "<group>";
@@ -5879,6 +5882,7 @@
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockupAnalyticsProvider.swift in Sources */,
+				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,
 				573A960524F4374B0091F3A5 /* TopBannerViewMirror.swift in Sources */,
 				5778E00A24DB1D8600B65CBF /* BehaviorSubjectTests.swift in Sources */,
 				B53A569721123D3B000776C9 /* ResultsControllerUIKitTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -8,11 +8,12 @@ final class AppCoordinatorTests: XCTestCase {
     private var stores: StoresManager!
     private var authenticationManager: AuthenticationManager!
 
+    private let window = UIWindow(frame: UIScreen.main.bounds)
+
     override func setUp() {
         super.setUp()
 
         tabBarController = MainTabBarController()
-        let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = tabBarController
         window.makeKeyAndVisible()
 
@@ -25,6 +26,11 @@ final class AppCoordinatorTests: XCTestCase {
         authenticationManager = nil
         stores.sessionManager.setStoreId(nil)
         stores = nil
+
+        // If not resetting the window, `AsyncDictionaryTests.testAsyncUpdatesWhereTheFirstOperationFinishesLast` fails.
+        window.resignKey()
+        window.rootViewController = nil
+
         tabBarController = nil
 
         super.tearDown()

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -67,18 +67,12 @@ final class AppCoordinatorTests: XCTestCase {
         stores.authenticate(credentials: SessionSettings.credentials)
         stores.sessionManager.setStoreId(134)
         let appCoordinator = AppCoordinator(tabBarController: tabBarController, stores: stores, authenticationManager: authenticationManager)
-        // Makes sure `MainTabBarController.viewDidLoad` is triggered so that each tab is set up.
-        XCTAssertNotNil(tabBarController.view)
 
         // When
         appCoordinator.start()
 
         // Then
         XCTAssertNil(tabBarController.presentedViewController)
-        let tabRootNavigationControllers = try XCTUnwrap(tabBarController.viewControllers as? [UINavigationController])
-        tabRootNavigationControllers.forEach { tabNavigationController in
-            XCTAssertGreaterThan(tabNavigationController.viewControllers.count, 0)
-        }
     }
 
     func test_starting_app_logged_in_then_logging_out_presents_authentication() throws {

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -1,0 +1,89 @@
+import TestKit
+import WordPressAuthenticator
+import XCTest
+@testable import WooCommerce
+
+final class AppCoordinatorTests: XCTestCase {
+    private var tabBarController: MainTabBarController!
+    private var stores: StoresManager!
+    private var authenticationManager: AuthenticationManager!
+
+    override func setUp() {
+        super.setUp()
+
+        tabBarController = MainTabBarController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = tabBarController
+        window.makeKeyAndVisible()
+
+        stores = MockupStoresManager(sessionManager: .makeForTesting(authenticated: false))
+        authenticationManager = AuthenticationManager()
+        authenticationManager.initialize()
+    }
+
+    override func tearDown() {
+        authenticationManager = nil
+        stores.sessionManager.setStoreId(nil)
+        stores = nil
+        tabBarController = nil
+
+        super.tearDown()
+    }
+
+    func test_starting_app_logged_out_presents_authentication() throws {
+        // Given
+        let appCoordinator = AppCoordinator(tabBarController: tabBarController, stores: stores, authenticationManager: authenticationManager)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        assertThat(tabBarController.presentedViewController, isAnInstanceOf: LoginNavigationController.self)
+    }
+
+    func test_starting_app_logged_in_without_selected_site_presents_store_picker() throws {
+        // Given
+        // Authenticates the app without selecting a site, so that the store picker is shown.
+        stores.authenticate(credentials: SessionSettings.credentials)
+        stores.sessionManager.setStoreId(nil)
+        let appCoordinator = AppCoordinator(tabBarController: tabBarController, stores: stores, authenticationManager: authenticationManager)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        let storePickerNavigationController = try XCTUnwrap(tabBarController.presentedViewController as? UINavigationController)
+        assertThat(storePickerNavigationController.topViewController, isAnInstanceOf: StorePickerViewController.self)
+    }
+
+    func test_starting_app_logged_in_with_selected_site_stays_on_tabbar() throws {
+        // Given
+        stores.authenticate(credentials: SessionSettings.credentials)
+        stores.sessionManager.setStoreId(134)
+        let appCoordinator = AppCoordinator(tabBarController: tabBarController, stores: stores, authenticationManager: authenticationManager)
+
+        // When
+        appCoordinator.start()
+
+        // Then
+        XCTAssertNil(tabBarController.presentedViewController)
+        let tabRootNavigationControllers = try XCTUnwrap(tabBarController.viewControllers as? [UINavigationController])
+        tabRootNavigationControllers.forEach { tabNavigationController in
+            XCTAssertGreaterThan(tabNavigationController.viewControllers.count, 0)
+        }
+    }
+
+    func test_starting_app_logged_in_then_logging_out_presents_authentication() throws {
+        // Given
+        stores.authenticate(credentials: SessionSettings.credentials)
+        stores.sessionManager.setStoreId(134)
+        let appCoordinator = AppCoordinator(tabBarController: tabBarController, stores: stores, authenticationManager: authenticationManager)
+
+        // When
+        appCoordinator.start()
+        stores.deauthenticate()
+
+        // Then
+        assertThat(tabBarController.presentedViewController, isAnInstanceOf: LoginNavigationController.self)
+    }
+}

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -67,6 +67,8 @@ final class AppCoordinatorTests: XCTestCase {
         stores.authenticate(credentials: SessionSettings.credentials)
         stores.sessionManager.setStoreId(134)
         let appCoordinator = AppCoordinator(tabBarController: tabBarController, stores: stores, authenticationManager: authenticationManager)
+        // Makes sure `MainTabBarController.viewDidLoad` is triggered so that each tab is set up.
+        XCTAssertNotNil(tabBarController.view)
 
         // When
         appCoordinator.start()

--- a/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
+++ b/WooCommerce/WooCommerceTests/Internal/SessionManager+Internal.swift
@@ -10,7 +10,9 @@ extension SessionManager {
     /// Returns a SessionManager instance with testing Keychain/UserDefaults
     ///
     static var testingInstance: SessionManager {
-        return SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
+        let sessionManager = SessionManager(defaults: SessionSettings.defaults, keychainServiceName: SessionSettings.keychainServiceName)
+        sessionManager.setStoreId(nil)
+        return sessionManager
     }
 
     /// Create an instance of unit testing.
@@ -20,6 +22,7 @@ extension SessionManager {
         // Force setting to `nil` if `authenticated` is `false` so that any auto-loaded credentials
         // will be removed.
         manager.defaultCredentials = authenticated ? SessionSettings.credentials : nil
+        manager.setStoreId(nil)
         return manager
     }
 

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -80,12 +80,13 @@ class StoresManagerTests: XCTestCase {
     func testDeauthenticateEffectivelyTogglesStoreManagerToDeauthenticatedState() {
         // Arrange
         let mockAuthenticationManager = MockAuthenticationManager()
-        ServiceLocator.setAuthenticationManager(mockAuthenticationManager)
         let manager = DefaultStoresManager.testingInstance
         var isLoggedInValues = [Bool]()
         cancellable = manager.isLoggedIn.subscribe { isLoggedIn in
             isLoggedInValues.append(isLoggedIn)
         }
+        let appCoordinator = AppCoordinator(tabBarController: MainTabBarController(), stores: manager, authenticationManager: mockAuthenticationManager)
+        appCoordinator.start()
 
         // Action
         manager.authenticate(credentials: SessionSettings.credentials)


### PR DESCRIPTION
Part of #2888

## Why

Before this PR, the authentication navigation code is scattered in different places:
- When logging out, the login UI is triggered by `DeauthenticatedState`'s `didEnter`
- When the app is launched in logged out state, or the app is logged in but requires a selected site, the logic to show the UI in these cases are in `AppDelegate`. We also want to keep `AppDelegate` lean and only have high-level app setup logic there.

This PR aims to consolidate all the authentication based navigation to one place (`AppCoordinator`). 

## Changes

- Created `AppCoordinator` that takes in `MainTabBarController` and dependencies from the `ServiceLocator`.
- In `AppDelegate`, replaced existing auth navigation code with `AppCoordinator`.
- Added/updated unit tests (there were quite some mysterious tests failing that took me a while to fix 😰 ). I had to [remove some asserts](https://github.com/woocommerce/woocommerce-ios/commit/65dc48d9b267a42fb9a0fd7e6b250a11c43c7af4) because I couldn't reproduce the [test failures on CI](https://app.circleci.com/pipelines/github/woocommerce/woocommerce-ios/8101/workflows/32a8139d-ba51-4a9c-8510-889ba3c16817/jobs/13647) (I tried reordering the tests as in CI).

## Testing

### Known pre-existing issue https://github.com/woocommerce/woocommerce-ios/issues/2888#issuecomment-701602846

This PR preserves the same logic as before, just moving the logic around. I'll fix this in a separate PR.
- Log in and stop when you reach the store picker.
- Force close the app (stopping or relaunching the app from Xcode, since [closing the app triggers deauthentication](https://github.com/woocommerce/woocommerce-ios/blob/20db5f84fbb75e3bda6e08179c3aff5b0860d321/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift#L273-L277))
- Open the app again. The store picker will be shown.
- Pick a store and continue with the login process. --> the app will show the dashboard but immediately show the login page again. The app should stay in logged in state.

Please confidence check on the authentication flow:

- Log out the app
- Log in to the app --> the auth flow should work as before
- Relaunch the app --> the app should stay logged in

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
