### PR TITLE
[Refunds] Update deleted refunds on web

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -387,6 +387,13 @@ public extension StorageType {
 
     // MARK: - Refunds
 
+    /// Retrieves all of the stored Refunds entities for the provided siteID and orderID.
+    ///
+    func loadRefunds(siteID: Int64, orderID: Int64) -> [Refund] {
+        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
+        return allObjects(ofType: Refund.self, matching: predicate, sortedBy: nil)
+    }
+
     /// Retrieves a stored Refund for the provided siteID, orderID, and refundID.
     ///
     func loadRefund(siteID: Int64, orderID: Int64, refundID: Int64) -> Refund? {

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -391,7 +391,8 @@ public extension StorageType {
     ///
     func loadRefunds(siteID: Int64, orderID: Int64) -> [Refund] {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)
-        return allObjects(ofType: Refund.self, matching: predicate, sortedBy: nil)
+        let descriptor = NSSortDescriptor(keyPath: \Refund.dateCreated, ascending: false)
+        return allObjects(ofType: Refund.self, matching: predicate, sortedBy: [descriptor])
     }
 
     /// Retrieves a stored Refund for the provided siteID, orderID, and refundID.

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -387,7 +387,7 @@ public extension StorageType {
 
     // MARK: - Refunds
 
-    /// Retrieves all of the stored Refunds entities for the provided siteID and orderID.
+    /// Retrieves all of the stored Refund entities for the provided siteID and orderID.
     ///
     func loadRefunds(siteID: Int64, orderID: Int64) -> [Refund] {
         let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld", siteID, orderID)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -332,7 +332,7 @@ extension OrderDetailsViewModel {
 
     func syncRefunds(onCompletion: ((Error?) -> ())? = nil) {
         let refundIDs = order.refunds.map { $0.refundID }
-        let action = RefundAction.retrieveRefunds(siteID: order.siteID, orderID: order.orderID, refundIDs: refundIDs) { (error) in
+        let action = RefundAction.retrieveRefunds(siteID: order.siteID, orderID: order.orderID, refundIDs: refundIDs, deleteStaleRefunds: true) { (error) in
             if let error = error {
                 DDLogError("⛔️ Error synchronizing detailed Refunds: \(error)")
                 onCompletion?(error)

--- a/Yosemite/Yosemite/Actions/RefundAction.swift
+++ b/Yosemite/Yosemite/Actions/RefundAction.swift
@@ -7,7 +7,7 @@ import Networking
 public enum RefundAction: Action {
     case createRefund(siteID: Int64, orderID: Int64, refund: Refund, onCompletion: (Refund?, Error?) -> Void)
     case retrieveRefund(siteID: Int64, orderID: Int64, refundID: Int64, onCompletion: (Refund?, Error?) -> Void)
-    case retrieveRefunds(siteID: Int64, orderID: Int64, refundIDs: [Int64], onCompletion: (Error?) -> Void)
+    case retrieveRefunds(siteID: Int64, orderID: Int64, refundIDs: [Int64], deleteStaleRefunds: Bool, onCompletion: (Error?) -> Void)
     case synchronizeRefunds(siteID: Int64, orderID: Int64, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
     case resetStoredRefunds(onCompletion: () -> Void)
 }

--- a/Yosemite/Yosemite/Stores/RefundStore.swift
+++ b/Yosemite/Yosemite/Stores/RefundStore.swift
@@ -36,8 +36,8 @@ public class RefundStore: Store {
             createRefund(siteID: siteID, orderID: orderID, refund: refund, onCompletion: onCompletion)
         case .retrieveRefund(let siteID, let orderID, let refundID, let onCompletion):
             retrieveRefund(siteID: siteID, orderID: orderID, refundID: refundID, onCompletion: onCompletion)
-        case .retrieveRefunds(let siteID, let orderID, let refundIDs, let onCompletion):
-            retrieveRefunds(siteID: siteID, orderID: orderID, refundIDs: refundIDs, onCompletion: onCompletion)
+        case .retrieveRefunds(let siteID, let orderID, let refundIDs, let deleteStaleRefunds, let onCompletion):
+            retrieveRefunds(siteID: siteID, orderID: orderID, refundIDs: refundIDs, deleteStaleRefunds: deleteStaleRefunds, onCompletion: onCompletion)
         case .synchronizeRefunds(let siteID, let orderID, let pageNumber, let pageSize, let onCompletion):
             synchronizeRefunds(siteID: siteID, orderID: orderID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case .resetStoredRefunds(let onCompletion):
@@ -86,14 +86,16 @@ private extension RefundStore {
 
     /// Retrieves all Refunds by an orderID.
     ///
-    func retrieveRefunds(siteID: Int64, orderID: Int64, refundIDs: [Int64], onCompletion: @escaping (Error?) -> Void) {
+    func retrieveRefunds(siteID: Int64, orderID: Int64, refundIDs: [Int64], deleteStaleRefunds: Bool, onCompletion: @escaping (Error?) -> Void) {
         remote.loadRefunds(for: siteID, by: orderID, with: refundIDs) { [weak self] (refunds, error) in
             guard let refunds = refunds else {
                 onCompletion(error)
                 return
             }
 
-            self?.removeStaleRefunds(siteID: siteID, orderID: orderID, newRefundIDs: refundIDs)
+            if deleteStaleRefunds {
+                self?.removeStaleRefunds(siteID: siteID, orderID: orderID, newRefundIDs: refundIDs)
+            }
             self?.upsertStoredRefundsInBackground(readOnlyRefunds: refunds) {
                 onCompletion(nil)
             }

--- a/Yosemite/Yosemite/Stores/RefundStore.swift
+++ b/Yosemite/Yosemite/Stores/RefundStore.swift
@@ -94,7 +94,7 @@ private extension RefundStore {
             }
 
             if deleteStaleRefunds {
-                self?.removeStaleRefunds(siteID: siteID, orderID: orderID, newRefundIDs: refundIDs)
+                self?.deleteStaleRefunds(siteID: siteID, orderID: orderID, newRefundIDs: refundIDs)
             }
             self?.upsertStoredRefundsInBackground(readOnlyRefunds: refunds) {
                 onCompletion(nil)
@@ -235,9 +235,9 @@ private extension RefundStore {
         }
     }
 
-    /// Remove all refunds from an order that whom IDs are not contained in the provided `newRefundIDs`array
+    /// Deletes all refunds from an order when their IDs are not contained in the provided `newRefundIDs`array.
     ///
-    private func removeStaleRefunds(siteID: Int64, orderID: Int64, newRefundIDs: [Int64]) {
+    private func deleteStaleRefunds(siteID: Int64, orderID: Int64, newRefundIDs: [Int64]) {
         let storage = storageManager.viewStorage
         let previousRefunds = storage.loadRefunds(siteID: siteID, orderID: orderID)
         let staleRefunds = previousRefunds.filter { !newRefundIDs.contains($0.refundID) }

--- a/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
@@ -417,6 +417,30 @@ class RefundStoreTests: XCTestCase {
 
         wait(for: [backgroundSaveExpectation], timeout: Constants.expectationTimeout)
     }
+
+    func test_stale_refunds_are_deleted_when_retrieving_new_refunds() {
+        // Given
+        let refundStore = RefundStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        refundStore.upsertStoredRefund(readOnlyRefund: self.sampleRefund(refundID: 999), in: self.viewStorage)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Refund.self), 1)
+
+        network.simulateResponse(requestUrlSuffix: "refunds", filename: "refunds-all")
+
+        // When
+        var retrieveError: Error?
+        waitForExpectation { exp in
+            let action = RefundAction.retrieveRefunds(siteID: sampleSiteID, orderID: sampleOrderID, refundIDs: [sampleRefundID, refundID]) { error in
+                retrieveError = error
+                exp.fulfill()
+            }
+            refundStore.onAction(action)
+        }
+
+        // Then
+        let storedRefunds = viewStorage.loadRefunds(siteID: sampleSiteID, orderID: sampleOrderID).map { $0.toReadOnly() }
+        XCTAssertEqual(storedRefunds, [sampleRefund(), sampleRefund2()])
+        XCTAssertNil(retrieveError)
+    }
 }
 
 
@@ -426,10 +450,10 @@ private extension RefundStoreTests {
 
     /// Generate a sample Refund
     ///
-    func sampleRefund(_ siteID: Int64? = nil) -> Networking.Refund {
+    func sampleRefund(_ siteID: Int64? = nil, refundID: Int64? = nil) -> Networking.Refund {
         let testSiteID = siteID ?? sampleSiteID
         let testDate = date(with: "2019-10-09T16:18:23")
-        return Refund(refundID: sampleRefundID,
+        return Refund(refundID: refundID ?? sampleRefundID,
                       orderID: sampleOrderID,
                       siteID: testSiteID,
                       dateCreated: testDate,

--- a/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/RefundStoreTests.swift
@@ -418,7 +418,7 @@ class RefundStoreTests: XCTestCase {
         wait(for: [backgroundSaveExpectation], timeout: Constants.expectationTimeout)
     }
 
-    func test_stale_refunds_are_deleted_when_retrieving_new_refundswith_deleteStaleRefunds_flag() {
+    func test_stale_refunds_are_deleted_when_retrieving_new_refunds_with_deleteStaleRefunds_flag() {
         // Given
         let refundStore = RefundStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         refundStore.upsertStoredRefund(readOnlyRefund: sampleRefund(refundID: 999), in: viewStorage)


### PR DESCRIPTION
fix https://github.com/woocommerce/woocommerce-ios/issues/3052

# Why

While testing the refunds creation feature I noticed that deleting a refund on web does not properly reflect in the app.
The issue happens because the app is only upserting new refunds as they come from web but does not handle the scenario of cleaning refunds deleted on web.

# How

To fix that I've added a method on `RefundStore` that deletes stale(web removed) refunds when indicated on `RefundAction.retrieveRefunds - deleteSlateRefunds flag` 

# Screenshots
**WEB**
<img width="1235" alt="core" src="https://user-images.githubusercontent.com/562080/96937493-e2073700-148d-11eb-9b51-618e26a5d648.png">


Before | After
---- | ----
<img width="393" alt="before" src="https://user-images.githubusercontent.com/562080/96937525-f3e8da00-148d-11eb-9d42-b523141d4f35.png"> | <img width="386" alt="after" src="https://user-images.githubusercontent.com/562080/96937530-f64b3400-148d-11eb-8a64-1ce73070bde5.png">



# Testing Steps
- Navigate to a refunded order
- Tap on refunded items and see items being refunded
- On web, go to that order and delete one or more refunds
- On the app, refresh the order detail and see that the previous refund disappears.


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
