### PR TITLE
[Issue Refund] Selected Items count label

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -67,7 +67,7 @@ private extension IssueRefundViewController {
     }
 
     @IBAction func selectAllButtonWasPressed(_ sender: Any) {
-        print("Select All button pressed")
+        viewModel.selectAllOrderItems()
     }
 
     func shippingSwitchChanged() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -229,7 +229,7 @@ extension IssueRefundViewModel {
         return productsTotalUseCase.calculateRefundValues().total + shippingTotalUseCase.calculateRefundValue()
     }
 
-    /// Returns a string with the count ofhow many items are selected for refund.
+    /// Returns a string with the count of how many items are selected for refund.
     ///
     private func createSelectedItemsCount() -> String {
         let count = state.refundQuantityStore.count()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -31,6 +31,7 @@ final class IssueRefundViewModel {
         didSet {
             sections = createSections()
             title = calculateTitle()
+            selectedItemsTitle = createSelectedItemsCount()
             onChange?()
         }
     }
@@ -44,9 +45,8 @@ final class IssueRefundViewModel {
     private(set) var title: String = ""
 
     /// String indicating how many items the user has selected to refund
-    /// This is temporary data, will be removed after implementing https://github.com/woocommerce/woocommerce-ios/issues/2842
     ///
-    let selectedItemsTitle: String = "0 items selected"
+    private(set) var selectedItemsTitle: String = ""
 
     /// The sections and rows to display in the `UITableView`.
     ///
@@ -64,6 +64,7 @@ final class IssueRefundViewModel {
         state = State(order: order, currencySettings: currencySettings)
         sections = createSections()
         title = calculateTitle()
+        selectedItemsTitle = createSelectedItemsCount()
     }
 
     /// Creates the `ViewModel` to be used when navigating to the page where the user can
@@ -136,6 +137,8 @@ private extension IssueRefundViewModel {
 private extension IssueRefundViewModel {
     enum Localization {
         static let refundShippingTitle = NSLocalizedString("Refund Shipping", comment: "Title of the switch in the IssueRefund screen to refund shipping")
+        static let itemSingular = NSLocalizedString("1 item selected", comment: "Title of the label indicating that there is 1 item to refund.")
+        static let itemsPlural = NSLocalizedString("%d items selected", comment: "Title of the label indicating that there are multiple items to refund.")
     }
 }
 
@@ -225,6 +228,13 @@ extension IssueRefundViewModel {
         let shippingTotalUseCase = RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: formatter)
         return productsTotalUseCase.calculateRefundValues().total + shippingTotalUseCase.calculateRefundValue()
     }
+
+    /// Returns the a string with the count of many items are selected for refund.
+    ///
+    private func createSelectedItemsCount() -> String {
+        let count = state.refundQuantityStore.count()
+        return String.pluralize(count, singular: Localization.itemSingular, plural: Localization.itemsPlural)
+    }
 }
 
 extension RefundItemViewModel: IssueRefundRow {}
@@ -261,6 +271,13 @@ private extension IssueRefundViewModel {
         ///
         func map<T>(transform: (_ item: OrderItem, _ quantity: Quantity) -> (T)) -> [T] {
             store.map(transform)
+        }
+
+        /// Returns the number of items referenced for refund.
+        /// Calculated by aggregating all stored quantities.
+        ///
+        func count() -> Int {
+            store.values.reduce(0) { $0 + $1 }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -109,6 +109,15 @@ extension IssueRefundViewModel {
         }
         state.refundQuantityStore.update(quantity: quantity, for: item)
     }
+
+    /// Marks all items as to be refunded
+    ///
+    func selectAllOrderItems() {
+        state.order.items.forEach { item in
+            let quantity = Int(truncating: item.quantity as NSDecimalNumber)
+            state.refundQuantityStore.update(quantity: quantity, for: item)
+        }
+    }
 }
 
 // MARK: Results Controller

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -36,7 +36,7 @@ final class IssueRefundViewModel {
         }
     }
 
-    /// Closured to notify the `ViewController` when the view model properties change
+    /// Closure to notify the `ViewController` when the view model properties change
     ///
     var onChange: (() -> (Void))?
 
@@ -229,7 +229,7 @@ extension IssueRefundViewModel {
         return productsTotalUseCase.calculateRefundValues().total + shippingTotalUseCase.calculateRefundValue()
     }
 
-    /// Returns the a string with the count of many items are selected for refund.
+    /// Returns a string with the count ofhow many items are selected for refund.
     ///
     private func createSelectedItemsCount() -> String {
         let count = state.refundQuantityStore.count()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -113,6 +113,27 @@ final class IssueRefundViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(3), nil)
     }
 
+    func test_viewModel_updates_refund_quantities_after_selecting_all() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+        viewModel.selectAllOrderItems()
+
+        // Then
+        XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(0), 3)
+        XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(1), 2)
+        XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(2), 1)
+        XCTAssertEqual(viewModel.currentQuantityForItemAtIndex(3), nil)
+    }
+
     func test_viewModel_correctly_adds_item_selections_to_title() {
         // Given
         let currencySettings = CurrencySettings()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -179,4 +179,60 @@ final class IssueRefundViewModelTests: XCTestCase {
         // 23.00(current products) + 7.52 (shipping) = 30.62
         XCTAssertEqual(viewModel.title, "$30.62")
     }
+
+    func test_viewModel_starts_with_zero_count_label() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+
+        // Then
+        let selectedItemsTitle = String(format: NSLocalizedString("%d items selected", comment: ""), 0)
+        XCTAssertEqual(viewModel.selectedItemsTitle, selectedItemsTitle)
+    }
+
+    func test_viewModel_correctly_calculates_1_selected_item_title() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+        viewModel.updateRefundQuantity(quantity: 1, forItemAtIndex: 2)
+
+        // Then
+        let selectedItemsTitle = NSLocalizedString("1 item selected", comment: "")
+        XCTAssertEqual(viewModel.selectedItemsTitle, selectedItemsTitle)
+    }
+
+    func test_viewModel_correctly_calculates_multitple_selected_item_title() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+            MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 12.50),
+            MockOrderItem.sampleItem(itemID: 3, quantity: 1, price: 13.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, currencySettings: currencySettings)
+        viewModel.selectAllOrderItems()
+
+        // Then
+        let selectedItemsTitle = String(format: NSLocalizedString("%d items selected", comment: ""), 6)
+        XCTAssertEqual(viewModel.selectedItemsTitle, selectedItemsTitle)
+    }
 }


### PR DESCRIPTION
closes #2840 

# Why

This PR takes care of two things:
- Updating the selected item label text to reflect the current selected state
- Enabling the "select all" button.

# How
- Added a `selectAllOrderItems` method on `IssueRefundViewModel` to select all orders items.
- Added a `createSelectedItemsCount` method on `IssueRefundViewModel` to update the selected items label text. 
- Added a `count` method to `RefundQuantityStore` to know how many items are marked for refund.

# Demo
![demo](https://user-images.githubusercontent.com/562080/95920268-bb058280-0d74-11eb-8aee-a2125933fea8.gif)

# Testing steps
- Navigate to a non-refunded order
- Tap the **issue refund** button
- See that the label reads: "0 items selected"
- Select one item to refund
- See that the label reads: "1 item selected"
- Tap on the "select all" button
- See that the label reads correctly.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
