### PR TITLE
[Issue Refunds] Create shipping refunds

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -21,6 +21,10 @@ struct RefundCreationUseCase {
     ///
     let items: [RefundableOrderItem]
 
+    /// Shipping line to be refunded, `nil` if shipping will not be refunded.
+    ///
+    let shippingLine: ShippingLine?
+
     /// Currency formatted needed for decimal calculations
     ///
     let currencyFormatter: CurrencyFormatter
@@ -40,10 +44,10 @@ struct RefundCreationUseCase {
                       items: createRefundItems())
     }
 
-    /// Retuns an array of `OrderItemRefund` based on the provided refundable items
+    /// Retuns an array of `OrderItemRefund` based on the provided refundable items and shipping line
     ///
     private func createRefundItems() -> [OrderItemRefund] {
-        items.map { refundable -> OrderItemRefund in
+        var refundItems = items.map { refundable -> OrderItemRefund in
             OrderItemRefund(itemID: refundable.item.itemID,
                             name: "",
                             productID: .min,
@@ -58,6 +62,30 @@ struct RefundCreationUseCase {
                             total: calculateTotal(of: refundable),
                             totalTax: "")
         }
+
+        if let shippingLine = shippingLine {
+            refundItems.append(createShippingItem(from: shippingLine))
+        }
+
+        return refundItems
+    }
+
+    /// Returns an `OrderItemRefund` based on the provided `ShippingLine`
+    ///
+    private func createShippingItem(from shippingLine: ShippingLine) -> OrderItemRefund {
+        OrderItemRefund(itemID: shippingLine.shippingID,
+                        name: "",
+                        productID: .min,
+                        variationID: .min,
+                        quantity: .zero,
+                        price: .zero,
+                        sku: nil,
+                        subtotal: "",
+                        subtotalTax: "",
+                        taxClass: "",
+                        taxes: createTaxes(from: shippingLine),
+                        total: shippingLine.total,
+                        totalTax: "")
     }
 
     /// Creates an array of `OrderItemTaxRefund` from the tax lines in the provided `RefundableOrderItem`
@@ -69,6 +97,16 @@ struct RefundCreationUseCase {
                                total: calculateTax(of: taxLine, purchasedQuantity: refundable.item.quantity, refundQuantity: refundable.decimalQuantity))
         }
     }
+
+    /// Creates an array of `OrderItemTaxRefund` from the tax lines in the provided `ShippingLine`
+    ///
+    private func createTaxes(from shippingLine: ShippingLine) -> [OrderItemTaxRefund] {
+        shippingLine.taxes.map { taxLine -> OrderItemTaxRefund in
+            OrderItemTaxRefund(taxID: taxLine.taxID, subtotal: "", total: taxLine.total)
+        }
+    }
+
+
 
     /// Calculates the refundable tax from a tax line by diving its total tax value by the purchased quantity and mutiplying it by the refunded quantity.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -44,7 +44,7 @@ struct RefundCreationUseCase {
                       items: createRefundItems())
     }
 
