### PR TITLE
Fix: wrong cell appearance in Downloadable Files when the title is long

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,20 +20,23 @@
                     <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="I1O-4G-30m">
                         <rect key="frame" x="16" y="10" width="288" height="24"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="htD-vN-CNs">
-                                <rect key="frame" x="0.0" y="0.0" width="246" height="24"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="htD-vN-CNs">
+                                <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="htD-vN-CNs" secondAttribute="height" multiplier="1:1" id="4FY-Di-29I"/>
+                                </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="HHf-VV-Yya">
-                                <rect key="frame" x="246" y="0.0" width="42" height="24"/>
+                                <rect key="frame" x="24" y="0.0" width="264" height="24"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6WI-8Q-5Qr" userLabel="Title label">
-                                        <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="748" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afj-1k-DXC" userLabel="Text label">
-                                        <rect key="frame" x="0.0" y="20.5" width="42" height="3.5"/>
+                                        <rect key="frame" x="0.0" y="20.5" width="264" height="3.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>


### PR DESCRIPTION
Fixes #3056 

In this PR I fixed an issue related to the constraints of `ImageAndTitleAndTextTableViewCell`, where the image disappears or will be compressed when the title inside the cell is too long.

## Testing
1. Open a product with downloadable files.
2. Add a downloadable file with a long title.
3. Make sure that in the downloadable files list the cell appearance is correct.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screen Shot - iPhone 11 Pro - 2020-10-27 at 12 04 48](https://user-images.githubusercontent.com/495617/97295027-16447400-184f-11eb-970d-658df3eece6e.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-27 at 12 12 36](https://user-images.githubusercontent.com/495617/97295036-1b092800-184f-11eb-9852-205e0a5e2fb0.png)



Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
