### PR TITLE
Update CI to XCode 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,20 @@ orbs:
   slack: circleci/slack@3.4.2
 
 commands:
-  fix-circleci:
+  fix-image:
     steps:
       - run:
-          name: Fix CircleCI
+          name: CI Image
           command: |
             # A placeholder command that fixes any issues present on the CircleCI box – there's often something wrong with it,
             # so preserving this step (even if empty) makes the diffs simpler.
-            echo "No issues for this image – skipping".
+            if [ $(echo $PATH | ruby -e "puts Kernel.gets.include?('/usr/local/bin')") != "true" ]; then
+              echo 'export PATH=/usr/local/bin:$PATH' >> $BASH_ENV
+              echo "Manually added `/usr/local/bin` to the $PATH:"
+              echo $PATH
+            fi
+            chruby ruby-2.6.6
+            gem install bundler
 jobs:
   Build Tests:
     executor:
@@ -22,16 +28,16 @@ jobs:
       xcode-version: "12.0.0"
     steps:
       - git/shallow-checkout
-      - fix-circleci
+      - fix-image
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
-      - ios/xcodebuild:
-          command: build-for-testing
-          arguments: -workspace 'WooCommerce.xcworkspace' -scheme 'WooCommerce' -configuration 'Debug' -sdk iphonesimulator -derivedDataPath DerivedData
+      - run:
+          name: Build for Testing
+          command: bundle exec fastlane build_for_testing
       - persist_to_workspace:
           root: ./
           paths:
@@ -46,7 +52,7 @@ jobs:
       - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "12.0.0"
-          device: iPhone 13
+          device: iPhone 11
       - attach_workspace:
           at: ./
       - run:
@@ -55,10 +61,7 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
-          command: >
-            bundle exec fastlane test_without_building
-            xctestrun:DerivedData/Build/Products/WooCommerce_UnitTests_iphonesimulator14.0-x86_64.xctestrun
-            destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: bundle exec fastlane test_without_building name:UnitTests try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -89,10 +92,7 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run UI Tests
-          command: >
-            bundle exec fastlane test_without_building
-            xctestrun:DerivedData/Build/Products/WooCommerce_UITests_iphonesimulator14.0-x86_64.xctestrun
-            destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: bundle exec fastlane test_without_building name:UITests
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:
@@ -116,7 +116,7 @@ jobs:
       xcode-version: "12.0.0"
     steps:
       - git/shallow-checkout
-      - fix-circleci
+      - fix-image
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
@@ -142,7 +142,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - git/shallow-checkout
-      - fix-circleci
+      - fix-image
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
@@ -179,8 +179,8 @@ workflows:
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
-          name: UI Tests (iPhone 13)
-          device: iPhone 13
+          name: UI Tests (iPhone 11)
+          device: iPhone 11
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -189,8 +189,8 @@ workflows:
                 - develop
                 - /^release.*/
       - UI Tests:
-          name: UI Tests (iPad Air 3rd generation)
-          device: iPad Air \\(3rd generation\\)
+          name: UI Tests (iPad Air 4th generation)
+          device: iPad Air \\(4th generation\\)
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -211,8 +211,8 @@ workflows:
       - Build Tests:
           requires: [ "Hold" ]
       - UI Tests:
-          name: Optional UI Tests (iPhone 13)
-          device: iPhone 13
+          name: Optional UI Tests (iPhone 11)
+          device: iPhone 11
           requires: [ "Build Tests" ]
       - UI Tests:
           name: Optional UI Tests (iPad Air 3rd generation)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,33 +14,24 @@ commands:
           command: |
             # A placeholder command that fixes any issues present on the CircleCI box – there's often something wrong with it,
             # so preserving this step (even if empty) makes the diffs simpler.
-            
-            # Add `/usr/local/bin` to the Xcode 11.2 image's $PATH in order to be able to use dependencies
-            if [ $(echo $PATH | ruby -e "puts Kernel.gets.include?('/usr/local/bin')") != "true" ]; then
-              echo 'export PATH=/usr/local/bin:$PATH' >> $BASH_ENV
-              echo "Manually added `/usr/local/bin` to the $PATH:"
-              echo $PATH
-            fi
-
-            chruby ruby-2.6.6
-            gem install bundler
+            echo "No issues for this image – skipping".
 jobs:
   Build Tests:
     executor:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - fix-circleci
       - git/shallow-checkout
+      - fix-circleci
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
       - run:
           name: Copy Secrets
           command: bundle exec fastlane run configure_apply
-      - run:
-          name: Build for Testing
-          command: cd ./Scripts && bundle exec fastlane build_for_testing
+      - ios/xcodebuild:
+          command: build-for-testing
+          arguments: -workspace 'WooCommerce.xcworkspace' -scheme 'WooCommerce' -configuration 'Debug' -sdk iphonesimulator -derivedDataPath DerivedData
       - persist_to_workspace:
           root: ./
           paths:
@@ -52,11 +43,10 @@ jobs:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - fix-circleci
       - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "12.0.0"
-          device: iPhone 11
+          device: iPhone 13
       - attach_workspace:
           at: ./
       - run:
@@ -65,7 +55,10 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
-          command: bundle exec fastlane test_without_building name:WooCommerce_UnitTests try_count:3
+          command: >
+            bundle exec fastlane test_without_building
+            xctestrun:DerivedData/Build/Products/WooCommerce_UnitTests_iphonesimulator14.0-x86_64.xctestrun
+            destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -80,7 +73,6 @@ jobs:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - fix-circleci
       - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "12.0.0"
