### PR TITLE
Products: added bottom sheet in Downloadable Files list

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -399,6 +399,12 @@ extension UIImage {
         return UIImage(named: "icon-scan")!
     }
 
+    /// WordPress Logo Icon
+    ///
+    static var wordPressLogoImage: UIImage {
+        return UIImage.gridicon(.mySites)
+    }
+
     /// Returns a star icon with the given size
     ///
     /// - Parameters:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
@@ -1,0 +1,35 @@
+import Yosemite
+
+/// `BottomSheetListSelectorCommand` for selecting a form action for adding a new Downloadable File.
+///
+final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelectorCommand {
+    var data: [DownloadableFileFormBottomSheetAction]
+
+    var selected: DownloadableFileFormBottomSheetAction?
+
+    typealias Model = DownloadableFileFormBottomSheetAction
+    typealias Cell = ImageAndTitleAndTextTableViewCell
+
+    private let onSelection: (DownloadableFileFormBottomSheetAction) -> Void
+
+    init(actions: [DownloadableFileFormBottomSheetAction],
+         onSelection: @escaping (DownloadableFileFormBottomSheetAction) -> Void) {
+        self.onSelection = onSelection
+        self.data = actions
+    }
+
+    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: DownloadableFileFormBottomSheetAction) {
+        cell.selectionStyle = .none
+        cell.accessoryType = .disclosureIndicator
+        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title, text: nil, image: UIImage.cloudImage, imageTintColor: nil, numberOfLinesForText: 0)
+        cell.updateUI(viewModel: viewModel)
+    }
+
+    func handleSelectedChange(selected: DownloadableFileFormBottomSheetAction) {
+        onSelection(selected)
+    }
+
+    func isSelected(model: DownloadableFileFormBottomSheetAction) -> Bool {
+        return model == selected
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
@@ -21,7 +21,11 @@ final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelec
     func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: DownloadableFileFormBottomSheetAction) {
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
-        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title, text: nil, image: UIImage.cloudImage, imageTintColor: nil, numberOfLinesForText: 0)
+        let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title,
+                                                                    text: nil,
+                                                                    image: UIImage.cloudImage,
+                                                                    imageTintColor: nil,
+                                                                    numberOfLinesForText: 0)
         cell.updateUI(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
@@ -3,22 +3,22 @@ import Yosemite
 /// `BottomSheetListSelectorCommand` for selecting a form action for adding a new Downloadable File.
 ///
 final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelectorCommand {
-    var data: [DownloadableFileFormBottomSheetAction]
+    let data: [DownloadableFileSource]
 
-    var selected: DownloadableFileFormBottomSheetAction?
+    var selected: DownloadableFileSource?
 
-    typealias Model = DownloadableFileFormBottomSheetAction
+    typealias Model = DownloadableFileSource
     typealias Cell = ImageAndTitleAndTextTableViewCell
 
-    private let onSelection: (DownloadableFileFormBottomSheetAction) -> Void
+    private let onSelection: (DownloadableFileSource) -> Void
 
-    init(actions: [DownloadableFileFormBottomSheetAction],
-         onSelection: @escaping (DownloadableFileFormBottomSheetAction) -> Void) {
+    init(actions: [DownloadableFileSource],
+         onSelection: @escaping (DownloadableFileSource) -> Void) {
         self.onSelection = onSelection
         self.data = actions
     }
 
-    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: DownloadableFileFormBottomSheetAction) {
+    func configureCell(cell: ImageAndTitleAndTextTableViewCell, model: DownloadableFileSource) {
         cell.selectionStyle = .none
         cell.accessoryType = .disclosureIndicator
         let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title,
@@ -30,11 +30,11 @@ final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelec
         cell.updateUI(viewModel: viewModel)
     }
 
-    func handleSelectedChange(selected: DownloadableFileFormBottomSheetAction) {
+    func handleSelectedChange(selected: DownloadableFileSource) {
         onSelection(selected)
     }
 
-    func isSelected(model: DownloadableFileFormBottomSheetAction) -> Bool {
+    func isSelected(model: DownloadableFileSource) -> Bool {
         return model == selected
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileBottomSheetListSelectorCommand.swift
@@ -23,8 +23,9 @@ final class DownloadableFileBottomSheetListSelectorCommand: BottomSheetListSelec
         cell.accessoryType = .disclosureIndicator
         let viewModel = ImageAndTitleAndTextTableViewCell.ViewModel(title: model.title,
                                                                     text: nil,
-                                                                    image: UIImage.cloudImage,
-                                                                    imageTintColor: nil,
+                                                                    textTintColor: .text,
+                                                                    image: model.image,
+                                                                    imageTintColor: .gray(.shade20),
                                                                     numberOfLinesForText: 0)
         cell.updateUI(viewModel: viewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileFormBottomSheetAction.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileFormBottomSheetAction.swift
@@ -13,13 +13,24 @@ extension DownloadableFileFormBottomSheetAction {
         switch self {
         case .fromDevice:
             return NSLocalizedString("From device",
-                                     comment: "Title of the product form bottom sheet action for editing inventory settings.")
+                                     comment: "Title of the downloadable file bottom sheet action for adding file from device.")
         case .fromWordPressMediaLibrary:
             return NSLocalizedString("From WordPress Media Library",
-                                     comment: "Title of the product form bottom sheet action for editing shipping settings.")
+                                     comment: "Title of the downloadable file bottom sheet action for adding file from WordPress Media Library.")
         case .fromFileURL:
             return NSLocalizedString("Enter file URL",
-                                     comment: "Title of the product form bottom sheet action for editing categories.")
+                                     comment: "Title of the downloadable file bottom sheet action for adding file from an URL.")
+        }
+    }
+
+    var image: UIImage {
+        switch self {
+        case .fromDevice:
+            return .invisibleImage
+        case .fromWordPressMediaLibrary:
+            return .cameraImage
+        case .fromFileURL:
+            return .wordPressLogoImage
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileFormBottomSheetAction.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileFormBottomSheetAction.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Yosemite
+
+/// Actions in the downloadable file form bottom sheet to add a new downloadable file.
+enum DownloadableFileFormBottomSheetAction {
+    case fromDevice
+    case fromWordPressMediaLibrary
+    case fromFileURL
+}
+
+extension DownloadableFileFormBottomSheetAction {
+    var title: String {
+        switch self {
+        case .fromDevice:
+            return NSLocalizedString("From device",
+                                     comment: "Title of the product form bottom sheet action for editing inventory settings.")
+        case .fromWordPressMediaLibrary:
+            return NSLocalizedString("From WordPress Media Library",
+                                     comment: "Title of the product form bottom sheet action for editing shipping settings.")
+        case .fromFileURL:
+            return NSLocalizedString("Enter file URL",
+                                     comment: "Title of the product form bottom sheet action for editing categories.")
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/BottomSheetListSelector/DownloadableFileSource.swift
@@ -2,22 +2,22 @@ import Foundation
 import Yosemite
 
 /// Actions in the downloadable file form bottom sheet to add a new downloadable file.
-enum DownloadableFileFormBottomSheetAction {
-    case fromDevice
-    case fromWordPressMediaLibrary
-    case fromFileURL
+enum DownloadableFileSource {
+    case device
+    case wordPressMediaLibrary
+    case fileURL
 }
 
-extension DownloadableFileFormBottomSheetAction {
+extension DownloadableFileSource {
     var title: String {
         switch self {
-        case .fromDevice:
+        case .device:
             return NSLocalizedString("From device",
                                      comment: "Title of the downloadable file bottom sheet action for adding file from device.")
-        case .fromWordPressMediaLibrary:
+        case .wordPressMediaLibrary:
             return NSLocalizedString("From WordPress Media Library",
                                      comment: "Title of the downloadable file bottom sheet action for adding file from WordPress Media Library.")
-        case .fromFileURL:
+        case .fileURL:
             return NSLocalizedString("Enter file URL",
                                      comment: "Title of the downloadable file bottom sheet action for adding file from an URL.")
         }
@@ -25,11 +25,11 @@ extension DownloadableFileFormBottomSheetAction {
 
     var image: UIImage {
         switch self {
-        case .fromDevice:
+        case .device:
             return .invisibleImage
-        case .fromWordPressMediaLibrary:
+        case .wordPressMediaLibrary:
             return .cameraImage
-        case .fromFileURL:
+        case .fileURL:
             return .wordPressLogoImage
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -46,7 +46,7 @@ private extension ProductDownloadListViewController {
 
     func configureAddButton() {
         addButton.setTitle(NSLocalizedString("Add File", comment: "Action to add downloadable file on the Product Downloadable Files screen"), for: .normal)
-        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+        addButton.addTarget(self, action: #selector(addButtonTapped(_:)), for: .touchUpInside)
         addButton.applySecondaryButtonStyle()
     }
 
@@ -123,9 +123,27 @@ extension ProductDownloadListViewController {
         viewModel.completeUpdating(onCompletion: onCompletion)
     }
 
-    @objc private func addButtonTapped() {
-        // TODO: - add analytics
-        addEditDownloadableFile(indexPath: nil, formType: .add)
+    @objc private func addButtonTapped(_ sender: UIButton) {
+        // TODO: - add analytics M5
+
+        let title = NSLocalizedString("Select upload method",
+                                      comment: "Title of the bottom sheet from the product downloadable file to add a new downloadable file.")
+        let viewProperties = BottomSheetListSelectorViewProperties(title: title)
+        let actions = viewModel.bottomSheetActions
+        let dataSource = DownloadableFileBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
+            self?.dismiss(animated: true) { [weak self] in
+                switch action {
+                case .fromDevice:
+                    return
+                case .fromWordPressMediaLibrary:
+                    return
+                case .fromFileURL:
+                    self?.addEditDownloadableFile(indexPath: nil, formType: .add)
+                }
+            }
+        }
+        let listSelectorPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: dataSource)
+        listSelectorPresenter.show(from: self, sourceView: sender, arrowDirections: .down)
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -128,17 +128,17 @@ extension ProductDownloadListViewController {
         let dataSource = DownloadableFileBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
             self?.dismiss(animated: true) { [weak self] in
                 switch action {
-                case .fromDevice:
+                case .device:
                     return
-                case .fromWordPressMediaLibrary:
+                case .wordPressMediaLibrary:
                     return
-                case .fromFileURL:
+                case .fileURL:
                     self?.addEditDownloadableFile(indexPath: nil, formType: .add)
                 }
             }
         }
         let listSelectorPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: dataSource)
-        listSelectorPresenter.show(from: self, sourceView: sender, arrowDirections: .down)
+        listSelectorPresenter.show(from: self, sourceView: sender, arrowDirections: .up)
     }
 
     private func presentBackNavigationActionSheet() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -214,14 +214,12 @@ private extension ProductDownloadListViewController {
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         menuAlert.view.tintColor = .text
 
-        let downloadSettingsTitle = Localization.downloadSettingsActionSheetTitle
-        let downloadSettingsAction = UIAlertAction(title: downloadSettingsTitle, style: .default) { [weak self] (action) in
+        let downloadSettingsAction = UIAlertAction(title: Localization.downloadSettingsAction, style: .default) { [weak self] (action) in
             self?.showDownloadableFilesSettings()
         }
         menuAlert.addAction(downloadSettingsAction)
 
-        let cancelTitle = Localization.cancelActionSheetTitle
-        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
+        let cancelAction = UIAlertAction(title: Localization.cancelAction, style: .cancel)
         menuAlert.addAction(cancelAction)
 
         let popoverController = menuAlert.popoverPresentationController
@@ -314,9 +312,9 @@ private extension ProductDownloadListViewController {
                                                   comment: "Edit product downloadable files screen - button title to apply changes to downloadable files")
         static let bottomSheetTitle = NSLocalizedString("Select upload method",
                                                         comment: "Title of the bottom sheet from the product downloadable file to add a new downloadable file.")
-        static let downloadSettingsActionSheetTitle = NSLocalizedString("Download Settings",
+        static let downloadSettingsAction = NSLocalizedString("Download Settings",
                                                                         comment: "Button title Download Settings in Downloadable Files More Options Action Sheet")
-        static let cancelActionSheetTitle = NSLocalizedString("Cancel",
+        static let cancelAction = NSLocalizedString("Cancel",
                                                               comment: "Button title Cancel in Downloadable Files More Options Action Sheet")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -313,8 +313,8 @@ private extension ProductDownloadListViewController {
         static let bottomSheetTitle = NSLocalizedString("Select upload method",
                                                         comment: "Title of the bottom sheet from the product downloadable file to add a new downloadable file.")
         static let downloadSettingsAction = NSLocalizedString("Download Settings",
-                                                                        comment: "Button title Download Settings in Downloadable Files More Options Action Sheet")
+                                                              comment: "Button title Download Settings in Downloadable Files More Options Action Sheet")
         static let cancelAction = NSLocalizedString("Cancel",
-                                                              comment: "Button title Cancel in Downloadable Files More Options Action Sheet")
+                                                    comment: "Button title Cancel in Downloadable Files More Options Action Sheet")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -45,7 +45,7 @@ private extension ProductDownloadListViewController {
     }
 
     func configureAddButton() {
-        addButton.setTitle(NSLocalizedString("Add File", comment: "Action to add downloadable file on the Product Downloadable Files screen"), for: .normal)
+        addButton.setTitle(Localization.addFileButton, for: .normal)
         addButton.addTarget(self, action: #selector(addButtonTapped(_:)), for: .touchUpInside)
         addButton.applySecondaryButtonStyle()
     }
@@ -72,8 +72,7 @@ private extension ProductDownloadListViewController {
     }
 
     func configureTitle() {
-        title = NSLocalizedString("Downloadable Files",
-                                  comment: "Edit product downloadable files screen - Screen title")
+        title = Localization.title
     }
 
     func configureRightButtons() {
@@ -85,15 +84,12 @@ private extension ProductDownloadListViewController {
                                          target: self,
                                          action: #selector(presentMoreActionSheetMenu(_:)))
             button.accessibilityTraits = .button
-            button.accessibilityLabel = NSLocalizedString("View downloadable file settings",
-                                                          comment: "The action to update downloadable files settings for a product")
+            button.accessibilityLabel = Localization.moreBarButtonAccessibilityLabel
             return button
         }()
         rightBarButtonItems.append(downloadSettingsBarButton)
 
-        let doneButtonTitle = NSLocalizedString("Done",
-                                                comment: "Edit product downloadable files screen - button title to apply changes to downloadable files")
-        let doneBarButton = UIBarButtonItem(title: doneButtonTitle,
+        let doneBarButton = UIBarButtonItem(title: Localization.doneButton,
                                              style: .done,
                                              target: self,
                                              action: #selector(doneButtonTapped))
@@ -126,8 +122,7 @@ extension ProductDownloadListViewController {
     @objc private func addButtonTapped(_ sender: UIButton) {
         // TODO: - add analytics M5
 
-        let title = NSLocalizedString("Select upload method",
-                                      comment: "Title of the bottom sheet from the product downloadable file to add a new downloadable file.")
+        let title = Localization.bottomSheetTitle
         let viewProperties = BottomSheetListSelectorViewProperties(title: title)
         let actions = viewModel.bottomSheetActions
         let dataSource = DownloadableFileBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
@@ -219,15 +214,13 @@ private extension ProductDownloadListViewController {
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         menuAlert.view.tintColor = .text
 
-        let downloadSettingsTitle = NSLocalizedString("Download Settings",
-                                                      comment: "Button title Download Settings in Downloadable Files More Options Action Sheet")
+        let downloadSettingsTitle = Localization.downloadSettingsActionSheetTitle
         let downloadSettingsAction = UIAlertAction(title: downloadSettingsTitle, style: .default) { [weak self] (action) in
             self?.showDownloadableFilesSettings()
         }
         menuAlert.addAction(downloadSettingsAction)
 
-        let cancelTitle = NSLocalizedString("Cancel",
-                                            comment: "Button title Cancel in Downloadable Files More Options Action Sheet")
+        let cancelTitle = Localization.cancelActionSheetTitle
         let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel)
         menuAlert.addAction(cancelAction)
 
@@ -305,5 +298,25 @@ private extension ProductDownloadListViewController {
                                                                     imageTintColor: .gray(.shade20),
                                                                     numberOfLinesForText: 1)
         cell.updateUI(viewModel: viewModel)
+    }
+}
+
+// MARK: - Constants
+
+private extension ProductDownloadListViewController {
+    enum Localization {
+        static let addFileButton = NSLocalizedString("Add File", comment: "Action to add downloadable file on the Product Downloadable Files screen")
+        static let title = NSLocalizedString("Downloadable Files",
+                                             comment: "Edit product downloadable files screen - Screen title")
+        static let moreBarButtonAccessibilityLabel = NSLocalizedString("View downloadable file settings",
+                                                                       comment: "The action to update downloadable files settings for a product")
+        static let doneButton = NSLocalizedString("Done",
+                                                  comment: "Edit product downloadable files screen - button title to apply changes to downloadable files")
+        static let bottomSheetTitle = NSLocalizedString("Select upload method",
+                                                        comment: "Title of the bottom sheet from the product downloadable file to add a new downloadable file.")
+        static let downloadSettingsActionSheetTitle = NSLocalizedString("Download Settings",
+                                                                        comment: "Button title Download Settings in Downloadable Files More Options Action Sheet")
+        static let cancelActionSheetTitle = NSLocalizedString("Cancel",
+                                                              comment: "Button title Cancel in Downloadable Files More Options Action Sheet")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
@@ -8,6 +8,9 @@ protocol ProductDownloadListViewModelOutput {
     var downloadLimit: Int64 { get }
     var downloadExpiry: Int64 { get }
 
+    // Actions available on the bottom sheet
+    var bottomSheetActions: [DownloadableFileFormBottomSheetAction] { get }
+
     // Convenience Methods
     @discardableResult
     func remove(at index: Int) -> ProductDownloadDragAndDrop?
@@ -42,6 +45,7 @@ enum ProductDownloadListError: Error {
 /// Provides view data for downloadable files settings, and handles init/UI/navigation actions needed in product downloadable files settings.
 ///
 final class ProductDownloadListViewModel: ProductDownloadListViewModelOutput {
+
     private let product: ProductFormDataModel
 
     // Editable data
@@ -49,6 +53,10 @@ final class ProductDownloadListViewModel: ProductDownloadListViewModelOutput {
     private(set) var downloadableFiles = [ProductDownloadDragAndDrop]()
     private(set) var downloadLimit: Int64
     private(set) var downloadExpiry: Int64
+
+    var bottomSheetActions: [DownloadableFileFormBottomSheetAction] {
+        return [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+    }
 
     init(product: ProductFormDataModel) {
         self.product = product
@@ -86,12 +94,6 @@ final class ProductDownloadListViewModel: ProductDownloadListViewModelOutput {
 }
 
 extension ProductDownloadListViewModel: ProductDownloadListActionHandler {
-
-    // MARK: - Tap actions
-
-    func didTapDownloadableFileFromRow(_ indexPath: IndexPath) {
-        //TODO: Show respective file in a new window
-    }
 
     // MARK: - UI changes
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
@@ -9,7 +9,7 @@ protocol ProductDownloadListViewModelOutput {
     var downloadExpiry: Int64 { get }
 
     // Actions available on the bottom sheet
-    var bottomSheetActions: [DownloadableFileFormBottomSheetAction] { get }
+    var bottomSheetActions: [DownloadableFileSource] { get }
 
     // Convenience Methods
     @discardableResult
@@ -54,8 +54,8 @@ final class ProductDownloadListViewModel: ProductDownloadListViewModelOutput {
     private(set) var downloadLimit: Int64
     private(set) var downloadExpiry: Int64
 
-    var bottomSheetActions: [DownloadableFileFormBottomSheetAction] {
-        return [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+    var bottomSheetActions: [DownloadableFileSource] {
+        [.device, .wordPressMediaLibrary, .fileURL]
     }
 
     init(product: ProductFormDataModel) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 		45912FE32526642200982948 /* ProductFormViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */; };
 		4592A54B24BF58DD00BC3DE0 /* ProductTagsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4592A54924BF58DD00BC3DE0 /* ProductTagsViewController.swift */; };
 		4592A54C24BF58DD00BC3DE0 /* ProductTagsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4592A54A24BF58DD00BC3DE0 /* ProductTagsViewController.xib */; };
-		4596853F2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596853E2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift */; };
+		4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596853E2540669900D17B90 /* DownloadableFileSource.swift */; };
 		45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */; };
 		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
 		45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */; };
@@ -1455,7 +1455,7 @@
 		45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+Helpers.swift"; sourceTree = "<group>"; };
 		4592A54924BF58DD00BC3DE0 /* ProductTagsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsViewController.swift; sourceTree = "<group>"; };
 		4592A54A24BF58DD00BC3DE0 /* ProductTagsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductTagsViewController.xib; sourceTree = "<group>"; };
-		4596853E2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileFormBottomSheetAction.swift; sourceTree = "<group>"; };
+		4596853E2540669900D17B90 /* DownloadableFileSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileSource.swift; sourceTree = "<group>"; };
 		45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
 		4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductMenuOrderViewController.swift; sourceTree = "<group>"; };
@@ -3077,7 +3077,7 @@
 		4596853D2540667700D17B90 /* BottomSheetListSelector */ = {
 			isa = PBXGroup;
 			children = (
-				4596853E2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift */,
+				4596853E2540669900D17B90 /* DownloadableFileSource.swift */,
 				45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */,
 			);
 			path = BottomSheetListSelector;
@@ -5675,7 +5675,7 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
-				4596853F2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift in Sources */,
+				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -425,6 +425,9 @@
 		45912FE32526642200982948 /* ProductFormViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */; };
 		4592A54B24BF58DD00BC3DE0 /* ProductTagsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4592A54924BF58DD00BC3DE0 /* ProductTagsViewController.swift */; };
 		4592A54C24BF58DD00BC3DE0 /* ProductTagsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4592A54A24BF58DD00BC3DE0 /* ProductTagsViewController.xib */; };
+		4596853F2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596853E2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift */; };
+		45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */; };
+		4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */; };
 		45A24E5F2451DF1A0050606B /* ProductMenuOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */; };
 		45A24E602451DF1A0050606B /* ProductMenuOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */; };
 		45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A4221924ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift */; };
@@ -1452,6 +1455,9 @@
 		45912FE22526642200982948 /* ProductFormViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewController+Helpers.swift"; sourceTree = "<group>"; };
 		4592A54924BF58DD00BC3DE0 /* ProductTagsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTagsViewController.swift; sourceTree = "<group>"; };
 		4592A54A24BF58DD00BC3DE0 /* ProductTagsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductTagsViewController.xib; sourceTree = "<group>"; };
+		4596853E2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileFormBottomSheetAction.swift; sourceTree = "<group>"; };
+		45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommand.swift; sourceTree = "<group>"; };
+		4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadableFileBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
 		45A24E5D2451DF1A0050606B /* ProductMenuOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductMenuOrderViewController.swift; sourceTree = "<group>"; };
 		45A24E5E2451DF1A0050606B /* ProductMenuOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProductMenuOrderViewController.xib; sourceTree = "<group>"; };
 		45A4221924ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchStoreNoticePresenter.swift; sourceTree = "<group>"; };
@@ -3068,6 +3074,15 @@
 			path = "Edit Tags";
 			sourceTree = "<group>";
 		};
+		4596853D2540667700D17B90 /* BottomSheetListSelector */ = {
+			isa = PBXGroup;
+			children = (
+				4596853E2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift */,
+				45968544254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift */,
+			);
+			path = BottomSheetListSelector;
+			sourceTree = "<group>";
+		};
 		45A24E5C2451DB710050606B /* Menu Order */ = {
 			isa = PBXGroup;
 			children = (
@@ -3493,6 +3508,7 @@
 				77307808251EA07100178696 /* ProductDownloadSettingsViewModelTests.swift */,
 				773077F2251E954300178696 /* ProductDownloadFileViewModelTests.swift */,
 				77423F16251CF77E0016A083 /* ProductDownloadListViewModelTests.swift */,
+				4596854A254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift */,
 			);
 			path = "Downloadable Files";
 			sourceTree = "<group>";
@@ -3515,6 +3531,7 @@
 				77E53EC42510C193003D385F /* ProductDownloadListViewController+Droppable.swift */,
 				77E53EBE2510C153003D385F /* ProductDownloadListViewModel.swift */,
 				77E53EC72510FE07003D385F /* ProductDownloadsEditableData.swift */,
+				4596853D2540667700D17B90 /* BottomSheetListSelector */,
 			);
 			path = "File List";
 			sourceTree = "<group>";
@@ -5519,6 +5536,7 @@
 				D85136C1231E09C300DD0539 /* ReviewsDataSource.swift in Sources */,
 				CE1AFE622200B1BD00432745 /* ApplicationLogDetailViewController.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
+				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
 				77E53EC82510FE07003D385F /* ProductDownloadsEditableData.swift in Sources */,
 				0235595B24496E88004BE2B8 /* BottomSheetListSelectorViewController+DrawerPresentable.swift in Sources */,
 				0227958D237A51F300787C63 /* OptionsTableViewController+Styles.swift in Sources */,
@@ -5657,6 +5675,7 @@
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */,
+				4596853F2540669900D17B90 /* DownloadableFileFormBottomSheetAction.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				02404EDA2314C36300FF1170 /* StatsVersionCoordinator.swift in Sources */,
@@ -6080,6 +6099,7 @@
 				6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */,
 				025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */,
 				6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */,
+				4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */,
 				6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */,
 				57F42E40253768D600EA87F7 /* TitleAndEditableValueTableViewCellViewModelTests.swift in Sources */,
 			);

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -326,4 +326,8 @@ final class IconsTests: XCTestCase {
     func testMenuImageIconIsNotNil() {
         XCTAssertNotNil(UIImage.menuImage)
     }
+
+    func test_wordPressLogoImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.wordPressLogoImage)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/DownloadableFileBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/DownloadableFileBottomSheetListSelectorCommandTests.swift
@@ -5,24 +5,24 @@ import XCTest
 final class DownloadableFileBottomSheetListSelectorCommandTests: XCTestCase {
     // MARK: - `handleSelectedChange`
 
-    func testCallbackIsCalledOnSelection() {
+    func test_callback_is_called_on_selection() {
         // Arrange
-        let actions: [DownloadableFileFormBottomSheetAction] = [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
-        var selectedActions = [DownloadableFileFormBottomSheetAction]()
+        let actions: [DownloadableFileSource] = [.device, .wordPressMediaLibrary, .fileURL]
+        var selectedActions = [DownloadableFileSource]()
         let command = DownloadableFileBottomSheetListSelectorCommand(actions: actions) { selected in
                                                                     selectedActions.append(selected)
         }
 
         // Action
-        command.handleSelectedChange(selected: .fromFileURL)
-        command.handleSelectedChange(selected: .fromWordPressMediaLibrary)
-        command.handleSelectedChange(selected: .fromDevice)
+        command.handleSelectedChange(selected: .fileURL)
+        command.handleSelectedChange(selected: .wordPressMediaLibrary)
+        command.handleSelectedChange(selected: .device)
 
         // Assert
-        let expectedActions: [DownloadableFileFormBottomSheetAction] = [
-            .fromFileURL,
-            .fromWordPressMediaLibrary,
-            .fromDevice
+        let expectedActions: [DownloadableFileSource] = [
+            .fileURL,
+            .wordPressMediaLibrary,
+            .device
         ]
         XCTAssertEqual(selectedActions, expectedActions)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/DownloadableFileBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/DownloadableFileBottomSheetListSelectorCommandTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import WooCommerce
+@testable import Yosemite
+
+final class DownloadableFileBottomSheetListSelectorCommandTests: XCTestCase {
+    // MARK: - `handleSelectedChange`
+
+    func testCallbackIsCalledOnSelection() {
+        // Arrange
+        let actions: [DownloadableFileFormBottomSheetAction] = [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+        var selectedActions = [DownloadableFileFormBottomSheetAction]()
+        let command = DownloadableFileBottomSheetListSelectorCommand(actions: actions) { selected in
+                                                                    selectedActions.append(selected)
+        }
+
+        // Action
+        command.handleSelectedChange(selected: .fromFileURL)
+        command.handleSelectedChange(selected: .fromWordPressMediaLibrary)
+        command.handleSelectedChange(selected: .fromDevice)
+
+        // Assert
+        let expectedActions: [DownloadableFileFormBottomSheetAction] = [
+            .fromFileURL,
+            .fromWordPressMediaLibrary,
+            .fromDevice
+        ]
+        XCTAssertEqual(selectedActions, expectedActions)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
@@ -22,6 +22,10 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertEqual(file.downloadableFile.downloadID, "1f9c11f99ceba63d4403c03bd5391b11")
         XCTAssertEqual(file.downloadableFile.name, "Song #1")
         XCTAssertEqual(file.downloadableFile.fileURL, "https://example.com/woo-single-1.ogg")
+
+        let expectedBottomSheetActions: [DownloadableFileFormBottomSheetAction] = [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+        XCTAssertEqual(viewModel.bottomSheetActions.count, 3)
+        XCTAssertEqual(viewModel.bottomSheetActions, expectedBottomSheetActions)
     }
 
     func test_readonly_values_are_as_expected_after_initializing_a_product_with_empty_downloadable_files() {
@@ -36,6 +40,10 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.count(), 0)
         XCTAssertEqual(viewModel.downloadLimit, -1)
         XCTAssertEqual(viewModel.downloadExpiry, -1)
+
+        let expectedBottomSheetActions: [DownloadableFileFormBottomSheetAction] = [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+        XCTAssertEqual(viewModel.bottomSheetActions.count, 3)
+        XCTAssertEqual(viewModel.bottomSheetActions, expectedBottomSheetActions)
     }
 
     // TODO: - test cases for `handleDownloadableFilesChange`

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
@@ -23,7 +23,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertEqual(file.downloadableFile.name, "Song #1")
         XCTAssertEqual(file.downloadableFile.fileURL, "https://example.com/woo-single-1.ogg")
 
-        let expectedBottomSheetActions: [DownloadableFileFormBottomSheetAction] = [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+        let expectedBottomSheetActions: [DownloadableFileSource] = [.device, .wordPressMediaLibrary, .fileURL]
         XCTAssertEqual(viewModel.bottomSheetActions.count, 3)
         XCTAssertEqual(viewModel.bottomSheetActions, expectedBottomSheetActions)
     }
@@ -41,7 +41,7 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.downloadLimit, -1)
         XCTAssertEqual(viewModel.downloadExpiry, -1)
 
-        let expectedBottomSheetActions: [DownloadableFileFormBottomSheetAction] = [.fromDevice, .fromWordPressMediaLibrary, .fromFileURL]
+        let expectedBottomSheetActions: [DownloadableFileSource] = [.device, .wordPressMediaLibrary, .fileURL]
         XCTAssertEqual(viewModel.bottomSheetActions.count, 3)
         XCTAssertEqual(viewModel.bottomSheetActions, expectedBottomSheetActions)
     }


### PR DESCRIPTION
Part of #2759 

## Description
As part of Downloadable Files, a feature part of Products M5, we should display a bottom sheet with the following options:
- From device
- From WordPress Media Library
- Enter file URL

In this PR I implemented the bottom sheet, and currently, only the addition of a file URL is working, the other two options will be added in other PRs.

## Changes
- Added a new image from gridicon, representing the WordPress icon + tests.
- Implemented the new `DownloadableFileBottomSheetListSelectorCommand` for selecting a form action for adding a new Donwnloadable File. + Tests
- Implemented `DownloadableFileFormBottomSheetAction`, representing the actions in the downloadable file form bottom sheet.
- `ProductDownloadListViewController`: moved `NSLocalizedString`s strings under the `Localization` enum, and implemented the opening of the bottom sheet when pressing the add button.
- Updated `ProductDownloadListViewModel` for returning all the bottom sheet actions + tests.

## Testing
1. Navigate to a product with Downloadable Files (or enable them from product settings).
2. Tap Downloadable Files row.
3. Press the button "Add File`
4. The bottom sheet should appear.
5. Tap the option "Enter file URL". -> The Add Downloadable File detail should be opened.

## Screenshots
| Dark mode OFF             |  Dark mode ON |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-21 at 18 12 11](https://user-images.githubusercontent.com/495617/96747768-fd5c3e80-13c8-11eb-9606-30440d075243.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-21 at 18 12 25](https://user-images.githubusercontent.com/495617/96747772-ff260200-13c8-11eb-9b77-30bfe1cd9c88.png)




Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
