### PR TITLE
[Issue Refunds] Update title based on refund content

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/Cells/RefundShippingDetailsViewModel.swift
@@ -22,18 +22,8 @@ extension RefundShippingDetailsViewModel {
         self.shippingTax = currencyFormatter.formatAmount(shippingLine.totalTax, with: currency) ?? ""
         self.shippingSubtotal = currencyFormatter.formatAmount(shippingLine.total, with: currency) ?? ""
         self.shippingTotal = {
-            let calculatedTotal = Self.calculateShippingTotal(of: shippingLine, using: currencyFormatter)
-            return currencyFormatter.formatAmount(calculatedTotal, with: currency) ?? ""
+            let useCase = RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: currencyFormatter)
+            return currencyFormatter.formatAmount(useCase.calculateRefundValue(), with: currency) ?? ""
         }()
-    }
-
-    /// Calculates the shipping total by adding the shipping cost + the shipping tax
-    ///
-    private static func calculateShippingTotal(of shippingLine: ShippingLine, using currencyFormatter: CurrencyFormatter) -> NSDecimalNumber {
-        guard let cost = currencyFormatter.convertToDecimal(from: shippingLine.total),
-            let tax = currencyFormatter.convertToDecimal(from: shippingLine.totalTax) else {
-                return .zero
-        }
-        return cost.adding(tax)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -30,23 +30,23 @@ final class IssueRefundViewModel {
     private var state: State {
         didSet {
             sections = createSections()
+            title = calculateTitle()
             onChange?()
         }
     }
 
-    /// Title for the navigation bar
-    /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
+    /// Closured to notify the `ViewController` when the view model properties change
     ///
-    let title: String = "$0.00"
+    var onChange: (() -> (Void))?
+
+    /// Title for the navigation bar
+    ///
+    private(set) var title: String = ""
 
     /// String indicating how many items the user has selected to refund
     /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///
     let selectedItemsTitle: String = "0 items selected"
-
-    /// Closured to notify the `ViewController` when the view model properties change
-    ///
-    var onChange: (() -> (Void))?
 
     /// The sections and rows to display in the `UITableView`.
     ///
@@ -63,6 +63,7 @@ final class IssueRefundViewModel {
     init(order: Order, currencySettings: CurrencySettings) {
         state = State(order: order, currencySettings: currencySettings)
         sections = createSections()
+        title = calculateTitle()
     }
 }
 
@@ -184,6 +185,30 @@ extension IssueRefundViewModel {
 
         let detailsRow = RefundShippingDetailsViewModel(shippingLine: shippingLine, currency: state.order.currency, currencySettings: state.currencySettings)
         return Section(rows: [switchRow, detailsRow])
+    }
+
+    /// Returns a string of the refund total formatted with the proper currency settings and store currency.
+    ///
+    private func calculateTitle() -> String {
+        let formatter = CurrencyFormatter(currencySettings: state.currencySettings)
+        let totalToRefund = calculateRefundTotal()
+        return formatter.formatAmount(totalToRefund, with: state.order.currency) ?? ""
+    }
+
+    /// Returns the total amount to refund. ProductsTotal + Shipping Total(If required)
+    ///
+    private func calculateRefundTotal() -> Decimal {
+        let formatter = CurrencyFormatter(currencySettings: state.currencySettings)
+        let refundItems = state.refundQuantityStore.map { RefundItemsValuesCalculationUseCase.RefundItem(item: $0, quantity: $1) }
+        let productsTotalUseCase = RefundItemsValuesCalculationUseCase(refundItems: refundItems, currencyFormatter: formatter)
+
+        // If shipping is not enabled, return only the products value
+        guard let shippingLine = state.order.shippingLines.first, state.shouldRefundShipping else {
+            return productsTotalUseCase.calculateRefundValues().total
+        }
+
+        let shippingTotalUseCase = RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: formatter)
+        return productsTotalUseCase.calculateRefundValues().total + shippingTotalUseCase.calculateRefundValue()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundShippingCalculationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundShippingCalculationUseCase.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Yosemite
+
+/// Calculates the total value(cost + tax) to be refunded from a shipping line.
+///
+struct RefundShippingCalculationUseCase {
+
+    /// Shipping line to be refunded
+    ///
+    let shippingLine: ShippingLine
+
+    /// Formatter to convert string values to decimal values
+    ///
+    let currencyFormatter: CurrencyFormatter
+
+    /// Calculates the total value(cost + tax) to be refunded.
+    ///
+    func calculateRefundValue() -> Decimal {
+        guard let cost = currencyFormatter.convertToDecimal(from: shippingLine.total) as Decimal?,
+            let tax = currencyFormatter.convertToDecimal(from: shippingLine.totalTax) as Decimal? else {
+                return .zero
+        }
+        return cost + tax
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -344,6 +344,8 @@
 		2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */; };
 		2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */; };
 		2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */; };
+		2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */; };
+		2667BFED25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */; };
 		267CFE1C2443A54200AF3A13 /* ProductCategoryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
@@ -1341,6 +1343,8 @@
 		2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCase.swift; sourceTree = "<group>"; };
 		2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemsValuesCalculationUseCaseTests.swift; sourceTree = "<group>"; };
 		2667BFE82530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalViewModelTests.swift; sourceTree = "<group>"; };
+		2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCase.swift; sourceTree = "<group>"; };
+		2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingCalculationUseCaseTests.swift; sourceTree = "<group>"; };
 		267CFE1824435A5500AF3A13 /* ProductCategoryViewModelBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryViewModelBuilderTests.swift; sourceTree = "<group>"; };
 		267CFE1A2443740900AF3A13 /* ProductCategoryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryCellViewModel.swift; sourceTree = "<group>"; };
 		2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveySubmittedViewController.swift; sourceTree = "<group>"; };
@@ -2810,6 +2814,7 @@
 				2667BFE2252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift */,
 				2667BFDC252F61C5008099D4 /* RefundShippingDetailsViewModelTests.swift */,
 				2667BFE62530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift */,