@@ -97,7 +89,10 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run UI Tests
-          command: bundle exec fastlane test_without_building name:WooCommerce_UITests try_count:3
+          command: >
+            bundle exec fastlane test_without_building
+            xctestrun:DerivedData/Build/Products/WooCommerce_UITests_iphonesimulator14.0-x86_64.xctestrun
+            destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:
@@ -120,8 +115,8 @@ jobs:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - fix-circleci
       - git/shallow-checkout
+      - fix-circleci
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
@@ -146,8 +141,8 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - fix-circleci
       - git/shallow-checkout
+      - fix-circleci
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
@@ -184,8 +179,8 @@ workflows:
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
-          name: UI Tests (iPhone 11)
-          device: iPhone 11
+          name: UI Tests (iPhone 13)
+          device: iPhone 13
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -194,8 +189,8 @@ workflows:
                 - develop
                 - /^release.*/
       - UI Tests:
-          name: UI Tests (iPad Air 4rd generation)
-          device: iPad Air \\(4rd generation\\)
+          name: UI Tests (iPad Air 3rd generation)
+          device: iPad Air \\(3rd generation\\)
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -216,12 +211,12 @@ workflows:
       - Build Tests:
           requires: [ "Hold" ]
       - UI Tests:
-          name: Optional UI Tests (iPhone 11)
-          device: iPhone 11
+          name: Optional UI Tests (iPhone 13)
+          device: iPhone 13
           requires: [ "Build Tests" ]
       - UI Tests:
-          name: Optional UI Tests (iPad Air 4rd generation)
-          device: iPad Air \\(4rd generation\\)
+          name: Optional UI Tests (iPad Air 3rd generation)
+          device: iPad Air \\(3rd generation\\)
           requires: [ "Build Tests" ]
   Installable Build:
     jobs:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -668,16 +668,6 @@ end
     return '13.3'
   end
 
-  desc "Build for Testing"
-    lane :build_for_testing do | options |
-      run_tests(
-        workspace: "../WooCommerce.xcworkspace",
-        scheme: "WooCommerce",
-        derived_data_path: "../DerivedData",
-        build_for_testing: true,
-      )
-  end
-
 ########################################################################
 # Test Lanes
 ########################################################################
@@ -688,28 +678,19 @@ end
   # It requires a prebuilt xctestrun file and simulator destination where the tests will be run.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [try_count:<Number of times to try tests>]
+  # bundle exec fastlane test_without_building [xctestrun:<Path to xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
   #
   # Example:
-  # bundle exec fastlane test_without_building name:UITests try_count:3
+  # bundle exec fastlane test_without_building xctestrun:WooCommerce_UITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
   #####################################################################################
   desc "Run tests without building"
   lane :test_without_building do | options |
-
-    # Find the referenced .xctestrun file based on its name
-    buildProductsPath = File.expand_path("../DerivedData/Build/Products/", File.dirname(Dir.pwd))
-
-    testPlanPath = Dir.glob(File.join(buildProductsPath, '*.xctestrun') ).select { |e|
-      e.include?(options[:name])
-    }.first
-
-    UI.user_error!("Unable to find .xctestrun file") unless testPlanPath != nil and File.exists? (testPlanPath)
-
     multi_scan(
       workspace: "WooCommerce.xcworkspace",
       scheme: "WooCommerce",
       test_without_building: true,
-      xctestrun: testPlanPath,
+      xctestrun: "#{options[:xctestrun]}",
+      destination: options[:destination],
       try_count: options[:try_count],
       output_directory: "build/results",
       result_bundle: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -362,6 +362,26 @@ ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.pot"
     File.write("comment.json", { body: comment_body }.to_json)
   end
 
+
+  #####################################################################################
+  # build_for_testing
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app for testing
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_for_testing 
+  #####################################################################################
+  desc "Build for Testing"
+  lane :build_for_testing do | options |
+    run_tests(
+      workspace: "WooCommerce.xcworkspace",
+      scheme: "WooCommerce",
+      derived_data_path: "DerivedData",
+      build_for_testing: true,
+    )
+  end
+
+
   ########################################################################
   # Screenshot Lanes
   ########################################################################  
@@ -678,19 +698,27 @@ end
   # It requires a prebuilt xctestrun file and simulator destination where the tests will be run.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane test_without_building [xctestrun:<Path to xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
+  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [try_count:<Number of times to try tests>]
   #
   # Example:
-  # bundle exec fastlane test_without_building xctestrun:WooCommerce_UITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+  # bundle exec fastlane test_without_building name:UITests try_count:3
   #####################################################################################
   desc "Run tests without building"
   lane :test_without_building do | options |
+    # Find the referenced .xctestrun file based on its name
+    buildProductsPath = File.expand_path("DerivedData/Build/Products/", File.dirname(Dir.pwd))
+
+    testPlanPath = Dir.glob(File.join(buildProductsPath, '*.xctestrun') ).select { |e|
+      e.include?(options[:name])
+    }.first
+
+    UI.user_error!("Unable to find .xctestrun file") unless testPlanPath != nil and File.exists? (testPlanPath)
+    
     multi_scan(
       workspace: "WooCommerce.xcworkspace",
       scheme: "WooCommerce",
       test_without_building: true,
-      xctestrun: "#{options[:xctestrun]}",
-      destination: options[:destination],
+      xctestrun: testPlanPath,
       try_count: options[:try_count],
       output_directory: "build/results",
       result_bundle: true


### PR DESCRIPTION
This PR updates the CI to work with XCode 12. Some commands are wrapped into Fastlane lanes so that they can be used locally (see https://github.com/wordpress-mobile/WordPress-iOS/pull/14848 for details). 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
