### PR TITLE
CONTRIBUTING.md: Add information about our PR merge policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,16 @@ The core team monitors and reviews all pull requests. Depending on the changes, 
 
 We do our best to respond quickly to all pull requests. If you don't get a response from us after a week, feel free to reach out to us via Slack.
 
+Note: If you are part of the org and have the permissions on the repo, don't forget to assign yourself to the PR, and add the appropriate GitHub label and Milestone for the PR
+
+### PR merge policy
+
+* PRs require one reviewer to approve the PR before it can be merged to the base branch
+* We keep the PR git history when merging (merge via "merge commit")
+* Who merges the PR once it's approved and green?
+  * For PRs authored by people external to the organisation and not having push permissions, the reviewer who approved the PR will merge it.
+  * For PRs authored by contributors with push permissions, the author of the PR will merge their own PR.
+
 ## Getting in Touch
 
 If you have questions or just want to say hi, join the [WooCommerce Community Slack](https://woocommerce.com/community-slack/) and drop a message on the `#mobile-apps` channel.


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/15170, add a mention in our contributing guidelines about the merge policy we use for this repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