+				2667BFEC25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift */,
 			);
 			path = "Issue Refund";
 			sourceTree = "<group>";
@@ -2848,6 +2853,7 @@
 				2667BFE0252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift */,
 				260C31612524EEB200157BC2 /* IssueRefundViewController.xib */,
 				2667BFE42530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift */,
+				2667BFEA2535FF09008099D4 /* RefundShippingCalculationUseCase.swift */,
 			);
 			path = "Issue Refunds";
 			sourceTree = "<group>";
@@ -5594,6 +5600,7 @@
 				0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
 				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,
+				2667BFEB2535FF09008099D4 /* RefundShippingCalculationUseCase.swift in Sources */,
 				CEEC9B5C21E79B3E0055EEF0 /* FeatureFlag.swift in Sources */,
 				26FE09DD24D9F3F600B9BDF5 /* SurveyLoadingView.swift in Sources */,
 				457151AB243B6E8000EB2DFA /* ProductSlugViewController.swift in Sources */,
@@ -5820,6 +5827,7 @@
 				02404EE2231501E000FF1170 /* StatsVersionCoordinatorTests.swift in Sources */,
 				02B1AFEE24BC5BA9005DB1E3 /* GroupedProductListSelectorDataSourceTests.swift in Sources */,
 				02CEBB8424C99A10002EDF35 /* Product+ShippingTests.swift in Sources */,
