### PR TITLE
Display "(No Title)" as Product title in the products list when a product doesn't have the title set

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 - [*] fix: the footer in app Settings is now correctly centered.
 - [*] fix: Products tab: earlier draft products now show up in the same order as in core when sorting by "Newest to Oldest".
 - [*] enhancement: in product details > price settings, the sale date pickers can be edited inline in iOS 14 now like in iOS 13 and before. Also, the sale end date picker editing does not automatically end on changes anymore.
-
+- [*] enhancement: in products list, the "(No Title)" placeholder will be showed when a product doesn't have the title set. [https://github.com/woocommerce/woocommerce-ios/pull/3068]
 
  
 5.3

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -27,7 +27,7 @@ struct ProductsTabProductViewModel {
 
     init(product: Product, isSelected: Bool = false, imageService: ImageService = ServiceLocator.imageService) {
         imageUrl = product.images.first?.src
-        name = product.name
+        name = product.name.isEmpty ? Localization.noTitle : product.name
         self.isSelected = isSelected
         detailsAttributedString = EditableProductModel(product: product).createDetailsAttributedString()
 
@@ -75,5 +75,11 @@ private extension EditableProductModel {
         let pluralFormat = NSLocalizedString("%ld variants", comment: "Label about number of variations shown on Products tab")
         let format = String.pluralize(numberOfVariations, singular: singularFormat, plural: pluralFormat)
         return String.localizedStringWithFormat(format, numberOfVariations)
+    }
+}
+
+private extension ProductsTabProductViewModel {
+    enum Localization {
+        static let noTitle = NSLocalizedString("(No Title)", comment: "Product title in Products list when there is no title")
     }
 }


### PR DESCRIPTION
Fixes #3049 

As discussed here p5T066-1zC#comment-6119, we should display `(No Title)` when a product in the Product List doesn't have the title set.

## Testing
1. Open the product list
2. Make sure that a product without the title in the list shows `(No Title)` 

<img src="https://user-images.githubusercontent.com/495617/97326394-3fc3c680-1874-11eb-9ab9-43eaa1779e0c.png" width=300 />


Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
