### PR TITLE
Remove Products M3 feature flag from the codebase

### DIFF
--- a/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
+++ b/WooCommerce/Classes/System/DefaultFeatureFlagService.swift
@@ -5,8 +5,6 @@ struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .barcodeScanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .editProductsRelease3:
-            return true
         case .editProductsRelease4:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .editProductsRelease5:

--- a/WooCommerce/Classes/System/FeatureFlag.swift
+++ b/WooCommerce/Classes/System/FeatureFlag.swift
@@ -10,10 +10,6 @@ enum FeatureFlag: Int {
     ///
     case barcodeScanner
 
-    /// Edit products - release 3
-    ///
-    case editProductsRelease3
-
     /// Edit products - release 4
     ///
     case editProductsRelease4

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -710,8 +710,7 @@ extension ProductDetailsViewModel {
         case .productVariants:
             ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
             let variationsViewController = ProductVariationsViewController(product: product,
-                                                                           formType: .readonly,
-                                                                           isEditProductsRelease3Enabled: false)
+                                                                           formType: .readonly)
             sender.navigationController?.pushViewController(variationsViewController, animated: true)
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -59,14 +59,12 @@ private extension AddProductCoordinator {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true,
                                              isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
-                                                       presentationStyle: .navigationStack,
-                                                       isEditProductsRelease3Enabled: true)
+                                                       presentationStyle: .navigationStack)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,7 +8,7 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool)
+    init(_ settings: ProductSettings, productType: ProductType)
 }
 
 // MARK: - Sections declaration for Product Settings
