### PR TITLE
Add/Edit Product > Price: sale date enhancements

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 - [*] fix: the footer in app Settings is now correctly centered.
 - [*] fix: Products tab: earlier draft products now show up in the same order as in core when sorting by "Newest to Oldest".
+- [*] enhancement: in product details > price settings, the sale date pickers can be edited inline in iOS 14 now like in iOS 13 and before. Also, the sale end date picker editing does not automatically end on changes anymore.
 
 
 5.3

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -222,8 +222,6 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     }
 
     func handleSaleEndDateChange(_ date: Date?) {
-        datePickerSaleToVisible = false
-
         if let date = date, let dateOnSaleStart = dateOnSaleStart, date < dateOnSaleStart {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -222,6 +222,9 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     }
 
     func handleSaleEndDateChange(_ date: Date?) {
+        if date == nil {
+            datePickerSaleToVisible = false
+        }
         if let date = date, let dateOnSaleStart = dateOnSaleStart, date < dateOnSaleStart {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/DatePickerTableViewCell.swift
@@ -16,10 +16,7 @@ final class DatePickerTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBottomBorder()
-    }
-
-    private func configureBottomBorder() {
-        bottomBorder.backgroundColor = .clear
+        configureDatePicker()
     }
 }
 
@@ -27,5 +24,17 @@ final class DatePickerTableViewCell: UITableViewCell {
 extension DatePickerTableViewCell {
     func getPicker() -> UIDatePicker {
         return picker
+    }
+}
+
+private extension DatePickerTableViewCell {
+    func configureBottomBorder() {
+        bottomBorder.backgroundColor = .clear
+    }
+
+    func configureDatePicker() {
+        if #available(iOS 14, *) {
+            picker.preferredDatePickerStyle = .wheels
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -718,7 +718,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         ])
     }
 
-    func test_handling_sale_end_date_does_not_hide_date_editing_rows() {
+    func test_handling_nonnil_sale_end_date_does_not_hide_date_editing_rows() {
         // Arrange
         let timezone = TimeZone(secondsFromGMT: 0)!
         let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
@@ -736,6 +736,27 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.sections, [
             Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
             Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ])
+    }
+
+    func test_handling_nil_sale_end_date_hides_date_editing_rows() {
+        // Arrange
+        let timezone = TimeZone(secondsFromGMT: 0)!
+        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let product = MockProduct().product(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
+
+        // Act
+        viewModel.didTapScheduleSaleToRow()
+        viewModel.handleSaleEndDateChange(nil)
+
+        // Assert
+        XCTAssertEqual(viewModel.sections, [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo]),
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -717,6 +717,28 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
             Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
         ])
     }
+
+    func test_handling_sale_end_date_does_not_hide_date_editing_rows() {
+        // Arrange
+        let timezone = TimeZone(secondsFromGMT: 0)!
+        let originalSaleStartDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-02T21:30:00")
+        let originalSaleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-09-27T21:30:00")
+        let product = MockProduct().product(dateOnSaleStart: originalSaleStartDate, dateOnSaleEnd: originalSaleEndDate)
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductPriceSettingsViewModel(product: model, timezoneForScheduleSaleDates: timezone)
+
+        // Act
+        viewModel.didTapScheduleSaleToRow()
+        let saleEndDate = DateFormatter.Defaults.dateTimeFormatter.date(from: "2020-09-20T21:30:00")!
+        viewModel.handleSaleEndDateChange(saleEndDate)
+
+        // Assert
+        XCTAssertEqual(viewModel.sections, [
+            Section(title: Strings.priceSectionTitle, rows: [.price, .salePrice]),
+            Section(title: nil, rows: [.scheduleSale, .scheduleSaleFrom, .scheduleSaleTo, .datePickerSaleTo, .removeSaleTo]),
+            Section(title: Strings.taxSectionTitle, rows: [.taxStatus, .taxClass])
+        ])
+    }
 }
 
 private extension ProductPriceSettingsViewModelTests {


### PR DESCRIPTION
Fixes #3040 

## Changes

- In `DatePickerTableViewCell`, configured the date picker to have `preferredDatePickerStyle = .wheels` in iOS 14+. I've tried using the new iOS 14 picker style [`preferredDatePickerStyle = .inline`](https://developer.apple.com/documentation/uikit/uidatepickerstyle/inline), but I couldn't get the height to work properly. With the current date picker cell height 216px (I also tested 250px), the top part of the iOS 14 style picker is truncated (weekday labels and year/month selector).
  - I also tried setting the cell height to automatic and setting the `UIDatePicker` to have `contentCompressionResistancePriority` as `required` vertically, but this didn't work either. Feel free to share any other ideas to show the new iOS 14 date picker inline!
- During testing, I also noticed that the sale end date editing is automatically ended whenever I changed just the year/month/day once. It felt weird since I might want to change other date fields. I made an update to fix this in `ProductPriceSettingsViewModel` with two test cases

## Testing

- Launch the app in iOS 14 simulator/device from Xcode 12
- Go to the products tab
- Tap on a product whose price is editable
- Tap on the price row
- Turn on "Schedule sale" toggle
- Tap on either "From" or "To" row --> the date picker should behave like in iOS 13
- Change the sale date to a different date --> the date picker should stay editable on any year/month/day changes
- Tap on "Remove end date" row --> the "Remove end date" row and date picker row should disappear and the sale end date is reset

## Example screenshots

iOS version | before | after
-- | -- | --
iOS 14.0 | ![Simulator Screen Shot - iPhone 11 - 2020-10-22 at 17 06 24](https://user-images.githubusercontent.com/1945542/96850066-f85ec400-1488-11eb-996d-fbdd764d0a5b.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-22 at 16 41 56](https://user-images.githubusercontent.com/1945542/96850052-f563d380-1488-11eb-8967-60d357009706.png)
iOS 13.1 | ![Simulator Screen Shot - iPhone 11 - 2020-10-22 at 17 09 09](https://user-images.githubusercontent.com/1945542/96850762-c6019680-1489-11eb-8aa2-baa00d234e82.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-22 at 17 10 09](https://user-images.githubusercontent.com/1945542/96850773-c7cb5a00-1489-11eb-8580-61b5d3f46f9d.png)

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