+				2667BFED25360681008099D4 /* RefundShippingCalculationUseCaseTests.swift in Sources */,
 				D83F5939225B424B00626E75 /* AddManualTrackingViewModelTests.swift in Sources */,
 				0257285C230ACC7E00A288C4 /* StoreStatsV4ChartAxisHelperTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -62,12 +62,12 @@ final class MockOrders {
                      refunds: [])
     }
 
-    static func sampleShippingLines() -> [ShippingLine] {
+    static func sampleShippingLines(cost: String = "133.00", tax: String = "0.00") -> [ShippingLine] {
         return [ShippingLine(shippingID: 123,
         methodTitle: "International Priority Mail Express Flat Rate",
         methodID: "usps",
-        total: "133.00",
-        totalTax: "0.00")]
+        total: cost,
+        totalTax: tax)]
     }
 
     func sampleAddress() -> Address {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -112,4 +112,50 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(2), 0)
         XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(3), nil)
     }
+
+    func test_viewModel_correctly_adds_item_selections_to_title() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+
+        // When
+        viewModel.updateRefundQuantity(quantity: 2, forItemAtIndex: 0)
+        viewModel.updateRefundQuantity(quantity: 1, forItemAtIndex: 1)
+
+        // Then
+        // 11.50(item 1) x 2 (quantity) = 23.00
+        // 12.50(item 2) x 1 (quantity = 12.50
+        // Total = 35.50
+        XCTAssertEqual(viewModel.title, "$35.50")
+    }
+
+    func test_viewModel_correctly_adds_shipping_selection_to_title() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+        ]
+        let shippingLines = MockOrders.sampleShippingLines(cost: "7.00", tax: "0.62")
+        let order = MockOrders().makeOrder(items: items, shippingLines: shippingLines)
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+
+        // 11.50 (item 1) x 2 (quantity) = 23.0
+        viewModel.updateRefundQuantity(quantity: 2, forItemAtIndex: 0)
+        XCTAssertEqual(viewModel.title, "$23.00")
+
+        // When
+        viewModel.toggleRefundShipping()
+
+        // Then
+        // 23.00(current products) + 7.52 (shipping) = 30.62
+        XCTAssertEqual(viewModel.title, "$30.62")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundShippingCalculationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundShippingCalculationUseCaseTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import Yosemite
+
+@testable import WooCommerce
+
+/// Test cases for `RefundShippingCalculationUseCase`
+///
+final class RefundShippingCalculationUseCaseTests: XCTestCase {
+    func test_useCase_correctly_calculates_total_from_shipping_line_without_taxes() {
+        // Given
+        let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let shippingLine = ShippingLine(shippingID: 123, methodTitle: "", methodID: "", total: "12.40", totalTax: "0.0")
+
+        // When
+        let useCase = RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: formatter)
+        let value = useCase.calculateRefundValue()
+
+        XCTAssertEqual(value, 12.40)
+    }
+
+    func test_useCase_correctly_calculates_total_from_shipping_line_with_taxes() {
+        // Given
+        let formatter = CurrencyFormatter(currencySettings: CurrencySettings())
+        let shippingLine = ShippingLine(shippingID: 123, methodTitle: "", methodID: "", total: "12.40", totalTax: "1.99")
+
+        // When
+        let useCase = RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: formatter)
+        let value = useCase.calculateRefundValue()
+
+        XCTAssertEqual(value, 14.39)
+    }
+}


### PR DESCRIPTION
closes #2842 

# Why

This pr takes care of updating the navigation bar title with the current amount to be refunded during the issue refund screen.

<img width="200" alt="Screen Shot 2020-10-13 at 2 53 27 PM" src="https://user-images.githubusercontent.com/562080/95909435-1b3ff880-0d64-11eb-9d29-79bf5614e9c2.png">

The calculation is made by accumulating the **Products Refund** value and the **Shipping Refund** value

# How
- Extracted the shipping calculation from `RefundShippingDetailsViewModel` to `RefundShippingCalculationUseCase ` to it can be reused on the main view model when calculating the title.
- Updated `IssueRefundViewModel` to have a variable title which is computed by using `RefundItemsValuesCalculationUseCase` and `RefundShippingCalculationUseCase`

# Demo
![demo-title](https://user-images.githubusercontent.com/562080/95910541-dae17a00-0d65-11eb-9942-a93faff2de17.gif)


# Testing Steps
- Navigate to a non-refunded order.
- Tap the issue refund button
- Select multiple items to refund 
- See that the title reflects the current selection
- Tap on "Refund Shipping" switch 
- See that the title updates by adding the value for the shipping

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