@@ -20,8 +20,8 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool) {
-            if isEditProductsRelease3Enabled && productType == .simple {
+        init(_ settings: ProductSettings, productType: ProductType) {
+            if productType == .simple {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
@@ -40,18 +40,11 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease3Enabled: Bool) {
-            if isEditProductsRelease3Enabled {
-                rows = [ProductSettingsRows.ReviewsAllowed(settings),
-                        ProductSettingsRows.Slug(settings),
-                        ProductSettingsRows.PurchaseNote(settings),
-                        ProductSettingsRows.MenuOrder(settings)]
-            }
-            else {
-                rows = [ProductSettingsRows.Slug(settings),
-                        ProductSettingsRows.PurchaseNote(settings),
-                        ProductSettingsRows.MenuOrder(settings)]
-            }
+        init(_ settings: ProductSettings, productType: ProductType) {
+            rows = [ProductSettingsRows.ReviewsAllowed(settings),
+            ProductSettingsRows.Slug(settings),
+            ProductSettingsRows.PurchaseNote(settings),
+            ProductSettingsRows.MenuOrder(settings)]
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -24,13 +24,11 @@ final class ProductSettingsViewController: UIViewController {
     init(product: Product,
          password: String?,
          formType: ProductFormType,
-         isEditProductsRelease3Enabled: Bool,
          completion: @escaping Completion,
          onPasswordRetrieved: @escaping PasswordRetrievedCompletion) {
         viewModel = ProductSettingsViewModel(product: product,
                                              password: password,
-                                             formType: formType,
-                                             isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                             formType: formType)
         onCompletion = completion
         onPasswordCompletion = onPasswordRetrieved
         super.init(nibName: nil, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -11,7 +11,7 @@ final class ProductSettingsViewModel {
 
     var productSettings: ProductSettings {
         didSet {
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings, productType: product.productType)
         }
     }
 
@@ -27,21 +27,18 @@ final class ProductSettingsViewModel {
     var onReload: (() -> Void)?
     var onPasswordRetrieved: ((_ password: String) -> Void)?
 
-    private let isEditProductsRelease3Enabled: Bool
-
-    init(product: Product, password: String?, formType: ProductFormType, isEditProductsRelease3Enabled: Bool) {
+    init(product: Product, password: String?, formType: ProductFormType) {
         self.product = product
         self.password = password
-        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         productSettings = ProductSettings(from: product, password: password)
 
         switch formType {
         case .add:
             self.password = ""
             productSettings.password = ""
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings, productType: product.productType)
         case .edit:
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings, productType: product.productType)
             /// If nil, we fetch the password from site post API because it was never fetched
             if password == nil {
                 retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
@@ -55,12 +52,11 @@ final class ProductSettingsViewModel {
                     self.password = password
                     self.productSettings.password = password
                     self.sections = Self.configureSections(self.productSettings,
-                                                           productType: product.productType,
-                                                           isEditProductsRelease3Enabled: self.isEditProductsRelease3Enabled)
+                                                           productType: product.productType)
                 }
             }
         case .readonly:
-            sections = Self.configureSections(productSettings, productType: product.productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+            sections = Self.configureSections(productSettings, productType: product.productType)
         }
     }
 
@@ -104,10 +100,9 @@ private extension ProductSettingsViewModel {
 //
 private extension ProductSettingsViewModel {
     static func configureSections(_ settings: ProductSettings,
-                                  productType: ProductType,
-                                  isEditProductsRelease3Enabled: Bool) -> [ProductSettingsSectionMediator] {
-        return [ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled),
-                ProductSettingsSections.MoreOptions(settings, productType: productType, isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                  productType: ProductType) -> [ProductSettingsSectionMediator] {
+        return [ProductSettingsSections.PublishSettings(settings, productType: productType),
+                ProductSettingsSections.MoreOptions(settings, productType: productType)
         ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -33,17 +33,14 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let product: EditableProductModel
     private let formType: ProductFormType
     private let editable: Bool
-    private let isEditProductsRelease3Enabled: Bool
     private let isEditProductsRelease5Enabled: Bool
 
     init(product: EditableProductModel,
          formType: ProductFormType,
-         isEditProductsRelease3Enabled: Bool,
          isEditProductsRelease5Enabled: Bool) {
         self.product = product
         self.formType = formType
         self.editable = formType != .readonly
-        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
     }
 
@@ -86,11 +83,9 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForSimpleProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
-        let shouldShowProductTypeRow = isEditProductsRelease3Enabled && formType == .edit
+        let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowProductTypeRow = formType == .edit
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
-        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
-        let shouldShowTagsRow = isEditProductsRelease3Enabled
         let showDownloadableProduct = isEditProductsRelease5Enabled && product.downloadable
 
         let actions: [ProductFormEditAction?] = [
@@ -98,8 +93,8 @@ private extension ProductFormActionsFactory {
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
             .inventorySettings(editable: editable),
-            shouldShowCategoriesRow ? .categories(editable: editable): nil,
-            shouldShowTagsRow ? .tags(editable: editable): nil,
+            .categories(editable: editable),
+            .tags(editable: editable),
             showDownloadableProduct ? .downloadableFiles: nil,
             .briefDescription(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
@@ -108,18 +103,16 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForAffiliateProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
-        let shouldShowProductTypeRow = isEditProductsRelease3Enabled && formType == .edit
-        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
-        let shouldShowTagsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowProductTypeRow = formType == .edit
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable),
             shouldShowReviewsRow ? .reviews: nil,
             .externalURL(editable: editable),
             .sku(editable: editable),
-            shouldShowCategoriesRow ? .categories(editable: editable): nil,
-            shouldShowTagsRow ? .tags(editable: editable): nil,
+            .categories(editable: editable),
+            .tags(editable: editable),
             .briefDescription(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
@@ -127,17 +120,15 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForGroupedProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
-        let shouldShowProductTypeRow = isEditProductsRelease3Enabled && formType == .edit
-        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
-        let shouldShowTagsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowProductTypeRow = formType == .edit
 
         let actions: [ProductFormEditAction?] = [
             .groupedProducts(editable: editable),
             shouldShowReviewsRow ? .reviews: nil,
             .sku(editable: editable),
-            shouldShowCategoriesRow ? .categories(editable: editable): nil,
-            shouldShowTagsRow ? .tags(editable: editable): nil,
+            .categories(editable: editable),
+            .tags(editable: editable),
             .briefDescription(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
@@ -145,18 +136,16 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
-        let shouldShowProductTypeRow = isEditProductsRelease3Enabled
-        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
-        let shouldShowTagsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowProductTypeRow = formType == .edit
 
         let actions: [ProductFormEditAction?] = [
             .variations(editable: editable),
             shouldShowReviewsRow ? .reviews: nil,
             .shippingSettings(editable: editable),
             .inventorySettings(editable: editable),
-            shouldShowCategoriesRow ? .categories(editable: editable): nil,
-            shouldShowTagsRow ? .tags(editable: editable): nil,
+            .categories(editable: editable),
+            .tags(editable: editable),
             .briefDescription(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: editable): nil
         ]
@@ -165,17 +154,15 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForNonCoreProduct() -> [ProductFormEditAction] {
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
-        let shouldShowReviewsRow = isEditProductsRelease3Enabled && product.reviewsAllowed
-        let shouldShowProductTypeRow = isEditProductsRelease3Enabled
-        let shouldShowCategoriesRow = isEditProductsRelease3Enabled
-        let shouldShowTagsRow = isEditProductsRelease3Enabled
+        let shouldShowReviewsRow = product.reviewsAllowed
+        let shouldShowProductTypeRow = formType == .edit
 
         let actions: [ProductFormEditAction?] = [
             shouldShowPriceSettingsRow ? .priceSettings(editable: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),
-            shouldShowCategoriesRow ? .categories(editable: editable): nil,
-            shouldShowTagsRow ? .tags(editable: editable): nil,
+            .categories(editable: editable),
+            .tags(editable: editable),
             .briefDescription(editable: editable),
             shouldShowProductTypeRow ? .productType(editable: false): nil
         ]

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -40,7 +40,6 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let productUIImageLoader: ProductUIImageLoader
 
     private let currency: String
-    private let isEditProductsRelease3Enabled: Bool
 
     private lazy var exitForm: () -> Void = {
         presentationStyle.createExitForm(viewController: self)
@@ -59,13 +58,11 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          eventLogger: ProductFormEventLoggerProtocol,
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
-         presentationStyle: ProductFormPresentationStyle,
-         isEditProductsRelease3Enabled: Bool) {
+         presentationStyle: ProductFormPresentationStyle) {
         self.viewModel = viewModel
         self.eventLogger = eventLogger
         self.currency = currency
         self.presentationStyle = presentationStyle
-        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         self.productImageActionHandler = productImageActionHandler
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
@@ -316,8 +313,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                     return
                 }
                 let variationsViewController = ProductVariationsViewController(product: product.product,
-                                                                               formType: viewModel.formType,
-                                                                               isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                                                               formType: viewModel.formType)
                 show(variationsViewController, sender: self)
             case .status, .noPriceWarning:
                 break
@@ -684,7 +680,6 @@ private extension ProductFormViewController {
         let viewController = ProductSettingsViewController(product: product.product,
                                                            password: password,
                                                            formType: viewModel.formType,
-                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
                                                            completion: { [weak self] (productSettings) in
             guard let self = self else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -59,7 +59,6 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
 
             actionsFactory = ProductFormActionsFactory(product: product,
                                                        formType: formType,
-                                                       isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
                                                        isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             productSubject.send(product)
         }
@@ -81,7 +80,6 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     }
 
     private let productImageActionHandler: ProductImageActionHandler
-    private let isEditProductsRelease3Enabled: Bool
     private let isEditProductsRelease5Enabled: Bool
 
     private var cancellable: ObservationToken?
@@ -89,17 +87,14 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     init(product: EditableProductModel,
          formType: ProductFormType,
          productImageActionHandler: ProductImageActionHandler,
-         isEditProductsRelease3Enabled: Bool,
          isEditProductsRelease5Enabled: Bool) {
         self.formType = formType
         self.productImageActionHandler = productImageActionHandler
-        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.originalProduct = product
         self.product = product
         self.actionsFactory = ProductFormActionsFactory(product: product,
                                                         formType: formType,
-                                                        isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
                                                         isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         self.isUpdateEnabledSubject = PublishSubject<Bool>()
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -20,7 +20,6 @@ struct ProductDetailsFactory {
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
                                 isEditProductsEnabled: forceReadOnly ? false: true,
-                                isEditProductsRelease3Enabled: true,
                                 isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
         onCompletion(vc)
     }
@@ -31,7 +30,6 @@ private extension ProductDetailsFactory {
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings,
                                isEditProductsEnabled: Bool,
-                               isEditProductsRelease3Enabled: Bool,
                                isEditProductsRelease5Enabled: Bool) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
@@ -41,13 +39,11 @@ private extension ProductDetailsFactory {
             let viewModel = ProductFormViewModel(product: productModel,
                                                  formType: .edit,
                                                  productImageActionHandler: productImageActionHandler,
-                                                 isEditProductsRelease3Enabled: isEditProductsRelease3Enabled,
                                                  isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             vc = ProductFormViewController(viewModel: viewModel,
                                            eventLogger: ProductFormEventLogger(),
                                            productImageActionHandler: productImageActionHandler,
-                                           presentationStyle: presentationStyle,
-                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                           presentationStyle: presentationStyle)
             // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
             vc.hidesBottomBarWhenPushed = true
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -21,7 +21,6 @@ struct ProductVariationDetailsFactory {
                                          presentationStyle: presentationStyle,
                                          currencySettings: currencySettings,
                                          isEditProductsEnabled: forceReadOnly ? false: true,
-                                         isEditProductsRelease3Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease3),
                                          isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
         onCompletion(vc)
     }
@@ -33,7 +32,6 @@ private extension ProductVariationDetailsFactory {
                                         presentationStyle: ProductFormPresentationStyle,
                                         currencySettings: CurrencySettings,
                                         isEditProductsEnabled: Bool,
-                                        isEditProductsRelease3Enabled: Bool,
                                         isEditProductsRelease5Enabled: Bool) -> UIViewController {
         // TODO-2931: add support for readonly mode based on `isEditProductsEnabled`.
         let vc: UIViewController
@@ -51,8 +49,7 @@ private extension ProductVariationDetailsFactory {
         vc = ProductFormViewController(viewModel: viewModel,
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
-                                       presentationStyle: presentationStyle,
-                                       isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
+                                       presentationStyle: presentationStyle)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -83,15 +83,13 @@ final class ProductVariationsViewController: UIViewController {
     private let formType: ProductFormType
 
     private let imageService: ImageService = ServiceLocator.imageService
-    private let isEditProductsRelease3Enabled: Bool
 
-    init(product: Product, formType: ProductFormType, isEditProductsRelease3Enabled: Bool) {
+    init(product: Product, formType: ProductFormType) {
         self.siteID = product.siteID
         self.productID = product.productID
         self.allAttributes = product.attributes
         self.parentProductSKU = product.sku
         self.formType = formType
-        self.isEditProductsRelease3Enabled = isEditProductsRelease3Enabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -283,31 +281,28 @@ extension ProductVariationsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        if isEditProductsRelease3Enabled {
-            ServiceLocator.analytics.track(.productVariationListVariationTapped)
+        ServiceLocator.analytics.track(.productVariationListVariationTapped)
 
-            let productVariation = resultsController.object(at: indexPath)
-            let model = EditableProductVariationModel(productVariation: productVariation,
+        let productVariation = resultsController.object(at: indexPath)
+        let model = EditableProductVariationModel(productVariation: productVariation,
+                                                  allAttributes: allAttributes,
+                                                  parentProductSKU: parentProductSKU)
+
+        let currencyCode = ServiceLocator.currencySettings.currencyCode
+        let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let productImageActionHandler = ProductImageActionHandler(siteID: productVariation.siteID,
+                                                                  product: model)
+        let viewModel = ProductVariationFormViewModel(productVariation: model,
                                                       allAttributes: allAttributes,
-                                                      parentProductSKU: parentProductSKU)
-
-            let currencyCode = ServiceLocator.currencySettings.currencyCode
-            let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
-            let productImageActionHandler = ProductImageActionHandler(siteID: productVariation.siteID,
-                                                                      product: model)
-            let viewModel = ProductVariationFormViewModel(productVariation: model,
-                                                          allAttributes: allAttributes,
-                                                          parentProductSKU: parentProductSKU,
-                                                          formType: formType,
-                                                          productImageActionHandler: productImageActionHandler)
-            let viewController = ProductFormViewController(viewModel: viewModel,
-                                                           eventLogger: ProductVariationFormEventLogger(),
-                                                           productImageActionHandler: productImageActionHandler,
-                                                           currency: currency,
-                                                           presentationStyle: .navigationStack,
-                                                           isEditProductsRelease3Enabled: isEditProductsRelease3Enabled)
-            navigationController?.pushViewController(viewController, animated: true)
-        }
+                                                      parentProductSKU: parentProductSKU,
+                                                      formType: formType,
+                                                      productImageActionHandler: productImageActionHandler)
+        let viewController = ProductFormViewController(viewModel: viewModel,
+                                                       eventLogger: ProductVariationFormEventLogger(),
+                                                       productImageActionHandler: productImageActionHandler,
+                                                       currency: currency,
+                                                       presentationStyle: .navigationStack)
+        navigationController?.pushViewController(viewController, animated: true)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mockups/MockFeatureFlagService.swift
@@ -1,16 +1,8 @@
 @testable import WooCommerce
 
 struct MockFeatureFlagService: FeatureFlagService {
-    private let isEditProductsRelease3On: Bool
-
-    init(isEditProductsRelease3On: Bool = false) {
-        self.isEditProductsRelease3On = isEditProductsRelease3On
-    }
-
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         switch featureFlag {
-        case .editProductsRelease3:
-            return isEditProductsRelease3On
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift
@@ -11,7 +11,6 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -34,7 +33,6 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -53,7 +51,6 @@ final class ProductFormActionsFactory_NonEmptyBottomSheetActionsTests: XCTestCas
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: true)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -13,7 +13,6 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model,
                                                        formType: .edit,
-                                                       isEditProductsRelease3Enabled: true,
                                                        isEditProductsRelease5Enabled: false)
 
         // Action
@@ -43,7 +42,6 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model,
                                                        formType: .edit,
-                                                       isEditProductsRelease3Enabled: true,
                                                        isEditProductsRelease5Enabled: false)
 
         // Action

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+AddProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+AddProductTests.swift
@@ -12,7 +12,6 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .add,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -40,7 +39,6 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .add,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -64,7 +62,6 @@ final class ProductFormActionsFactory_AddProductTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .add,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactory+VisibilityTests.swift
@@ -13,7 +13,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -28,7 +27,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -45,7 +43,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -61,7 +58,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -79,7 +75,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -95,7 +90,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -113,7 +107,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -129,7 +122,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -147,7 +139,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -163,7 +154,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -181,7 +171,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: true)
 
         // Assert
@@ -196,7 +185,6 @@ final class ProductFormActionsFactory_VisibilityTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: true)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormActionsFactoryTests.swift
@@ -12,7 +12,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -41,7 +40,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -70,7 +68,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -98,7 +95,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: true)
 
         // Assert
@@ -127,7 +123,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -155,7 +150,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -180,7 +174,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -202,7 +195,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -230,7 +222,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -258,7 +249,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert
@@ -280,7 +270,6 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         // Action
         let factory = ProductFormActionsFactory(product: model,
                                                 formType: .edit,
-                                                isEditProductsRelease3Enabled: true,
                                                 isEditProductsRelease5Enabled: false)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ChangesTests.swift
@@ -16,7 +16,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
 
@@ -56,7 +55,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -74,7 +72,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -93,7 +90,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         let expectation = self.expectation(description: "Wait for image upload")
         productImageActionHandler.addUpdateObserver(self) { statuses in
@@ -118,7 +114,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -142,7 +137,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -160,7 +154,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -183,7 +176,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -205,7 +197,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -223,7 +214,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -241,7 +231,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -259,7 +248,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -280,7 +268,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -298,7 +285,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -316,7 +302,6 @@ final class ProductFormViewModel_ChangesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -30,7 +30,6 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         let taxClass = TaxClass(siteID: product.siteID, name: "standard", slug: product.taxClass ?? "standard")
         cancellableProduct = viewModel.observableProduct.subscribe { _ in
@@ -83,7 +82,6 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
@@ -126,7 +124,6 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in
@@ -165,7 +162,6 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         // The password is set from a separate DotCom API.
         viewModel.resetPassword("134")
@@ -211,7 +207,6 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
         var isProductUpdated: Bool?
         cancellableProduct = viewModel.observableProduct.subscribe { product in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -124,7 +124,6 @@ private extension ProductFormViewModel_SaveTests {
         return ProductFormViewModel(product: model,
                                     formType: formType,
                                     productImageActionHandler: productImageActionHandler,
-                                    isEditProductsRelease3Enabled: true,
                                     isEditProductsRelease5Enabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -14,7 +14,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -33,7 +32,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -52,7 +50,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -87,7 +84,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -121,7 +117,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -155,7 +150,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -180,7 +174,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -203,7 +196,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: true,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -225,7 +217,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -244,7 +235,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -286,7 +276,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -305,7 +294,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -326,7 +314,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action
@@ -345,7 +332,6 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease3Enabled: false,
                                              isEditProductsRelease5Enabled: false)
 
         // Action

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModelTests.swift
@@ -162,7 +162,6 @@ private extension ProductFormViewModelTests {
         return ProductFormViewModel(product: model,
                                     formType: formType,
                                     productImageActionHandler: productImageActionHandler,
-                                    isEditProductsRelease3Enabled: true,
                                     isEditProductsRelease5Enabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -20,7 +20,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.grouped
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -42,7 +42,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.simple
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType, isEditProductsRelease3Enabled: true)
+        let section = ProductSettingsSections.PublishSettings(settings, productType: productType)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -66,6 +66,6 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
 private extension ProductSettingsViewModel {
     convenience init(product: Product, password: String?) {
-        self.init(product: product, password: password, formType: .edit, isEditProductsRelease3Enabled: true)
+        self.init(product: product, password: password, formType: .edit)
     }
 }


### PR DESCRIPTION
Fixes #2954 
Fixes #2893 

## Changes

Removed `isEditProductsRelease3Enabled` and `FeatureFlag.editProductsRelease3` from the codebase.

## Testing

No user-facing changes are expected, feel free to confidence check on product editing/creation:

### Simple product
- Go to the Products tab
- Tap on a simple product --> make sure each field is editable, and the ellipsis menu includes product settings

### Variable product
- Go to the Products tab
- Tap on a variable product
- Tap on the variations row
- Tap on a variation --> make sure the variation is editable like before

### Add product
- Go to the Products tab
- Tap on "+" CTA in the navigation bar
- Tap "Simple product" --> make sure each field is editable, and the ellipsis menu includes product settings

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
