### PR TITLE
Fixed warning showed on Kingfisher in Xcode 12

### DIFF
--- a/WooCommerce/Classes/Tools/ImageService/KingfisherImageDownloader+ImageDownloadable.swift
+++ b/WooCommerce/Classes/Tools/ImageService/KingfisherImageDownloader+ImageDownloadable.swift
@@ -4,13 +4,13 @@ extension Kingfisher.DownloadTask: ImageDownloadTask {}
 
 extension Kingfisher.ImageDownloader: ImageDownloader {
     func downloadImage(with url: URL, onCompletion: ((Result<UIImage, Error>) -> Void)?) -> ImageDownloadTask? {
-        return downloadImage(with: url, options: nil) { result in
+        return downloadImage(with: url, options: nil, completionHandler: { result in
             switch result {
             case .success(let imageResult):
                 onCompletion?(.success(imageResult.image))
             case .failure(let kingfisherError):
                 onCompletion?(.failure(kingfisherError))
             }
-        }
+        })
     }
 }


### PR DESCRIPTION
This PR fixes a simple warning appeared with Xcode 12 about an unlabeled trailing closure used in one of our extension of the Kingfisher pod. 

## Testing
- CI
- This warning should disappear:
<img width="317" alt="Schermata 2020-10-19 alle 15 26 02" src="https://user-images.githubusercontent.com/495617/96457852-8d12b900-1220-11eb-961e-ee218d9e957f.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