-    /// Retuns an array of `OrderItemRefund` based on the provided refundable items and shipping line
+    /// Returns an array of `OrderItemRefund` based on the provided refundable items and shipping line
     ///
     private func createRefundItems() -> [OrderItemRefund] {
         var refundItems = items.map { refundable -> OrderItemRefund in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundCreationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundCreationUseCaseTests.swift
@@ -17,6 +17,7 @@ final class RefundCreationUseCaseTests: XCTestCase {
                                             reason: "Test Reason",
                                             automaticallyRefundsPayment: true,
                                             items: [],
+                                            shippingLine: nil,
                                             currencyFormatter: formatter)
 
         // When
@@ -38,6 +39,7 @@ final class RefundCreationUseCaseTests: XCTestCase {
                                             reason: nil,
                                             automaticallyRefundsPayment: false,
                                             items: items,
+                                            shippingLine: nil,
                                             currencyFormatter: formatter)
 
         // When
@@ -71,6 +73,7 @@ final class RefundCreationUseCaseTests: XCTestCase {
                                             reason: nil,
                                             automaticallyRefundsPayment: false,
                                             items: items,
+                                            shippingLine: nil,
                                             currencyFormatter: formatter)
 
         // When
@@ -85,5 +88,73 @@ final class RefundCreationUseCaseTests: XCTestCase {
         XCTAssertEqual(refund.items[0].taxes[0].total, "0.40")
         XCTAssertEqual(refund.items[0].taxes[1].taxID, 12)
         XCTAssertEqual(refund.items[0].taxes[1].total, "2.20")
+    }
+
+    func test_refund_shipping_values_with_no_items_are_transformed_correctly() {
+        // Given
+        let shippingTaxes = ShippingLineTax(taxID: 2, subtotal: "", total: "0.99")
+        let shippingLine = ShippingLine(shippingID: 5, methodTitle: "", methodID: "", total: "7.00", totalTax: "0.99", taxes: [shippingTaxes])
+        let useCase = RefundCreationUseCase(amount: "7.99",
+                                            reason: nil,
+                                            automaticallyRefundsPayment: false,
+                                            items: [],
+                                            shippingLine: shippingLine,
+                                            currencyFormatter: formatter)
+
+        // When
+        let refund = useCase.createRefund()
+
+        // Then
+        XCTAssertEqual(refund.items.count, 1)
+
+        // Shipping Line
+        XCTAssertEqual(refund.items[0].itemID, 5)
+        XCTAssertEqual(refund.items[0].quantity, 0)
+        XCTAssertEqual(refund.items[0].total, "7.00")
+
+        // Shipping Line taxes
+        XCTAssertEqual(refund.items[0].taxes[0].taxID, 2)
+        XCTAssertEqual(refund.items[0].taxes[0].total, "0.99")
+    }
+
+    func test_refund_shipping_values_with_order_items_are_transformed_correctly() {
+        // Given
+        let items: [RefundableOrderItem] = [
+            .init(item: MockOrderItem.sampleItem(itemID: 1, quantity: 2, price: 5.1, totalTax: "0.0"), quantity: 1),
+            .init(item: MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 6.3, totalTax: "0.0"), quantity: 2)
+        ]
+        let shippingTaxes = ShippingLineTax(taxID: 2, subtotal: "", total: "0.99")
+        let shippingLine = ShippingLine(shippingID: 5, methodTitle: "", methodID: "", total: "7.00", totalTax: "0.99", taxes: [shippingTaxes])
+        let useCase = RefundCreationUseCase(amount: "7.99",
+                                            reason: nil,
+                                            automaticallyRefundsPayment: false,
+                                            items: items,
+                                            shippingLine: shippingLine,
+                                            currencyFormatter: formatter)
+
+        // When
+        let refund = useCase.createRefund()
+
+        // Then
+        XCTAssertEqual(refund.items.count, items.count + 1) // 1 from the shipping line
+
+        // Fist Item
+        XCTAssertEqual(refund.items[0].itemID, 1)
+        XCTAssertEqual(refund.items[0].quantity, 1)
+        XCTAssertEqual(refund.items[0].total, "5.10")
+        XCTAssertEqual(refund.items[0].taxes, [])
+
+        // Second Item
+        XCTAssertEqual(refund.items[1].itemID, 2)
+        XCTAssertEqual(refund.items[1].quantity, 2)
+        XCTAssertEqual(refund.items[1].total, "12.60")
+        XCTAssertEqual(refund.items[0].taxes, [])
+
+        // Shipping Line
+        XCTAssertEqual(refund.items[2].itemID, 5)
+        XCTAssertEqual(refund.items[2].quantity, 0)
+        XCTAssertEqual(refund.items[2].total, "7.00")
+        XCTAssertEqual(refund.items[2].taxes[0].taxID, 2)
+        XCTAssertEqual(refund.items[2].taxes[0].total, "0.99")
     }
 }


### PR DESCRIPTION
closes #2843 

# Why

This PR updates the `RefundCreationUseCase` to be able to create a refund object that will refund a shipping line remotely.

# How 

- Added `shippingLine` property on `RefundCreationUseCase` that will create a specific `OrderItemRefund` for refunding shipping values.

# Testing Steps

This code is not yet integrated into the app, but you can try it in the following way.

1. Replace the code in `createRefundConfirmationViewModel` method on `IssueRefundViewModel` line 77 with
```swift
func createRefundConfirmationViewModel() -> RefundConfirmationViewModel {
        let items = state.refundQuantityStore.map { RefundableOrderItem(item: $0, quantity: Decimal($1)) }
        let shippingLine = state.shouldRefundShipping ? state.order.shippingLines.first : nil
        let useCase = RefundCreationUseCase(amount: "\(calculateRefundTotal())",
                                            reason: "iOS Shipping refund",
                                            automaticallyRefundsPayment: false,
                                            items: items,
                                            shippingLine: shippingLine,
                                            currencyFormatter: CurrencyFormatter(currencySettings: state.currencySettings))
        let refund = useCase.createRefund()

        let action = RefundAction.createRefund(siteID: state.order.siteID,
                                               orderID: state.order.orderID,
                                               refund: refund) { _, error  in
            if let error = error {
                print("Error: \(error)")
            }
        }
        ServiceLocator.stores.dispatch(action)

        return RefundConfirmationViewModel(order: state.order, currencySettings: state.currencySettings)
    }
```
This will fire a create refund action after tapping the next button on the issue refund screen.

2. Go to an un-refunded order that has shipping

3. Toggle the refund shipping switch. You can select some order items too.

4. Tap Next

5. Go to the sore admin and see that shipping was refunded correctly.

<img width="1247" alt="refund" src="https://user-images.githubusercontent.com/562080/96904039-35609180-145c-11eb-8b26-c4433100bc10.png">


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
