### PR TITLE
[Issue Refund] Refund API encoding

### DIFF
--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -57,7 +57,7 @@ public struct OrderItemRefund: Codable {
     /// The public decoder for OrderItemRefund.
     ///
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let container = try decoder.container(keyedBy: DecodingKeys.self)
 
         let itemID = try container.decode(Int64.self, forKey: .itemID)
         let name = try container.decode(String.self, forKey: .name)
@@ -95,27 +95,20 @@ public struct OrderItemRefund: Codable {
     /// The public encoder for OrderItemRefund.
     ///
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: EncodingKeys.self)
 
-        try container.encode(itemID, forKey: .itemID)
-        try container.encode(name, forKey: .name)
-        try container.encode(productID, forKey: .productID)
-        try container.encode(variationID, forKey: .variationID)
+        try container.encode(quantity, forKey: .quantity)
+        try container.encode(total,  forKey: .total)
+        try container.encode(taxesDictionary(), forKey: .taxes)
+    }
 
-        // Decimal does not play nice when encoding.
-        // Cast the Decimal to an NSNumber, then convert to a Double.
-        let doubleValue = Double(truncating: quantity as NSNumber)
-        try container.encode(doubleValue, forKey: .quantity)
-        try container.encode(price.stringValue, forKey: .price)
-
-        try container.encode(subtotal, forKey: .subtotal)
-        try container.encode(subtotalTax, forKey: .subtotalTax)
-        try container.encode(taxClass, forKey: .taxClass)
-
-        try container.encode(taxes, forKey: .taxes)
-
-        try container.encode(total, forKey: .total)
-        try container.encode(totalTax, forKey: .totalTax)
+    /// Converts the taxes array to a dictionary as the API expects it.
+    /// {  "tax_id_1" : "1.99", "tax_id_2" : "0.99" }
+    ///
+    private func taxesDictionary() -> [String: String] {
+        taxes.reduce(into: [:]) { dictionary, taxItem in
+            dictionary[String(taxItem.taxID)] = taxItem.total
+        }
     }
 }
 
