### PR TITLE
Fix: added Core Data model 32 and 33 inside the test for loading the expected model version

### DIFF
--- a/Storage/StorageTests/CoreData/ManagedObjectModelsInventoryTests.swift
+++ b/Storage/StorageTests/CoreData/ManagedObjectModelsInventoryTests.swift
@@ -59,7 +59,8 @@ final class ManagedObjectModelsInventoryTests: XCTestCase {
             "Model 28",
             "Model 29",
             "Model 30",
-            "Model 31"
+            "Model 31",
+            "Model 32"
         ]
 
         // When

--- a/Storage/StorageTests/CoreData/ManagedObjectModelsInventoryTests.swift
+++ b/Storage/StorageTests/CoreData/ManagedObjectModelsInventoryTests.swift
@@ -60,7 +60,8 @@ final class ManagedObjectModelsInventoryTests: XCTestCase {
             "Model 29",
             "Model 30",
             "Model 31",
-            "Model 32"
+            "Model 32",
+            "Model 33"
         ]
 
         // When


### PR DESCRIPTION
Super minor fix: the method `test_it_can_load_the_expected_model_versions` was not considering the last Core Data models, n°32 and n°33.

## Testing
- Just CI

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
