### PR TITLE
Remove `OrderItem`'s custom `Equatable` implementation

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -117,22 +117,7 @@ private extension OrderItem {
 
 // MARK: - Comparable Conformance
 //
-extension OrderItem: Comparable {
-    public static func == (lhs: OrderItem, rhs: OrderItem) -> Bool {
-        return lhs.itemID == rhs.itemID &&
-            lhs.name == rhs.name &&
-            lhs.productID == rhs.productID &&
-            lhs.variationID == rhs.variationID &&
-            lhs.quantity == rhs.quantity &&
-            lhs.price == rhs.price &&
-            lhs.sku == rhs.sku &&
-            lhs.subtotal == rhs.subtotal &&
-            lhs.subtotalTax == rhs.subtotalTax &&
-            lhs.taxClass == rhs.taxClass &&
-            lhs.total == rhs.total &&
-            lhs.totalTax == rhs.totalTax
-    }
-
+extension OrderItem: Equatable, Comparable {
     public static func < (lhs: OrderItem, rhs: OrderItem) -> Bool {
         return lhs.itemID < rhs.itemID ||
             (lhs.itemID == rhs.itemID && lhs.productID < rhs.productID) ||

--- a/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/OrderItem+ReadOnlyConvertible.swift
@@ -26,7 +26,7 @@ extension Storage.OrderItem: ReadOnlyConvertible {
     /// Returns a ReadOnly version of the receiver.
     ///
     public func toReadOnly() -> Yosemite.OrderItem {
-        let orderItemTaxes = taxes?.map { $0.toReadOnly() } ?? [Yosemite.OrderItemTax]()
+        let orderItemTaxes = taxes?.map { $0.toReadOnly() }.sorted(by: { $0.taxID < $1.taxID }) ?? [Yosemite.OrderItemTax]()
 
         return OrderItem(itemID: itemID,
                          name: name ?? "",

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -344,7 +344,7 @@ final class OrderStoreTests: XCTestCase {
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrder(), in: viewStorage)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItem.self), 2)
-        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 0)
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderItemTax.self), 2)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderCoupon.self), 1)
 
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrderMutated(), in: viewStorage)
@@ -818,7 +818,7 @@ private extension OrderStoreTests {
                               subtotal: "50.00",
                               subtotalTax: "2.00",
                               taxClass: "",
-                              taxes: [],
+                              taxes: [.init(taxID: 1, subtotal: "2", total: "1.2")],
                               total: "30.00",
                               totalTax: "1.20")
 
@@ -832,7 +832,7 @@ private extension OrderStoreTests {
                               subtotal: "10.00",
                               subtotalTax: "0.40",
                               taxClass: "",
-                              taxes: [],
+                              taxes: [.init(taxID: 1, subtotal: "0.4", total: "0")],
                               total: "0.00",
                               totalTax: "0.00")
 
@@ -915,7 +915,7 @@ private extension OrderStoreTests {
     }
 
     func taxesMutated() -> [Networking.OrderItemTax] {
-        return [Networking.OrderItemTax(taxID: 75, subtotal: "0.45", total: "0.45"),
-                Networking.OrderItemTax(taxID: 73, subtotal: "0.9", total: "0.9")]
+        [Networking.OrderItemTax(taxID: 73, subtotal: "0.9", total: "0.9"),
+         Networking.OrderItemTax(taxID: 75, subtotal: "0.45", total: "0.45")]
     }
 }


### PR DESCRIPTION
Prerequisite for #2280

## Changes

While I was working the Yosemite & Networking layer changes for #2280, I removed the custom implementation of `OrderItem`'s `Equatable` since I was adding `attributes` property and then I noticed that it actually already ignores `taxes` on `develop`. It's dangerous to have a custom `Equatable` implementation because we don't have a good way to enforce comparisons on every property. I think it's a good practice that we use the default `Equatable` implementation whenever possible.

This PR:
- Removed the custom implementation of `OrderItem`'s `Equatable`
- Updated `Storage.OrderItem`'s conversion to readonly type by specifying an order for `taxes` relationship by its `taxID` tentatively (it's currently a `Set` in storage layer) so that we can expect the same result in unit tests
- Fixed unit tests

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
