### PR TITLE
The footer in App Settings is now centered

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,8 @@
+5.4
+-----
+- [*] fix: the footer in app Settings is now correctly centered.
+
+
 5.3
 -----
 - [*] Opening a product from order details now shows readonly product details of the same styles as in editable product details.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/SettingsViewController.swift
@@ -117,6 +117,8 @@ private extension SettingsViewController {
 
         tableView.tableFooterView = footerContainer
         footerContainer.addSubview(footerView)
+        footerView.translatesAutoresizingMaskIntoConstraints = false
+        footerContainer.pinSubviewToAllEdges(footerView)
     }
 
     func refreshViewContent() {


### PR DESCRIPTION
## Description
The footer in App Settings wasn't centered because the view wasn't pinned to all the edges.

## Testing
1. Open the App Settings screen.
2. Make sure that the footer is not correctly centered.


## Screenshots
| Before            |  After |
:-------------------------:|:-------------------------:
![96443007-4024e780-120c-11eb-9554-0db1f89cbf3d](https://user-images.githubusercontent.com/495617/96446396-a6603900-1211-11eb-8cea-0e63404e1567.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-19 at 13 40 55](https://user-images.githubusercontent.com/495617/96446399-a7916600-1211-11eb-9c1c-8abe480fbaf8.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
