### PR TITLE
Fix StorateType_loadOrderItemTax method

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -52,7 +52,7 @@ public extension StorageType {
     /// Retrieves the Stored Order Item Tax.
     ///
     func loadOrderItemTax(itemID: Int64, taxID: Int64) -> OrderItemTax? {
-        let predicate = NSPredicate(format: "item.itemID = %ld AND taxID = %ld", taxID)
+        let predicate = NSPredicate(format: "item.itemID = %ld AND taxID = %ld", itemID, taxID)
         return firstObject(ofType: OrderItemTax.self, matching: predicate)
     }
 

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -85,7 +85,7 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
             Networking.OrderItemTax(taxID: 2, subtotal: "", total: "0.2"),
             Networking.OrderItemTax(taxID: 3, subtotal: "", total: "0.6")
         ]
-        let item = sampleOrderItem(itemID: 22, taxes: taxes)
+        let item = makeOrderItem(itemID: 22, taxes: taxes)
         let order = makeOrder().copy(orderID: 98).copy(items: [item])
         let useCase = OrdersUpsertUseCase(storage: viewStorage)
 
@@ -124,7 +124,7 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
 
 private extension OrdersUpsertUseCaseTests {
 
-    func sampleOrderItem(itemID: Int64, taxes: [Networking.OrderItemTax]) -> Networking.OrderItem {
+    func makeOrderItem(itemID: Int64, taxes: [Networking.OrderItemTax]) -> Networking.OrderItem {
         OrderItem(itemID: itemID,
                   name: "",
                   productID: 0,

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -79,6 +79,27 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         XCTAssertEqual(persistedShippingLine.toReadOnly(), shippingLine)
     }
 
+    func test_it_persists_order_item_taxes_in_storage() throws {
+        // Given
+        let taxes = [
+            Networking.OrderItemTax(taxID: 2, subtotal: "", total: "0.2"),
+            Networking.OrderItemTax(taxID: 3, subtotal: "", total: "0.6")
+        ]
+        let item = sampleOrderItem(itemID: 22, taxes: taxes)
+        let order = makeOrder().copy(orderID: 98).copy(items: [item])
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+
+        // When
+        useCase.upsert([order])
+
+        // Then
+        let tax1 = try XCTUnwrap(viewStorage.loadOrderItemTax(itemID: 22, taxID: 2))
+        XCTAssertEqual(tax1.toReadOnly(), taxes[0])
+
+        let tax2 = try XCTUnwrap(viewStorage.loadOrderItemTax(itemID: 22, taxID: 3))
+        XCTAssertEqual(tax2.toReadOnly(), taxes[1])
+    }
+
     func test_it_persists_shipping_line_taxes_in_storage() throws {
         // Given
         let taxes = [
@@ -102,6 +123,23 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
 }
 
 private extension OrdersUpsertUseCaseTests {
+
+    func sampleOrderItem(itemID: Int64, taxes: [Networking.OrderItemTax]) -> Networking.OrderItem {
+        OrderItem(itemID: itemID,
+                  name: "",
+                  productID: 0,
+                  variationID: 0,
+                  quantity: 0,
+                  price: 0,
+                  sku: nil,
+                  subtotal: "",
+                  subtotalTax: "",
+                  taxClass: "",
+                  taxes: taxes,
+                  total: "",
+                  totalTax: "")
+    }
+
     func makeOrder() -> Networking.Order {
         Order(siteID: defaultSiteID,
               orderID: 0,

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -360,7 +360,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(storageOrder2?.toReadOnly(), sampleOrderMutated2())
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 1)
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 5)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 4)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 0)
     }
 


### PR DESCRIPTION
closes https://github.com/woocommerce/woocommerce-ios/projects/17#card-47838232

# Why 

While working on refunds I noticed that the `loadOrderItemTax` was not properly passing the `itemID` parameter to the search predicate. This was used in `OrdersItemUpsertUseCase` to know if an `OrderItemTax` already existed, and since the method always failed to match an `OrderItemTax` the app was inserting new copies on every order synchronization.

# How
The fix is to pass the `itemID` value to the predicate

# Testing
- Make sure unit tests pass

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
