### PR TITLE
[Issue Refund] Handle free shipping

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -199,6 +199,13 @@ extension IssueRefundViewModel {
             return nil
         }
 
+        // If there is no amount to refund (EG: free shipping), hide the refund shipping section
+        let formatter = CurrencyFormatter(currencySettings: state.currencySettings)
+        let shippingValues = RefundShippingCalculationUseCase(shippingLine: shippingLine, currencyFormatter: formatter)
+        guard shippingValues.calculateRefundValue() > 0 else {
+            return nil
+        }
+
         // If `shouldRefundShipping` is disabled, return only the `switchRow`
         let switchRow = ShippingSwitchViewModel(title: Localization.refundShippingTitle, isOn: state.shouldRefundShipping)
         guard state.shouldRefundShipping else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -24,6 +24,24 @@ final class IssueRefundViewModelTests: XCTestCase {
         }
     }
 
+    func test_viewModel_does_not_have_shipping_section_on_order_with_free_shipping() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let shippingLines = MockOrders.sampleShippingLines(cost: "0.0", tax: "0.0")
+        let order = MockOrders().makeOrder(shippingLines: shippingLines)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        let rows = viewModel.sections.flatMap { $0.rows }
+        XCTAssertFalse(rows.isEmpty)
+        rows.forEach { viewModel in
+            XCTAssertFalse(viewModel is IssueRefundViewModel.ShippingSwitchViewModel)
+            XCTAssertFalse(viewModel is RefundShippingDetailsViewModel)
+        }
+    }
+
     func test_viewModel_does_have_shipping_section_on_order_with_shipping() throws {
         // Given
         let currencySettings = CurrencySettings()


### PR DESCRIPTION
fixes #3058

# Why

While reviewing #3048, @jaclync noticed that enabling the "refund shipping" switch for free shipping orders made not much sense so this PR takes care of hiding that section for that scenario

# How

Use `RefundShippingCalculationUseCase` to know if there is no amount to refund before returning the "refund shipping" section

# Gif
![free-shipping-demo](https://user-images.githubusercontent.com/562080/97224667-78de3700-179f-11eb-9f87-4254e78a3532.gif)

# Testing Steps

- Navigate to an order with free shipping
- Tap on issue refund button
- Corroborate that the "refund shipping" section is not visible 

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
