### PR TITLE
[Issue Refunds] Fix refund values format

### DIFF
--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -81,9 +81,9 @@ public class CurrencyFormatter {
     ///       Note this assumption will be wrong for India.
     ///
     func localize(_ decimalAmount: Decimal,
-                  with decimalSeparator: String? = ".",
-                  in decimalPosition: Int = 2,
-                  including thousandSeparator: String? = ",") -> String? {
+                  decimalSeparator: String? = ".",
+                  decimalPosition: Int = 2,
+                  thousandSeparator: String? = ",") -> String? {
         localize(decimalAmount as NSDecimalNumber, with: decimalSeparator, in: decimalPosition, including: thousandSeparator)
     }
 

--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -67,6 +67,7 @@ public class CurrencyFormatter {
         numberFormatter.generatesDecimalNumbers = true
         numberFormatter.minimumFractionDigits = decimalPosition
         numberFormatter.maximumFractionDigits = decimalPosition
+        numberFormatter.roundingMode = .halfUp
 
         return numberFormatter.string(from: absoluteAmount)
     }

--- a/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
+++ b/WooCommerce/Classes/Tools/Currency/CurrencyFormatter.swift
@@ -82,9 +82,9 @@ public class CurrencyFormatter {
     ///       Note this assumption will be wrong for India.
     ///
     func localize(_ decimalAmount: Decimal,
-                  decimalSeparator: String? = ".",
-                  decimalPosition: Int = 2,
-                  thousandSeparator: String? = ",") -> String? {
+                  with decimalSeparator: String? = ".",
+                  in decimalPosition: Int = 2,
+                  including thousandSeparator: String? = ",") -> String? {
         localize(decimalAmount as NSDecimalNumber, with: decimalSeparator, in: decimalPosition, including: thousandSeparator)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -114,7 +114,7 @@ struct RefundCreationUseCase {
         let totalTax = currencyFormatter.convertToDecimal(from: taxLine.total) ?? 0
         let itemTax = (totalTax as Decimal) / purchasedQuantity
         let refundableTax = itemTax * refundQuantity
-        return currencyFormatter.localize(refundableTax) ?? "\(refundableTax)"
+        return currencyFormatter.localize(refundableTax, thousandSeparator: "") ?? "\(refundableTax)"
     }
 
     /// Calculates the refundable total price from a `RefundableOrderItem` by diving the item price value by the purchased quantity
@@ -122,6 +122,6 @@ struct RefundCreationUseCase {
     ///
     private func calculateTotal(of refundable: RefundableOrderItem) -> String {
         let total = (refundable.item.price as Decimal) * refundable.decimalQuantity
-        return currencyFormatter.localize(total) ?? "\(total)"
+        return currencyFormatter.localize(total, thousandSeparator: "") ?? "\(total)"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -106,15 +106,13 @@ struct RefundCreationUseCase {
         }
     }
 
-
-
     /// Calculates the refundable tax from a tax line by diving its total tax value by the purchased quantity and mutiplying it by the refunded quantity.
     ///
     private func calculateTax(of taxLine: OrderItemTax, purchasedQuantity: Decimal, refundQuantity: Decimal) -> String {
         let totalTax = currencyFormatter.convertToDecimal(from: taxLine.total) ?? 0
         let itemTax = (totalTax as Decimal) / purchasedQuantity
         let refundableTax = itemTax * refundQuantity
-        return currencyFormatter.localize(refundableTax, thousandSeparator: "") ?? "\(refundableTax)"
+        return "\(refundableTax)"
     }
 
     /// Calculates the refundable total price from a `RefundableOrderItem` by diving the item price value by the purchased quantity
@@ -122,6 +120,6 @@ struct RefundCreationUseCase {
     ///
     private func calculateTotal(of refundable: RefundableOrderItem) -> String {
         let total = (refundable.item.price as Decimal) * refundable.decimalQuantity
-        return currencyFormatter.localize(total, thousandSeparator: "") ?? "\(total)"
+        return "\(total)"
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundCreationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundCreationUseCaseTests.swift
@@ -157,4 +157,29 @@ final class RefundCreationUseCaseTests: XCTestCase {
         XCTAssertEqual(refund.items[2].taxes[0].taxID, 2)
         XCTAssertEqual(refund.items[2].taxes[0].total, "0.99")
     }
+
+    func test_refund_shipping_values_does_not_contain_thousands_separator_when_computing_big_amounts() {
+        // Given
+        let taxes = [
+            OrderItemTax(taxID: 11, subtotal: "", total: "1130.6"),
+        ]
+        let items: [RefundableOrderItem] = [
+            .init(item: MockOrderItem.sampleItem(itemID: 1, quantity: 2, price: 1200.0, totalTax: "0.0"), quantity: 1),
+            .init(item: MockOrderItem.sampleItem(itemID: 2, quantity: 2, price: 650.7, taxes: taxes, totalTax: "1130.6"), quantity: 2)
+        ]
+        let useCase = RefundCreationUseCase(amount: "17.60",
+                                            reason: nil,
+                                            automaticallyRefundsPayment: false,
+                                            items: items,
+                                            shippingLine: nil,
+                                            currencyFormatter: formatter)
+
+        // When
+        let refund = useCase.createRefund()
+
+        // Then
+        XCTAssertEqual(refund.items[0].total, "1200.00")
+        XCTAssertEqual(refund.items[1].total, "1301.40")
+        XCTAssertEqual(refund.items[1].taxes[0].total, "1130.60")
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundCreationUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundCreationUseCaseTests.swift
@@ -53,8 +53,8 @@ final class RefundCreationUseCaseTests: XCTestCase {
         XCTAssertEqual(refund.items[0].quantity, 1)
         XCTAssertEqual(refund.items[1].quantity, 2)
 
-        XCTAssertEqual(refund.items[0].total, "5.10")
-        XCTAssertEqual(refund.items[1].total, "12.60")
+        XCTAssertEqual(refund.items[0].total, "5.1")
+        XCTAssertEqual(refund.items[1].total, "12.6")
 
         XCTAssertEqual(refund.items[0].taxes, [])
         XCTAssertEqual(refund.items[0].taxes, [])
@@ -83,11 +83,11 @@ final class RefundCreationUseCaseTests: XCTestCase {
         XCTAssertEqual(refund.items.count, items.count)
         XCTAssertEqual(refund.items[0].itemID, 1)
         XCTAssertEqual(refund.items[0].quantity, 2)
-        XCTAssertEqual(refund.items[0].total, "10.20")
+        XCTAssertEqual(refund.items[0].total, "10.2")
         XCTAssertEqual(refund.items[0].taxes[0].taxID, 11)
-        XCTAssertEqual(refund.items[0].taxes[0].total, "0.40")
+        XCTAssertEqual(refund.items[0].taxes[0].total, "0.4")
         XCTAssertEqual(refund.items[0].taxes[1].taxID, 12)
-        XCTAssertEqual(refund.items[0].taxes[1].total, "2.20")
+        XCTAssertEqual(refund.items[0].taxes[1].total, "2.2")
     }
 
     func test_refund_shipping_values_with_no_items_are_transformed_correctly() {
@@ -141,13 +141,13 @@ final class RefundCreationUseCaseTests: XCTestCase {
         // Fist Item
         XCTAssertEqual(refund.items[0].itemID, 1)
         XCTAssertEqual(refund.items[0].quantity, 1)
-        XCTAssertEqual(refund.items[0].total, "5.10")
+        XCTAssertEqual(refund.items[0].total, "5.1")
         XCTAssertEqual(refund.items[0].taxes, [])
 
         // Second Item
         XCTAssertEqual(refund.items[1].itemID, 2)
         XCTAssertEqual(refund.items[1].quantity, 2)
-        XCTAssertEqual(refund.items[1].total, "12.60")
+        XCTAssertEqual(refund.items[1].total, "12.6")
         XCTAssertEqual(refund.items[0].taxes, [])
 
         // Shipping Line
@@ -178,8 +178,8 @@ final class RefundCreationUseCaseTests: XCTestCase {
         let refund = useCase.createRefund()
 
         // Then
-        XCTAssertEqual(refund.items[0].total, "1200.00")
-        XCTAssertEqual(refund.items[1].total, "1301.40")
-        XCTAssertEqual(refund.items[1].taxes[0].total, "1130.60")
+        XCTAssertEqual(refund.items[0].total, "1200")
+        XCTAssertEqual(refund.items[1].total, "1301.4")
+        XCTAssertEqual(refund.items[1].taxes[0].total, "1130.6")
     }
 }


### PR DESCRIPTION

# Why

I noticed two "edge?" cases when refunding items:

1. Format of values that were bigger than `999` had a thousand separator that the API can't read well.
2. Some values were being rounded down after when the value had more than two decimals EG: 13.456 was 13.45

# How

To fix this I'm migrating away from `CurrencyFormatter.localize()` when creating the refund object, since we want the raw number without any thousand separations and rounding.

Also I'm adding a `round up` rule on `CurrencyFormatter.localize()` so values like `13.456` are displayed as `13.46` and not `13.45` like core does it.

# Screenshots
**Before:**
App | Web
---- | ----
<img width="386" alt="before-app" src="https://user-images.githubusercontent.com/562080/97469567-8cf77500-1914-11eb-8be8-8f6cc7e64a8c.png"> | <img width="511" alt="before-refund" src="https://user-images.githubusercontent.com/562080/97469574-8f59cf00-1914-11eb-8e61-c188ac175b47.png">

**Tax was rendered as `121.14` and value refunded was `121.14`**


**After**
App | Web
---- | ----
<img width="387" alt="Screen Shot 2020-10-28 at 9 12 53 AM" src="https://user-images.githubusercontent.com/562080/97469863-df389600-1914-11eb-932a-d54fdfbc347d.png"> | <img width="452" alt="Screen Shot 2020-10-28 at 10 32 27 AM" src="https://user-images.githubusercontent.com/562080/97469938-f1b2cf80-1914-11eb-8175-2e33cf441ec4.png">

**Tax is rendered as `121.15` and value refunded is `121.145`**
**Refunding the other item makes the refund complete**

<img width="336" alt="Screen Shot 2020-10-28 at 11 01 20 AM" src="https://user-images.githubusercontent.com/562080/97470417-7e5d8d80-1915-11eb-8dc0-67d8b998db8c.png">

# Testing steps

This code is not yet integrated into the app, but you can try it in the following way.

1. Replace the code in `createRefundConfirmationViewModel` method on `IssueRefundViewModel` line 77 with
```swift
func createRefundConfirmationViewModel() -> RefundConfirmationViewModel {
        let items = state.refundQuantityStore.map { RefundableOrderItem(item: $0, quantity: Decimal($1)) }
        let shippingLine = state.shouldRefundShipping ? state.order.shippingLines.first : nil
        let useCase = RefundCreationUseCase(amount: "\(calculateRefundTotal())",
                                            reason: "iOS Shipping refund",
                                            automaticallyRefundsPayment: false,
                                            items: items,
                                            shippingLine: shippingLine,
                                            currencyFormatter: CurrencyFormatter(currencySettings: state.currencySettings))
        let refund = useCase.createRefund()

        let action = RefundAction.createRefund(siteID: state.order.siteID,
                                               orderID: state.order.orderID,
                                               refund: refund) { _, error  in
            if let error = error {
                print("Error: \(error)")
            }
        }
        ServiceLocator.stores.dispatch(action)

        return RefundConfirmationViewModel(order: state.order, currencySettings: state.currencySettings)
    }
```
This will fire a create refund action after tapping the next button on the issue refund screen.

2. Create an order where the final tax value(tax * quantity) has an odd number.
3. Refund items until the order gets totally refunded
3. Corroborate in the website that everything makes sense!

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
