### PR TITLE
Mark or unmark a Product as Downloadable from Product Settings

### DIFF
--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -56,7 +56,7 @@ final class ProductDetailsViewModel {
     var productID: Int64 {
         return product.productID
     }
-    
+
     let isEditProductsRelease5Enabled: Bool
 
     // MARK: - private variables
@@ -125,7 +125,7 @@ final class ProductDetailsViewModel {
     init(product: Product, isEditProductsRelease5Enabled: Bool) {
         self.product = product
         self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
-        
+
         refreshResultsController()
     }
 

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -56,6 +56,8 @@ final class ProductDetailsViewModel {
     var productID: Int64 {
         return product.productID
     }
+    
+    let isEditProductsRelease5Enabled: Bool
 
     // MARK: - private variables
 
@@ -120,9 +122,10 @@ final class ProductDetailsViewModel {
 
     /// Designated initializer.
     ///
-    init(product: Product) {
+    init(product: Product, isEditProductsRelease5Enabled: Bool) {
         self.product = product
-
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
+        
         refreshResultsController()
     }
 
@@ -709,7 +712,6 @@ extension ProductDetailsViewModel {
             WebviewHelper.launch(product.externalURL, with: sender)
         case .productVariants:
             ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
-            let isEditProductsRelease5Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
             let variationsViewController = ProductVariationsViewController(product: product,
                                                                            formType: .readonly,
                                                                            isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)

--- a/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsViewModel.swift
@@ -709,8 +709,10 @@ extension ProductDetailsViewModel {
             WebviewHelper.launch(product.externalURL, with: sender)
         case .productVariants:
             ServiceLocator.analytics.track(.productDetailViewVariationsTapped)
+            let isEditProductsRelease5Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
             let variationsViewController = ProductVariationsViewController(product: product,
-                                                                           formType: .readonly)
+                                                                           formType: .readonly,
+                                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             sender.navigationController?.pushViewController(variationsViewController, animated: true)
         default:
             break

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -56,15 +56,17 @@ private extension AddProductCoordinator {
         let currency = ServiceLocator.currencySettings.symbol(from: currencyCode)
         let productImageActionHandler = ProductImageActionHandler(siteID: product.siteID,
                                                                   product: model)
+        let isEditProductsRelease5Enabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5)
         let viewModel = ProductFormViewModel(product: model,
                                              formType: .add,
                                              productImageActionHandler: productImageActionHandler,
-                                             isEditProductsRelease5Enabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease5))
+                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         let viewController = ProductFormViewController(viewModel: viewModel,
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
-                                                       presentationStyle: .navigationStack)
+                                                       presentationStyle: .navigationStack,
+                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/Product+DownloadSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/Product+DownloadSettingsViewModels.swift
@@ -4,9 +4,9 @@ extension Product {
     static func createDownloadLimitViewModel(downloadLimit: Int64,
                                                 onTextChange: @escaping (_ text: String?) -> Void) -> TitleAndTextFieldTableViewCell.ViewModel {
         let text = downloadLimit >= 0 ? String(downloadLimit) : nil
-        return TitleAndTextFieldTableViewCell.ViewModel(title: ProductDownloadSettingsViewModel.Strings.downloadLimitTitle,
+        return TitleAndTextFieldTableViewCell.ViewModel(title: ProductDownloadSettingsViewModel.Localization.downloadLimitTitle,
                                                         text: text,
-                                                        placeholder: ProductDownloadSettingsViewModel.Strings.downloadLimitPlaceholder,
+                                                        placeholder: ProductDownloadSettingsViewModel.Localization.downloadLimitPlaceholder,
                                                         keyboardType: .numberPad,
                                                         textFieldAlignment: .trailing,
                                                         onTextChange: onTextChange)
@@ -15,9 +15,9 @@ extension Product {
     static func createDownloadExpiryViewModel(downloadExpiry: Int64,
                                                onTextChange: @escaping (_ text: String?) -> Void) -> TitleAndTextFieldTableViewCell.ViewModel {
         let text = downloadExpiry >= 0 ? String(downloadExpiry) : nil
-        return TitleAndTextFieldTableViewCell.ViewModel(title: ProductDownloadSettingsViewModel.Strings.downloadExpiryTitle,
+        return TitleAndTextFieldTableViewCell.ViewModel(title: ProductDownloadSettingsViewModel.Localization.downloadExpiryTitle,
                                                         text: text,
-                                                        placeholder: ProductDownloadSettingsViewModel.Strings.downloadExpiryPlaceholder,
+                                                        placeholder: ProductDownloadSettingsViewModel.Localization.downloadExpiryPlaceholder,
                                                         keyboardType: .numberPad,
                                                         textFieldAlignment: .trailing,
                                                         onTextChange: onTextChange)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewModel.swift
@@ -41,8 +41,8 @@ final class ProductDownloadSettingsViewModel: ProductDownloadSettingsViewModelOu
     }
 
     var sections: [Section] {
-        let limitSection = Section(footer: Strings.downloadLimitFooter, rows: [.limit])
-        let expirySection = Section(footer: Strings.downloadExpiryFooter, rows: [.expiry])
+        let limitSection = Section(footer: Localization.downloadLimitFooter, rows: [.limit])
+        let expirySection = Section(footer: Localization.downloadExpiryFooter, rows: [.expiry])
 
         switch product {
         case is EditableProductModel:
@@ -120,7 +120,7 @@ private extension ProductDownloadSettingsViewModel {
 }
 
 extension ProductDownloadSettingsViewModel {
-    enum Strings {
+    enum Localization {
         static let downloadLimitTitle = NSLocalizedString("Download limit",
                                                           comment: "Title of the cell in Product Download limit > Download limit")
         static let downloadLimitPlaceholder = NSLocalizedString("No limit",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -51,7 +51,7 @@ enum ProductSettingsRows {
                 cell.apply(style: .regular)
             }
 
-            cell.updateUI(title: NSLocalizedString("Status", comment: "Status label in Product Settings"), value: settings.status.description)
+            cell.updateUI(title: Localization.status, value: settings.status.description)
         }
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
@@ -96,7 +96,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Visibility", comment: "Visibility label in Product Settings")
+            let title = Localization.visibility
             cell.updateUI(title: title, value: ProductVisibility(status: settings.status, password: settings.password).description)
             cell.accessoryType = .disclosureIndicator
         }
@@ -134,7 +134,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Catalog Visibility", comment: "Catalog Visibility label in Product Settings")
+            let title = Localization.catalogVisibility
             cell.updateUI(title: title, value: settings.catalogVisibility.description)
             cell.accessoryType = .disclosureIndicator
         }
@@ -166,8 +166,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Virtual Product", comment: "Virtual Product label in Product Settings")
-
+            let title = Localization.virtualProduct
             cell.title = title
             cell.isOn = settings.virtual
             cell.onChange = { newValue in
@@ -197,9 +196,8 @@ enum ProductSettingsRows {
                  return
              }
 
-              let title = NSLocalizedString("Downloadable Product", comment: "Downloadable Product label in Product Settings")
-
-              cell.title = title
+            let title = Localization.downloadableProduct
+             cell.title = title
              cell.isOn = settings.downloadable
              cell.onChange = { newValue in
                  //TODO: Add analytics M5
@@ -228,8 +226,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Enable Reviews", comment: "Enable Reviews label in Product Settings")
-
+            let title = Localization.enableReviews
             cell.title = title
             cell.isOn = settings.reviewsAllowed
             cell.onChange = { newValue in
@@ -259,7 +256,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Slug", comment: "Slug label in Product Settings")
+            let title = Localization.slug
             cell.updateUI(title: title, value: settings.slug)
             cell.accessoryType = .disclosureIndicator
         }
@@ -290,7 +287,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Purchase Note", comment: "Purchase note label in Product Settings")
+            let title = Localization.purchaseNote
             cell.updateUI(title: title, value: settings.purchaseNote?.strippedHTML)
             cell.accessoryType = .disclosureIndicator
         }
@@ -321,7 +318,7 @@ enum ProductSettingsRows {
                 return
             }
 
-            let title = NSLocalizedString("Menu Order", comment: "Menu order label in Product Settings")
+            let title = Localization.menuOrder
             cell.updateUI(title: title, value: String(settings.menuOrder))
             cell.accessoryType = .disclosureIndicator
         }
@@ -338,5 +335,19 @@ enum ProductSettingsRows {
         let reuseIdentifier: String = SettingTitleAndValueTableViewCell.reuseIdentifier
 
         let cellTypes: [UITableViewCell.Type] = [SettingTitleAndValueTableViewCell.self]
+    }
+}
+
+extension ProductSettingsRows {
+    enum Localization {
+        static let status = NSLocalizedString("Status", comment: "Status label in Product Settings")
+        static let visibility = NSLocalizedString("Visibility", comment: "Visibility label in Product Settings")
+        static let catalogVisibility = NSLocalizedString("Catalog Visibility", comment: "Catalog Visibility label in Product Settings")
+        static let virtualProduct = NSLocalizedString("Virtual Product", comment: "Virtual Product label in Product Settings")
+        static let downloadableProduct = NSLocalizedString("Downloadable Product", comment: "Downloadable Product label in Product Settings")
+        static let enableReviews = NSLocalizedString("Enable Reviews", comment: "Enable Reviews label in Product Settings")
+        static let slug = NSLocalizedString("Slug", comment: "Slug label in Product Settings")
+        static let purchaseNote = NSLocalizedString("Purchase Note", comment: "Purchase note label in Product Settings")
+        static let menuOrder = NSLocalizedString("Menu Order", comment: "Menu order label in Product Settings")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -185,6 +185,37 @@ enum ProductSettingsRows {
         let cellTypes: [UITableViewCell.Type] = [SwitchTableViewCell.self]
     }
 
+    struct DownloadableProduct: ProductSettingsRowMediator {
+         private let settings: ProductSettings
+
+          init(_ settings: ProductSettings) {
+             self.settings = settings
+         }
+
+          func configure(cell: UITableViewCell) {
+             guard let cell = cell as? SwitchTableViewCell else {
+                 return
+             }
+
+              let title = NSLocalizedString("Downloadable Product", comment: "Downloadable Product label in Product Settings")
+
+              cell.title = title
+             cell.isOn = settings.downloadable
+             cell.onChange = { newValue in
+                 //TODO: Add analytics M5
+                 self.settings.downloadable = newValue
+             }
+         }
+
+          func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
+             // Empty because we don't need to handle the tap on this cell
+         }
+
+          let reuseIdentifier: String = SwitchTableViewCell.reuseIdentifier
+
+          let cellTypes: [UITableViewCell.Type] = [SwitchTableViewCell.self]
+     }
+
     struct ReviewsAllowed: ProductSettingsRowMediator {
         private let settings: ProductSettings
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -8,7 +8,7 @@ protocol ProductSettingsSectionMediator {
     var title: String { get }
     var rows: [ProductSettingsRowMediator] { get }
 
-    init(_ settings: ProductSettings, productType: ProductType)
+    init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease5Enabled: Bool)
 }
 
 // MARK: - Sections declaration for Product Settings
@@ -20,14 +20,15 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType) {
+        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease5Enabled: Bool) {
             if productType == .simple {
-                rows = [ProductSettingsRows.Status(settings),
+                let tempRows: [ProductSettingsRowMediator?] = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
                         ProductSettingsRows.VirtualProduct(settings),
-                        ProductSettingsRows.DownloadableProduct(settings)
+                        isEditProductsRelease5Enabled ? ProductSettingsRows.DownloadableProduct(settings) : nil
                 ]
+                rows = tempRows.compactMap { $0 }
             } else {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
@@ -42,7 +43,7 @@ enum ProductSettingsSections {
 
         let rows: [ProductSettingsRowMediator]
 
-        init(_ settings: ProductSettings, productType: ProductType) {
+        init(_ settings: ProductSettings, productType: ProductType, isEditProductsRelease5Enabled: Bool) {
             rows = [ProductSettingsRows.ReviewsAllowed(settings),
             ProductSettingsRows.Slug(settings),
             ProductSettingsRows.PurchaseNote(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsSections.swift
@@ -25,7 +25,9 @@ enum ProductSettingsSections {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),
                         ProductSettingsRows.CatalogVisibility(settings),
-                        ProductSettingsRows.VirtualProduct(settings)]
+                        ProductSettingsRows.VirtualProduct(settings),
+                        ProductSettingsRows.DownloadableProduct(settings)
+                ]
             } else {
                 rows = [ProductSettingsRows.Status(settings),
                         ProductSettingsRows.Visibility(settings),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -24,11 +24,13 @@ final class ProductSettingsViewController: UIViewController {
     init(product: Product,
          password: String?,
          formType: ProductFormType,
+         isEditProductsRelease5Enabled: Bool,
          completion: @escaping Completion,
          onPasswordRetrieved: @escaping PasswordRetrievedCompletion) {
         viewModel = ProductSettingsViewModel(product: product,
                                              password: password,
-                                             formType: formType)
+                                             formType: formType,
+                                             isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         onCompletion = completion
         onPasswordCompletion = onPasswordRetrieved
         super.init(nibName: nil, bundle: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -11,7 +11,9 @@ final class ProductSettingsViewModel {
 
     var productSettings: ProductSettings {
         didSet {
-            sections = Self.configureSections(productSettings, productType: product.productType)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         }
     }
 
@@ -27,18 +29,25 @@ final class ProductSettingsViewModel {
     var onReload: (() -> Void)?
     var onPasswordRetrieved: ((_ password: String) -> Void)?
 
-    init(product: Product, password: String?, formType: ProductFormType) {
+    private let isEditProductsRelease5Enabled: Bool
+
+    init(product: Product, password: String?, formType: ProductFormType, isEditProductsRelease5Enabled: Bool) {
         self.product = product
         self.password = password
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         productSettings = ProductSettings(from: product, password: password)
 
         switch formType {
         case .add:
             self.password = ""
             productSettings.password = ""
-            sections = Self.configureSections(productSettings, productType: product.productType)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         case .edit:
-            sections = Self.configureSections(productSettings, productType: product.productType)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             /// If nil, we fetch the password from site post API because it was never fetched
             if password == nil {
                 retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
@@ -52,11 +61,14 @@ final class ProductSettingsViewModel {
                     self.password = password
                     self.productSettings.password = password
                     self.sections = Self.configureSections(self.productSettings,
-                                                           productType: product.productType)
+                                                           productType: product.productType,
+                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
                 }
             }
         case .readonly:
-            sections = Self.configureSections(productSettings, productType: product.productType)
+            sections = Self.configureSections(productSettings,
+                                              productType: product.productType,
+                                              isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         }
     }
 
@@ -100,9 +112,14 @@ private extension ProductSettingsViewModel {
 //
 private extension ProductSettingsViewModel {
     static func configureSections(_ settings: ProductSettings,
-                                  productType: ProductType) -> [ProductSettingsSectionMediator] {
-        return [ProductSettingsSections.PublishSettings(settings, productType: productType),
-                ProductSettingsSections.MoreOptions(settings, productType: productType)
+                                  productType: ProductType,
+                                  isEditProductsRelease5Enabled: Bool) -> [ProductSettingsSectionMediator] {
+        return [ProductSettingsSections.PublishSettings(settings,
+                                                        productType: productType,
+                                                        isEditProductsRelease5Enabled: isEditProductsRelease5Enabled),
+                ProductSettingsSections.MoreOptions(settings,
+                                                    productType: productType,
+                                                    isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -40,6 +40,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let productUIImageLoader: ProductUIImageLoader
 
     private let currency: String
+    private let isEditProductsRelease5Enabled: Bool
 
     private lazy var exitForm: () -> Void = {
         presentationStyle.createExitForm(viewController: self)
@@ -58,11 +59,13 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          eventLogger: ProductFormEventLoggerProtocol,
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
-         presentationStyle: ProductFormPresentationStyle) {
+         presentationStyle: ProductFormPresentationStyle,
+         isEditProductsRelease5Enabled: Bool) {
         self.viewModel = viewModel
         self.eventLogger = eventLogger
         self.currency = currency
         self.presentationStyle = presentationStyle
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         self.productImageActionHandler = productImageActionHandler
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
@@ -313,7 +316,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                     return
                 }
                 let variationsViewController = ProductVariationsViewController(product: product.product,
-                                                                               formType: viewModel.formType)
+                                                                               formType: viewModel.formType,
+                                                                               isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
                 show(variationsViewController, sender: self)
             case .status, .noPriceWarning:
                 break
@@ -680,6 +684,7 @@ private extension ProductFormViewController {
         let viewController = ProductSettingsViewController(product: product.product,
                                                            password: password,
                                                            formType: viewModel.formType,
+                                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled,
                                                            completion: { [weak self] (productSettings) in
             guard let self = self else {
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -80,7 +80,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     }
 
     private let productImageActionHandler: ProductImageActionHandler
-    private (set) var isEditProductsRelease5Enabled: Bool
+    private let isEditProductsRelease5Enabled: Bool
 
     private var cancellable: ObservationToken?
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -80,7 +80,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
     }
 
     private let productImageActionHandler: ProductImageActionHandler
-    private let isEditProductsRelease5Enabled: Bool
+    private (set) var isEditProductsRelease5Enabled: Bool
 
     private var cancellable: ObservationToken?
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -227,6 +227,7 @@ extension ProductFormViewModel {
                                                                      featured: settings.featured,
                                                                      catalogVisibilityKey: settings.catalogVisibility.rawValue,
                                                                      virtual: settings.virtual,
+                                                                     downloadable: settings.downloadable,
                                                                      reviewsAllowed: settings.reviewsAllowed,
                                                                      purchaseNote: settings.purchaseNote,
                                                                      menuOrder: settings.menuOrder))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -48,7 +48,8 @@ private extension ProductDetailsFactory {
             // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
             vc.hidesBottomBarWhenPushed = true
         } else {
-            let viewModel = ProductDetailsViewModel(product: product)
+            let viewModel = ProductDetailsViewModel(product: product,
+                                                    isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             vc = ProductDetailsViewController(viewModel: viewModel)
         }
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -43,7 +43,8 @@ private extension ProductDetailsFactory {
             vc = ProductFormViewController(viewModel: viewModel,
                                            eventLogger: ProductFormEventLogger(),
                                            productImageActionHandler: productImageActionHandler,
-                                           presentationStyle: presentationStyle)
+                                           presentationStyle: presentationStyle,
+                                           isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
             // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
             vc.hidesBottomBarWhenPushed = true
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductVariationDetailsFactory.swift
@@ -49,7 +49,8 @@ private extension ProductVariationDetailsFactory {
         vc = ProductFormViewController(viewModel: viewModel,
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
-                                       presentationStyle: presentationStyle)
+                                       presentationStyle: presentationStyle,
+                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -83,13 +83,15 @@ final class ProductVariationsViewController: UIViewController {
     private let formType: ProductFormType
 
     private let imageService: ImageService = ServiceLocator.imageService
+    private let isEditProductsRelease5Enabled: Bool
 
-    init(product: Product, formType: ProductFormType) {
+    init(product: Product, formType: ProductFormType, isEditProductsRelease5Enabled: Bool) {
         self.siteID = product.siteID
         self.productID = product.productID
         self.allAttributes = product.attributes
         self.parentProductSKU = product.sku
         self.formType = formType
+        self.isEditProductsRelease5Enabled = isEditProductsRelease5Enabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -301,7 +303,8 @@ extension ProductVariationsViewController: UITableViewDelegate {
                                                        eventLogger: ProductVariationFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
-                                                       presentationStyle: .navigationStack)
+                                                       presentationStyle: .navigationStack,
+                                                       isEditProductsRelease5Enabled: isEditProductsRelease5Enabled)
         navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadSettingsViewModelTests.swift
@@ -27,8 +27,8 @@ final class ProductDownloadSettingsViewModelTests: XCTestCase {
 
         // Act
         let expectedSections: [ProductDownloadSettingsViewController.Section] = [
-            .init(footer: ProductDownloadSettingsViewModel.Strings.downloadLimitFooter, rows: [ProductDownloadSettingsViewController.Row.limit]),
-            .init(footer: ProductDownloadSettingsViewModel.Strings.downloadExpiryFooter, rows: [ProductDownloadSettingsViewController.Row.expiry])
+            .init(footer: ProductDownloadSettingsViewModel.Localization.downloadLimitFooter, rows: [ProductDownloadSettingsViewController.Row.limit]),
+            .init(footer: ProductDownloadSettingsViewModel.Localization.downloadExpiryFooter, rows: [ProductDownloadSettingsViewController.Row.expiry])
         ]
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+UpdatesTests.swift
@@ -243,6 +243,7 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
         let password = ""
         let catalogVisibility = "search"
         let virtual = true
+        let downloadable = true
         let reviewsAllowed = true
         let slug = "this-is-a-test"
         let purchaseNote = "This is a purchase note"
@@ -255,7 +256,8 @@ final class ProductFormViewModel_UpdatesTests: XCTestCase {
                                               reviewsAllowed: reviewsAllowed,
                                               slug: slug,
                                               purchaseNote: purchaseNote,
-                                              menuOrder: menuOrder)
+                                              menuOrder: menuOrder,
+                                              downloadable: downloadable)
         viewModel.updateProductSettings(productSettings)
 
         // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsRowsTests.swift
@@ -20,14 +20,15 @@ final class ProductSettingsRowsTests: XCTestCase {
                                        reviewsAllowed: false,
                                        slug: "",
                                        purchaseNote: nil,
-                                       menuOrder: 0)
+                                       menuOrder: 0,
+                                       downloadable: false)
     }
 
     override func tearDown() {
         super.tearDown()
     }
 
-    func testVirtualProductRowChangedWhenUpdated() throws {
+    func test_virtual_product_row_changed_when_updated() throws {
         let settings = try XCTUnwrap(originalSettings)
 
         // Given
@@ -43,7 +44,7 @@ final class ProductSettingsRowsTests: XCTestCase {
         XCTAssertEqual(settings.virtual, true)
     }
 
-    func testReviewsAllowedRowChangedWhenUpdated() throws {
+    func test_reviewsAllowed_row_changed_when_updated() throws {
         let settings = try XCTUnwrap(originalSettings)
 
         // Given
@@ -58,4 +59,20 @@ final class ProductSettingsRowsTests: XCTestCase {
         // Then
         XCTAssertEqual(settings.reviewsAllowed, true)
     }
+
+    func test_downloadable_product_row_changed_when_updated() throws {
+         let settings = try XCTUnwrap(originalSettings)
+
+          // Given
+         let downloadableProduct = ProductSettingsRows.DownloadableProduct(settings)
+
+          let cell = SwitchTableViewCell()
+         downloadableProduct.configure(cell: cell)
+
+          // When
+         cell.onChange?(true)
+
+          // Then
+         XCTAssertEqual(settings.downloadable, true)
+     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -6,7 +6,7 @@ import Yosemite
 ///
 final class ProductSettingsSectionsTests: XCTestCase {
 
-    func testGivenANonSimpleProductThenItDoesNotShowTheVirtualProductOption() {
+    func test_given_a_non_simple_product_then_it_does_not_show_the_virtual_produc_option() {
         // Given
         let settings = ProductSettings(status: .draft,
                                        featured: false,
@@ -16,7 +16,8 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        reviewsAllowed: false,
                                        slug: "",
                                        purchaseNote: nil,
-                                       menuOrder: 0)
+                                       menuOrder: 0,
+                                       downloadable: false)
         let productType = ProductType.grouped
 
         // When
@@ -28,7 +29,7 @@ final class ProductSettingsSectionsTests: XCTestCase {
         }))
     }
 
-    func testGivenASimpleProductThenItShowsTheVirtualProductOption() {
+    func test_given_a_simple_product_then_it_shows_the_virtual_product_option() {
         // Given
         let settings = ProductSettings(status: .draft,
                                        featured: false,
@@ -38,7 +39,8 @@ final class ProductSettingsSectionsTests: XCTestCase {
                                        reviewsAllowed: false,
                                        slug: "",
                                        purchaseNote: nil,
-                                       menuOrder: 0)
+                                       menuOrder: 0,
+                                       downloadable: false)
         let productType = ProductType.simple
 
         // When
@@ -49,4 +51,52 @@ final class ProductSettingsSectionsTests: XCTestCase {
             $0 is ProductSettingsRows.VirtualProduct
         }))
     }
+    
+    func test_given_a_non_simple_product_then_it_does_not_show_the_downloadable_product_option() {
+         // Given
+         let settings = ProductSettings(status: .draft,
+                                        featured: false,
+                                        password: nil,
+                                        catalogVisibility: .catalog,
+                                        virtual: false,
+                                        reviewsAllowed: false,
+                                        slug: "",
+                                        purchaseNote: nil,
+                                        menuOrder: 0,
+                                        downloadable: false)
+         let productType = ProductType.grouped
+
+          // When
+         let section = ProductSettingsSections.PublishSettings(settings,
+                                                               productType: productType)
+
+          // Then
+         XCTAssertNil(section.rows.first(where: {
+             $0 is ProductSettingsRows.DownloadableProduct
+         }))
+     }
+
+      func test_given_a_simple_product_then_it_shows_the_downloadable_product_option() {
+         // Given
+         let settings = ProductSettings(status: .draft,
+                                        featured: false,
+                                        password: nil,
+                                        catalogVisibility: .catalog,
+                                        virtual: false,
+                                        reviewsAllowed: false,
+                                        slug: "",
+                                        purchaseNote: nil,
+                                        menuOrder: 0,
+                                        downloadable: false)
+         let productType = ProductType.simple
+
+          // When
+         let section = ProductSettingsSections.PublishSettings(settings,
+                                                               productType: productType)
+
+          // Then
+         XCTAssertNotNil(section.rows.first(where: {
+             $0 is ProductSettingsRows.DownloadableProduct
+         }))
+     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsSectionsTests.swift
@@ -6,7 +6,7 @@ import Yosemite
 ///
 final class ProductSettingsSectionsTests: XCTestCase {
 
-    func test_given_a_non_simple_product_then_it_does_not_show_the_virtual_produc_option() {
+    func test_given_a_non_simple_product_then_it_does_not_show_the_virtual_product_option() {
         // Given
         let settings = ProductSettings(status: .draft,
                                        featured: false,
@@ -21,7 +21,9 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.grouped
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType)
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease5Enabled: true)
 
         // Then
         XCTAssertNil(section.rows.first(where: {
@@ -44,14 +46,16 @@ final class ProductSettingsSectionsTests: XCTestCase {
         let productType = ProductType.simple
 
         // When
-        let section = ProductSettingsSections.PublishSettings(settings, productType: productType)
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease5Enabled: true)
 
         // Then
         XCTAssertNotNil(section.rows.first(where: {
             $0 is ProductSettingsRows.VirtualProduct
         }))
     }
-    
+
     func test_given_a_non_simple_product_then_it_does_not_show_the_downloadable_product_option() {
          // Given
          let settings = ProductSettings(status: .draft,
@@ -68,7 +72,8 @@ final class ProductSettingsSectionsTests: XCTestCase {
 
           // When
          let section = ProductSettingsSections.PublishSettings(settings,
-                                                               productType: productType)
+                                                               productType: productType,
+                                                               isEditProductsRelease5Enabled: true)
 
           // Then
          XCTAssertNil(section.rows.first(where: {
@@ -92,11 +97,37 @@ final class ProductSettingsSectionsTests: XCTestCase {
 
           // When
          let section = ProductSettingsSections.PublishSettings(settings,
-                                                               productType: productType)
+                                                               productType: productType,
+                                                               isEditProductsRelease5Enabled: true)
 
           // Then
          XCTAssertNotNil(section.rows.first(where: {
              $0 is ProductSettingsRows.DownloadableProduct
          }))
      }
+
+    func test_when_isEditProductsRelease5Enabled_is_false_the_downloadable_product_option_is_hidden() {
+        // Given
+        let settings = ProductSettings(status: .draft,
+                                       featured: false,
+                                       password: nil,
+                                       catalogVisibility: .catalog,
+                                       virtual: false,
+                                       reviewsAllowed: false,
+                                       slug: "",
+                                       purchaseNote: nil,
+                                       menuOrder: 0,
+                                       downloadable: false)
+        let productType = ProductType.simple
+
+         // When
+        let section = ProductSettingsSections.PublishSettings(settings,
+                                                              productType: productType,
+                                                              isEditProductsRelease5Enabled: false)
+
+         // Then
+        XCTAssertNil(section.rows.first(where: {
+            $0 is ProductSettingsRows.DownloadableProduct
+        }))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -68,6 +68,9 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
 private extension ProductSettingsViewModel {
     convenience init(product: Product, password: String?) {
-        self.init(product: product, password: password, formType: .edit)
+        self.init(product: product,
+                  password: password,
+                  formType: .edit,
+                  isEditProductsRelease5Enabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Settings/ProductSettingsViewModelTests.swift
@@ -6,7 +6,8 @@ final class ProductSettingsViewModelTests: XCTestCase {
 
     func testOnReloadClosure() {
 
-        let product = MockProduct().product(virtual: true,
+        let product = MockProduct().product(downloadable: false,
+                                            virtual: true,
                                             status: .publish,
                                             featured: true,
                                             catalogVisibility: .search,
@@ -31,7 +32,8 @@ final class ProductSettingsViewModelTests: XCTestCase {
                                                     reviewsAllowed: true,
                                                     slug: "this-is-a-slug",
                                                     purchaseNote: "This is a purchase note",
-                                                    menuOrder: 1)
+                                                    menuOrder: 1,
+                                                    downloadable: true)
 
         waitForExpectations(timeout: 1.5, handler: nil)
     }

--- a/Yosemite/Yosemite/Model/Products/ProductSettings.swift
+++ b/Yosemite/Yosemite/Model/Products/ProductSettings.swift
@@ -13,6 +13,7 @@ public final class ProductSettings {
     public var slug: String
     public var purchaseNote: String?
     public var menuOrder: Int
+    public var downloadable: Bool
 
     public init(status: ProductStatus,
                 featured: Bool,
@@ -22,7 +23,8 @@ public final class ProductSettings {
                 reviewsAllowed: Bool,
                 slug: String,
                 purchaseNote: String?,
-                menuOrder: Int) {
+                menuOrder: Int,
+                downloadable: Bool) {
         self.status = status
         self.featured = featured
         self.password = password
@@ -32,6 +34,7 @@ public final class ProductSettings {
         self.slug = slug
         self.purchaseNote = purchaseNote
         self.menuOrder = menuOrder
+        self.downloadable = downloadable
     }
 
     public convenience init(from product: Product, password: String?) {
@@ -43,7 +46,8 @@ public final class ProductSettings {
                   reviewsAllowed: product.reviewsAllowed,
                   slug: product.slug,
                   purchaseNote: product.purchaseNote,
-                  menuOrder: product.menuOrder)
+                  menuOrder: product.menuOrder,
+                  downloadable: product.downloadable)
     }
 }
 
@@ -59,6 +63,7 @@ extension ProductSettings: Equatable {
             lhs.reviewsAllowed == rhs.reviewsAllowed &&
             lhs.slug == rhs.slug &&
             lhs.purchaseNote == rhs.purchaseNote &&
-            lhs.menuOrder == rhs.menuOrder
+            lhs.menuOrder == rhs.menuOrder &&
+            lhs.downloadable == rhs.downloadable
     }
 }


### PR DESCRIPTION
Fixes #2757  

## Description
Now it's possible to mark/unmark every simple product as downloadable, from the Product Settings. This is part of Products MIlestone 5.

## Changes
- Introduced `isEditProductsRelease5Enabled` when needed for hiding the downloadable row in settings if the feature flag is not enabled.
- Added `DownloadableProduct` in `ProductSettingsRows`.
- Managed the appearance of the downloadable row in `ProductSettingsSections`.
- Added `downloadable` in `ProductSettings`.
- Added and updated unit tests.

## Testing

#### Case 1
1. From the Products tab, select any Simple product.
2. Tap on the top right navigation bar button, then open the "Product Settings".
3. You should be able to see a new switchable row, titled `Downloadable Product`.
4. Make any changes on/off to the downloadable switch and update the product.
5. Come back again to this page to verify that your changes are reflected properly.

#### Case 2
1. From the Products tab, select a non-simple product.
2. Go to the product settings -> the Downloadable Product row shouldn't be visible.

## Screenshots
| Dark mode OFF             |  Dark mode ON |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-15 at 15 23 06](https://user-images.githubusercontent.com/495617/96132474-be2a7b00-0efa-11eb-8ec6-24efb30c675c.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-15 at 15 24 58](https://user-images.githubusercontent.com/495617/96132484-bff43e80-0efa-11eb-9015-29cc8e46b31d.png)


## GIF
<img src="https://user-images.githubusercontent.com/495617/96132439-b4087c80-0efa-11eb-9a4a-9676f133769e.gif" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