@@ -124,7 +117,7 @@ public struct OrderItemRefund: Codable {
 ///
 private extension OrderItemRefund {
 
-    enum CodingKeys: String, CodingKey {
+    enum DecodingKeys: String, CodingKey {
         case itemID         = "id"
         case variationID    = "variation_id"
         case name
@@ -138,6 +131,12 @@ private extension OrderItemRefund {
         case total
         case totalTax       = "total_tax"
         case taxes
+    }
+
+    enum EncodingKeys: String, CodingKey {
+        case quantity = "qty"
+        case total = "refund_total"
+        case taxes = "refund_tax"
     }
 }
 

--- a/Networking/Networking/Model/Refund/OrderItemRefund.swift
+++ b/Networking/Networking/Model/Refund/OrderItemRefund.swift
@@ -98,7 +98,7 @@ public struct OrderItemRefund: Codable {
         var container = encoder.container(keyedBy: EncodingKeys.self)
 
         try container.encode(quantity, forKey: .quantity)
-        try container.encode(total,  forKey: .total)
+        try container.encode(total, forKey: .total)
         try container.encode(taxesDictionary(), forKey: .taxes)
     }
 

--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -48,7 +48,7 @@ public struct Refund: Codable {
         self.items = items
     }
 
-    // The public initializer for a Refund
+    /// The public initializer for a Refund
     ///
     public init(from decoder: Decoder) throws {
         guard let orderID = decoder.userInfo[.orderID] as? Int64 else {
@@ -81,19 +81,24 @@ public struct Refund: Codable {
                   items: items)
     }
 
-    // The public initializer for an encodable Refund
+    /// The public initializer for an encodable Refund
     ///
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: EncodingKeys.self)
 
         try container.encode(amount, forKey: .amount)
         try container.encode(reason, forKey: .reason)
-
-        // FIXME: What happens when you encode a struct that has a nested struct?
-        // `items` contains `taxes: [OrderItemTaxRefund]`.
-        try container.encode(items, forKey: .items)
-
         try container.encode(createAutomated, forKey: .createAutomatedRefund)
+        try container.encode(itemsDictionary(), forKey: .items)
+    }
+
+    /// Converts the items array to a dictionary as the API expects it.
+    /// {  "item_id_1" : item1, "item_id_2" : item2 }
+    ///
+    private func itemsDictionary() -> [String: OrderItemRefund] {
+        items.reduce(into: [:]) { dictionary, item in
+            dictionary[String(item.itemID)] = item
+        }
     }
 }
 

--- a/Networking/Networking/Model/Refund/Refund.swift
+++ b/Networking/Networking/Model/Refund/Refund.swift
@@ -66,7 +66,7 @@ public struct Refund: Codable {
         let amount = try container.decode(String.self, forKey: .amount)
         let reason = try container.decode(String.self, forKey: .reason)
         let refundedByUserID = try container.decode(Int64.self, forKey: .refundedByUserID)
-        let isAutomated = try container.decode(Bool.self, forKey: .automatedRefund)
+        let isAutomated = try container.decodeIfPresent(Bool.self, forKey: .automatedRefund) ?? false
         let items = try container.decode([OrderItemRefund].self, forKey: .items)
 
         self.init(refundID: refundID,

--- a/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
@@ -61,6 +61,64 @@ final class RefundMapperTests: XCTestCase {
         XCTAssertEqual(item.sku, "HOODIE-SHIP-YOUR-IDEA-BLUE-XL")
         XCTAssertEqual(item.price, NSDecimalNumber(integerLiteral: 27))
     }
+
+    func test_refund_is_encoded_correctly_with_items_and_taxes() throws {
+        // Given
+        let refund = sampleRefund(includeTaxes: true)
+        let mapper = RefundMapper(siteID: dummySiteID, orderID: 123)
+
+        // Ref: https://github.com/woocommerce/woocommerce/blob/0a81188e42fd3797ea2dd09f35c777e787801808/includes/wc-order-functions.php#L535-L573
+        let expectedDictionary: [String: Any] = [
+            "amount": refund.amount,
+            "api_refund": refund.createAutomated ?? false,
+            "reason": refund.reason,
+            "line_items": [
+                "\(refund.items[0].itemID)": [
+                    "qty": refund.items[0].quantity,
+                    "refund_total": refund.items[0].total,
+                    "refund_tax": [
+                        "\(refund.items[0].taxes[0].taxID)": refund.items[0].taxes[0].total
+                    ]
+                ]
+            ]
+        ]
+
+        // When
+        let refundEncoded = try mapper.map(refund: refund)
+        let refundDictionary = try JSONSerialization.jsonObject(with: refundEncoded, options: []) as? [String: Any]
+
+        // Then
+        let dictionaryEquals = NSDictionary(dictionary: refundDictionary ?? [:]).isEqual(to: expectedDictionary)
+        XCTAssertTrue(dictionaryEquals)
+    }
+
+    func test_refund_is_encoded_correctly_with_items_and_no_taxes() throws {
+        // Given
+        let refund = sampleRefund(includeTaxes: false)
+        let mapper = RefundMapper(siteID: dummySiteID, orderID: 123)
+
+        // Ref: https://github.com/woocommerce/woocommerce/blob/0a81188e42fd3797ea2dd09f35c777e787801808/includes/wc-order-functions.php#L535-L573
+        let expectedDictionary: [String: Any] = [
+            "amount": refund.amount,
+            "api_refund": refund.createAutomated ?? false,
+            "reason": refund.reason,
+            "line_items": [
+                "\(refund.items[0].itemID)": [
+                    "qty": refund.items[0].quantity,
+                    "refund_total": refund.items[0].total,
+                    "refund_tax": [:]
+                ]
+            ]
+        ]
+
+        // When
+        let refundEncoded = try mapper.map(refund: refund)
+        let refundDictionary = try JSONSerialization.jsonObject(with: refundEncoded, options: []) as? [String: Any]
+
+        // Then
+        let dictionaryEquals = NSDictionary(dictionary: refundDictionary ?? [:]).isEqual(to: expectedDictionary)
+        XCTAssertTrue(dictionaryEquals)
+    }
 }
 
 
@@ -82,5 +140,39 @@ private extension RefundMapperTests {
     ///
     func mapLoadRefundResponse() -> Refund? {
         return mapRefund(from: "refund-single")
+    }
+
+    /// Creates a dummy refund with items and taxes
+    ///
+    func sampleRefund(includeTaxes: Bool) -> Refund {
+        Refund(refundID: 1,
+               orderID: 1,
+               siteID: dummySiteID,
+               dateCreated: Date(),
+               amount: "19.60",
+               reason: "Some Reason",
+               refundedByUserID: 1,
+               isAutomated: nil,
+               createAutomated: false,
+               items: [sampleItem(includeTaxes: includeTaxes)])
+    }
+
+    /// Creates a dummy refund items with taxes
+    ///
+    func sampleItem(includeTaxes: Bool) -> OrderItemRefund {
+        let taxes = includeTaxes ? [OrderItemTaxRefund(taxID: 1, subtotal: "1.60", total: "1.60")] : []
+        return OrderItemRefund(itemID: 19,
+                               name: "",
+                               productID: 1,
+                               variationID: 1,
+                               quantity: 1,
+                               price: 18.0,
+                               sku: nil,
+                               subtotal: "18.0",
+                               subtotalTax: "1.60",
+                               taxClass: "",
+                               taxes: taxes,
+                               total: "18.0",
+                               totalTax: "1.60")
     }
 }

--- a/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/RefundMapperTests.swift
@@ -67,7 +67,7 @@ final class RefundMapperTests: XCTestCase {
         let refund = sampleRefund(includeTaxes: true)
         let mapper = RefundMapper(siteID: dummySiteID, orderID: 123)
 
-        // Ref: https://github.com/woocommerce/woocommerce/blob/0a81188e42fd3797ea2dd09f35c777e787801808/includes/wc-order-functions.php#L535-L573
+        // Ref:  https://git.io/JTRsF
         let expectedDictionary: [String: Any] = [
             "amount": refund.amount,
             "api_refund": refund.createAutomated ?? false,
@@ -97,7 +97,7 @@ final class RefundMapperTests: XCTestCase {
         let refund = sampleRefund(includeTaxes: false)
         let mapper = RefundMapper(siteID: dummySiteID, orderID: 123)
 
-        // Ref: https://github.com/woocommerce/woocommerce/blob/0a81188e42fd3797ea2dd09f35c777e787801808/includes/wc-order-functions.php#L535-L573
+        // Ref:  https://git.io/JTRsF
         let expectedDictionary: [String: Any] = [
             "amount": refund.amount,
             "api_refund": refund.createAutomated ?? false,


### PR DESCRIPTION
part of #2843 

# Why

As part of the refund shipping investigation, we noticed that the way to refund items on the API is not very mobile-friendly because its structure does not match with proper JSON objects.
```
{
  "amount": "97,99",
  "reason": "refund-product-wp-console",
  "api_refund": false,
  "line_items": {
    "63": {
      "refund_total": "90.0",
      "refund_tax": {
        "1": "7,99"
      }
    }
  }
}
```
ref: p91TBi-3hR-p2

This PR updates the `Refund` and `OrderItemRefund` entities to match the encoding required by the API.

# How

- On `Refund.swift` I added a method `itemsDictionary` that reduces the items array into a dictionary in the correct format.
- On `OrderItemRefund.swift` I added a method `taxesDictionary` that reduces the taxes array into a dictionary in the correct format
- On `OrderItemRefund.swift` I added an `EncodingKeys` enum as those keys are different from the `Decoding` ones

# Testing steps
Make sure the tests pass.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
