### PR TITLE
[Issue Refunds] Disable next button on Issue Refund Screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -56,6 +56,7 @@ private extension IssueRefundViewController {
     func updateWithViewModelContent() {
         title = viewModel.title
         itemsSelectedLabel.text = viewModel.selectedItemsTitle
+        nextButton.isEnabled = viewModel.isNextButtonEnabled
         tableView.reloadData()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -36,6 +36,7 @@ final class IssueRefundViewModel {
             sections = createSections()
             title = calculateTitle()
             selectedItemsTitle = createSelectedItemsCount()
+            isNextButtonEnabled = calculateNextButtonEnableState()
             onChange?()
         }
     }
@@ -51,6 +52,10 @@ final class IssueRefundViewModel {
     /// String indicating how many items the user has selected to refund
     ///
     private(set) var selectedItemsTitle: String = ""
+
+    /// Boolean indicating if the next button is enabled
+    ///
+    private(set) var isNextButtonEnabled: Bool = false
 
     /// The sections and rows to display in the `UITableView`.
     ///
@@ -69,6 +74,7 @@ final class IssueRefundViewModel {
         state = State(order: order, itemsToRefund: items, currencySettings: currencySettings)
         sections = createSections()
         title = calculateTitle()
+        isNextButtonEnabled = calculateNextButtonEnableState()
         selectedItemsTitle = createSelectedItemsCount()
     }
 
@@ -245,6 +251,12 @@ extension IssueRefundViewModel {
     private func createSelectedItemsCount() -> String {
         let count = state.refundQuantityStore.count()
         return String.pluralize(count, singular: Localization.itemSingular, plural: Localization.itemsPlural)
+    }
+
+    /// Calculates wether the next button should be enabled or not
+    ///
+    private func calculateNextButtonEnableState() -> Bool {
+        return state.refundQuantityStore.count() > 0 || state.shouldRefundShipping
     }
 
     /// Return an array of `RefundableOrderItems` by taking out all previously refunded items

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/IssueRefundViewModelTests.swift
@@ -342,4 +342,52 @@ final class IssueRefundViewModelTests: XCTestCase {
         // Price is 11.50 and tax is 0.99 (2.97 / 3(quantity))
         XCTAssertEqual(viewModel.title, "$12.49")
     }
+
+    func test_viewModel_starts_with_next_button_disabled() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+
+        // When
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+    }
+
+    func test_viewModel_next_button_gets_enabled_after_selecting_items() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+
+        // When
+        viewModel.selectAllOrderItems()
+
+        // Then
+        XCTAssertTrue(viewModel.isNextButtonEnabled)
+    }
+
+    func test_viewModel_next_button_gets_disabled_after_selecting_and_then_unselecting_items() {
+        // Given
+        let currencySettings = CurrencySettings()
+        let items = [
+            MockOrderItem.sampleItem(itemID: 1, quantity: 3, price: 11.50),
+        ]
+        let order = MockOrders().makeOrder(items: items)
+        let viewModel = IssueRefundViewModel(order: order, refunds: [], currencySettings: currencySettings)
+        viewModel.selectAllOrderItems()
+
+        // When
+        viewModel.updateRefundQuantity(quantity: 0, forItemAtIndex: 0)
+
+        // Then
+        XCTAssertFalse(viewModel.isNextButtonEnabled)
+    }
 }


### PR DESCRIPTION
closes #3066 

# Why

There is no point in letting a user refund on items, so this PR disables the next button of the "Issue Refund" screen if there is no item selected to refund.

PS: While doing this I noticed that there is a problem with the disabled state of the buttons and since it's a broader problem I'll tackle it in a separate PR https://github.com/woocommerce/woocommerce-ios/issues/3081

# How

- Added a `isNextButtonEnabled` property on `IssueRefundViewModel` which is calculated everytime the `state` struct mutates.
- Updates `IssueRefundViewController` to change the button enabled state.

# Screenshot
![button gif](https://user-images.githubusercontent.com/562080/97608504-70287380-19e0-11eb-91b6-1661d0fef0eb.gif)

# Testing Steps

- Go to an no-refunded order
- Tap issue refund button
- See next button disabled
- Select an item or the shipping refund switch
- See the next button enabled

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
