### PR TITLE
GridIcon crash fix attempt

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -51,10 +51,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // As first thing, setup the crash logging
         setupCrashLogging()
 
-        // Setup the Interface!
-        setupMainWindow()
-        setupComponentsAppearance()
-
         // Setup Components
         setupAnalytics()
         setupAuthenticationManager()
@@ -70,9 +66,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             appleIDCredentialChecker.observeLoggedInStateForAppleIDObservations()
         }
 
-        // Start app navigation.
-        appCoordinator?.start()
-
         // Components that require prior Auth
         setupZendesk()
 
@@ -86,6 +79,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        // Setup the Interface!
+        setupMainWindow()
+        setupComponentsAppearance()
+
+        // Start app navigation.
+        appCoordinator?.start()
+
         return true
     }
 


### PR DESCRIPTION
Report: https://github.com/woocommerce/woocommerce-ios/issues/2454

# Why

There seems to be a `GridIcon` crash while trying to load the `statsAlt` image. After looking at it I wasn't able to reproduce the crash or to come with a concrete reason on why this is crashing.

Analyzing the crash logs, the crash seems to happen while the app state is `inactive` and the icon that crashes is the icon on the first tab that is loaded when the app launches.

After backtracking how and when that icon is loaded I noticed that it is loaded from the `willFinishLaunchingWithOptions` in the `AppDelegate`.

My only guess is that for some reason, and on some devices, the grid icon bundle is not yet loaded when we tried to load the `statsAlt` image for setting the icon on the first tab.

# How

In this PR I'm taking a wild guess on moving our setup UI code to `didFinishLaunchingWithOptions` to try and "guarantee" that the `GridIcon` bundle exists at the moment of the VC creation.

# Testing Steps
- Smoke test the app when launching it from a closed state

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
