### PR TITLE
SentryCrashLogger: Add timestamp value

### DIFF
--- a/WooCommerce/Classes/Tools/Logging/SentryCrashLogger.swift
+++ b/WooCommerce/Classes/Tools/Logging/SentryCrashLogger.swift
@@ -25,6 +25,7 @@ private extension CrashLogging {
         let event = Event(level: level)
         event.message = message
         event.extra = properties
+        event.timestamp = Date()
 
         Client.shared?.snapshotStacktrace {
             Client.shared?.appendStacktrace(to: event)


### PR DESCRIPTION
Fixes #2964.  



## Problem

Since https://github.com/woocommerce/woocommerce-ios/pull/2775, we stopped receiving errors that are sent to Sentry via [`logMessageAndWait` ](https://github.com/woocommerce/woocommerce-ios/blob/c0c953752c36b750dd9a80a62c87465415df3222/WooCommerce/Classes/Tools/Logging/SentryCrashLogger.swift#L24). The app would just crash. These are mostly Core Data errors that we're tracking. 

## Solution 

The cause was [`SentryEvent.timestamp`](https://github.com/getsentry/sentry-cocoa/blob/51b790da739a8c54a61af679a8c4265e6c5f674b/Sources/Sentry/Public/SentryEvent.h#L24-L27) was expected to be `nil` but it is incorrectly labeled as such. It is apparently `nil` when you instantiate a new `SentryEvent`. And we do that in here:

https://github.com/woocommerce/woocommerce-ios/blob/c0c953752c36b750dd9a80a62c87465415df3222/WooCommerce/Classes/Tools/Logging/SentryCrashLogger.swift#L24-L27

When we try to access `SentryEvent.timestamp` in Tracks later, we get a crash. 

## Testing

1. Use **Xcode 11**
1. Enable `force-crash-logging` in Xcode scheme. 
2. Add this line before `return true` in `AppDelegate`'s `willFinishLaunchingOptions`. 

    ```swift
    SentryCrashLogger().logMessageAndWait("Hola", properties: nil, level: .fatal)
    ```
3. Confirm the app does not crash. 

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

