### PR TITLE
Fix placeholders in dashboard charts and orders tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 - [*] fix: the footer in app Settings is now correctly centered.
 - [*] fix: Products tab: earlier draft products now show up in the same order as in core when sorting by "Newest to Oldest".
 - [*] enhancement: in product details > price settings, the sale date pickers can be edited inline in iOS 14 now like in iOS 13 and before. Also, the sale end date picker editing does not automatically end on changes anymore.
+- [*] fix: the placeholder views in the top dashboard chart and orders tab do not have unexpected white background color in Dark mode in iOS 14 anymore.
 
 
  

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 - [*] fix: the footer in app Settings is now correctly centered.
 - [*] fix: Products tab: earlier draft products now show up in the same order as in core when sorting by "Newest to Oldest".
 - [*] enhancement: in product details > price settings, the sale date pickers can be edited inline in iOS 14 now like in iOS 13 and before. Also, the sale end date picker editing does not automatically end on changes anymore.
-- [*] fix: the placeholder views in the top dashboard chart and orders tab do not have unexpected white background color in Dark mode in iOS 14 anymore.
+- [*] fix: the placeholder views in the top dashboard chart and orders tab do not have unexpected white background color in Dark mode in iOS 14 anymore. [https://github.com/woocommerce/woocommerce-ios/pull/3063]
 
 
  

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartPlaceholderView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartPlaceholderView.swift
@@ -31,6 +31,7 @@ private extension ChartPlaceholderView {
     ///
     func setupView() {
         backgroundColor = .listForeground
+        topStackView.backgroundColor = .listForeground
     }
 
     /// Applies Rounded Style to the upper views.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -47,7 +47,7 @@ final class OrderListViewController: UIViewController {
 
     /// Ghostable TableView.
     ///
-    private(set) var ghostableTableView = UITableView()
+    private(set) var ghostableTableView = UITableView(frame: .zero, style: .grouped)
 
     /// Pull To Refresh Support.
     ///
@@ -356,7 +356,9 @@ private extension OrderListViewController {
     /// Renders the Placeholder Orders
     ///
     func displayPlaceholderOrders() {
-        let options = GhostOptions(reuseIdentifier: OrderTableViewCell.reuseIdentifier, rowsPerSection: Settings.placeholderRowsPerSection)
+        let options = GhostOptions(displaysSectionHeader: false,
+                                   reuseIdentifier: OrderTableViewCell.reuseIdentifier,
+                                   rowsPerSection: Settings.placeholderRowsPerSection)
 
         // If the ghostable table view gets stuck for any reason,
         // let's reset the state before using it again


### PR DESCRIPTION
Fixes #2801 
Fixes #3043 

These dark mode color / placeholder bugs have been bugging me for a while (felt like broken windows)!

## Changes

I'm guessing the default background color in some views got changed in iOS 14, so that it shows white background color in some placeholder views in dark mode only in iOS 14 (both iOS 14.0 and 14.1).

- Fixed the white background color in chart placeholder view (`ChartPlaceholderView`) by setting the top stack view's background color explicitly.
- In `OrderListViewController`, updated its ghostable table view from the default `plain` style to `grouped` to remove empty cells (#2801) and then disabled section header now that it's a grouped table view with padding at the top.

## Testing

The best way to see placeholder state without manual code changes is to switch to another store. I also tested in iOS 13.1 simulator in both light and dark mode.

- Launch the app in **iOS 14** sim/device and **dark mode**
- Switch to another store --> the chart placeholder view should look good (no unexpected white background color)
- Go to the orders tab --> the placeholder table view should look good (no empty cells below and no unexpected white background color above the placeholder cells)

## Example screenshots

before | after
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 17 05 10](https://user-images.githubusercontent.com/1945542/97281171-26bd1480-1878-11eb-8727-27f070d33175.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 16 37 23](https://user-images.githubusercontent.com/1945542/97281165-24f35100-1878-11eb-8cc7-68f57e5ccc05.png)
![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 17 05 12](https://user-images.githubusercontent.com/1945542/97281350-5bc96700-1878-11eb-9f13-a3220ef47683.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 16 56 37](https://user-images.githubusercontent.com/1945542/97281339-58ce7680-1878-11eb-9ecb-84f742b24dc9.png)

Light mode screenshots

dashboard tab | orders tab
-- | --
![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 16 37 59](https://user-images.githubusercontent.com/1945542/97281445-7ef41680-1878-11eb-8ebf-f75eb36384c4.png) | ![Simulator Screen Shot - iPhone 11 - 2020-10-27 at 16 57 00](https://user-images.githubusercontent.com/1945542/97281459-81ef0700-1878-11eb-8598-1881e76a8333.png)


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
