### PR TITLE
Settings > Experimental Features: add back Products feature switch for Products for M4

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 5.3
 -----
+- [**] In Settings > Experimental Features, a Products switch is now available for turning Products M4 features on and off (default off). Products M4 features: add a simple/grouped/external product with actions to publish or save as draft.
 - [*] Opening a product from order details now shows readonly product details of the same styles as in editable product details.
 - [*] Opening a product variation from order details now shows readonly product variation details and this product variation does not appear in the Products tab anymore.
 - [*] Enhancement: when not saving a product as "published", the in-progress modal now shows title and message like "saving your product" instead of "publishing your product".

--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -5,7 +5,7 @@ public enum FeedbackType: String, Codable {
     ///
     case general
 
-    /// identifier for the products m3 beta feedback survey
+    /// identifier for the products m4 beta feedback survey
     ///
-    case productsM3
+    case productsM4
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -57,9 +57,9 @@ extension WooAnalyticsEvent {
     public enum FeedbackContext: String {
         /// Shown in Stats but is for asking general feedback.
         case general
-        /// Shown in products banner for Milestone 3 features. New product banners should have
+        /// Shown in products banner for Milestone 4 features. New product banners should have
         /// their own `FeedbackContext` option.
-        case productsM3 = "products_m3"
+        case productsM4 = "products_m4"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -79,9 +79,9 @@ extension WooConstants {
         case inAppFeedback = "https://automattic.survey.fm/woo-app-general-feedback-user-survey"
 #endif
 
-        /// URL for the productsM3 feedback survey
+        /// URL for the products M4 feedback survey
         ///
-        case productsM3Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
+        case productsM4Feedback = "https://automattic.survey.fm/woo-app-feature-feedback-products"
 
         /// Returns the URL version of the receiver
         ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -121,7 +121,7 @@ private extension BetaFeaturesViewController {
     func configureProductsSwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
 
-        let title = NSLocalizedString("Products",
+        let title = NSLocalizedString("Creating products",
                                       comment: "My Store > Settings > Experimental features > Products")
 
         cell.title = title
@@ -145,7 +145,7 @@ private extension BetaFeaturesViewController {
     func configureProductsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
 
-        let description = NSLocalizedString("Test out the new products section as we get ready to launch them",
+        let description = NSLocalizedString("Test out the new product creation as we get ready to launch",
                                             comment: "My Store > Settings > Experimental features > Products")
         cell.textLabel?.text = description
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesViewController.swift
@@ -79,8 +79,9 @@ private extension BetaFeaturesViewController {
     /// Configure sections for table view.
     ///
     func configureSections() {
-        // This is empty because there aren't any ongoing experiments
-        self.sections = []
+        self.sections = [
+            productsSection()
+        ]
     }
 
     func productsSection() -> Section {
@@ -120,8 +121,8 @@ private extension BetaFeaturesViewController {
     func configureProductsSwitch(cell: SwitchTableViewCell) {
         configureCommonStylesForSwitchCell(cell)
 
-        let title = NSLocalizedString("Product editing",
-                                      comment: "My Store > Settings > Experimental features > Product editing")
+        let title = NSLocalizedString("Products",
+                                      comment: "My Store > Settings > Experimental features > Products")
 
         cell.title = title
 
@@ -144,8 +145,8 @@ private extension BetaFeaturesViewController {
     func configureProductsDescription(cell: BasicTableViewCell) {
         configureCommonStylesForDescriptionCell(cell)
 
-        let description = NSLocalizedString("Test out new product editing functionalities as we get ready to launch them",
-                                            comment: "My Store > Settings > Experimental features > Product editing")
+        let description = NSLocalizedString("Test out the new products section as we get ready to launch them",
+                                            comment: "My Store > Settings > Experimental features > Products")
         cell.textLabel?.text = description
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -285,7 +285,7 @@ private extension SettingsViewController {
 
     /// This is false because there are no ongoing experiments
     func couldShowBetaFeaturesRow() -> Bool {
-        return false
+        true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -16,15 +16,15 @@ struct ProductsTopBannerFactory {
                           onGiveFeedbackButtonPressed: @escaping () -> Void,
                           onDismissButtonPressed: @escaping () -> Void,
                           onCompletion: @escaping (TopBannerView) -> Void) {
-        let action = AppSettingsAction.loadProductsFeatureSwitch { _ in
-            let title = Strings.title
+        let action = AppSettingsAction.loadProductsFeatureSwitch { isFeatureSwitchOn in
+            let title = isFeatureSwitchOn ? Localization.titleWhenRelease4IsEnabled: Localization.title
             let icon: UIImage = .megaphoneIcon
-            let infoText = Strings.infoWhenRelease3IsEnabled
-            let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Strings.giveFeedback) {
+            let infoText = isFeatureSwitchOn ? Localization.infoWhenRelease4IsEnabled: Localization.info
+            let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
                 analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .gaveFeedback))
                 onGiveFeedbackButtonPressed()
             }
-            let dismissAction = TopBannerViewModel.ActionButton(title: Strings.dismiss) {
+            let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
                 analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .dismissed))
                 onDismissButtonPressed()
             }
@@ -44,16 +44,20 @@ struct ProductsTopBannerFactory {
 }
 
 private extension ProductsTopBannerFactory {
-    enum Strings {
+    enum Localization {
         static let title =
             NSLocalizedString("New editing options available",
-                              comment: "The title of the Work In Progress top banner on the Products tab.")
+                              comment: "The title of the Work In Progress top banner on the Products tab when Products feature switch is disabled.")
         static let info =
-            NSLocalizedString("We've added more editing functionalities to products! You can now update images, see previews and share your products.",
-                              comment: "The info of the Work In Progress top banner on the Products tab.")
-        static let infoWhenRelease3IsEnabled =
             NSLocalizedString("You can now edit grouped, external and variable products, change product type and update categories and tags",
-                              comment: "The info of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")
+                              comment: "The info of the Work In Progress top banner on the Products tab when Products feature switch is disabled.")
+        static let titleWhenRelease4IsEnabled =
+            NSLocalizedString("Create products from the app!",
+                              comment: "The title of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")
+        static let infoWhenRelease4IsEnabled =
+            NSLocalizedString(
+                "It’s now possible to create simple, grouped \nand external products on the go from the Woo app. Not ready yet? Save them as draft!",
+                comment: "The info of the Work In Progress top banner on the Products tab when Products feature switch is enabled.")
         static let giveFeedback =
             NSLocalizedString("Give feedback",
                               comment: "The title of the button to give feedback about products beta features on the banner on the products tab")

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsTopBannerFactory.swift
@@ -21,11 +21,11 @@ struct ProductsTopBannerFactory {
             let icon: UIImage = .megaphoneIcon
             let infoText = isFeatureSwitchOn ? Localization.infoWhenRelease4IsEnabled: Localization.info
             let giveFeedbackAction = TopBannerViewModel.ActionButton(title: Localization.giveFeedback) {
-                analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .gaveFeedback))
+                analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .gaveFeedback))
                 onGiveFeedbackButtonPressed()
             }
             let dismissAction = TopBannerViewModel.ActionButton(title: Localization.dismiss) {
-                analytics.track(event: .featureFeedbackBanner(context: .productsM3, action: .dismissed))
+                analytics.track(event: .featureFeedbackBanner(context: .productsM4, action: .dismissed))
                 onDismissButtonPressed()
             }
             let actions = [giveFeedbackAction, dismissAction]

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -573,7 +573,7 @@ private extension ProductsViewController {
     ///
     func presentProductsFeedback() {
         // Present survey
-        let navigationController = SurveyCoordinatingController(survey: .productsM3Feedback)
+        let navigationController = SurveyCoordinatingController(survey: .productsM4Feedback)
         present(navigationController, animated: true) { [weak self] in
 
             // Mark survey as given and update top banner view

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -234,8 +234,20 @@ private extension ProductsViewController {
             return button
         }()
 
+        updateNavigationBarRightButtonItems()
+    }
+
+    /// Fetches the feature switch value from app settings and updates its navigation bar right button items.
+    func updateNavigationBarRightButtonItems() {
+        let action = AppSettingsAction.loadProductsFeatureSwitch { [weak self] isFeatureSwitchOn in
+            self?.updateNavigationBarRightButtonItems(isProductsFeatureSwitchOn: isFeatureSwitchOn)
+        }
+        ServiceLocator.stores.dispatch(action)
+    }
+
+    func updateNavigationBarRightButtonItems(isProductsFeatureSwitchOn: Bool) {
         var rightBarButtonItems = [UIBarButtonItem]()
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.editProductsRelease4) {
+        if isProductsFeatureSwitchOn {
             let buttonItem: UIBarButtonItem = {
                 let button = UIBarButtonItem(image: .plusImage,
                                              style: .plain,
@@ -357,14 +369,16 @@ private extension ProductsViewController {
 private extension ProductsViewController {
     func observeProductsFeatureSwitchChange() {
         NotificationCenter.default.addObserver(forName: .ProductsFeatureSwitchDidChange, object: nil, queue: nil) { [weak self] _ in
-            self?.updateTopBannerView()
+            guard let self = self else { return }
+            self.updateTopBannerView()
+            self.updateNavigationBarRightButtonItems()
         }
     }
 
     /// Fetches products feedback visibility from AppSettingsStore and update products top banner accordingly
     ///
     func updateTopBannerView() {
-        let action = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { [weak self] result in
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { [weak self] result in
             switch result {
             case .success(let visible):
                 if visible {
@@ -563,7 +577,7 @@ private extension ProductsViewController {
         present(navigationController, animated: true) { [weak self] in
 
             // Mark survey as given and update top banner view
-            let action = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .given(Date())) { result in
+            let action = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .given(Date())) { result in
                 if let error = result.failure {
                     CrashLogging.logError(error)
                 }
@@ -576,7 +590,7 @@ private extension ProductsViewController {
     /// Mark feedback request as dismissed and update banner visibility
     ///
     func dismissProductsBanner() {
-        let action = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .dismissed) { [weak self] result in
+        let action = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .dismissed) { [weak self] result in
             if let error = result.failure {
                 CrashLogging.logError(error)
             }

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -79,14 +79,14 @@ final class SurveyViewController: UIViewController, SurveyViewControllerOutputs 
 extension SurveyViewController {
     enum Source {
         case inAppFeedback
-        case productsM3Feedback
+        case productsM4Feedback
 
         fileprivate var url: URL {
             switch self {
             case .inAppFeedback:
                 return WooConstants.URLs.inAppFeedback.asURL()
-            case .productsM3Feedback:
-                return WooConstants.URLs.productsM3Feedback.asURL()
+            case .productsM4Feedback:
+                return WooConstants.URLs.productsM4Feedback.asURL()
             }
         }
 
@@ -94,7 +94,7 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return NSLocalizedString("How can we improve?", comment: "Title on the navigation bar for the in-app feedback survey")
-            case .productsM3Feedback:
+            case .productsM4Feedback:
                 return NSLocalizedString("Give feedback", comment: "Title on the navigation bar for the products feedback survey")
             }
         }
@@ -104,8 +104,8 @@ extension SurveyViewController {
             switch self {
             case .inAppFeedback:
                 return .general
-            case .productsM3Feedback:
-                return .productsM3
+            case .productsM4Feedback:
+                return .productsM4
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTopBannerFactoryTests.swift
@@ -40,7 +40,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "products_m3")
+        XCTAssertEqual(properties["context"] as? String, "products_m4")
         XCTAssertEqual(properties["action"] as? String, "gave_feedback")
     }
 
@@ -59,7 +59,7 @@ final class ProductsTopBannerFactoryTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.first, "feature_feedback_banner")
 
         let properties = try XCTUnwrap(analyticsProvider.receivedProperties.first)
-        XCTAssertEqual(properties["context"] as? String, "products_m3")
+        XCTAssertEqual(properties["context"] as? String, "products_m4")
         XCTAssertEqual(properties["action"] as? String, "dismissed")
     }
 }

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -64,7 +64,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         return true
     }
 
-    /// Returns whether the productsM3 feedback request should be displayed
+    /// Returns whether the productsM4 feedback request should be displayed
     ///
     private func shouldProductsFeedbackBeVisible() -> Bool {
         return settings.feedbackStatus(of: feedbackType) == .pending

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -37,7 +37,7 @@ struct InAppFeedbackCardVisibilityUseCase {
         switch feedbackType {
         case .general:
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
-        case .productsM3:
+        case .productsM4:
             return shouldProductsFeedbackBeVisible()
         }
     }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -65,6 +65,13 @@ public class AppSettingsStore: Store {
         return documents!.appendingPathComponent(Constants.productsRelease3FeatureSwitchFileName)
     }()
 
+    /// URL to the plist file that we use to determine the visibility for Product features M4.
+    ///
+    private lazy var productsRelease4FeatureSwitchURL: URL = {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        return documents!.appendingPathComponent(Constants.productsRelease4FeatureSwitchFileName)
+    }()
+
     private lazy var generalAppSettingsFileURL: URL! = {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
         return documents!.appendingPathComponent(Constants.generalAppSettingsFileName)
@@ -430,7 +437,7 @@ private extension AppSettingsStore {
     }
 
     func loadProductsFeatureSwitch(onCompletion: (Bool) -> Void) {
-        guard let existingData: ProductsFeatureSwitchPListWrapper = try? fileStorage.data(for: productsRelease3FeatureSwitchURL) else {
+        guard let existingData: ProductsFeatureSwitchPListWrapper = try? fileStorage.data(for: productsRelease4FeatureSwitchURL) else {
             onCompletion(false)
             return
         }
@@ -438,7 +445,7 @@ private extension AppSettingsStore {
     }
 
     func setProductsFeatureSwitch(isEnabled: Bool, onCompletion: () -> Void) {
-        let fileURL = productsRelease3FeatureSwitchURL
+        let fileURL = productsRelease4FeatureSwitchURL
         let wrapper = ProductsFeatureSwitchPListWrapper(isEnabled: isEnabled)
         do {
             try fileStorage.write(wrapper, to: fileURL)
@@ -453,6 +460,7 @@ private extension AppSettingsStore {
         do {
             try fileStorage.deleteFile(at: productsFeatureSwitchURL)
             try fileStorage.deleteFile(at: productsRelease3FeatureSwitchURL)
+            try fileStorage.deleteFile(at: productsRelease4FeatureSwitchURL)
         } catch {
             DDLogError("⛔️ Deleting the product feature switch files failed. Error: \(error)")
         }
@@ -488,5 +496,6 @@ private enum Constants {
     static let statsVersionLastShownFileName = "stats-version-last-shown.plist"
     static let productsFeatureSwitchFileName = "products-feature-switch.plist"
     static let productsRelease3FeatureSwitchFileName = "products-m3-feature-switch.plist"
+    static let productsRelease4FeatureSwitchFileName = "products-m4-feature-switch.plist"
     static let generalAppSettingsFileName = "general-app-settings.plist"
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -158,7 +158,7 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
     func test_shouldBeVisible_for_productM3_is_true_if_no_settings_are_found() throws {
         // Given
         let settings = GeneralAppSettings(installationDate: nil, feedbacks: [:])
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -169,8 +169,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM3_is_true_if_feedback_has_pending_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM3, feedbackSatus: .pending)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM4, feedbackSatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -181,8 +181,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM3_is_false_if_feedback_has_dismissed_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM3, feedbackSatus: .dismissed)
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM4, feedbackSatus: .dismissed)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()
@@ -193,8 +193,8 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
 
     func test_shouldBeVisible_for_productM3_is_false_if_feedback_has_given_status() throws {
         // Given
-        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM3, feedbackSatus: .given(Date()))
-        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM3)
+        let settings = createAppSetting(instalationDate: nil, feedbackType: .productsM4, feedbackSatus: .given(Date()))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .productsM4)
 
         // When
         let shouldBeVisible = try useCase.shouldBeVisible()

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsFeatureSwitch.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests+ProductsFeatureSwitch.swift
@@ -28,9 +28,9 @@ final class AppSettingsStoreTests_ProductsFeatureSwitch: XCTestCase {
     }()
 
     // Current feature switch file URL
-    private lazy var productsRelease3FeatureSwitchURL: URL = {
+    private lazy var productsRelease4FeatureSwitchURL: URL = {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        return documents!.appendingPathComponent("products-m3-feature-switch.plist")
+        return documents!.appendingPathComponent("products-m4-feature-switch.plist")
     }()
 
     override func setUp() {
@@ -102,7 +102,7 @@ final class AppSettingsStoreTests_ProductsFeatureSwitch: XCTestCase {
 
     func test_setting_current_file_URL_to_true_and_loading_products_feature_switch_returns_true() {
         // Arrange
-        try? fileStorage.write(ProductsFeatureSwitchPListWrapper(isEnabled: true), to: productsRelease3FeatureSwitchURL)
+        try? fileStorage.write(ProductsFeatureSwitchPListWrapper(isEnabled: true), to: productsRelease4FeatureSwitchURL)
 
         // Action
         var isFeatureSwitchEnabled: Bool?

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -355,12 +355,12 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_loadFeedbackVisibility_for_productsM3_returns_true_after_marking_it_as_pending() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .pending) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .pending) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)
@@ -375,12 +375,12 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_dismissed() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .dismissed) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .dismissed) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)
@@ -395,12 +395,12 @@ final class AppSettingsStoreTests: XCTestCase {
     func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_given() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
-        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM3, status: .given(Date())) { _ in }
+        let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .given(Date())) { _ in }
         subject?.onAction(updateAction)
 
         // When
         var visibilityResult: Result<Bool, Error>?
-        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM3) { result in
+        let queryAction = AppSettingsAction.loadFeedbackVisibility(type: .productsM4) { result in
             visibilityResult = result
         }
         subject?.onAction(queryAction)

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -352,7 +352,7 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(shouldBeVisibleResult).get())
     }
 
-    func test_loadFeedbackVisibility_for_productsM3_returns_true_after_marking_it_as_pending() throws {
+    func test_loadFeedbackVisibility_for_productsM4_returns_true_after_marking_it_as_pending() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .pending) { _ in }
@@ -372,7 +372,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
     }
 
-    func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_dismissed() throws {
+    func test_loadFeedbackVisibility_for_productsM4_returns_false_after_marking_it_as_dismissed() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .dismissed) { _ in }
@@ -392,7 +392,7 @@ final class AppSettingsStoreTests: XCTestCase {
 
     }
 
-    func test_loadFeedbackVisibility_for_productsM3_returns_false_after_marking_it_as_given() throws {
+    func test_loadFeedbackVisibility_for_productsM4_returns_false_after_marking_it_as_given() throws {
         // Given
         try fileStorage?.deleteFile(at: expectedGeneralAppSettingsFileURL)
         let updateAction = AppSettingsAction.updateFeedbackStatus(type: .productsM4, status: .given(Date())) { _ in }


### PR DESCRIPTION
Fixes #2991 

## Changes

- Added back Products feature switch in `SettingsViewController`, `BetaFeaturesViewController`, and `AppSettingsStore`
  - `AppSettingsStore` now uses a different PList file URL
- Updated WIP banner copy based on Products feature switch in `ProductsTopBannerFactory`
- In `ProductsViewController` (products tab), updated navigation bar right button items based on Products feature switch changes
- Renamed `FeedbackContext.productsM3` case to `productsM4` 

## Testing

- Launch the app
- Go to the Products tab --> there should be no "+" CTA in the navigation bar, and the WIP banner should mention product editing like in production (or see screenshot) if you haven't launched the app in this PR branch yet
- Go to Settings > Experimental Features --> the Products feature switch should be off
- Turn on the Products feature switch
- Go to the Products tab --> there should be a "+" CTA in the navigation bar, and the WIP banner should mention product creation (see screenshot)
- Tap on the "+" CTA and make sure you can create a product remotely
- Relaunch the app
- Go to the Products tab --> there should still be a "+" CTA in the navigation bar, and the WIP banner should mention product creation
- Go to Settings > Experimental Features --> the Products feature switch should stay on

## Example screenshots

feature switch state | WIP banner
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-10-19 at 13 40 54](https://user-images.githubusercontent.com/1945542/96528794-1c1de080-12b6-11eb-88e9-2a3ab1ebd7dc.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-19 at 13 41 02](https://user-images.githubusercontent.com/1945542/96405958-fe4a7000-1210-11eb-986c-b1e04f0ff0ba.png)
![Simulator Screen Shot - iPhone 11 - 2020-10-20 at 09 23 11](https://user-images.githubusercontent.com/1945542/96563350-6d4cc500-12f4-11eb-8f41-743b591d32eb.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-19 at 13 41 10](https://user-images.githubusercontent.com/1945542/96405961-00143380-1211-11eb-9be3-9fb4f1fb6e7f.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
