### PR TITLE
Add CODE-OF-CONDUCT and CONTRIBUTING docs

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,28 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing a [project maintainer](https://make.wordpress.org/community/contact/), with a subject (the field labeled `Your Question`) that includes `Code of Conduct - WCiOS`. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# How to Contribute
+
+First off, thank you for contributing! We're excited to collaborate with you! 🎉
+
+The following is a set of guidelines for the many ways you can join our collective effort.
+
+Before anything else, please take a moment to read our [Code of Conduct](CODE-OF-CONDUCT.md). We expect all participants, from full-timers to occasional tinkerers, to uphold it.
+
+## Reporting Bugs, Asking Questions, and Suggesting Features
+
+Have a suggestion or feedback? Please go to the [Ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=84283.) to share suggestions or feedback.
+
+For bug reports, please [open a new issue](https://github.com/woocommerce/woocommerce-ios/issues/new/choose). Screenshots help us resolve issues and answer questions faster, so thanks for including some if you can.
+
+## Translating
+
+We use GlotPress to manage translations. Please go to the [WooCommerce for iOS GlotPress page](https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/) for more information on how to add or edit translations.
+
+## Beta Testing
+
+Interested in using the upcoming versions of WooCommerce? Do you love giving feedback on new features and don't mind reporting bugs that come up along the way? Join us in the beta-testing program by going to the [Beta Testing Community ](https://woocommercehalo.wordpress.com/) page.
+
+## Submitting Code Changes
+
+If you're just getting started and want to familiarize yourself with the app’s code, we suggest looking at [these issues](https://github.com/woocommerce/woocommerce-ios/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) with the **good first issue** label. But if you’d like to tackle something different, you're more than welcome to visit the [Issues](https://github.com/woocommerce/woocommerce-ios/issues) page and pick an item that interests you.
+
+We always try to avoid duplicating efforts, so if you decide to work on an issue, leave a comment to state your intent. If you choose to focus on a new feature or the change you’re proposing is significant, we recommend waiting for a response before proceeding. The issue may no longer align with project goals.
+
+If the change is trivial, feel free to send a pull request without notifying us.
+
+### Pull Requests and Code Reviews
+
+All code contributions pass through pull requests. If you haven't created a pull request before, we recommend this free video series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
+
+The core team monitors and reviews all pull requests. Depending on the changes, we will either approve them or close them with an explanation. We might also work with you to improve a pull request before approval.
+
+We do our best to respond quickly to all pull requests. If you don't get a response from us after a week, feel free to reach out to us via Slack.
+
+## Getting in Touch
+
+If you have questions or just want to say hi, join the [WooCommerce Community Slack](https://woocommerce.com/community-slack/) and drop a message on the `#mobile-apps` channel.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@
 </p>
 
 <p align="center">
-    <a href="#-build-instructions">Build Instructions</a> • 
-    <a href="#-documentation">Documentation</a> • 
-    <a href="#-automation">Automation</a> • 
+    <a href="#-build-instructions">Build Instructions</a> •
+    <a href="#-documentation">Documentation</a> •
+    <a href="#-contributing">Contributing</a> •
+    <a href="#-automation">Automation</a> •
     <a href="#-security">Security</a> •
-    <a href="#-need-help">Need Help?</a> • 
-    <a href="#-resources">Resources</a> • 
+    <a href="#-need-help">Need Help?</a> •
+    <a href="#-resources">Resources</a> •
     <a href="#-license">License</a>
 </p>
 
@@ -101,6 +102,10 @@ Please, remember to not add this information on your commits and PRs.
     - [Beta Testing](https://woocommercehalo.wordpress.com/setup/join-ios-beta/)
 - Features
     - [In-app Feedback](docs/in-app-feedback.md)
+
+## 👏 Contributing
+
+Read our [Contributing Guide](CONTRIBUTING.md) to learn about reporting issues, contributing code, and more ways to contribute.
 
 ## 🤖 Automation
 


### PR DESCRIPTION
Closes #2226. 

I added a `CODE-OF-CONDUCT.md` (copied from WCAndroid) and a `CONTRIBUTING.md` doc. The `CONTRIBUTING.md` contents are from a template that was reviewed by Editorial a long time ago (p2JRYi-41r-p2). 

## Testing

Please view the files and make sure that the links are pointing to where they should be. 

- [Code of Conduct](https://github.com/woocommerce/woocommerce-ios/blob/issue/2226-write-contributing-doc/CODE-OF-CONDUCT.md)
- [Contributing](https://github.com/woocommerce/woocommerce-ios/blob/issue/2226-write-contributing-doc/CONTRIBUTING.md)

## Submitter Checklist

- [x] If it's feasible, I have added unit tests. 
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

